### PR TITLE
Generates tagging tests for values not known at plan time

### DIFF
--- a/internal/generate/tagstests/main.go
+++ b/internal/generate/tagstests/main.go
@@ -125,6 +125,8 @@ func main() {
 			generateTestConfig(g, testDirPath, "tags0", true, configTmplFile, configTmpl)
 			generateTestConfig(g, testDirPath, "tagsNull", false, configTmplFile, configTmpl)
 			generateTestConfig(g, testDirPath, "tagsNull", true, configTmplFile, configTmpl)
+			generateTestConfig(g, testDirPath, "tagsComputed1", false, configTmplFile, configTmpl)
+			generateTestConfig(g, testDirPath, "tagsComputed2", false, configTmplFile, configTmpl)
 		}
 	}
 
@@ -166,6 +168,7 @@ type goImport struct {
 type ConfigDatum struct {
 	Tags            string
 	WithDefaultTags bool
+	ComputedTag     bool
 }
 
 //go:embed test.go.gtpl
@@ -388,6 +391,7 @@ func generateTestConfig(g *common.Generator, dirPath, test string, withDefaults 
 	configData := ConfigDatum{
 		Tags:            test,
 		WithDefaultTags: withDefaults,
+		ComputedTag:     (test == "tagsComputed"),
 	}
 	if err := tf.WriteTemplateSet(tfTemplates, configData); err != nil {
 		g.Fatalf("error generating Terraform file %q: %s", mainPath, err)

--- a/internal/generate/tagstests/test.go.gtpl
+++ b/internal/generate/tagstests/test.go.gtpl
@@ -1048,7 +1048,7 @@ func {{ template "testname" . }}_tags_ComputedTag_OnCreate(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
-						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags"){{ if eq .Implementation "framework" }}.AtMapKey("computedkey1"){{ end}}),
 					},
 					PostApplyPreRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
@@ -1110,7 +1110,7 @@ func {{ template "testname" . }}_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags"){{ if eq .Implementation "framework" }}.AtMapKey("computedkey1"){{ end}}),
 					},
 					PostApplyPreRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
@@ -1171,7 +1171,7 @@ func {{ template "testname" . }}_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags"){{ if eq .Implementation "framework" }}.AtMapKey("key1"){{ end}}),
 					},
 					PostApplyPreRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),

--- a/internal/generate/tagstests/test.go.gtpl
+++ b/internal/generate/tagstests/test.go.gtpl
@@ -53,6 +53,8 @@ import (
  	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
  	{{- end }}
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 	{{ range .GoImports -}}
@@ -1018,6 +1020,173 @@ func {{ template "testname" . }}_tags_DefaultTags_nullNonOverlappingResourceTag(
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				{{- template "ImportBody" .ImportIgnore -}}
+			},
+		},
+	})
+}
+
+func {{ template "testname" . }}_tags_ComputedTag_OnCreate(t *testing.T) {
+	{{- template "Init" . }}
+
+	resource.{{ if .Serialize }}Test{{ else }}ParallelTest{{ end }}(t, resource.TestCase{
+		{{ template "TestCaseSetupNoProviders" . }}
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/{{ .Name }}/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					{{- template "ExistsCheck" . -}}
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/{{ .Name }}/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				{{- template "ImportBody" .ImportIgnore -}}
+			},
+		},
+	})
+}
+
+func {{ template "testname" . }}_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	{{- template "Init" . }}
+
+	resource.{{ if .Serialize }}Test{{ else }}ParallelTest{{ end }}(t, resource.TestCase{
+		{{ template "TestCaseSetupNoProviders" . }}
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/{{ .Name }}/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					{{- template "ExistsCheck" . -}}
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/{{ .Name }}/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					{{- template "ExistsCheck" . -}}
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/{{ .Name }}/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				{{- template "ImportBody" .ImportIgnore -}}
+			},
+		},
+	})
+}
+
+func {{ template "testname" . }}_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	{{- template "Init" . }}
+
+	resource.{{ if .Serialize }}Test{{ else }}ParallelTest{{ end }}(t, resource.TestCase{
+		{{ template "TestCaseSetupNoProviders" . }}
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/{{ .Name }}/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					{{- template "ExistsCheck" . -}}
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/{{ .Name }}/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					{{- template "ExistsCheck" . -}}
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/{{ .Name }}/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				{{- template "ImportBody" .ImportIgnore -}}
 			},

--- a/internal/generate/tagstests/test.go.gtpl
+++ b/internal/generate/tagstests/test.go.gtpl
@@ -80,6 +80,9 @@ func {{ template "testname" . }}_tagsSerial(t *testing.T) {
 	t.Run("DefaultTags_emptyResourceTag", {{ template "testname" . }}_tags_DefaultTags_emptyResourceTag)
 	t.Run("DefaultTags_nullOverlappingResourceTag", {{ template "testname" . }}_tags_DefaultTags_nullOverlappingResourceTag)
 	t.Run("DefaultTags_nullNonOverlappingResourceTag", {{ template "testname" . }}_tags_DefaultTags_nullNonOverlappingResourceTag)
+	t.Run("ComputedTag_OnCreate", {{ template "testname" . }}_tags_ComputedTag_OnCreate)
+	t.Run("ComputedTag_OnUpdate_Add", {{ template "testname" . }}_tags_ComputedTag_OnUpdate_Add)
+	t.Run("ComputedTag_OnUpdate_Replace", {{ template "testname" . }}_tags_ComputedTag_OnUpdate_Replace)
 }
 {{ end }}
 

--- a/internal/generate/tagstests/test.tf.gtpl
+++ b/internal/generate/tagstests/test.tf.gtpl
@@ -9,6 +9,15 @@
   tags = {
     (var.tagKey1) = null
   }
+{{- else if eq . "tagsComputed1"}}
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+{{- else if eq . "tagsComputed2"}}
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
 {{- end -}}
 {{ end -}}
 
@@ -21,9 +30,18 @@ provider "aws" {
 
 {{ end }}
 
+{{- if or (eq .Tags "tagsComputed1") (eq .Tags "tagsComputed2") -}}
+provider "null" {}
+
+{{ end -}}
+
 {{- block "body" .Tags }}
 Missing block "body" in template
 {{ end }}
+{{ if or (eq .Tags "tagsComputed1") (eq .Tags "tagsComputed2") -}}
+resource "null_resource" "test" {}
+
+{{ end -}}
 
 variable "rName" {
   type     = string
@@ -40,11 +58,30 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
-{{- end }}
+{{ else if eq .Tags "tagsComputed1" }}
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+{{ else if eq .Tags "tagsComputed2" }}
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
 
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+{{- end }}
 {{ if .WithDefaultTags -}}
 variable "provider_tags" {
   type     = map(string)
   nullable = false
 }
-{{ end -}}
+{{- end }}

--- a/internal/service/accessanalyzer/analyzer_tags_gen_test.go
+++ b/internal/service/accessanalyzer/analyzer_tags_gen_test.go
@@ -32,6 +32,9 @@ func testAccAccessAnalyzerAnalyzer_tagsSerial(t *testing.T) {
 	t.Run("DefaultTags_emptyResourceTag", testAccAccessAnalyzerAnalyzer_tags_DefaultTags_emptyResourceTag)
 	t.Run("DefaultTags_nullOverlappingResourceTag", testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nullOverlappingResourceTag)
 	t.Run("DefaultTags_nullNonOverlappingResourceTag", testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nullNonOverlappingResourceTag)
+	t.Run("ComputedTag_OnCreate", testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnCreate)
+	t.Run("ComputedTag_OnUpdate_Add", testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Add)
+	t.Run("ComputedTag_OnUpdate_Replace", testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Replace)
 }
 
 func testAccAccessAnalyzerAnalyzer_tags(t *testing.T) {

--- a/internal/service/accessanalyzer/analyzer_tags_gen_test.go
+++ b/internal/service/accessanalyzer/analyzer_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1074,6 +1076,194 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nullNonOverlappingResourceTa
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.AnalyzerSummary
+	resourceName := "aws_accessanalyzer_analyzer.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Analyzer/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Analyzer/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.AnalyzerSummary
+	resourceName := "aws_accessanalyzer_analyzer.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Analyzer/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Analyzer/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Analyzer/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.AnalyzerSummary
+	resourceName := "aws_accessanalyzer_analyzer.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.AccessAnalyzerServiceID),
+		CheckDestroy: testAccCheckAnalyzerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Analyzer/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Analyzer/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAnalyzerExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Analyzer/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/accessanalyzer/testdata/Analyzer/tags/main_gen.tf
+++ b/internal/service/accessanalyzer/testdata/Analyzer/tags/main_gen.tf
@@ -7,7 +7,6 @@ resource "aws_accessanalyzer_analyzer" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/accessanalyzer/testdata/Analyzer/tags0/main_gen.tf
+++ b/internal/service/accessanalyzer/testdata/Analyzer/tags0/main_gen.tf
@@ -6,7 +6,6 @@ resource "aws_accessanalyzer_analyzer" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/accessanalyzer/testdata/Analyzer/tags0_defaults/main_gen.tf
+++ b/internal/service/accessanalyzer/testdata/Analyzer/tags0_defaults/main_gen.tf
@@ -12,12 +12,10 @@ resource "aws_accessanalyzer_analyzer" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/accessanalyzer/testdata/Analyzer/tagsComputed1/main_gen.tf
+++ b/internal/service/accessanalyzer/testdata/Analyzer/tagsComputed1/main_gen.tf
@@ -1,31 +1,26 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-provider "aws" {
-  default_tags {
-    tags = var.provider_tags
-  }
-}
+provider "null" {}
 
 resource "aws_accessanalyzer_analyzer" "test" {
   analyzer_name = var.rName
 
   tags = {
-    (var.tagKey1) = null
+    (var.unknownTagKey) = null_resource.test.id
   }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "tagKey1" {
+variable "unknownTagKey" {
   type     = string
   nullable = false
 }
 
-variable "provider_tags" {
-  type     = map(string)
-  nullable = false
-}
+

--- a/internal/service/accessanalyzer/testdata/Analyzer/tagsComputed2/main_gen.tf
+++ b/internal/service/accessanalyzer/testdata/Analyzer/tagsComputed2/main_gen.tf
@@ -1,0 +1,36 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_accessanalyzer_analyzer" "test" {
+  analyzer_name = var.rName
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/accessanalyzer/testdata/Analyzer/tagsNull/main_gen.tf
+++ b/internal/service/accessanalyzer/testdata/Analyzer/tagsNull/main_gen.tf
@@ -9,7 +9,6 @@ resource "aws_accessanalyzer_analyzer" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -19,4 +18,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/accessanalyzer/testdata/Analyzer/tags_defaults/main_gen.tf
+++ b/internal/service/accessanalyzer/testdata/Analyzer/tags_defaults/main_gen.tf
@@ -13,7 +13,6 @@ resource "aws_accessanalyzer_analyzer" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -23,7 +22,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/acmpca/certificate_authority_tags_gen_test.go
+++ b/internal/service/acmpca/certificate_authority_tags_gen_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/acmpca/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1129,6 +1131,203 @@ func TestAccACMPCACertificateAuthority_tags_DefaultTags_nullNonOverlappingResour
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"permanent_deletion_time_in_days",
+				},
+			},
+		},
+	})
+}
+
+func TestAccACMPCACertificateAuthority_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.CertificateAuthority
+	resourceName := "aws_acmpca_certificate_authority.test"
+	rName := acctest.RandomDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
+		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/CertificateAuthority/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateAuthorityExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/CertificateAuthority/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"permanent_deletion_time_in_days",
+				},
+			},
+		},
+	})
+}
+
+func TestAccACMPCACertificateAuthority_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.CertificateAuthority
+	resourceName := "aws_acmpca_certificate_authority.test"
+	rName := acctest.RandomDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
+		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/CertificateAuthority/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateAuthorityExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/CertificateAuthority/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateAuthorityExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/CertificateAuthority/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"permanent_deletion_time_in_days",
+				},
+			},
+		},
+	})
+}
+
+func TestAccACMPCACertificateAuthority_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.CertificateAuthority
+	resourceName := "aws_acmpca_certificate_authority.test"
+	rName := acctest.RandomDomainName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
+		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/CertificateAuthority/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateAuthorityExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/CertificateAuthority/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckCertificateAuthorityExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/CertificateAuthority/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/acmpca/testdata/CertificateAuthority/tags/main_gen.tf
+++ b/internal/service/acmpca/testdata/CertificateAuthority/tags/main_gen.tf
@@ -17,7 +17,6 @@ resource "aws_acmpca_certificate_authority" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/acmpca/testdata/CertificateAuthority/tags0_defaults/main_gen.tf
+++ b/internal/service/acmpca/testdata/CertificateAuthority/tags0_defaults/main_gen.tf
@@ -22,12 +22,10 @@ resource "aws_acmpca_certificate_authority" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/acmpca/testdata/CertificateAuthority/tagsComputed1/main_gen.tf
+++ b/internal/service/acmpca/testdata/CertificateAuthority/tagsComputed1/main_gen.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
   usage_mode                      = "SHORT_LIVED_CERTIFICATE"
@@ -14,9 +16,19 @@ resource "aws_acmpca_certificate_authority" "test" {
     }
   }
 
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
 }
 
+resource "null_resource" "test" {}
+
 variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
   type     = string
   nullable = false
 }

--- a/internal/service/acmpca/testdata/CertificateAuthority/tagsComputed2/main_gen.tf
+++ b/internal/service/acmpca/testdata/CertificateAuthority/tagsComputed2/main_gen.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_acmpca_certificate_authority" "test" {
   permanent_deletion_time_in_days = 7
   usage_mode                      = "SHORT_LIVED_CERTIFICATE"
@@ -14,11 +16,31 @@ resource "aws_acmpca_certificate_authority" "test" {
     }
   }
 
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
 

--- a/internal/service/acmpca/testdata/CertificateAuthority/tagsNull/main_gen.tf
+++ b/internal/service/acmpca/testdata/CertificateAuthority/tagsNull/main_gen.tf
@@ -19,7 +19,6 @@ resource "aws_acmpca_certificate_authority" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -29,4 +28,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/acmpca/testdata/CertificateAuthority/tagsNull_defaults/main_gen.tf
+++ b/internal/service/acmpca/testdata/CertificateAuthority/tagsNull_defaults/main_gen.tf
@@ -25,7 +25,6 @@ resource "aws_acmpca_certificate_authority" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/acmpca/testdata/CertificateAuthority/tags_defaults/main_gen.tf
+++ b/internal/service/acmpca/testdata/CertificateAuthority/tags_defaults/main_gen.tf
@@ -23,7 +23,6 @@ resource "aws_acmpca_certificate_authority" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -33,7 +32,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/batch/compute_environment_tags_gen_test.go
+++ b/internal/service/batch/compute_environment_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1055,6 +1057,194 @@ func TestAccBatchComputeEnvironment_tags_DefaultTags_nullNonOverlappingResourceT
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironment_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.ComputeEnvironmentDetail
+	resourceName := "aws_batch_compute_environment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ComputeEnvironment/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ComputeEnvironment/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironment_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.ComputeEnvironmentDetail
+	resourceName := "aws_batch_compute_environment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ComputeEnvironment/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ComputeEnvironment/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ComputeEnvironment/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironment_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.ComputeEnvironmentDetail
+	resourceName := "aws_batch_compute_environment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ComputeEnvironment/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ComputeEnvironment/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckComputeEnvironmentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ComputeEnvironment/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/batch/job_definition_tags_gen_test.go
+++ b/internal/service/batch/job_definition_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1130,6 +1132,203 @@ func TestAccBatchJobDefinition_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinition_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.JobDefinition
+	resourceName := "aws_batch_job_definition.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobDefinition/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobDefinition/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.JobDefinition
+	resourceName := "aws_batch_job_definition.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobDefinition/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobDefinition/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobDefinition/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.JobDefinition
+	resourceName := "aws_batch_job_definition.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobDefinition/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobDefinition/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobDefinition/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/batch/job_queue_tags_gen_test.go
+++ b/internal/service/batch/job_queue_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1061,6 +1063,194 @@ func TestAccBatchJobQueue_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchJobQueue_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobQueue/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobQueueExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags").AtMapKey("computedkey1")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobQueue/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchJobQueue_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobQueue/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobQueueExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobQueue/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobQueueExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags").AtMapKey("computedkey1")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobQueue/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchJobQueue_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.JobQueueDetail
+	resourceName := "aws_batch_job_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobQueue/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobQueueExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobQueue/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobQueueExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags").AtMapKey("key1")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/JobQueue/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/batch/scheduling_policy_tags_gen_test.go
+++ b/internal/service/batch/scheduling_policy_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1055,6 +1057,194 @@ func TestAccBatchSchedulingPolicy_tags_DefaultTags_nullNonOverlappingResourceTag
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchSchedulingPolicy_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.SchedulingPolicyDetail
+	resourceName := "aws_batch_scheduling_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SchedulingPolicy/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSchedulingPolicyExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SchedulingPolicy/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchSchedulingPolicy_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.SchedulingPolicyDetail
+	resourceName := "aws_batch_scheduling_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SchedulingPolicy/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSchedulingPolicyExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SchedulingPolicy/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSchedulingPolicyExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SchedulingPolicy/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBatchSchedulingPolicy_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v batch.SchedulingPolicyDetail
+	resourceName := "aws_batch_scheduling_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
+		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SchedulingPolicy/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSchedulingPolicyExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SchedulingPolicy/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSchedulingPolicyExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SchedulingPolicy/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/batch/testdata/ComputeEnvironment/tags/main_gen.tf
+++ b/internal/service/batch/testdata/ComputeEnvironment/tags/main_gen.tf
@@ -66,7 +66,6 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/ComputeEnvironment/tags0/main_gen.tf
+++ b/internal/service/batch/testdata/ComputeEnvironment/tags0/main_gen.tf
@@ -65,7 +65,6 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/ComputeEnvironment/tagsComputed1/main_gen.tf
+++ b/internal/service/batch/testdata/ComputeEnvironment/tagsComputed1/main_gen.tf
@@ -1,17 +1,16 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-provider "aws" {
-  default_tags {
-    tags = var.provider_tags
-  }
-}
+provider "null" {}
 
 resource "aws_batch_compute_environment" "test" {
   compute_environment_name = var.rName
   service_role             = aws_iam_role.batch_service.arn
   type                     = "UNMANAGED"
 
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
 
   depends_on = [aws_iam_role_policy_attachment.batch_service]
 }
@@ -71,12 +70,16 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
+resource "null_resource" "test" {}
+
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "provider_tags" {
-  type     = map(string)
+variable "unknownTagKey" {
+  type     = string
   nullable = false
 }
+
+

--- a/internal/service/batch/testdata/ComputeEnvironment/tagsComputed2/main_gen.tf
+++ b/internal/service/batch/testdata/ComputeEnvironment/tagsComputed2/main_gen.tf
@@ -1,17 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-provider "aws" {
-  default_tags {
-    tags = var.provider_tags
-  }
-}
+provider "null" {}
 
 resource "aws_batch_compute_environment" "test" {
   compute_environment_name = var.rName
   service_role             = aws_iam_role.batch_service.arn
   type                     = "UNMANAGED"
 
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
 
   depends_on = [aws_iam_role_policy_attachment.batch_service]
 }
@@ -71,12 +71,25 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
+resource "null_resource" "test" {}
+
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "provider_tags" {
-  type     = map(string)
+variable "unknownTagKey" {
+  type     = string
   nullable = false
 }
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/batch/testdata/ComputeEnvironment/tagsNull/main_gen.tf
+++ b/internal/service/batch/testdata/ComputeEnvironment/tagsNull/main_gen.tf
@@ -68,7 +68,6 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -78,4 +77,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/batch/testdata/ComputeEnvironment/tagsNull_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/ComputeEnvironment/tagsNull_defaults/main_gen.tf
@@ -74,7 +74,6 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/ComputeEnvironment/tags_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/ComputeEnvironment/tags_defaults/main_gen.tf
@@ -72,7 +72,6 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -82,7 +81,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/batch/testdata/JobDefinition/tags/main_gen.tf
+++ b/internal/service/batch/testdata/JobDefinition/tags/main_gen.tf
@@ -14,7 +14,6 @@ resource "aws_batch_job_definition" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/JobDefinition/tags0/main_gen.tf
+++ b/internal/service/batch/testdata/JobDefinition/tags0/main_gen.tf
@@ -13,7 +13,6 @@ resource "aws_batch_job_definition" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/JobDefinition/tags0_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/JobDefinition/tags0_defaults/main_gen.tf
@@ -19,12 +19,10 @@ resource "aws_batch_job_definition" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/batch/testdata/JobDefinition/tagsComputed1/main_gen.tf
+++ b/internal/service/batch/testdata/JobDefinition/tagsComputed1/main_gen.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_batch_job_definition" "test" {
   name = var.rName
   type = "container"
@@ -12,16 +14,18 @@ resource "aws_batch_job_definition" "test" {
   })
 
   tags = {
-    (var.tagKey1) = null
+    (var.unknownTagKey) = null_resource.test.id
   }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "tagKey1" {
+variable "unknownTagKey" {
   type     = string
   nullable = false
 }

--- a/internal/service/batch/testdata/JobDefinition/tagsComputed2/main_gen.tf
+++ b/internal/service/batch/testdata/JobDefinition/tagsComputed2/main_gen.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_batch_job_definition" "test" {
   name = var.rName
   type = "container"
@@ -12,18 +14,30 @@ resource "aws_batch_job_definition" "test" {
   })
 
   tags = {
-    (var.tagKey1) = null
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
   }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "tagKey1" {
+variable "unknownTagKey" {
   type     = string
   nullable = false
 }
 
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
 

--- a/internal/service/batch/testdata/JobDefinition/tagsNull_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/JobDefinition/tagsNull_defaults/main_gen.tf
@@ -22,7 +22,6 @@ resource "aws_batch_job_definition" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/JobDefinition/tags_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/JobDefinition/tags_defaults/main_gen.tf
@@ -20,7 +20,6 @@ resource "aws_batch_job_definition" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -30,7 +29,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/batch/testdata/JobQueue/tags/main_gen.tf
+++ b/internal/service/batch/testdata/JobQueue/tags/main_gen.tf
@@ -74,7 +74,6 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/JobQueue/tags0/main_gen.tf
+++ b/internal/service/batch/testdata/JobQueue/tags0/main_gen.tf
@@ -73,7 +73,6 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/JobQueue/tags0_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/JobQueue/tags0_defaults/main_gen.tf
@@ -79,12 +79,10 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/batch/testdata/JobQueue/tagsComputed1/main_gen.tf
+++ b/internal/service/batch/testdata/JobQueue/tagsComputed1/main_gen.tf
@@ -1,9 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-provider "aws" {
-  default_tags {
-    tags = var.provider_tags
+provider "null" {}
+
+resource "aws_batch_job_queue" "test" {
+  name     = var.rName
+  priority = 1
+  state    = "DISABLED"
+
+  compute_environments = [aws_batch_compute_environment.test.arn]
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
   }
 }
 
@@ -11,7 +19,6 @@ resource "aws_batch_compute_environment" "test" {
   compute_environment_name = var.rName
   service_role             = aws_iam_role.batch_service.arn
   type                     = "UNMANAGED"
-
 
   depends_on = [aws_iam_role_policy_attachment.batch_service]
 }
@@ -71,12 +78,16 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
+resource "null_resource" "test" {}
+
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "provider_tags" {
-  type     = map(string)
+variable "unknownTagKey" {
+  type     = string
   nullable = false
 }
+
+

--- a/internal/service/batch/testdata/JobQueue/tagsComputed2/main_gen.tf
+++ b/internal/service/batch/testdata/JobQueue/tagsComputed2/main_gen.tf
@@ -1,9 +1,18 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-provider "aws" {
-  default_tags {
-    tags = var.provider_tags
+provider "null" {}
+
+resource "aws_batch_job_queue" "test" {
+  name     = var.rName
+  priority = 1
+  state    = "DISABLED"
+
+  compute_environments = [aws_batch_compute_environment.test.arn]
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
   }
 }
 
@@ -11,7 +20,6 @@ resource "aws_batch_compute_environment" "test" {
   compute_environment_name = var.rName
   service_role             = aws_iam_role.batch_service.arn
   type                     = "UNMANAGED"
-
 
   depends_on = [aws_iam_role_policy_attachment.batch_service]
 }
@@ -71,12 +79,25 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
+resource "null_resource" "test" {}
+
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "provider_tags" {
-  type     = map(string)
+variable "unknownTagKey" {
+  type     = string
   nullable = false
 }
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/batch/testdata/JobQueue/tagsNull/main_gen.tf
+++ b/internal/service/batch/testdata/JobQueue/tagsNull/main_gen.tf
@@ -76,7 +76,6 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -86,4 +85,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/batch/testdata/JobQueue/tagsNull_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/JobQueue/tagsNull_defaults/main_gen.tf
@@ -82,7 +82,6 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/JobQueue/tags_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/JobQueue/tags_defaults/main_gen.tf
@@ -80,7 +80,6 @@ resource "aws_iam_instance_profile" "ecs_instance" {
   role = aws_iam_role_policy_attachment.ecs_instance.role
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -90,7 +89,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/batch/testdata/SchedulingPolicy/tags/main_gen.tf
+++ b/internal/service/batch/testdata/SchedulingPolicy/tags/main_gen.tf
@@ -12,7 +12,6 @@ resource "aws_batch_scheduling_policy" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/SchedulingPolicy/tags0/main_gen.tf
+++ b/internal/service/batch/testdata/SchedulingPolicy/tags0/main_gen.tf
@@ -11,7 +11,6 @@ resource "aws_batch_scheduling_policy" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/SchedulingPolicy/tags0_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/SchedulingPolicy/tags0_defaults/main_gen.tf
@@ -17,12 +17,10 @@ resource "aws_batch_scheduling_policy" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/batch/testdata/SchedulingPolicy/tagsComputed1/main_gen.tf
+++ b/internal/service/batch/testdata/SchedulingPolicy/tagsComputed1/main_gen.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_batch_scheduling_policy" "test" {
   name = var.rName
 
@@ -10,16 +12,18 @@ resource "aws_batch_scheduling_policy" "test" {
   }
 
   tags = {
-    (var.tagKey1) = null
+    (var.unknownTagKey) = null_resource.test.id
   }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "tagKey1" {
+variable "unknownTagKey" {
   type     = string
   nullable = false
 }

--- a/internal/service/batch/testdata/SchedulingPolicy/tagsComputed2/main_gen.tf
+++ b/internal/service/batch/testdata/SchedulingPolicy/tagsComputed2/main_gen.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_batch_scheduling_policy" "test" {
   name = var.rName
 
@@ -10,18 +12,30 @@ resource "aws_batch_scheduling_policy" "test" {
   }
 
   tags = {
-    (var.tagKey1) = null
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
   }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "tagKey1" {
+variable "unknownTagKey" {
   type     = string
   nullable = false
 }
 
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
 

--- a/internal/service/batch/testdata/SchedulingPolicy/tagsNull_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/SchedulingPolicy/tagsNull_defaults/main_gen.tf
@@ -20,7 +20,6 @@ resource "aws_batch_scheduling_policy" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/batch/testdata/SchedulingPolicy/tags_defaults/main_gen.tf
+++ b/internal/service/batch/testdata/SchedulingPolicy/tags_defaults/main_gen.tf
@@ -18,7 +18,6 @@ resource "aws_batch_scheduling_policy" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -28,7 +27,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/instance_profile_tags_gen_test.go
+++ b/internal/service/iam/instance_profile_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1055,6 +1057,194 @@ func TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMInstanceProfile_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.InstanceProfile
+	resourceName := "aws_iam_instance_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/InstanceProfile/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/InstanceProfile/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.InstanceProfile
+	resourceName := "aws_iam_instance_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/InstanceProfile/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/InstanceProfile/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/InstanceProfile/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.InstanceProfile
+	resourceName := "aws_iam_instance_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/InstanceProfile/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/InstanceProfile/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInstanceProfileExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/InstanceProfile/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/iam/openid_connect_provider_tags_gen_test.go
+++ b/internal/service/iam/openid_connect_provider_tags_gen_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1040,6 +1042,191 @@ func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResource
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_iam_openid_connect_provider.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/OpenIDConnectProvider/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/OpenIDConnectProvider/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_iam_openid_connect_provider.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/OpenIDConnectProvider/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/OpenIDConnectProvider/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/OpenIDConnectProvider/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_iam_openid_connect_provider.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/OpenIDConnectProvider/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/OpenIDConnectProvider/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/OpenIDConnectProvider/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/iam/policy_tags_gen_test.go
+++ b/internal/service/iam/policy_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1055,6 +1057,194 @@ func TestAccIAMPolicy_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicy_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.Policy
+	resourceName := "aws_iam_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Policy/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPolicyExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Policy/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.Policy
+	resourceName := "aws_iam_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Policy/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPolicyExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Policy/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPolicyExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Policy/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.Policy
+	resourceName := "aws_iam_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Policy/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPolicyExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Policy/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPolicyExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Policy/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/iam/role_tags_gen_test.go
+++ b/internal/service/iam/role_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1055,6 +1057,194 @@ func TestAccIAMRole_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T)
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMRole_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.Role
+	resourceName := "aws_iam_role.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Role/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRoleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Role/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMRole_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.Role
+	resourceName := "aws_iam_role.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Role/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRoleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Role/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRoleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Role/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMRole_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.Role
+	resourceName := "aws_iam_role.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckRoleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Role/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRoleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Role/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckRoleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Role/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/iam/service_linked_role_tags_gen_test.go
+++ b/internal/service/iam/service_linked_role_tags_gen_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1040,6 +1042,191 @@ func TestAccIAMServiceLinkedRole_tags_DefaultTags_nullNonOverlappingResourceTag(
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMServiceLinkedRole_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_iam_service_linked_role.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ServiceLinkedRole/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ServiceLinkedRole/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMServiceLinkedRole_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_iam_service_linked_role.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ServiceLinkedRole/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ServiceLinkedRole/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ServiceLinkedRole/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMServiceLinkedRole_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_iam_service_linked_role.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ServiceLinkedRole/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ServiceLinkedRole/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckServiceLinkedRoleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/ServiceLinkedRole/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/iam/testdata/InstanceProfile/tags/main_gen.tf
+++ b/internal/service/iam/testdata/InstanceProfile/tags/main_gen.tf
@@ -31,7 +31,6 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/InstanceProfile/tags0/main_gen.tf
+++ b/internal/service/iam/testdata/InstanceProfile/tags0/main_gen.tf
@@ -30,7 +30,6 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/InstanceProfile/tags0_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/InstanceProfile/tags0_defaults/main_gen.tf
@@ -36,12 +36,10 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/InstanceProfile/tagsComputed1/main_gen.tf
+++ b/internal/service/iam/testdata/InstanceProfile/tagsComputed1/main_gen.tf
@@ -1,0 +1,50 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_instance_profile" "test" {
+  name = var.rName
+  role = aws_iam_role.test.name
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = "${var.rName}-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+

--- a/internal/service/iam/testdata/InstanceProfile/tagsComputed2/main_gen.tf
+++ b/internal/service/iam/testdata/InstanceProfile/tagsComputed2/main_gen.tf
@@ -1,0 +1,60 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_instance_profile" "test" {
+  name = var.rName
+  role = aws_iam_role.test.name
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
+resource "aws_iam_role" "test" {
+  name = "${var.rName}-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com"
+        ]
+      },
+      "Action": [
+        "sts:AssumeRole"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/iam/testdata/InstanceProfile/tagsNull/main_gen.tf
+++ b/internal/service/iam/testdata/InstanceProfile/tagsNull/main_gen.tf
@@ -33,7 +33,6 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -43,4 +42,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/iam/testdata/InstanceProfile/tagsNull_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/InstanceProfile/tagsNull_defaults/main_gen.tf
@@ -39,7 +39,6 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/InstanceProfile/tags_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/InstanceProfile/tags_defaults/main_gen.tf
@@ -37,7 +37,6 @@ resource "aws_iam_role" "test" {
 EOF
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -47,7 +46,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/OpenIDConnectProvider/tags/main_gen.tf
+++ b/internal/service/iam/testdata/OpenIDConnectProvider/tags/main_gen.tf
@@ -13,7 +13,6 @@ resource "aws_iam_openid_connect_provider" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/OpenIDConnectProvider/tags0/main_gen.tf
+++ b/internal/service/iam/testdata/OpenIDConnectProvider/tags0/main_gen.tf
@@ -12,7 +12,6 @@ resource "aws_iam_openid_connect_provider" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/OpenIDConnectProvider/tags0_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/OpenIDConnectProvider/tags0_defaults/main_gen.tf
@@ -18,12 +18,10 @@ resource "aws_iam_openid_connect_provider" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/OpenIDConnectProvider/tagsComputed1/main_gen.tf
+++ b/internal/service/iam/testdata/OpenIDConnectProvider/tagsComputed1/main_gen.tf
@@ -1,0 +1,32 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_openid_connect_provider" "test" {
+  url = "https://accounts.testle.com/${var.rName}"
+
+  client_id_list = [
+    "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com",
+  ]
+
+  thumbprint_list = ["cf23df2207d99a74fbe169e3eba035e633b65d94"]
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+

--- a/internal/service/iam/testdata/OpenIDConnectProvider/tagsComputed2/main_gen.tf
+++ b/internal/service/iam/testdata/OpenIDConnectProvider/tagsComputed2/main_gen.tf
@@ -1,0 +1,42 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_openid_connect_provider" "test" {
+  url = "https://accounts.testle.com/${var.rName}"
+
+  client_id_list = [
+    "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.testleusercontent.com",
+  ]
+
+  thumbprint_list = ["cf23df2207d99a74fbe169e3eba035e633b65d94"]
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/iam/testdata/OpenIDConnectProvider/tagsNull/main_gen.tf
+++ b/internal/service/iam/testdata/OpenIDConnectProvider/tagsNull/main_gen.tf
@@ -15,7 +15,6 @@ resource "aws_iam_openid_connect_provider" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -25,4 +24,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/iam/testdata/OpenIDConnectProvider/tagsNull_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/OpenIDConnectProvider/tagsNull_defaults/main_gen.tf
@@ -21,7 +21,6 @@ resource "aws_iam_openid_connect_provider" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/OpenIDConnectProvider/tags_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/OpenIDConnectProvider/tags_defaults/main_gen.tf
@@ -19,7 +19,6 @@ resource "aws_iam_openid_connect_provider" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -29,7 +28,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/Policy/tags/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tags/main_gen.tf
@@ -26,7 +26,6 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/Policy/tags0/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tags0/main_gen.tf
@@ -25,7 +25,6 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/Policy/tags0_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tags0_defaults/main_gen.tf
@@ -31,12 +31,10 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/Policy/tagsComputed1/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tagsComputed1/main_gen.tf
@@ -1,0 +1,45 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_policy" "test" {
+  name = var.rName
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+    }
+  ]
+}
+EOF
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+}
+
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+

--- a/internal/service/iam/testdata/Policy/tagsComputed2/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tagsComputed2/main_gen.tf
@@ -1,0 +1,55 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_policy" "test" {
+  name = var.rName
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+    }
+  ]
+}
+EOF
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/iam/testdata/Policy/tagsNull/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tagsNull/main_gen.tf
@@ -28,7 +28,6 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -38,4 +37,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/iam/testdata/Policy/tagsNull_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tagsNull_defaults/main_gen.tf
@@ -34,7 +34,6 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/Policy/tags_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tags_defaults/main_gen.tf
@@ -32,7 +32,6 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -42,7 +41,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/Role/tags/main_gen.tf
+++ b/internal/service/iam/testdata/Role/tags/main_gen.tf
@@ -21,7 +21,6 @@ resource "aws_iam_role" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/Role/tags0/main_gen.tf
+++ b/internal/service/iam/testdata/Role/tags0/main_gen.tf
@@ -20,7 +20,6 @@ resource "aws_iam_role" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/Role/tags0_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/Role/tags0_defaults/main_gen.tf
@@ -26,12 +26,10 @@ resource "aws_iam_role" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/Role/tagsComputed1/main_gen.tf
+++ b/internal/service/iam/testdata/Role/tagsComputed1/main_gen.tf
@@ -1,0 +1,40 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole",
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+      }
+      Effect = "Allow"
+      Sid    = ""
+    }]
+  })
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+

--- a/internal/service/iam/testdata/Role/tagsComputed2/main_gen.tf
+++ b/internal/service/iam/testdata/Role/tagsComputed2/main_gen.tf
@@ -1,0 +1,50 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name = var.rName
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole",
+      Principal = {
+        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+      }
+      Effect = "Allow"
+      Sid    = ""
+    }]
+  })
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/iam/testdata/Role/tagsNull/main_gen.tf
+++ b/internal/service/iam/testdata/Role/tagsNull/main_gen.tf
@@ -23,7 +23,6 @@ resource "aws_iam_role" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -33,4 +32,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/iam/testdata/Role/tagsNull_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/Role/tagsNull_defaults/main_gen.tf
@@ -29,7 +29,6 @@ resource "aws_iam_role" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/Role/tags_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/Role/tags_defaults/main_gen.tf
@@ -27,7 +27,6 @@ resource "aws_iam_role" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -37,7 +36,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/ServiceLinkedRole/tags/main_gen.tf
+++ b/internal/service/iam/testdata/ServiceLinkedRole/tags/main_gen.tf
@@ -8,7 +8,6 @@ resource "aws_iam_service_linked_role" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/ServiceLinkedRole/tags0/main_gen.tf
+++ b/internal/service/iam/testdata/ServiceLinkedRole/tags0/main_gen.tf
@@ -7,7 +7,6 @@ resource "aws_iam_service_linked_role" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/ServiceLinkedRole/tags0_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/ServiceLinkedRole/tags0_defaults/main_gen.tf
@@ -13,12 +13,10 @@ resource "aws_iam_service_linked_role" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/ServiceLinkedRole/tagsComputed1/main_gen.tf
+++ b/internal/service/iam/testdata/ServiceLinkedRole/tagsComputed1/main_gen.tf
@@ -1,0 +1,27 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_service_linked_role" "test" {
+  aws_service_name = "autoscaling.amazonaws.com"
+  custom_suffix    = var.rName
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+

--- a/internal/service/iam/testdata/ServiceLinkedRole/tagsComputed2/main_gen.tf
+++ b/internal/service/iam/testdata/ServiceLinkedRole/tagsComputed2/main_gen.tf
@@ -1,0 +1,37 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_service_linked_role" "test" {
+  aws_service_name = "autoscaling.amazonaws.com"
+  custom_suffix    = var.rName
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/iam/testdata/ServiceLinkedRole/tagsNull/main_gen.tf
+++ b/internal/service/iam/testdata/ServiceLinkedRole/tagsNull/main_gen.tf
@@ -10,7 +10,6 @@ resource "aws_iam_service_linked_role" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -20,4 +19,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/iam/testdata/ServiceLinkedRole/tagsNull_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/ServiceLinkedRole/tagsNull_defaults/main_gen.tf
@@ -16,7 +16,6 @@ resource "aws_iam_service_linked_role" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/ServiceLinkedRole/tags_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/ServiceLinkedRole/tags_defaults/main_gen.tf
@@ -14,7 +14,6 @@ resource "aws_iam_service_linked_role" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -24,7 +23,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/User/tags/main_gen.tf
+++ b/internal/service/iam/testdata/User/tags/main_gen.tf
@@ -7,7 +7,6 @@ resource "aws_iam_user" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/User/tags0/main_gen.tf
+++ b/internal/service/iam/testdata/User/tags0/main_gen.tf
@@ -6,7 +6,6 @@ resource "aws_iam_user" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/User/tags0_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/User/tags0_defaults/main_gen.tf
@@ -12,12 +12,10 @@ resource "aws_iam_user" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/User/tagsComputed1/main_gen.tf
+++ b/internal/service/iam/testdata/User/tagsComputed1/main_gen.tf
@@ -1,0 +1,26 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_user" "test" {
+  name = var.rName
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+

--- a/internal/service/iam/testdata/User/tagsComputed2/main_gen.tf
+++ b/internal/service/iam/testdata/User/tagsComputed2/main_gen.tf
@@ -1,0 +1,36 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_user" "test" {
+  name = var.rName
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/iam/testdata/User/tagsNull/main_gen.tf
+++ b/internal/service/iam/testdata/User/tagsNull/main_gen.tf
@@ -9,7 +9,6 @@ resource "aws_iam_user" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -19,4 +18,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/iam/testdata/User/tagsNull_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/User/tagsNull_defaults/main_gen.tf
@@ -15,7 +15,6 @@ resource "aws_iam_user" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/User/tags_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/User/tags_defaults/main_gen.tf
@@ -13,7 +13,6 @@ resource "aws_iam_user" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -23,7 +22,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/VirtualMFADevice/tags/main_gen.tf
+++ b/internal/service/iam/testdata/VirtualMFADevice/tags/main_gen.tf
@@ -7,7 +7,6 @@ resource "aws_iam_virtual_mfa_device" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/VirtualMFADevice/tags0/main_gen.tf
+++ b/internal/service/iam/testdata/VirtualMFADevice/tags0/main_gen.tf
@@ -6,7 +6,6 @@ resource "aws_iam_virtual_mfa_device" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/VirtualMFADevice/tags0_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/VirtualMFADevice/tags0_defaults/main_gen.tf
@@ -12,12 +12,10 @@ resource "aws_iam_virtual_mfa_device" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/testdata/VirtualMFADevice/tagsComputed1/main_gen.tf
+++ b/internal/service/iam/testdata/VirtualMFADevice/tagsComputed1/main_gen.tf
@@ -1,0 +1,26 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_virtual_mfa_device" "test" {
+  virtual_mfa_device_name = var.rName
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+

--- a/internal/service/iam/testdata/VirtualMFADevice/tagsComputed2/main_gen.tf
+++ b/internal/service/iam/testdata/VirtualMFADevice/tagsComputed2/main_gen.tf
@@ -1,0 +1,36 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "null" {}
+
+resource "aws_iam_virtual_mfa_device" "test" {
+  virtual_mfa_device_name = var.rName
+
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
+}
+
+resource "null_resource" "test" {}
+
+variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/iam/testdata/VirtualMFADevice/tagsNull/main_gen.tf
+++ b/internal/service/iam/testdata/VirtualMFADevice/tagsNull/main_gen.tf
@@ -9,7 +9,6 @@ resource "aws_iam_virtual_mfa_device" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -19,4 +18,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/iam/testdata/VirtualMFADevice/tagsNull_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/VirtualMFADevice/tagsNull_defaults/main_gen.tf
@@ -15,7 +15,6 @@ resource "aws_iam_virtual_mfa_device" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/iam/testdata/VirtualMFADevice/tags_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/VirtualMFADevice/tags_defaults/main_gen.tf
@@ -13,7 +13,6 @@ resource "aws_iam_virtual_mfa_device" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -23,7 +22,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/iam/user_tags_gen_test.go
+++ b/internal/service/iam/user_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1130,6 +1132,203 @@ func TestAccIAMUser_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T)
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy",
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMUser_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.User
+	resourceName := "aws_iam_user.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckUserDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/User/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/User/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy",
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMUser_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.User
+	resourceName := "aws_iam_user.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckUserDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/User/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/User/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/User/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_destroy",
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMUser_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.User
+	resourceName := "aws_iam_user.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckUserDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/User/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/User/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/User/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/iam/virtual_mfa_device_tags_gen_test.go
+++ b/internal/service/iam/virtual_mfa_device_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1130,6 +1132,203 @@ func TestAccIAMVirtualMFADevice_tags_DefaultTags_nullNonOverlappingResourceTag(t
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"base_32_string_seed", "qr_code_png",
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMVirtualMFADevice_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.VirtualMFADevice
+	resourceName := "aws_iam_virtual_mfa_device.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/VirtualMFADevice/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/VirtualMFADevice/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"base_32_string_seed", "qr_code_png",
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.VirtualMFADevice
+	resourceName := "aws_iam_virtual_mfa_device.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/VirtualMFADevice/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/VirtualMFADevice/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/VirtualMFADevice/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"base_32_string_seed", "qr_code_png",
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.VirtualMFADevice
+	resourceName := "aws_iam_virtual_mfa_device.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
+		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/VirtualMFADevice/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/VirtualMFADevice/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVirtualMFADeviceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/VirtualMFADevice/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/servicecatalog/portfolio_tags_gen_test.go
+++ b/internal/service/servicecatalog/portfolio_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1063,6 +1065,194 @@ func TestAccServiceCatalogPortfolio_tags_DefaultTags_nullNonOverlappingResourceT
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccServiceCatalogPortfolio_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v servicecatalog.DescribePortfolioOutput
+	resourceName := "aws_servicecatalog_portfolio.test"
+	rName := sdkacctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Portfolio/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPortfolioExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Portfolio/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccServiceCatalogPortfolio_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v servicecatalog.DescribePortfolioOutput
+	resourceName := "aws_servicecatalog_portfolio.test"
+	rName := sdkacctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Portfolio/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPortfolioExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Portfolio/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPortfolioExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Portfolio/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccServiceCatalogPortfolio_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v servicecatalog.DescribePortfolioOutput
+	resourceName := "aws_servicecatalog_portfolio.test"
+	rName := sdkacctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Portfolio/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPortfolioExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Portfolio/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPortfolioExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Portfolio/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/servicecatalog/product_tags_gen_test.go
+++ b/internal/service/servicecatalog/product_tags_gen_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1123,6 +1125,200 @@ func TestAccServiceCatalogProduct_tags_DefaultTags_nullNonOverlappingResourceTag
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language", "provisioning_artifact_parameters.0.disable_template_validation",
+				},
+			},
+		},
+	})
+}
+
+func TestAccServiceCatalogProduct_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_servicecatalog_product.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		CheckDestroy: testAccCheckProductDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Product/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckProductExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Product/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language", "provisioning_artifact_parameters.0.disable_template_validation",
+				},
+			},
+		},
+	})
+}
+
+func TestAccServiceCatalogProduct_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_servicecatalog_product.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		CheckDestroy: testAccCheckProductDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Product/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckProductExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Product/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckProductExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Product/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"accept_language", "provisioning_artifact_parameters.0.disable_template_validation",
+				},
+			},
+		},
+	})
+}
+
+func TestAccServiceCatalogProduct_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_servicecatalog_product.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		CheckDestroy: testAccCheckProductDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Product/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckProductExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Product/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckProductExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Product/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/servicecatalog/testdata/Portfolio/tags/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Portfolio/tags/main_gen.tf
@@ -9,7 +9,6 @@ resource "aws_servicecatalog_portfolio" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/servicecatalog/testdata/Portfolio/tags0/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Portfolio/tags0/main_gen.tf
@@ -8,7 +8,6 @@ resource "aws_servicecatalog_portfolio" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/servicecatalog/testdata/Portfolio/tagsComputed1/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Portfolio/tagsComputed1/main_gen.tf
@@ -1,25 +1,28 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-provider "aws" {
-  default_tags {
-    tags = var.provider_tags
-  }
-}
+provider "null" {}
 
 resource "aws_servicecatalog_portfolio" "test" {
   name          = var.rName
   description   = "test-b"
   provider_name = "test-c"
 
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "provider_tags" {
-  type     = map(string)
+variable "unknownTagKey" {
+  type     = string
   nullable = false
 }
+
+

--- a/internal/service/servicecatalog/testdata/Portfolio/tagsComputed2/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Portfolio/tagsComputed2/main_gen.tf
@@ -1,24 +1,38 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_servicecatalog_portfolio" "test" {
   name          = var.rName
   description   = "test-b"
   provider_name = "test-c"
 
   tags = {
-    (var.tagKey1) = null
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
   }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "tagKey1" {
+variable "unknownTagKey" {
   type     = string
   nullable = false
 }
 
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
 

--- a/internal/service/servicecatalog/testdata/Portfolio/tagsNull_defaults/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Portfolio/tagsNull_defaults/main_gen.tf
@@ -17,7 +17,6 @@ resource "aws_servicecatalog_portfolio" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/servicecatalog/testdata/Portfolio/tags_defaults/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Portfolio/tags_defaults/main_gen.tf
@@ -15,7 +15,6 @@ resource "aws_servicecatalog_portfolio" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -25,7 +24,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/servicecatalog/testdata/Product/tags/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tags/main_gen.tf
@@ -53,7 +53,6 @@ resource "aws_s3_object" "test" {
 
 data "aws_partition" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/servicecatalog/testdata/Product/tags0/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tags0/main_gen.tf
@@ -52,7 +52,6 @@ resource "aws_s3_object" "test" {
 
 data "aws_partition" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/servicecatalog/testdata/Product/tagsComputed1/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tagsComputed1/main_gen.tf
@@ -1,11 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-provider "aws" {
-  default_tags {
-    tags = var.provider_tags
-  }
-}
+provider "null" {}
 
 resource "aws_servicecatalog_product" "test" {
   description = var.rName
@@ -22,6 +18,9 @@ resource "aws_servicecatalog_product" "test" {
     type                        = "CLOUD_FORMATION_TEMPLATE"
   }
 
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
 }
 
 resource "aws_s3_bucket" "test" {
@@ -58,12 +57,16 @@ resource "aws_s3_object" "test" {
 
 data "aws_partition" "current" {}
 
+resource "null_resource" "test" {}
+
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "provider_tags" {
-  type     = map(string)
+variable "unknownTagKey" {
+  type     = string
   nullable = false
 }
+
+

--- a/internal/service/servicecatalog/testdata/Product/tagsComputed2/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tagsComputed2/main_gen.tf
@@ -1,11 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-provider "aws" {
-  default_tags {
-    tags = var.provider_tags
-  }
-}
+provider "null" {}
 
 resource "aws_servicecatalog_product" "test" {
   description = var.rName
@@ -22,6 +18,10 @@ resource "aws_servicecatalog_product" "test" {
     type                        = "CLOUD_FORMATION_TEMPLATE"
   }
 
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
 }
 
 resource "aws_s3_bucket" "test" {
@@ -58,12 +58,25 @@ resource "aws_s3_object" "test" {
 
 data "aws_partition" "current" {}
 
+resource "null_resource" "test" {}
+
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "provider_tags" {
-  type     = map(string)
+variable "unknownTagKey" {
+  type     = string
   nullable = false
 }
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/servicecatalog/testdata/Product/tagsNull/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tagsNull/main_gen.tf
@@ -55,7 +55,6 @@ resource "aws_s3_object" "test" {
 
 data "aws_partition" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -65,4 +64,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/servicecatalog/testdata/Product/tagsNull_defaults/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tagsNull_defaults/main_gen.tf
@@ -61,7 +61,6 @@ resource "aws_s3_object" "test" {
 
 data "aws_partition" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/servicecatalog/testdata/Product/tags_defaults/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tags_defaults/main_gen.tf
@@ -59,7 +59,6 @@ resource "aws_s3_object" "test" {
 
 data "aws_partition" "current" {}
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -69,7 +68,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/servicecatalog/testdata/ProvisionedProduct/tags/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/ProvisionedProduct/tags/main_gen.tf
@@ -100,7 +100,6 @@ data "aws_servicecatalog_launch_paths" "test" {
   product_id = aws_servicecatalog_product_portfolio_association.test.product_id
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/servicecatalog/testdata/ProvisionedProduct/tags0_defaults/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/ProvisionedProduct/tags0_defaults/main_gen.tf
@@ -105,12 +105,10 @@ data "aws_servicecatalog_launch_paths" "test" {
   product_id = aws_servicecatalog_product_portfolio_association.test.product_id
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/servicecatalog/testdata/ProvisionedProduct/tagsComputed1/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/ProvisionedProduct/tagsComputed1/main_gen.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_servicecatalog_provisioned_product" "test" {
   name                       = var.rName
   product_id                 = aws_servicecatalog_constraint.test.product_id
@@ -12,6 +14,9 @@ resource "aws_servicecatalog_provisioned_product" "test" {
     value = "${var.rName}-dest"
   }
 
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
 }
 
 resource "aws_s3_bucket" "test" {
@@ -99,7 +104,14 @@ data "aws_servicecatalog_launch_paths" "test" {
   product_id = aws_servicecatalog_product_portfolio_association.test.product_id
 }
 
+resource "null_resource" "test" {}
+
 variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
   type     = string
   nullable = false
 }

--- a/internal/service/servicecatalog/testdata/ProvisionedProduct/tagsComputed2/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/ProvisionedProduct/tagsComputed2/main_gen.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_servicecatalog_provisioned_product" "test" {
   name                       = var.rName
   product_id                 = aws_servicecatalog_constraint.test.product_id
@@ -12,6 +14,10 @@ resource "aws_servicecatalog_provisioned_product" "test" {
     value = "${var.rName}-dest"
   }
 
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
 }
 
 resource "aws_s3_bucket" "test" {
@@ -99,9 +105,25 @@ data "aws_servicecatalog_launch_paths" "test" {
   product_id = aws_servicecatalog_product_portfolio_association.test.product_id
 }
 
+resource "null_resource" "test" {}
+
 variable "rName" {
   type     = string
   nullable = false
 }
 
+variable "unknownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
 

--- a/internal/service/servicecatalog/testdata/ProvisionedProduct/tagsNull/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/ProvisionedProduct/tagsNull/main_gen.tf
@@ -102,7 +102,6 @@ data "aws_servicecatalog_launch_paths" "test" {
   product_id = aws_servicecatalog_product_portfolio_association.test.product_id
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -112,4 +111,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/servicecatalog/testdata/ProvisionedProduct/tagsNull_defaults/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/ProvisionedProduct/tagsNull_defaults/main_gen.tf
@@ -108,7 +108,6 @@ data "aws_servicecatalog_launch_paths" "test" {
   product_id = aws_servicecatalog_product_portfolio_association.test.product_id
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/servicecatalog/testdata/ProvisionedProduct/tags_defaults/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/ProvisionedProduct/tags_defaults/main_gen.tf
@@ -106,7 +106,6 @@ data "aws_servicecatalog_launch_paths" "test" {
   product_id = aws_servicecatalog_product_portfolio_association.test.product_id
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -116,7 +115,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/xray/group_tags_gen_test.go
+++ b/internal/service/xray/group_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1055,6 +1057,194 @@ func TestAccXRayGroup_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccXRayGroup_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.Group
+	resourceName := "aws_xray_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
+		CheckDestroy: testAccCheckGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Group/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Group/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccXRayGroup_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.Group
+	resourceName := "aws_xray_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
+		CheckDestroy: testAccCheckGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Group/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Group/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Group/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccXRayGroup_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.Group
+	resourceName := "aws_xray_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
+		CheckDestroy: testAccCheckGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Group/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Group/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/Group/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/xray/sampling_rule_tags_gen_test.go
+++ b/internal/service/xray/sampling_rule_tags_gen_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1055,6 +1057,194 @@ func TestAccXRaySamplingRule_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 						"providerkey1": config.StringVariable("providervalue1"),
 					}),
 					"tagKey1": config.StringVariable("resourcekey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccXRaySamplingRule_tags_ComputedTag_OnCreate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.SamplingRule
+	resourceName := "aws_xray_sampling_rule.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
+		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SamplingRule/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSamplingRuleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SamplingRule/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccXRaySamplingRule_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.SamplingRule
+	resourceName := "aws_xray_sampling_rule.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
+		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SamplingRule/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSamplingRuleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SamplingRule/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSamplingRuleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SamplingRule/tagsComputed2/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("computedkey1"),
+					"knownTagKey":   config.StringVariable("key1"),
+					"knownTagValue": config.StringVariable("value1"),
+				},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccXRaySamplingRule_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.SamplingRule
+	resourceName := "aws_xray_sampling_rule.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
+		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SamplingRule/tags/"),
+				ConfigVariables: config.Variables{
+					"rName": config.StringVariable(rName),
+					"tags": config.MapVariable(map[string]config.Variable{
+						"key1": config.StringVariable("value1"),
+					}),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSamplingRuleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SamplingRule/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSamplingRuleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "tags.key1", "null_resource.test", "id"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New("tags")),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				ConfigDirectory:          config.StaticDirectory("testdata/SamplingRule/tagsComputed1/"),
+				ConfigVariables: config.Variables{
+					"rName":         config.StringVariable(rName),
+					"unknownTagKey": config.StringVariable("key1"),
 				},
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/service/xray/testdata/Group/tags/main_gen.tf
+++ b/internal/service/xray/testdata/Group/tags/main_gen.tf
@@ -8,7 +8,6 @@ resource "aws_xray_group" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/xray/testdata/Group/tags0_defaults/main_gen.tf
+++ b/internal/service/xray/testdata/Group/tags0_defaults/main_gen.tf
@@ -13,12 +13,10 @@ resource "aws_xray_group" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/xray/testdata/Group/tagsComputed1/main_gen.tf
+++ b/internal/service/xray/testdata/Group/tagsComputed1/main_gen.tf
@@ -1,13 +1,25 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_xray_group" "test" {
   group_name        = var.rName
   filter_expression = "responsetime > 5"
 
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
 }
 
+resource "null_resource" "test" {}
+
 variable "rName" {
+  type     = string
+  nullable = false
+}
+
+variable "unknownTagKey" {
   type     = string
   nullable = false
 }

--- a/internal/service/xray/testdata/Group/tagsComputed2/main_gen.tf
+++ b/internal/service/xray/testdata/Group/tagsComputed2/main_gen.tf
@@ -1,32 +1,37 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-provider "aws" {
-  default_tags {
-    tags = var.provider_tags
-  }
-}
+provider "null" {}
 
 resource "aws_xray_group" "test" {
   group_name        = var.rName
   filter_expression = "responsetime > 5"
 
   tags = {
-    (var.tagKey1) = null
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
   }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "tagKey1" {
+variable "unknownTagKey" {
   type     = string
   nullable = false
 }
 
-variable "provider_tags" {
-  type     = map(string)
+variable "knownTagKey" {
+  type     = string
   nullable = false
 }
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
+

--- a/internal/service/xray/testdata/Group/tagsNull/main_gen.tf
+++ b/internal/service/xray/testdata/Group/tagsNull/main_gen.tf
@@ -10,7 +10,6 @@ resource "aws_xray_group" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -20,4 +19,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/xray/testdata/Group/tags_defaults/main_gen.tf
+++ b/internal/service/xray/testdata/Group/tags_defaults/main_gen.tf
@@ -14,7 +14,6 @@ resource "aws_xray_group" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -24,7 +23,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/xray/testdata/SamplingRule/tags0/main_gen.tf
+++ b/internal/service/xray/testdata/SamplingRule/tags0/main_gen.tf
@@ -20,7 +20,6 @@ resource "aws_xray_sampling_rule" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/xray/testdata/SamplingRule/tags0_defaults/main_gen.tf
+++ b/internal/service/xray/testdata/SamplingRule/tags0_defaults/main_gen.tf
@@ -26,12 +26,10 @@ resource "aws_xray_sampling_rule" "test" {
 
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)

--- a/internal/service/xray/testdata/SamplingRule/tagsComputed1/main_gen.tf
+++ b/internal/service/xray/testdata/SamplingRule/tagsComputed1/main_gen.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_xray_sampling_rule" "test" {
   rule_name      = var.rName
   priority       = 5
@@ -18,16 +20,20 @@ resource "aws_xray_sampling_rule" "test" {
     Hello = "World"
   }
 
-  tags = var.tags
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+  }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "tags" {
-  type     = map(string)
+variable "unknownTagKey" {
+  type     = string
   nullable = false
 }
 

--- a/internal/service/xray/testdata/SamplingRule/tagsComputed2/main_gen.tf
+++ b/internal/service/xray/testdata/SamplingRule/tagsComputed2/main_gen.tf
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+provider "null" {}
+
 resource "aws_xray_sampling_rule" "test" {
   rule_name      = var.rName
   priority       = 5
@@ -18,17 +20,31 @@ resource "aws_xray_sampling_rule" "test" {
     Hello = "World"
   }
 
-  tags = var.tags
+  tags = {
+    (var.unknownTagKey) = null_resource.test.id
+    (var.knownTagKey)   = var.knownTagValue
+  }
 }
+
+resource "null_resource" "test" {}
 
 variable "rName" {
   type     = string
   nullable = false
 }
 
-variable "tags" {
-  type     = map(string)
+variable "unknownTagKey" {
+  type     = string
   nullable = false
 }
 
+variable "knownTagKey" {
+  type     = string
+  nullable = false
+}
+
+variable "knownTagValue" {
+  type     = string
+  nullable = false
+}
 

--- a/internal/service/xray/testdata/SamplingRule/tagsNull/main_gen.tf
+++ b/internal/service/xray/testdata/SamplingRule/tagsNull/main_gen.tf
@@ -23,7 +23,6 @@ resource "aws_xray_sampling_rule" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -33,4 +32,5 @@ variable "tagKey1" {
   type     = string
   nullable = false
 }
+
 

--- a/internal/service/xray/testdata/SamplingRule/tagsNull_defaults/main_gen.tf
+++ b/internal/service/xray/testdata/SamplingRule/tagsNull_defaults/main_gen.tf
@@ -29,7 +29,6 @@ resource "aws_xray_sampling_rule" "test" {
   }
 }
 
-
 variable "rName" {
   type     = string
   nullable = false

--- a/internal/service/xray/testdata/SamplingRule/tags_defaults/main_gen.tf
+++ b/internal/service/xray/testdata/SamplingRule/tags_defaults/main_gen.tf
@@ -27,7 +27,6 @@ resource "aws_xray_sampling_rule" "test" {
   tags = var.tags
 }
 
-
 variable "rName" {
   type     = string
   nullable = false
@@ -37,7 +36,6 @@ variable "tags" {
   type     = map(string)
   nullable = false
 }
-
 
 variable "provider_tags" {
   type     = map(string)


### PR DESCRIPTION
### Description

Adds generated tagging tests for values not known at plan time

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccAccessAnalyzer_serial/Analyzer/tags PKG=accessanalyzer

--- PASS: TestAccAccessAnalyzer_serial (317.73s)
    --- PASS: TestAccAccessAnalyzer_serial/Analyzer (317.73s)
        --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags (317.73s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/basic (32.69s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/null (12.34s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/AddOnUpdate (19.63s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/EmptyTag_OnCreate (17.15s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/EmptyTag_OnUpdate_Add (23.21s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/EmptyTag_OnUpdate_Replace (15.26s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_providerOnly (33.69s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_nonOverlapping (25.61s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_overlapping (26.29s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_updateToProviderOnly (15.86s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_updateToResourceOnly (14.88s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_emptyResourceTag (9.95s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_nullOverlappingResourceTag (10.01s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/DefaultTags_nullNonOverlappingResourceTag (9.88s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/ComputedTag_OnCreate (13.33s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/ComputedTag_OnUpdate_Add (18.94s)
            --- PASS: TestAccAccessAnalyzer_serial/Analyzer/tags/ComputedTag_OnUpdate_Replace (19.02s)
```

```console
% make testacc TESTS=tags PKG=batch

--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_nullOverlappingResourceTag (48.12s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_emptyResourceTag (48.33s)
--- PASS: TestAccBatchSchedulingPolicy_tags_DefaultTags_emptyResourceTag (48.43s)
--- PASS: TestAccBatchSchedulingPolicy_tags_ComputedTag_OnCreate (48.50s)
--- PASS: TestAccBatchSchedulingPolicy_tags_DefaultTags_nullOverlappingResourceTag (58.95s)
--- PASS: TestAccBatchSchedulingPolicy_tags_DefaultTags_nullNonOverlappingResourceTag (59.55s)
--- PASS: TestAccBatchSchedulingPolicy_tags_null (68.15s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_updateToResourceOnly (72.44s)
--- PASS: TestAccBatchSchedulingPolicy_tags_EmptyTag_OnUpdate_Replace (79.93s)
--- PASS: TestAccBatchSchedulingPolicy_tags_DefaultTags_updateToProviderOnly (80.91s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_updateToProviderOnly (84.89s)
--- PASS: TestAccBatchSchedulingPolicy_tags_ComputedTag_OnUpdate_Replace (93.22s)
--- PASS: TestAccBatchSchedulingPolicy_tags_ComputedTag_OnUpdate_Add (93.81s)
--- PASS: TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Replace (102.17s)
--- PASS: TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Add (104.70s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_nullNonOverlappingResourceTag (59.84s)
--- PASS: TestAccBatchJobDefinition_tags_ComputedTag_OnCreate (62.87s)
--- PASS: TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Add (125.92s)
--- PASS: TestAccBatchSchedulingPolicy_tags_DefaultTags_updateToResourceOnly (84.40s)
--- PASS: TestAccBatchSchedulingPolicy_tags_AddOnUpdate (79.41s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_overlapping (139.64s)
--- PASS: TestAccBatchSchedulingPolicy_tags_EmptyTag_OnCreate (97.71s)
--- PASS: TestAccBatchJobDefinition_tags_AddOnUpdate (77.55s)
--- PASS: TestAccBatchComputeEnvironment_tags_ComputedTag_OnCreate (63.58s)
--- PASS: TestAccBatchJobDefinition_tags_EmptyTag_OnCreate (83.81s)
--- PASS: TestAccBatchSchedulingPolicy_tags_EmptyTag_OnUpdate_Add (113.68s)
--- PASS: TestAccBatchJobDefinition_tags (172.95s)
--- PASS: TestAccBatchComputeEnvironment_tags_DefaultTags_nullNonOverlappingResourceTag (66.22s)
--- PASS: TestAccBatchComputeEnvironment_tags_DefaultTags_nullOverlappingResourceTag (63.84s)
--- PASS: TestAccBatchComputeEnvironment_tags (185.64s)
--- PASS: TestAccBatchComputeEnvironment_tags_DefaultTags_updateToProviderOnly (92.64s)
--- PASS: TestAccBatchComputeEnvironment_tags_DefaultTags_emptyResourceTag (60.24s)
--- PASS: TestAccBatchComputeEnvironment_tags_ComputedTag_OnUpdate_Replace (94.73s)
--- PASS: TestAccBatchSchedulingPolicy_tags_DefaultTags_nonOverlapping (125.20s)
--- PASS: TestAccBatchSchedulingPolicy_tags_DefaultTags_overlapping (122.38s)
--- PASS: TestAccBatchComputeEnvironment_tags_ComputedTag_OnUpdate_Add (95.03s)
--- PASS: TestAccBatchComputeEnvironment_tags_DefaultTags_updateToResourceOnly (77.87s)
--- PASS: TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Replace (47.43s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_overlapping (227.95s)
--- PASS: TestAccBatchSchedulingPolicy_tags_DefaultTags_providerOnly (148.77s)
--- PASS: TestAccBatchJobDefinition_tags_null (43.10s)
--- PASS: TestAccBatchComputeEnvironment_tags_EmptyTag_OnUpdate_Replace (78.60s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_nonOverlapping (94.98s)
--- PASS: TestAccBatchComputeEnvironment_tags_EmptyTag_OnCreate (90.08s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_providerOnly (123.27s)
--- PASS: TestAccBatchComputeEnvironment_tags_null (60.52s)
--- PASS: TestAccBatchComputeEnvironment_tags_EmptyTag_OnUpdate_Add (105.14s)
--- PASS: TestAccBatchComputeEnvironment_tags_AddOnUpdate (72.24s)
--- PASS: TestAccBatchComputeEnvironment_tags_DefaultTags_nonOverlapping (117.84s)
--- PASS: TestAccBatchComputeEnvironment_tags_DefaultTags_overlapping (118.70s)
--- PASS: TestAccBatchSchedulingPolicy_tags (101.82s)
--- PASS: TestAccBatchComputeEnvironment_tags_DefaultTags_providerOnly (130.64s)
--- PASS: TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Replace (160.70s)
--- PASS: TestAccBatchJobQueue_tags_AddOnUpdate (149.80s)
--- PASS: TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Add (184.62s)
--- PASS: TestAccBatchJobQueue_tags_ComputedTag_OnCreate (127.48s)
--- PASS: TestAccBatchJobQueue_tags_EmptyTag_OnCreate (153.74s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_nonOverlapping (202.58s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_providerOnly (207.53s)
--- PASS: TestAccBatchJobQueue_tags_ComputedTag_OnUpdate_Replace (133.24s)
--- PASS: TestAccBatchJobQueue_tags_ComputedTag_OnUpdate_Add (130.57s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_updateToResourceOnly (115.33s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_emptyResourceTag (116.81s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_updateToProviderOnly (113.37s)
--- PASS: TestAccBatchJobQueue_tags (137.13s)
```

```console
% make testacc TESTS=tags PKG=iam

--- PASS: TestAccIAMRoleDataSource_tags (35.96s)
--- PASS: TestAccIAMRole_tags_ComputedTag_OnCreate (48.31s)
--- PASS: TestAccIAMPolicy_tags_ComputedTag_OnCreate (48.33s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_emptyResourceTag (49.13s)
--- PASS: TestAccIAMUser_tags_null (54.00s)
--- PASS: TestAccIAMVirtualMFADevice_tags_null (56.44s)
--- PASS: TestAccIAMUser_tags_AddOnUpdate (67.60s)
--- PASS: TestAccIAMUser_tags_DefaultTags_updateToResourceOnly (70.31s)
--- PASS: TestAccIAMRole_tags_AddOnUpdate (72.80s)
--- PASS: TestAccIAMRole_tags_EmptyTag_OnUpdate_Replace (72.90s)
--- PASS: TestAccIAMUser_tags_DefaultTags_updateToProviderOnly (72.95s)
--- PASS: TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Add (75.70s)
--- PASS: TestAccIAMRole_tags_ComputedTag_OnUpdate_Replace (78.16s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nullNonOverlappingResourceTag (44.68s)
--- PASS: TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Replace (80.70s)
--- PASS: TestAccIAMRole_tags_ComputedTag_OnUpdate_Add (82.73s)
--- PASS: TestAccIAMServiceLinkedRole_tags_DefaultTags_updateToProviderOnly (89.98s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nullOverlappingResourceTag (44.79s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nullOverlappingResourceTag (44.21s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nullNonOverlappingResourceTag (47.07s)
--- PASS: TestAccIAMRole_tags_DefaultTags_emptyResourceTag (44.65s)
--- PASS: TestAccIAMRole_tags_EmptyTag_OnUpdate_Add (109.13s)
--- PASS: TestAccIAMRole_tags_DefaultTags_updateToResourceOnly (71.43s)
--- PASS: TestAccIAMVirtualMFADevice_tags_ComputedTag_OnCreate (51.18s)
--- PASS: TestAccIAMServiceLinkedRole_tags_DefaultTags_overlapping (134.16s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_nullNonOverlappingResourceTag (48.63s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_nullOverlappingResourceTag (45.62s)
--- PASS: TestAccIAMRole_tags_DefaultTags_updateToProviderOnly (68.96s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyResourceTag (48.56s)
--- PASS: TestAccIAMRole_tags_EmptyTag_OnCreate (81.01s)
--- PASS: TestAccIAMVirtualMFADevice_tags (150.20s)
--- PASS: TestAccIAMRole_tags_null (57.54s)
--- PASS: TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Add (74.61s)
--- PASS: TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Replace (77.21s)
--- PASS: TestAccIAMInstanceProfile_tags (158.12s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToResourceOnly (69.53s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nonOverlapping (115.04s)
--- PASS: TestAccIAMServiceLinkedRole_tags_EmptyTag_OnCreate (91.99s)
--- PASS: TestAccIAMRole_tags_DefaultTags_overlapping (119.66s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToProviderOnly (72.62s)
--- PASS: TestAccIAMServiceLinkedRole_tags_null (64.89s)
--- PASS: TestAccIAMServiceLinkedRole_tags_EmptyTag_OnUpdate_Replace (77.88s)
--- PASS: TestAccIAMUserDataSource_tags (30.63s)
--- PASS: TestAccIAMRole_tags_DefaultTags_providerOnly (159.85s)
--- PASS: TestAccIAMRole_tags (153.99s)
--- PASS: TestAccIAMUser_tags_DefaultTags_providerOnly (154.31s)
--- PASS: TestAccIAMServiceLinkedRole_tags_AddOnUpdate (89.58s)
--- PASS: TestAccIAMServiceLinkedRole_tags_EmptyTag_OnUpdate_Add (110.17s)
--- PASS: TestAccIAMServiceLinkedRole_tags_DefaultTags_nonOverlapping (124.24s)
--- PASS: TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Replace (67.35s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_overlapping (112.33s)
--- PASS: TestAccIAMServerCertificate_tags (88.36s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_nonOverlapping (117.05s)
--- PASS: TestAccIAMUser_tags_DefaultTags_overlapping (117.33s)
--- PASS: TestAccIAMUser_tags_DefaultTags_nonOverlapping (117.60s)
--- PASS: TestAccIAMUser_tags (144.41s)
--- PASS: TestAccIAMServiceLinkedRole_tags_ComputedTag_OnUpdate_Replace (89.51s)
--- PASS: TestAccIAMVirtualMFADevice_tags_EmptyTag_OnCreate (75.78s)
--- PASS: TestAccIAMServiceLinkedRole_tags_DefaultTags_providerOnly (163.39s)
--- PASS: TestAccIAMServiceLinkedRole_tags (154.69s)
--- PASS: TestAccIAMVirtualMFADevice_tags_AddOnUpdate (64.03s)
--- PASS: TestAccIAMServiceLinkedRole_tags_ComputedTag_OnUpdate_Add (80.77s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace (67.32s)
--- PASS: TestAccIAMServiceLinkedRole_tags_ComputedTag_OnCreate (70.38s)
--- PASS: TestAccIAMServiceLinkedRole_tags_DefaultTags_emptyResourceTag (52.19s)
--- PASS: TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Add (98.32s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_updateToResourceOnly (61.38s)
--- PASS: TestAccIAMServiceLinkedRole_tags_DefaultTags_nullNonOverlappingResourceTag (56.81s)
--- PASS: TestAccIAMServiceLinkedRole_tags_DefaultTags_nullOverlappingResourceTag (65.03s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_updateToProviderOnly (62.88s)
--- PASS: TestAccIAMVirtualMFADevice_tags_DefaultTags_providerOnly (142.96s)
--- PASS: TestAccIAMSAMLProvider_tags (87.38s)
--- PASS: TestAccIAMServiceLinkedRole_tags_DefaultTags_updateToResourceOnly (68.76s)
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Replace (64.26s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag (42.33s)
--- PASS: TestAccIAMPolicy_tags_null (54.48s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnCreate (47.39s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResourceTag (44.30s)
--- PASS: TestAccIAMPolicy_tags_AddOnUpdate (66.84s)
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnCreate (75.48s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag (46.68s)
--- PASS: TestAccIAMPolicy_tags (142.40s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Add (75.46s)
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Add (99.65s)
--- PASS: TestAccIAMUser_tags_ComputedTag_OnCreate (51.55s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly (71.08s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_overlapping (119.52s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly (74.66s)
--- PASS: TestAccIAMUser_tags_EmptyTag_OnUpdate_Replace (72.93s)
--- PASS: TestAccIAMUser_tags_DefaultTags_nullNonOverlappingResourceTag (48.46s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nonOverlapping (119.44s)
--- PASS: TestAccIAMUser_tags_DefaultTags_nullOverlappingResourceTag (51.74s)
--- PASS: TestAccIAMUser_tags_EmptyTag_OnCreate (80.93s)
--- PASS: TestAccIAMUser_tags_DefaultTags_emptyResourceTag (49.14s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping (123.81s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_nullOverlappingResourceTag (53.30s)
--- PASS: TestAccIAMUser_tags_EmptyTag_OnUpdate_Add (106.46s)
--- PASS: TestAccIAMUser_tags_ComputedTag_OnUpdate_Add (80.58s)
--- PASS: TestAccIAMUser_tags_ComputedTag_OnUpdate_Replace (80.74s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_emptyResourceTag (49.38s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_providerOnly (158.85s)
--- PASS: TestAccIAMOpenidConnectProviderDataSource_tags (33.39s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping (121.22s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_null (56.44s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate (68.81s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate (78.65s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_updateToResourceOnly (72.67s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_updateToProviderOnly (72.51s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add (100.10s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag (45.79s)
--- PASS: TestAccIAMInstanceProfile_tags_ComputedTag_OnCreate (49.17s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Replace (69.33s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly (146.77s)
--- PASS: TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Replace (67.25s)
--- PASS: TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Add (66.57s)
--- PASS: TestAccIAMInstanceProfile_tags_null (38.90s)
--- PASS: TestAccIAMInstanceProfile_tags_EmptyTag_OnCreate (62.74s)
--- PASS: TestAccIAMInstanceProfile_tags_AddOnUpdate (48.77s)
--- PASS: TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Replace (49.72s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_overlapping (96.73s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_nonOverlapping (96.26s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_providerOnly (128.34s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags (101.55s)
--- PASS: TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Add (63.02s)
```

```console
% make testacc TESTS=tags PKG=servicecatalog

--- PASS: TestAccServiceCatalogPortfolio_tags_ComputedTag_OnCreate (24.77s)
--- PASS: TestAccServiceCatalogProduct_tags_DefaultTags_updateToResourceOnly (51.50s)
--- PASS: TestAccServiceCatalogPortfolio_tags (55.31s)
--- PASS: TestAccServiceCatalogProduct_tags_DefaultTags_updateToProviderOnly (61.24s)
--- PASS: TestAccServiceCatalogProduct_tags_ComputedTag_OnUpdate_Replace (70.59s)
--- PASS: TestAccServiceCatalogProduct_tags_DefaultTags_overlapping (92.74s)
--- PASS: TestAccServiceCatalogProduct_tags_null (42.06s)
--- PASS: TestAccServiceCatalogProduct_tags_DefaultTags_nonOverlapping (106.79s)
--- PASS: TestAccServiceCatalogProduct_tags_AddOnUpdate (58.02s)
--- PASS: TestAccServiceCatalogPortfolio_tags_ComputedTag_OnUpdate_Replace (46.59s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_ComputedTag_OnCreate (127.57s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_nullOverlappingResourceTag (127.62s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_nullNonOverlappingResourceTag (130.09s)
--- PASS: TestAccServiceCatalogPortfolio_tags_ComputedTag_OnUpdate_Add (45.72s)
--- PASS: TestAccServiceCatalogPortfolio_tags_DefaultTags_nullNonOverlappingResourceTag (25.39s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_null (146.33s)
--- PASS: TestAccServiceCatalogProduct_tags_ComputedTag_OnCreate (49.98s)
--- PASS: TestAccServiceCatalogProduct_tags_DefaultTags_providerOnly (128.19s)
--- PASS: TestAccServiceCatalogPortfolio_tags_DefaultTags_nullOverlappingResourceTag (31.58s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_updateToResourceOnly (169.75s)
--- PASS: TestAccServiceCatalogPortfolio_tags_DefaultTags_updateToResourceOnly (57.34s)
--- PASS: TestAccServiceCatalogProduct_tags_ComputedTag_OnUpdate_Add (81.03s)
--- PASS: TestAccServiceCatalogPortfolio_tags_DefaultTags_updateToProviderOnly (59.31s)
--- PASS: TestAccServiceCatalogPortfolio_tags_DefaultTags_overlapping (83.50s)
--- PASS: TestAccServiceCatalogProduct_tags_DefaultTags_nullNonOverlappingResourceTag (56.08s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_updateToProviderOnly (195.48s)
--- PASS: TestAccServiceCatalogPortfolio_tags_AddOnUpdate (51.90s)
--- PASS: TestAccServiceCatalogPortfolio_tags_null (42.66s)
--- PASS: TestAccServiceCatalogProduct_tags_DefaultTags_nullOverlappingResourceTag (49.40s)
--- PASS: TestAccServiceCatalogProduct_tags (142.47s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_ComputedTag_OnUpdate_Replace (216.28s)
--- PASS: TestAccServiceCatalogPortfolio_tags_DefaultTags_nonOverlapping (70.17s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_AddOnUpdate (219.64s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags (220.20s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_ComputedTag_OnUpdate_Add (220.45s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_providerOnly (223.74s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_nonOverlapping (224.68s)
--- PASS: TestAccServiceCatalogPortfolio_tags_DefaultTags_providerOnly (84.97s)
--- PASS: TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_overlapping (316.02s)
```

```console
% make testacc TESTS=tags PKG=xray

--- PASS: TestAccXRaySamplingRule_tags_DefaultTags_nullNonOverlappingResourceTag (45.11s)
--- PASS: TestAccXRaySamplingRule_tags_DefaultTags_nullOverlappingResourceTag (48.22s)
--- PASS: TestAccXRaySamplingRule_tags_DefaultTags_emptyResourceTag (48.48s)
--- PASS: TestAccXRayGroup_tags_ComputedTag_OnCreate (48.65s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_nullOverlappingResourceTag (48.66s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_nullNonOverlappingResourceTag (48.81s)
--- PASS: TestAccXRaySamplingRule_tags_ComputedTag_OnCreate (53.78s)
--- PASS: TestAccXRaySamplingRule_tags_EmptyTag_OnUpdate_Replace (69.00s)
--- PASS: TestAccXRaySamplingRule_tags_DefaultTags_updateToResourceOnly (69.26s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_updateToProviderOnly (73.89s)
--- PASS: TestAccXRaySamplingRule_tags_DefaultTags_updateToProviderOnly (75.80s)
--- PASS: TestAccXRayGroup_tags_ComputedTag_OnUpdate_Replace (77.87s)
--- PASS: TestAccXRayGroup_tags_ComputedTag_OnUpdate_Add (81.38s)
--- PASS: TestAccXRaySamplingRule_tags_ComputedTag_OnUpdate_Replace (82.35s)
--- PASS: TestAccXRaySamplingRule_tags_ComputedTag_OnUpdate_Add (82.36s)
--- PASS: TestAccXRayGroup_tags_EmptyTag_OnUpdate_Replace (75.99s)
--- PASS: TestAccXRaySamplingRule_tags_DefaultTags_nonOverlapping (122.70s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_emptyResourceTag (48.53s)
--- PASS: TestAccXRaySamplingRule_tags_AddOnUpdate (72.63s)
--- PASS: TestAccXRaySamplingRule_tags_DefaultTags_overlapping (126.48s)
--- PASS: TestAccXRaySamplingRule_tags_EmptyTag_OnCreate (79.77s)
--- PASS: TestAccXRaySamplingRule_tags_null (56.39s)
--- PASS: TestAccXRayGroup_tags_null (53.00s)
--- PASS: TestAccXRayGroup_tags_AddOnUpdate (61.94s)
--- PASS: TestAccXRayGroup_tags_EmptyTag_OnCreate (71.50s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_updateToResourceOnly (58.28s)
--- PASS: TestAccXRaySamplingRule_tags_EmptyTag_OnUpdate_Add (93.69s)
--- PASS: TestAccXRaySamplingRule_tags (143.23s)
--- PASS: TestAccXRayGroup_tags (143.44s)
--- PASS: TestAccXRaySamplingRule_tags_DefaultTags_providerOnly (145.97s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_nonOverlapping (98.75s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_overlapping (99.75s)
--- PASS: TestAccXRayGroup_tags_EmptyTag_OnUpdate_Add (79.01s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_providerOnly (106.95s)
```

