### PR TITLE
fix(rds): DescribeOrderableDBInstanceOptionsInput MaxRecords to 1000

### DIFF
--- a/.changelog/37251.txt
+++ b/.changelog/37251.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_rds_orderable_db_instance: Fix `InvalidParameterValue: Invalid value 3412 for MaxRecords. Must be between 20 and 1000` errors
+```

--- a/internal/service/rds/orderable_instance_data_source.go
+++ b/internal/service/rds/orderable_instance_data_source.go
@@ -214,7 +214,7 @@ func dataSourceOrderableInstanceRead(ctx context.Context, d *schema.ResourceData
 	conn := meta.(*conns.AWSClient).RDSConn(ctx)
 
 	input := &rds.DescribeOrderableDBInstanceOptionsInput{
-		MaxRecords: aws.Int64(3412),
+		MaxRecords: aws.Int64(1000),
 	}
 
 	if v, ok := d.GetOk("availability_zone_group"); ok {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

RDS `DescribeOrderableDBInstanceOptions` `MaxRecords` is 1000.

Doc: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeOrderableDBInstanceOptions.html


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37221 
Closes #37258
Introduced in: https://github.com/hashicorp/terraform-provider-aws/pull/35698

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccRDSOrderableInstanceDataSource_ K=rds
# It would be great if anyone can run this, but the change looks simple enough.

...
```
