### PR TITLE
r/aws_iam_openid_connect_provider: Make `thumbprint_list` attribute optional

### DIFF
--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -66,6 +66,34 @@ func TestAccIAMOpenIDConnectProvider_basic(t *testing.T) {
 	})
 }
 
+func TestAccIAMOpenIDConnectProvider_withoutThumbprints(t *testing.T) {
+	ctx := acctest.Context(t)
+	url := "accounts.google.com"
+	resourceName := "aws_iam_openid_connect_provider.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenIDConnectProviderConfig_withoutThumbprints(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					acctest.CheckResourceAttrGlobalARN(resourceName, "arn", "iam", fmt.Sprintf("oidc-provider/%s", url)),
+					resource.TestCheckResourceAttr(resourceName, "url", url),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.0",
+						"266362248691-342342xasdasdasda-apps.googleusercontent.com"),
+					resource.TestCheckResourceAttr(resourceName, "thumbprint_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIAMOpenIDConnectProvider_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rString := sdkacctest.RandString(5)
@@ -189,6 +217,18 @@ resource "aws_iam_openid_connect_provider" "test" {
   thumbprint_list = ["cf23df2207d99a74fbe169e3eba035e633b65d94", "c784713d6f9cb67b55dd84f4e4af7832d42b8f55"]
 }
 `, rName)
+}
+
+func testAccOpenIDConnectProviderConfig_withoutThumbprints() string {
+	return `
+resource "aws_iam_openid_connect_provider" "test" {
+  url = "https://accounts.google.com"
+
+  client_id_list = [
+    "266362248691-342342xasdasdasda-apps.googleusercontent.com",
+  ]
+}
+`
 }
 
 func testAccOpenIDConnectProviderConfig_clientIDList_first(rName string) string {

--- a/website/docs/r/iam_openid_connect_provider.html.markdown
+++ b/website/docs/r/iam_openid_connect_provider.html.markdown
@@ -19,8 +19,6 @@ resource "aws_iam_openid_connect_provider" "default" {
   client_id_list = [
     "266362248691-342342xasdasdasda-apps.googleusercontent.com",
   ]
-
-  thumbprint_list = ["cf23df2207d99a74fbe169e3eba035e633b65d94"]
 }
 ```
 
@@ -30,7 +28,11 @@ This resource supports the following arguments:
 
 * `url` - (Required) The URL of the identity provider. Corresponds to the _iss_ claim.
 * `client_id_list` - (Required) A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)
-* `thumbprint_list` - (Required) A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s).
+* `thumbprint_list` - (Optional) A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s).
+
+  AWS secures communication with some OIDC identity providers (IdPs) through a library of trusted root certificate authorities (CAs) instead of using a certificate thumbprint to verify the IdP server certificate. In these cases, a specified thumbprint list remains in the configuration, but is not used for validation. These OIDC IdPs include Auth0, GitHub, GitLab, Google, and those that use an Amazon S3 bucket to host a JSON Web Key Set (JWKS) endpoint.
+
+  If it is not specified, and the IdP is not included in the aforementioned group, IAM will retrieve and use the top intermediate certificate authority (CA) thumbprint of the OIDC identity provider server certificate.
 * `tags` - (Optional) Map of resource tags for the IAM OIDC provider. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description

Make the `thumbprint_list` argument optional in the `aws_iam_openid_connect_provider` resource.

AWS now secures communication with some OIDC identity providers (IdPs) through a library of trusted root certificate authorities (CAs) instead of using a certificate thumbprint to verify the IdP server certificate.

And with orher IdPs, if the thumbprint list is not specified, IAM will retrieve and use the top intermediate certificate authority (CA) thumbprint of the OIDC identity provider server certificate.



### Relations

Closes #32480
Closes #35112

### References

The thumbprint list was made optional in the go-sdk 1.51.20:
https://github.com/aws/aws-sdk-go/blob/main/CHANGELOG.md#release-v15120-2024-04-11

### Output from Acceptance Testing

<details><summary>Output</summary>

```console
% make testacc TESTS=TestAccIAMOpenIDConnectProvider_ PKG=iam
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMOpenIDConnectProvider_'  -timeout 360m
=== RUN   TestAccIAMOpenIDConnectProvider_tags
=== PAUSE TestAccIAMOpenIDConnectProvider_tags
=== RUN   TestAccIAMOpenIDConnectProvider_tags_null
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_null
=== RUN   TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate
=== RUN   TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate
=== RUN   TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccIAMOpenIDConnectProvider_basic
=== PAUSE TestAccIAMOpenIDConnectProvider_basic
=== RUN   TestAccIAMOpenIDConnectProvider_withoutThumbprints
=== PAUSE TestAccIAMOpenIDConnectProvider_withoutThumbprints
=== RUN   TestAccIAMOpenIDConnectProvider_disappears
=== PAUSE TestAccIAMOpenIDConnectProvider_disappears
=== RUN   TestAccIAMOpenIDConnectProvider_clientIDListOrder
=== PAUSE TestAccIAMOpenIDConnectProvider_clientIDListOrder
=== CONT  TestAccIAMOpenIDConnectProvider_tags
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping
=== CONT  TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping
=== CONT  TestAccIAMOpenIDConnectProvider_basic
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly
=== CONT  TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate
=== CONT  TestAccIAMOpenIDConnectProvider_tags_null
=== CONT  TestAccIAMOpenIDConnectProvider_disappears
=== CONT  TestAccIAMOpenIDConnectProvider_clientIDListOrder
=== CONT  TestAccIAMOpenIDConnectProvider_withoutThumbprints
--- PASS: TestAccIAMOpenIDConnectProvider_withoutThumbprints (31.51s)
--- PASS: TestAccIAMOpenIDConnectProvider_disappears (32.15s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResourceTag (35.89s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag (35.98s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag (36.08s)
--- PASS: TestAccIAMOpenIDConnectProvider_clientIDListOrder (36.70s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_null (41.33s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly (43.81s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate (46.16s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace (46.37s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly (47.33s)
--- PASS: TestAccIAMOpenIDConnectProvider_basic (47.84s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate (50.86s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add (59.34s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping (64.69s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping (64.99s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags (74.95s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly (77.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        81.779s
```

</details>