### PR TITLE
Ensure regressions action runs on pull_request_target

### DIFF
--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -3,7 +3,7 @@ on:
   issues:
     types:
       - labeled
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 jobs:


### PR DESCRIPTION
### Description

Updates the regression Slack notifier to use `pull_request_target` rather than `pull_request`. This ensures that the action runs without needing to be approved, and that it can access the necessary secrets.

### Output from Acceptance Testing

N/a, Actions