### PR TITLE
r/aws_ec2_instance: Support modifying an ec2 instance's IPv6 addresses in-place

### DIFF
--- a/.changelog/37262.txt
+++ b/.changelog/37262.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_instance: Don't force an instance rebuild when modifying `ipv6_addresses`
+```

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -1338,6 +1338,47 @@ func TestAccEC2Instance_IPv6_supportAddressCountWithIPv4(t *testing.T) {
 	})
 }
 
+func TestAccEC2Instance_IPv6_supportIPv6Addresses(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v ec2.Instance
+	resourceName := "aws_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	originalCount := 0
+	updatedCount := 3
+	finalCount := 1
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_ipv6_addresses(rName, originalCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", fmt.Sprint(originalCount)),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_ipv6_addresses(rName, updatedCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", fmt.Sprint(updatedCount)),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_ipv6_addresses(rName, finalCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", fmt.Sprint(finalCount)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEC2Instance_IPv6AddressCount(t *testing.T) {
 	ctx := acctest.Context(t)
 	var original ec2.Instance
@@ -6811,6 +6852,26 @@ resource "aws_instance" "test" {
   }
 }
 `, rName))
+}
+
+func testAccInstanceConfig_ipv6_addresses(rName string, addressCount int) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		testAccInstanceVPCIPv6Config(rName),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami                = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  subnet_id          = aws_subnet.test.id
+  instance_type      = "t3.small"
+  ipv6_addresses     = [
+    for i in range(%[2]d):
+	    cidrhost(aws_subnet.test.ipv6_cidr_block, 10+i)
+  ]
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, addressCount))
 }
 
 func testAccInstanceConfig_ipv6Support(rName string) string {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -6860,12 +6860,12 @@ func testAccInstanceConfig_ipv6_addresses(rName string, addressCount int) string
 		testAccInstanceVPCIPv6Config(rName),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
-  ami                = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
-  subnet_id          = aws_subnet.test.id
-  instance_type      = "t3.small"
-  ipv6_addresses     = [
-    for i in range(%[2]d):
-	    cidrhost(aws_subnet.test.ipv6_cidr_block, 10+i)
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  subnet_id     = aws_subnet.test.id
+  instance_type = "t3.small"
+  ipv6_addresses = [
+    for i in range(%[2]d) :
+    cidrhost(aws_subnet.test.ipv6_cidr_block, 10 + i)
   ]
   tags = {
     Name = %[1]q


### PR DESCRIPTION
### Description
This allows you to set specific IPv6 addresses on an EC2 instance, without triggering an instance replacement.

This also switches to using a set for `aws_instance.ipv6_addresses`, on the grounds that AWS treats it as a set. I'm a little nervous about this, although it seems to go fine in practice.

### Output from Acceptance Testing
```console
#> make testacc TESTARGS='-run=TestAccEC2Instance_IPv6\|TestAccEC2Instance_basic\|TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError\|TestAccEC2Instance_IPv6_supportIPv6Addresses' PKG=ec2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccEC2Instance_IPv6\|TestAccEC2Instance_basic\|TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError\|TestAccEC2Instance_IPv6_supportIPv6Addresses -timeout 360m
=== RUN   TestAccEC2Instance_basic
=== PAUSE TestAccEC2Instance_basic
=== RUN   TestAccEC2Instance_IPv6_supportAddressCount
=== PAUSE TestAccEC2Instance_IPv6_supportAddressCount
=== RUN   TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError
=== PAUSE TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError
=== RUN   TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
=== PAUSE TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
=== RUN   TestAccEC2Instance_IPv6_supportIPv6Addresses
=== PAUSE TestAccEC2Instance_IPv6_supportIPv6Addresses
=== RUN   TestAccEC2Instance_IPv6AddressCount
=== PAUSE TestAccEC2Instance_IPv6AddressCount
=== RUN   TestAccEC2Instance_basicWithSpot
=== PAUSE TestAccEC2Instance_basicWithSpot
=== CONT  TestAccEC2Instance_basic
=== CONT  TestAccEC2Instance_IPv6_supportIPv6Addresses
=== CONT  TestAccEC2Instance_basicWithSpot
--- PASS: TestAccEC2Instance_basic (183.68s)
=== CONT  TestAccEC2Instance_IPv6AddressCount
--- PASS: TestAccEC2Instance_IPv6_supportIPv6Addresses (313.23s)
=== CONT  TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError (4.42s)
=== CONT  TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
--- PASS: TestAccEC2Instance_IPv6AddressCount (228.67s)
=== CONT  TestAccEC2Instance_IPv6_supportAddressCount
--- PASS: TestAccEC2Instance_basicWithSpot (426.71s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCountWithIPv4 (178.24s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCount (165.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	584.663s
...
```
