### PR TITLE
tools/awssdkpatch: use expression for string slice/map patch

### DIFF
--- a/tools/awssdkpatch/patch.tmpl
+++ b/tools/awssdkpatch/patch.tmpl
@@ -34,19 +34,19 @@ arn.x
 +aws.ToString
 
 @@
-var x identifier
+var x expression
 @@
 -aws.StringSlice([]string{x})
 +[]string{x}
 
 @@
-var x identifier
+var x expression
 @@
 -aws.StringValueSlice(x)
 +x
 
 @@
-var x identifier
+var x expression
 @@
 -aws.StringValueMap(x)
 +x


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
By switching the metavariable from an `identifier` to an `expression`, this patch will now also be able to patch cases where the function argument is a struct field. For example, the following case works with an `identifier` metavariable:

```go
var thing []*string

// match
d.Set("thing", aws.StringValueSlice(thing))
```

But if a struct field is passed, the patch does not match:

```go
type Output struct {
  Field []*string
}

// No match
d.Set("thing", aws.StringValueSlice(out.Field))
```

Changing to an `expression` means anything that has a value (and can therefore be passed into a function) will now match.

Ref: https://github.com/uber-go/gopatch/blob/main/docs/Appendix.md#identifiers-vs-expressions-vs-statements


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #32976 

