### PR TITLE
feat: add field for cross account support in endpoint groups for AGA

### DIFF
--- a/internal/service/globalaccelerator/endpoint_group.go
+++ b/internal/service/globalaccelerator/endpoint_group.go
@@ -67,6 +67,11 @@ func resourceEndpointGroup() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(0, 255),
 						},
+						"cross_account_attachment_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
 					},
 				},
 			},
@@ -381,6 +386,10 @@ func expandEndpointConfiguration(tfMap map[string]interface{}) *awstypes.Endpoin
 
 	if v, ok := tfMap["weight"].(int); ok {
 		apiObject.Weight = aws.Int32(int32(v))
+	}
+
+	if v, ok := tfMap["cross_account_attachment_arn"].(string); ok && v != "" {
+		apiObject.AttachmentArn = aws.String(v)
 	}
 
 	return apiObject

--- a/internal/service/globalaccelerator/endpoint_group_test.go
+++ b/internal/service/globalaccelerator/endpoint_group_test.go
@@ -46,6 +46,46 @@ func TestAccGlobalAcceleratorEndpointGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "health_check_path", ""),
 					resource.TestCheckResourceAttr(resourceName, "health_check_port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "health_check_protocol", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "cross_account_attachment_arn", ""),
+					acctest.MatchResourceAttrGlobalARN(resourceName, "listener_arn", "globalaccelerator", regexache.MustCompile(`accelerator/[^/]+/listener/[^/]+`)),
+					resource.TestCheckResourceAttr(resourceName, "port_override.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "threshold_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_dial_percentage", "100"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGlobalAcceleratorEndpointGroup_crossAccount(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.EndpointGroup
+	resourceName := "aws_globalaccelerator_endpoint_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlobalAcceleratorServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEndpointGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointGroupConfig_crossAccount(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEndpointGroupExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrGlobalARN(resourceName, "arn", "globalaccelerator", regexache.MustCompile(`accelerator/[^/]+/listener/[^/]+/endpoint-group/[^/]+`)),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "endpoint_group_region", acctest.Region()),
+					resource.TestCheckResourceAttr(resourceName, "health_check_interval_seconds", "30"),
+					resource.TestCheckResourceAttr(resourceName, "health_check_path", ""),
+					resource.TestCheckResourceAttr(resourceName, "health_check_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "health_check_protocol", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "cross_account_attachment_arn", "arn:aws:elasticloadbalancing:us-west-1:111111111111:loadbalancer/net/nlb-01/8a6825aea9cdab43"),
 					acctest.MatchResourceAttrGlobalARN(resourceName, "listener_arn", "globalaccelerator", regexache.MustCompile(`accelerator/[^/]+/listener/[^/]+`)),
 					resource.TestCheckResourceAttr(resourceName, "port_override.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "threshold_count", "3"),
@@ -873,4 +913,29 @@ resource "aws_globalaccelerator_endpoint_group" "test" {
   traffic_dial_percentage       = 0
 }
 `, rName)
+}
+
+func testAccEndpointGroupConfig_crossAccount(rName string) string {
+	return fmt.Sprintf(`
+	resource "aws_globalaccelerator_accelerator" "test" {
+	  name            = %[1]q
+	  ip_address_type = "IPV4"
+	  enabled         = false
+	}
+
+	resource "aws_globalaccelerator_listener" "test" {
+	  accelerator_arn = aws_globalaccelerator_accelerator.test.id
+	  protocol        = "TCP"
+
+	  port_range {
+		from_port = 80
+		to_port   = 80
+	  }
+	}
+
+	resource "aws_globalaccelerator_endpoint_group" "test" {
+	  listener_arn = aws_globalaccelerator_listener.test.id
+	  cross_account_attachment_arn = "arn:aws:elasticloadbalancing:us-west-1:111111111111:loadbalancer/net/nlb-01/8a6825aea9cdab43"
+	}
+	`, rName)
 }

--- a/website/docs/cdktf/python/r/globalaccelerator_endpoint_group.html.markdown
+++ b/website/docs/cdktf/python/r/globalaccelerator_endpoint_group.html.markdown
@@ -58,6 +58,7 @@ Terraform will only perform drift detection of its value when present in a confi
 **Note:** When client IP address preservation is enabled, the Global Accelerator service creates an EC2 Security Group in the VPC named `GlobalAccelerator` that must be deleted (potentially outside of Terraform) before the VPC will successfully delete. If this EC2 Security Group is not deleted, Terraform will retry the VPC deletion for a few minutes before reporting a `DependencyViolation` error. This cannot be resolved by re-running Terraform.
 * `endpoint_id` - (Optional) An ID for the endpoint. If the endpoint is a Network Load Balancer or Application Load Balancer, this is the Amazon Resource Name (ARN) of the resource. If the endpoint is an Elastic IP address, this is the Elastic IP address allocation ID.
 * `weight` - (Optional) The weight associated with the endpoint. When you add weights to endpoints, you configure AWS Global Accelerator to route traffic based on proportions that you specify.
+* `cross_account_attachment_arn` - (Optional) An ARN of an exposed cross-account attachment. See the [AWS documentation](https://docs.aws.amazon.com/global-accelerator/latest/dg/cross-account-resources.html) for more details.
 
 `port_override` supports the following arguments:
 

--- a/website/docs/r/globalaccelerator_endpoint_group.html.markdown
+++ b/website/docs/r/globalaccelerator_endpoint_group.html.markdown
@@ -45,6 +45,7 @@ Terraform will only perform drift detection of its value when present in a confi
 **Note:** When client IP address preservation is enabled, the Global Accelerator service creates an EC2 Security Group in the VPC named `GlobalAccelerator` that must be deleted (potentially outside of Terraform) before the VPC will successfully delete. If this EC2 Security Group is not deleted, Terraform will retry the VPC deletion for a few minutes before reporting a `DependencyViolation` error. This cannot be resolved by re-running Terraform.
 * `endpoint_id` - (Optional) An ID for the endpoint. If the endpoint is a Network Load Balancer or Application Load Balancer, this is the Amazon Resource Name (ARN) of the resource. If the endpoint is an Elastic IP address, this is the Elastic IP address allocation ID.
 * `weight` - (Optional) The weight associated with the endpoint. When you add weights to endpoints, you configure AWS Global Accelerator to route traffic based on proportions that you specify.
+*  `cross_account_attachment_arn` - (Optional) An ARN of an exposed cross-account attachment. See the [AWS documentation](https://docs.aws.amazon.com/global-accelerator/latest/dg/cross-account-resources.html) for more details.
 
 `port_override` supports the following arguments:
 


### PR DESCRIPTION
### Description

In https://github.com/hashicorp/terraform-provider-aws/pull/35991 we added support for making cross account attachments ([docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/globalaccelerator_cross_account_attachment)). There was one part missing, using them in the endpoint group for the Global Accelerator (AGA). 

This add support for setting this field: https://docs.aws.amazon.com/global-accelerator/latest/api/API_EndpointConfiguration.html

### Output from Acceptance Testing
...in progress...