### PR TITLE
docs: Add AWS Resource Tagging Standard ARN to the ref list in the aws_securityhub_standards_subscription resource doc

### DIFF
--- a/website/docs/r/securityhub_standards_subscription.html.markdown
+++ b/website/docs/r/securityhub_standards_subscription.html.markdown
@@ -34,15 +34,16 @@ This resource supports the following arguments:
 
 * `standards_arn` - (Required) The ARN of a standard - see below.
 
-Currently available standards (remember to replace `${var.region}` as appropriate):
+Currently available standards (remember to replace `${var.partition}` and `${var.region}` as appropriate):
 
-| Name                                     | ARN                                                                                             |
-|------------------------------------------|-------------------------------------------------------------------------------------------------|
-| AWS Foundational Security Best Practices | `arn:aws:securityhub:${var.region}::standards/aws-foundational-security-best-practices/v/1.0.0` |
-| CIS AWS Foundations Benchmark v1.2.0     | `arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0`                           |
-| CIS AWS Foundations Benchmark v1.4.0     | `arn:aws:securityhub:${var.region}::standards/cis-aws-foundations-benchmark/v/1.4.0`            |
-| NIST SP 800-53 Rev. 5                    | `arn:aws:securityhub:${var.region}::standards/nist-800-53/v/5.0.0`                              |
-| PCI DSS                                  | `arn:aws:securityhub:${var.region}::standards/pci-dss/v/3.2.1`                                  |
+| Name                                     | ARN                                                                                                          |
+|------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| AWS Foundational Security Best Practices | `arn:${var.partition}:securityhub:${var.region}::standards/aws-foundational-security-best-practices/v/1.0.0` |
+| AWS Resource Tagging Standard            | `arn:${var.partition}:securityhub:${var.region}::standards/aws-resource-tagging-standard/v/1.0.0`            |
+| CIS AWS Foundations Benchmark v1.2.0     | `arn:${var.partition}:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0`                           |
+| CIS AWS Foundations Benchmark v1.4.0     | `arn:${var.partition}:securityhub:${var.region}::standards/cis-aws-foundations-benchmark/v/1.4.0`            |
+| NIST SP 800-53 Rev. 5                    | `arn:${var.partition}:securityhub:${var.region}::standards/nist-800-53/v/5.0.0`                              |
+| PCI DSS                                  | `arn:${var.partition}:securityhub:${var.region}::standards/pci-dss/v/3.2.1`                                  |
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the ARN of the newly released AWS Resource Tagging Standard to the `aws_securityhub_standards_subscription` resource documentation. I've also changed the partition segment of all ARNs to `${var.partition}` to account for partition differences.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37272

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[AWS Resource Tagging Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/standards-tagging.html) for more info, although the page has the wrong standard name - it shouldn't have the account ID. I checked the ARN using AWS CLI and verify it by enabling it in the CLI as well:

```bash
$ aws securityhub batch-enable-standards --standards-subscription-requests StandardsArn=arn:aws:securityhub:ca-central-1::standards/aws-resource-ta
gging-standard/v/1.0.0                                                                                                                                                                 
{
    "StandardsSubscriptions": [
        {
            "StandardsSubscriptionArn": "arn:aws:securityhub:ca-central-1:297530387907:subscription/aws-resource-tagging-standard/v/1.0.0",
            "StandardsArn": "arn:aws:securityhub:ca-central-1::standards/aws-resource-tagging-standard/v/1.0.0",
            "StandardsInput": {},
            "StandardsStatus": "PENDING"
        }
    ]
}
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a