### PR TITLE
docs: Add missing SSE-KMS-WITH-SERVICE-ROLE valid value to catalog_encryption_mode for aws_glue_data_catalog_encryption_settings

### DIFF
--- a/website/docs/r/glue_data_catalog_encryption_settings.html.markdown
+++ b/website/docs/r/glue_data_catalog_encryption_settings.html.markdown
@@ -48,7 +48,7 @@ This resource supports the following arguments:
 
 ### encryption_at_rest
 
-* `catalog_encryption_mode` - (Required) The encryption-at-rest mode for encrypting Data Catalog data. Valid values are `DISABLED` and `SSE-KMS`.
+* `catalog_encryption_mode` - (Required) The encryption-at-rest mode for encrypting Data Catalog data. Valid values: `DISABLED`, `SSE-KMS`, `SSE-KMS-WITH-SERVICE-ROLE`.
 * `catalog_encryption_service_role` - (Optional) The ARN of the AWS IAM role used for accessing encrypted Data Catalog data.
 * `sse_aws_kms_key_id` - (Optional) The ARN of the AWS KMS key to use for encryption at rest.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the missing valid value `SSE-KMS-WITH-SERVICE-ROLE` for the `catalog_encryption_mode` argument in the `aws_glue_data_catalog_encryption_settings` resource doc.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37243

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [EncryptionAtRest](https://docs.aws.amazon.com/glue/latest/webapi/API_EncryptionAtRest.html) to confirm list of valid values.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a