### PR TITLE
Update pipes_pipe.html.markdown

### DIFF
--- a/website/docs/r/pipes_pipe.html.markdown
+++ b/website/docs/r/pipes_pipe.html.markdown
@@ -172,7 +172,7 @@ resource "aws_pipes_pipe" "example" {
 The following arguments are required:
 
 * `role_arn` - (Required) ARN of the role that allows the pipe to send data to the target.
-* `source` - (Required) Source resource of the pipe (typically an ARN).
+* `source` - (Required) Source resource of the pipe. This field typically requires an ARN (Amazon Resource Name). However, when using a self-managed Kafka cluster, you should use a different format. Instead of an ARN, use 'smk://' followed by the bootstrap server's address.
 * `target` - (Required) Target resource of the pipe (typically an ARN).
 
 The following arguments are optional:


### PR DESCRIPTION
In this commit, I updated the source field in the AWS provider configuration to use the 'smk://' format for self-managed Kafka clusters. This change allows users to specify the source for EventBridge pipes when using a self-managed Kafka cluster as the source, resolving an issue where the documentation was unclear about what to provide in the source field.

Additionally, I ensured that the commit message provides clear and concise information about the nature of the changes made. This includes updating the source field to use the 'smk://' format and providing an explanation of the change in the commit message.

Overall, this commit aims to improve clarity and usability in the AWS provider documentation by providing clear guidance on how to configure EventBridge pipes with a self-managed Kafka cluster as the source.

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
