### PR TITLE
F aws_rds_global_cluster data source

### DIFF
--- a/internal/service/rds/global_cluster_data_source.go
+++ b/internal/service/rds/global_cluster_data_source.go
@@ -1,0 +1,142 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+)
+
+// @SDKDataSource("aws_rds_global_cluster")
+func DataSourceGlobalCluster() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceGlobalClusterRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"deletion_protection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"force_destroy": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"global_cluster_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"global_cluster_members": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"db_cluster_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_writer": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"global_cluster_resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_db_cluster_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"storage_encrypted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RDSConn(ctx)
+
+	globalClusterIdentifier := d.Get("global_cluster_identifier").(string)
+
+	resp, err := conn.DescribeGlobalClusters(&rds.DescribeGlobalClustersInput{
+		GlobalClusterIdentifier: aws.String(globalClusterIdentifier)})
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Global RDS Cluster (%s): %s", globalClusterIdentifier, err)
+	}
+
+	if resp == nil {
+		return sdkdiag.AppendErrorf(diags, "reading Global RDS Cluster (%s): empty response", globalClusterIdentifier)
+	}
+
+	var globalCluster *rds.GlobalCluster
+	for _, c := range resp.GlobalClusters {
+		if aws.StringValue(c.GlobalClusterIdentifier) == globalClusterIdentifier {
+			globalCluster = c
+			break
+		}
+	}
+
+	if globalCluster == nil {
+		return sdkdiag.AppendErrorf(diags, "reading Global RDS Cluster (%s): cluster not found", globalClusterIdentifier)
+	}
+
+	d.SetId(aws.StringValue(globalCluster.GlobalClusterIdentifier))
+
+	d.Set("arn", globalCluster.GlobalClusterArn)
+	d.Set("database_name", globalCluster.DatabaseName)
+	d.Set("deletion_protection", globalCluster.DeletionProtection)
+	d.Set("engine", globalCluster.Engine)
+	d.Set("engine_version", globalCluster.EngineVersion)
+	d.Set("global_cluster_identifier", globalCluster.GlobalClusterIdentifier)
+
+	var gcmList []interface{}
+	for _, gcm := range globalCluster.GlobalClusterMembers {
+		gcmMap := map[string]interface{}{
+			"db_cluster_arn": aws.StringValue(gcm.DBClusterArn),
+			"is_writer":      aws.BoolValue(gcm.IsWriter),
+		}
+
+		gcmList = append(gcmList, gcmMap)
+	}
+	if err := d.Set("global_cluster_members", gcmList); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting global_cluster_members: %s", err)
+	}
+
+	if err := d.Set("global_cluster_members", flattenGlobalClusterMembers(globalCluster.GlobalClusterMembers)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting global_cluster_members: %s", err)
+	}
+
+	d.Set("global_cluster_resource_id", globalCluster.GlobalClusterResourceId)
+	d.Set("storage_encrypted", globalCluster.StorageEncrypted)
+
+	return diags
+}

--- a/internal/service/rds/global_cluster_data_source_test.go
+++ b/internal/service/rds/global_cluster_data_source_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSGlobalClusterDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_rds_global_cluster.test"
+	resourceName := "aws_rds_global_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "arn", resourceName, "arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "database_name", resourceName, "database_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "deletion_protection", resourceName, "deletion_protection"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine", resourceName, "engine"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine_version", resourceName, "engine_version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_identifier", resourceName, "global_cluster_identifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_members", resourceName, "global_cluster_members"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_resource_id", resourceName, "global_cluster_resource_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "storage_encrypted", resourceName, "storage_encrypted"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGlobalClusterDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(2), fmt.Sprintf(`
+
+data "aws_region" "alternate" {
+	provider = "awsalternate"
+}
+		
+data "aws_region" "current" {}
+resource "aws_rds_global_cluster" "test" {
+		global_cluster_identifier = "%[1]s"
+		engine                    = "aurora-postgresql"
+		engine_version            = "12.4"
+		database_name             = "example_db"
+}
+
+resource "aws_rds_cluster" "primary" {
+		engine                    = aws_rds_global_cluster.test.engine
+		engine_version            = aws_rds_global_cluster.test.engine_version
+		cluster_identifier        = "test-primary-cluster"
+		master_username           = "username"
+		master_password           = "somepass123"
+		database_name             = "example_db"
+		global_cluster_identifier = aws_rds_global_cluster.test.id
+		db_subnet_group_name      = "test"
+		skip_final_snapshot       = true
+		
+		depends_on = [
+			aws_rds_global_cluster.test
+		]
+}
+
+resource "aws_rds_cluster_instance" "primary" {
+		identifier           = "test-primary-cluster-instance"
+		cluster_identifier   = aws_rds_cluster.primary.id
+		instance_class       = "db.r4.large"
+		db_subnet_group_name = "test"
+		engine               = aws_rds_global_cluster.test.engine
+		engine_version       = aws_rds_global_cluster.test.engine_version
+		
+		depends_on = [
+			aws_rds_cluster.primary
+		]
+}
+
+resource "aws_rds_cluster" "secondary" {
+		provider                  = "awsalternate"
+		engine                    = aws_rds_global_cluster.test.engine
+		engine_version            = aws_rds_global_cluster.test.engine_version
+		cluster_identifier        = "test-secondary-cluster"
+		global_cluster_identifier = aws_rds_global_cluster.test.id
+		replication_source_identifier = aws_rds_cluster.primary.arn
+		source_region 			  = data.aws_region.alternate.name
+		db_subnet_group_name      = "test"
+		skip_final_snapshot       = true
+		depends_on = [
+			aws_rds_cluster_instance.primary
+		]
+}
+
+resource "aws_rds_cluster_instance" "secondary" {
+		provider             = "awsalternate"
+		identifier           = "test-secondary-cluster-instance"
+		cluster_identifier   = aws_rds_cluster.secondary.id
+		instance_class       = "db.r4.large"
+		db_subnet_group_name = "test"
+		engine               = aws_rds_global_cluster.test.engine
+		engine_version       = aws_rds_global_cluster.test.engine_version
+	  
+		depends_on = [
+			aws_rds_cluster.secondary
+		]
+}
+
+data "aws_rds_global_cluster" "test" {
+	global_cluster_identifier = aws_rds_global_cluster.test.global_cluster_identifier
+}
+`, rName))
+}

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -88,6 +88,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_rds_engine_version",
 		},
 		{
+			Factory:  DataSourceGlobalCluster,
+			TypeName: "aws_rds_global_cluster",
+		},
+		{
 			Factory:  DataSourceOrderableInstance,
 			TypeName: "aws_rds_orderable_db_instance",
 		},

--- a/website/docs/d/rds_global_cluster.html.markdown
+++ b/website/docs/d/rds_global_cluster.html.markdown
@@ -1,0 +1,125 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_rds_global_cluster"
+description: |-
+  Terraform data source for managing an AWS RDS (Relational Database) Global Cluster.
+---
+<!---
+TIP: A few guiding principles for writing documentation:
+1. Use simple language while avoiding jargon and figures of speech.
+2. Focus on brevity and clarity to keep a reader's attention.
+3. Use active voice and present tense whenever you can.
+4. Document your feature as it exists now; do not mention the future or past if you can help it.
+5. Use accessible and inclusive language.
+--->
+
+# Data Source: aws_rds_global_cluster
+
+Terraform data source for managing an AWS RDS (Relational Database) Global Cluster.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_region" "alternate" {
+	provider = "awsalternate"
+}
+	
+data "aws_region" "current" {}
+resource "aws_rds_global_cluster" "test" {
+	global_cluster_identifier = "%[1]s"
+	engine                    = "aurora-postgresql"
+	engine_version            = "12.4"
+	database_name             = "example_db"
+}
+resource "aws_rds_cluster" "primary" {
+	engine                    = aws_rds_global_cluster.test.engine
+	engine_version            = aws_rds_global_cluster.test.engine_version
+	cluster_identifier        = "test-primary-cluster"
+	master_username           = "username"
+	master_password           = "somepass123"
+	database_name             = "example_db"
+	global_cluster_identifier = aws_rds_global_cluster.test.id
+	db_subnet_group_name      = "test"
+	skip_final_snapshot       = true
+	
+	depends_on = [
+		aws_rds_global_cluster.test
+	]
+}
+resource "aws_rds_cluster_instance" "primary" {
+	identifier           = "test-primary-cluster-instance"
+	cluster_identifier   = aws_rds_cluster.primary.id
+	instance_class       = "db.r4.large"
+	db_subnet_group_name = "test"
+	engine               = aws_rds_global_cluster.test.engine
+	engine_version       = aws_rds_global_cluster.test.engine_version
+	
+	depends_on = [
+		aws_rds_cluster.primary
+	]
+}
+resource "aws_rds_cluster" "secondary" {
+	provider                  = "awsalternate"
+	engine                    = aws_rds_global_cluster.test.engine
+	engine_version            = aws_rds_global_cluster.test.engine_version
+	cluster_identifier        = "test-secondary-cluster"
+	global_cluster_identifier = aws_rds_global_cluster.test.id
+	replication_source_identifier = aws_rds_cluster.primary.arn
+	source_region 			  = data.aws_region.alternate.name
+	db_subnet_group_name      = "test"
+	skip_final_snapshot       = true
+	depends_on = [
+		aws_rds_cluster_instance.primary
+	]
+}
+resource "aws_rds_cluster_instance" "secondary" {
+	provider             = "awsalternate"
+	identifier           = "test-secondary-cluster-instance"
+	cluster_identifier   = aws_rds_cluster.secondary.id
+	instance_class       = "db.r4.large"
+	db_subnet_group_name = "test"
+	engine               = aws_rds_global_cluster.test.engine
+	engine_version       = aws_rds_global_cluster.test.engine_version
+  
+	depends_on = [
+		aws_rds_cluster.secondary
+	]
+}
+data "aws_rds_global_cluster" "test" {
+	global_cluster_identifier = aws_rds_global_cluster.test.global_cluster_identifier
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `global_cluster_identifier` - (Required) The global cluster identifier of the RDS global cluster.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - RDS Global Cluster Amazon Resource Name (ARN)
+* `global_cluster_identifier` - Global cluster identifier.
+* `database_name` - Name of the automatically created database on cluster creation.
+* `deletion_protection` -  If the Global Cluster should have deletion protection enabled. The database can't be deleted when this value is set to `true`.
+* `engine` - Name of the database engine.
+* `engine_version` -   Version of the database engine for this Global Cluster.
+* `storage_encrypted` - Whether the DB cluster is encrypted.
+* `global_cluster_members` -  Set of objects containing Global Cluster members.
+  * `db_cluster_arn` - Amazon Resource Name (ARN) of member DB Cluster
+  * `is_writer` - Whether the member is the primary DB Cluster
+* `global_cluster_resource_id` - AWS Region-unique, immutable identifier for the global database cluster. 
+
+
+		
+					resource.TestCheckResourceAttrPair(dataSourceName, "deletion_protection", resourceName, "deletion_protection"),
+
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_members", resourceName, "global_cluster_members"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_resource_id", resourceName, "global_cluster_resource_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "storage_encrypted", resourceName, "storage_encrypted"),


### PR DESCRIPTION

### Description

Create a new data source aws_rds_global_cluster for RDS


### Output from Acceptance Testing

```console
% ❯ make testacc TESTS=TestAccRDSGlobalClusterDataSource_basic PKG=rds
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSGlobalClusterDataSource_basic'  -timeout 360m
=== RUN   TestAccRDSGlobalClusterDataSource_basic
=== PAUSE TestAccRDSGlobalClusterDataSource_basic
=== CONT  TestAccRDSGlobalClusterDataSource_basic
--- PASS: TestAccRDSGlobalClusterDataSource_basic (2817.52s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	2825.034s
```
