### PR TITLE
meta: Prefer constants over string literals

### DIFF
--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -641,6 +641,7 @@ rules:
     paths:
       include:
         - "internal/service/iam/*.go"
+        - "internal/service/meta/*.go"
     patterns:
       - pattern: '"name"'
     severity: ERROR

--- a/internal/service/meta/region_data_source.go
+++ b/internal/service/meta/region_data_source.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @FrameworkDataSource
@@ -48,7 +49,7 @@ func (d *dataSourceRegion) Schema(ctx context.Context, req datasource.SchemaRequ
 				Optional: true,
 				Computed: true,
 			},
-			"name": schema.StringAttribute{
+			names.AttrName: schema.StringAttribute{
 				Optional: true,
 				Computed: true,
 			},

--- a/internal/service/meta/region_data_source_test.go
+++ b/internal/service/meta/region_data_source_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfmeta "github.com/hashicorp/terraform-provider-aws/internal/service/meta"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestFindRegionByEC2Endpoint(t *testing.T) {
@@ -96,7 +97,7 @@ func TestAccMetaRegionDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "description", regexache.MustCompile(`^.+$`)),
 					acctest.CheckResourceAttrRegionalHostnameService(dataSourceName, "endpoint", ec2.EndpointsID),
-					resource.TestCheckResourceAttr(dataSourceName, "name", acctest.Region()),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrName, acctest.Region()),
 				),
 			},
 		},
@@ -117,7 +118,7 @@ func TestAccMetaRegionDataSource_endpoint(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "description", regexache.MustCompile(`^.+$`)),
 					resource.TestMatchResourceAttr(dataSourceName, "endpoint", regexache.MustCompile(fmt.Sprintf("^%s\\.[^.]+\\.%s$", ec2.EndpointsID, acctest.PartitionDNSSuffix()))),
-					resource.TestMatchResourceAttr(dataSourceName, "name", regexache.MustCompile(`^.+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, names.AttrName, regexache.MustCompile(`^.+$`)),
 				),
 			},
 		},
@@ -138,7 +139,7 @@ func TestAccMetaRegionDataSource_endpointAndName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "description", regexache.MustCompile(`^.+$`)),
 					resource.TestMatchResourceAttr(dataSourceName, "endpoint", regexache.MustCompile(fmt.Sprintf("^ec2\\.[^.]+\\.%s$", acctest.PartitionDNSSuffix()))),
-					resource.TestMatchResourceAttr(dataSourceName, "name", regexache.MustCompile(`^.+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, names.AttrName, regexache.MustCompile(`^.+$`)),
 				),
 			},
 		},
@@ -159,7 +160,7 @@ func TestAccMetaRegionDataSource_name(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "description", regexache.MustCompile(`^.+$`)),
 					resource.TestMatchResourceAttr(dataSourceName, "endpoint", regexache.MustCompile(fmt.Sprintf("^ec2\\.[^.]+\\.%s$", acctest.PartitionDNSSuffix()))),
-					resource.TestMatchResourceAttr(dataSourceName, "name", regexache.MustCompile(`^.+$`)),
+					resource.TestMatchResourceAttr(dataSourceName, names.AttrName, regexache.MustCompile(`^.+$`)),
 				),
 			},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37293

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAcc K=meta
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/meta/... -v -count 1 -parallel 20 -run='TestAcc'  -timeout 360m
=== RUN   TestAccMetaARNDataSource_basic
=== PAUSE TestAccMetaARNDataSource_basic
=== RUN   TestAccMetaARNDataSource_s3Bucket
=== PAUSE TestAccMetaARNDataSource_s3Bucket
=== RUN   TestAccMetaBillingServiceAccountDataSource_basic
=== PAUSE TestAccMetaBillingServiceAccountDataSource_basic
=== RUN   TestAccMetaDefaultTagsDataSource_basic
=== PAUSE TestAccMetaDefaultTagsDataSource_basic
=== RUN   TestAccMetaDefaultTagsDataSource_empty
=== PAUSE TestAccMetaDefaultTagsDataSource_empty
=== RUN   TestAccMetaDefaultTagsDataSource_multiple
=== PAUSE TestAccMetaDefaultTagsDataSource_multiple
=== RUN   TestAccMetaDefaultTagsDataSource_ignore
=== PAUSE TestAccMetaDefaultTagsDataSource_ignore
=== RUN   TestAccMetaIPRangesDataSource_basic
=== PAUSE TestAccMetaIPRangesDataSource_basic
=== RUN   TestAccMetaIPRangesDataSource_none
=== PAUSE TestAccMetaIPRangesDataSource_none
=== RUN   TestAccMetaIPRangesDataSource_url
=== PAUSE TestAccMetaIPRangesDataSource_url
=== RUN   TestAccMetaIPRangesDataSource_uppercase
=== PAUSE TestAccMetaIPRangesDataSource_uppercase
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== RUN   TestAccMetaRegionDataSource_endpointAndName
=== PAUSE TestAccMetaRegionDataSource_endpointAndName
=== RUN   TestAccMetaRegionDataSource_name
=== PAUSE TestAccMetaRegionDataSource_name
=== RUN   TestAccMetaRegionsDataSource_basic
=== PAUSE TestAccMetaRegionsDataSource_basic
=== RUN   TestAccMetaRegionsDataSource_filter
=== PAUSE TestAccMetaRegionsDataSource_filter
=== RUN   TestAccMetaRegionsDataSource_allRegions
=== PAUSE TestAccMetaRegionsDataSource_allRegions
=== RUN   TestAccMetaRegionsDataSource_nonExistentRegion
=== PAUSE TestAccMetaRegionsDataSource_nonExistentRegion
=== RUN   TestAccMetaService_basic
=== PAUSE TestAccMetaService_basic
=== RUN   TestAccMetaService_byReverseDNSName
=== PAUSE TestAccMetaService_byReverseDNSName
=== RUN   TestAccMetaService_byDNSName
=== PAUSE TestAccMetaService_byDNSName
=== RUN   TestAccMetaService_byParts
=== PAUSE TestAccMetaService_byParts
=== RUN   TestAccMetaService_unsupported
=== PAUSE TestAccMetaService_unsupported
=== CONT  TestAccMetaARNDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionsDataSource_nonExistentRegion
=== CONT  TestAccMetaService_byDNSName
=== CONT  TestAccMetaRegionsDataSource_filter
=== CONT  TestAccMetaRegionDataSource_endpointAndName
=== CONT  TestAccMetaService_unsupported
=== CONT  TestAccMetaService_byReverseDNSName
=== CONT  TestAccMetaIPRangesDataSource_basic
=== CONT  TestAccMetaRegionsDataSource_allRegions
=== CONT  TestAccMetaRegionDataSource_name
=== CONT  TestAccMetaService_basic
=== CONT  TestAccMetaRegionDataSource_basic
=== CONT  TestAccMetaRegionsDataSource_basic
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaIPRangesDataSource_uppercase
=== CONT  TestAccMetaDefaultTagsDataSource_empty
=== CONT  TestAccMetaIPRangesDataSource_url
=== CONT  TestAccMetaDefaultTagsDataSource_ignore
=== CONT  TestAccMetaService_byParts
--- PASS: TestAccMetaRegionDataSource_endpoint (39.47s)
=== CONT  TestAccMetaIPRangesDataSource_none
--- PASS: TestAccMetaRegionsDataSource_filter (40.10s)
=== CONT  TestAccMetaDefaultTagsDataSource_multiple
--- PASS: TestAccMetaService_byReverseDNSName (40.25s)
=== CONT  TestAccMetaBillingServiceAccountDataSource_basic
--- PASS: TestAccMetaRegionsDataSource_basic (40.27s)
=== CONT  TestAccMetaDefaultTagsDataSource_basic
--- PASS: TestAccMetaIPRangesDataSource_basic (40.27s)
=== CONT  TestAccMetaARNDataSource_s3Bucket
--- PASS: TestAccMetaService_unsupported (40.27s)
--- PASS: TestAccMetaRegionsDataSource_allRegions (40.27s)
--- PASS: TestAccMetaService_byDNSName (40.28s)
--- PASS: TestAccMetaService_basic (40.28s)
--- PASS: TestAccMetaIPRangesDataSource_url (40.50s)
--- PASS: TestAccMetaDefaultTagsDataSource_empty (40.50s)
--- PASS: TestAccMetaIPRangesDataSource_uppercase (40.51s)
--- PASS: TestAccMetaService_byParts (40.51s)
--- PASS: TestAccMetaPartitionDataSource_basic (40.51s)
--- PASS: TestAccMetaRegionDataSource_name (40.52s)
--- PASS: TestAccMetaRegionDataSource_basic (40.52s)
--- PASS: TestAccMetaARNDataSource_basic (40.52s)
--- PASS: TestAccMetaRegionDataSource_endpointAndName (40.52s)
--- PASS: TestAccMetaRegionsDataSource_nonExistentRegion (40.52s)
--- PASS: TestAccMetaDefaultTagsDataSource_ignore (50.85s)
--- PASS: TestAccMetaDefaultTagsDataSource_basic (12.23s)
--- PASS: TestAccMetaDefaultTagsDataSource_multiple (12.41s)
--- PASS: TestAccMetaBillingServiceAccountDataSource_basic (13.17s)
--- PASS: TestAccMetaARNDataSource_s3Bucket (13.18s)
--- PASS: TestAccMetaIPRangesDataSource_none (14.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	56.631s
```
