### PR TITLE
fix: Fix by_provider regex for aws_bedrock_foundation_models data source

### DIFF
--- a/.changelog/37306.txt
+++ b/.changelog/37306.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_bedrock_foundation_models: Fix validation regex for the `by_provider` argument
+```

--- a/internal/service/bedrock/foundation_models_data_source.go
+++ b/internal/service/bedrock/foundation_models_data_source.go
@@ -52,7 +52,7 @@ func (d *foundationModelsDataSource) Schema(ctx context.Context, request datasou
 			"by_provider": schema.StringAttribute{
 				Optional: true,
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexache.MustCompile(`^[a-z0-9-]{1,63}$`), ""),
+					stringvalidator.RegexMatches(regexache.MustCompile(`^[A-Za-z0-9- ]{1,63}$`), ""),
 				},
 			},
 			names.AttrID: framework.IDAttribute(),

--- a/internal/service/bedrock/foundation_models_data_source_test.go
+++ b/internal/service/bedrock/foundation_models_data_source_test.go
@@ -93,6 +93,27 @@ func TestAccBedrockFoundationModelsDataSource_byOutputModality(t *testing.T) {
 	})
 }
 
+func TestAccBedrockFoundationModelsDataSource_byProvider(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_bedrock_foundation_models.test"
+	provider := "Mistral AI"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFoundationModelsDataSourceConfig_byProvider(provider),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceName, "id"),
+					acctest.CheckResourceAttrGreaterThanValue(datasourceName, "model_summaries.#", 0),
+				),
+			},
+		},
+	})
+}
+
 func testAccFoundationModelsDataSourceConfig_basic() string {
 	return `
 data "aws_bedrock_foundation_models" "test" {}
@@ -121,4 +142,12 @@ data "aws_bedrock_foundation_models" "test" {
   by_output_modality = %[1]q
 }
 `, outputModality)
+}
+
+func testAccFoundationModelsDataSourceConfig_byProvider(provider string) string {
+	return fmt.Sprintf(`
+data "aws_bedrock_foundation_models" "test" {
+  by_provider = %[1]q
+}
+`, provider)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the regex for the `by_provider` argument in the `aws_bedrock_foundation_models` data source.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37305

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [ListFoundationModels](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_ListFoundationModels.html) for the correct regex.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```bash
$ make testacc TESTS=TestAccBedrockFoundationModelsDataSource_ PKG=bedrock
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/bedrock/... -v -count 1 -parallel 20 -run='TestAccBedrockFoundationModelsDataSource_'  -timeout 360m
=== RUN   TestAccBedrockFoundationModelsDataSource_basic
=== PAUSE TestAccBedrockFoundationModelsDataSource_basic
=== RUN   TestAccBedrockFoundationModelsDataSource_byCustomizationType
=== PAUSE TestAccBedrockFoundationModelsDataSource_byCustomizationType
=== RUN   TestAccBedrockFoundationModelsDataSource_byInferenceType
=== PAUSE TestAccBedrockFoundationModelsDataSource_byInferenceType
=== RUN   TestAccBedrockFoundationModelsDataSource_byOutputModality
=== PAUSE TestAccBedrockFoundationModelsDataSource_byOutputModality
=== RUN   TestAccBedrockFoundationModelsDataSource_byProvider
=== PAUSE TestAccBedrockFoundationModelsDataSource_byProvider
=== CONT  TestAccBedrockFoundationModelsDataSource_basic
=== CONT  TestAccBedrockFoundationModelsDataSource_byOutputModality
=== CONT  TestAccBedrockFoundationModelsDataSource_byProvider
=== CONT  TestAccBedrockFoundationModelsDataSource_byInferenceType
=== CONT  TestAccBedrockFoundationModelsDataSource_byCustomizationType
--- PASS: TestAccBedrockFoundationModelsDataSource_byCustomizationType (13.40s)
--- PASS: TestAccBedrockFoundationModelsDataSource_byProvider (13.40s)
--- PASS: TestAccBedrockFoundationModelsDataSource_byInferenceType (13.51s)
--- PASS: TestAccBedrockFoundationModelsDataSource_byOutputModality (13.82s)
--- PASS: TestAccBedrockFoundationModelsDataSource_basic (13.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    14.088s
```
