### PR TITLE
r/aws_imagebuilder_pipeline: add support for workflows

### DIFF
--- a/.changelog/37317.txt
+++ b/.changelog/37317.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_imagebuilder_image_pipeline: Add `execution_role` and `workflow` arguments
+```

--- a/internal/service/imagebuilder/image_pipeline.go
+++ b/internal/service/imagebuilder/image_pipeline.go
@@ -214,17 +214,17 @@ func ResourceImagePipeline() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.StringLenBetween(1, 100),
 						},
-						"parameter": {
+						names.AttrParameter: {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"name": {
+									names.AttrName: {
 										Type:         schema.TypeString,
 										Required:     true,
 										ValidateFunc: validation.StringLenBetween(1, 128),
 									},
-									"value": {
+									names.AttrValue: {
 										Type:     schema.TypeString,
 										Required: true,
 									},

--- a/internal/service/imagebuilder/image_pipeline.go
+++ b/internal/service/imagebuilder/image_pipeline.go
@@ -78,6 +78,11 @@ func ResourceImagePipeline() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"execution_role": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidARN,
+			},
 			"image_recipe_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -193,6 +198,47 @@ func ResourceImagePipeline() *schema.Resource {
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"workflow": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"on_failure": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice(imagebuilder.OnWorkflowFailure_Values(), false),
+						},
+						"parallel_group": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 100),
+						},
+						"parameter": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringLenBetween(1, 128),
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"workflow_arn": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+					},
+				},
+			},
 		},
 
 		CustomizeDiff: verify.SetTagsDiff,
@@ -221,6 +267,10 @@ func resourceImagePipelineCreate(ctx context.Context, d *schema.ResourceData, me
 		input.DistributionConfigurationArn = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("execution_role"); ok {
+		input.ExecutionRole = aws.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("image_recipe_arn"); ok {
 		input.ImageRecipeArn = aws.String(v.(string))
 	}
@@ -247,6 +297,10 @@ func resourceImagePipelineCreate(ctx context.Context, d *schema.ResourceData, me
 
 	if v, ok := d.GetOk(names.AttrStatus); ok {
 		input.Status = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("workflow"); ok && len(v.([]interface{})) > 0 {
+		input.Workflows = expandWorkflowConfigurations(v.([]interface{}))
 	}
 
 	output, err := conn.CreateImagePipelineWithContext(ctx, input)
@@ -299,6 +353,7 @@ func resourceImagePipelineRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(names.AttrDescription, imagePipeline.Description)
 	d.Set("distribution_configuration_arn", imagePipeline.DistributionConfigurationArn)
 	d.Set("enhanced_image_metadata_enabled", imagePipeline.EnhancedImageMetadataEnabled)
+	d.Set("execution_role", imagePipeline.ExecutionRole)
 	d.Set("image_recipe_arn", imagePipeline.ImageRecipeArn)
 	if imagePipeline.ImageScanningConfiguration != nil {
 		d.Set("image_scanning_configuration", []interface{}{flattenImageScanningConfiguration(imagePipeline.ImageScanningConfiguration)})
@@ -319,6 +374,7 @@ func resourceImagePipelineRead(ctx context.Context, d *schema.ResourceData, meta
 		d.Set(names.AttrSchedule, nil)
 	}
 	d.Set(names.AttrStatus, imagePipeline.Status)
+	d.Set("workflow", flattenWorkflowConfigurations(imagePipeline.Workflows))
 
 	setTagsOut(ctx, imagePipeline.Tags)
 
@@ -333,11 +389,13 @@ func resourceImagePipelineUpdate(ctx context.Context, d *schema.ResourceData, me
 		names.AttrDescription,
 		"distribution_configuration_arn",
 		"enhanced_image_metadata_enabled",
+		"execution_role",
 		"image_scanning_configuration",
 		"image_tests_configuration",
 		"infrastructure_configuration_arn",
 		names.AttrSchedule,
 		names.AttrStatus,
+		"workflow",
 	) {
 		input := &imagebuilder.UpdateImagePipelineInput{
 			ClientToken:                  aws.String(id.UniqueId()),
@@ -355,6 +413,10 @@ func resourceImagePipelineUpdate(ctx context.Context, d *schema.ResourceData, me
 
 		if v, ok := d.GetOk("distribution_configuration_arn"); ok {
 			input.DistributionConfigurationArn = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("execution_role"); ok {
+			input.ExecutionRole = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk("image_recipe_arn"); ok {
@@ -379,6 +441,10 @@ func resourceImagePipelineUpdate(ctx context.Context, d *schema.ResourceData, me
 
 		if v, ok := d.GetOk(names.AttrStatus); ok {
 			input.Status = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("workflow"); ok && len(v.([]interface{})) > 0 {
+			input.Workflows = expandWorkflowConfigurations(v.([]interface{}))
 		}
 
 		_, err := conn.UpdateImagePipelineWithContext(ctx, input)

--- a/internal/service/imagebuilder/image_pipeline_test.go
+++ b/internal/service/imagebuilder/image_pipeline_test.go
@@ -659,7 +659,7 @@ func TestAccImageBuilderImagePipeline_workflow(t *testing.T) {
 				Config: testAccImagePipelineConfig_workflow(rName, imagebuilder.OnWorkflowFailureAbort, "test1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImagePipelineExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "workflow.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workflow.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "workflow.0.on_failure", imagebuilder.OnWorkflowFailureAbort),
 					resource.TestCheckResourceAttr(resourceName, "workflow.0.parallel_group", "test1"),
 				),
@@ -673,7 +673,7 @@ func TestAccImageBuilderImagePipeline_workflow(t *testing.T) {
 				Config: testAccImagePipelineConfig_workflow(rName, imagebuilder.OnWorkflowFailureContinue, "test2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImagePipelineExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "workflow.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workflow.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "workflow.0.on_failure", imagebuilder.OnWorkflowFailureContinue),
 					resource.TestCheckResourceAttr(resourceName, "workflow.0.parallel_group", "test2"),
 				),
@@ -697,8 +697,8 @@ func TestAccImageBuilderImagePipeline_workflowParameter(t *testing.T) {
 				Config: testAccImagePipelineConfig_workflowParameter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImagePipelineExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "workflow.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "workflow.0.parameter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workflow.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "workflow.0.parameter.#", acctest.Ct1),
 				),
 			},
 			{
@@ -710,8 +710,8 @@ func TestAccImageBuilderImagePipeline_workflowParameter(t *testing.T) {
 				Config: testAccImagePipelineConfig_workflowParameter(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImagePipelineExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "workflow.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "workflow.0.parameter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workflow.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "workflow.0.parameter.#", acctest.Ct1),
 				),
 			},
 		},

--- a/website/docs/r/imagebuilder_image_pipeline.html.markdown
+++ b/website/docs/r/imagebuilder_image_pipeline.html.markdown
@@ -37,11 +37,13 @@ The following arguments are optional:
 * `description` - (Optional) Description of the image pipeline.
 * `distribution_configuration_arn` - (Optional) Amazon Resource Name (ARN) of the Image Builder Distribution Configuration.
 * `enhanced_image_metadata_enabled` - (Optional) Whether additional information about the image being created is collected. Defaults to `true`.
+* `execution_role` - (Optional) Amazon Resource Name (ARN) of the service-linked role to be used by Image Builder to [execute workflows](https://docs.aws.amazon.com/imagebuilder/latest/userguide/manage-image-workflows.html).
 * `image_recipe_arn` - (Optional) Amazon Resource Name (ARN) of the image recipe.
 * `image_scanning_configuration` - (Optional) Configuration block with image scanning configuration. Detailed below.
 * `image_tests_configuration` - (Optional) Configuration block with image tests configuration. Detailed below.
 * `schedule` - (Optional) Configuration block with schedule settings. Detailed below.
 * `status` - (Optional) Status of the image pipeline. Valid values are `DISABLED` and `ENABLED`. Defaults to `ENABLED`.
+* `workflow` - (Optional) Configuration block with the workflow configuration. Detailed below.
 * `tags` - (Optional) Key-value map of resource tags for the image pipeline. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### image_scanning_configuration
@@ -76,6 +78,25 @@ The following arguments are optional:
 * `pipeline_execution_start_condition` - (Optional) Condition when the pipeline should trigger a new image build. Valid values are `EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE` and `EXPRESSION_MATCH_ONLY`. Defaults to `EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE`.
 
 * `timezone` - (Optional) The timezone that applies to the scheduling expression. For example, "Etc/UTC", "America/Los_Angeles" in the [IANA timezone format](https://www.joda.org/joda-time/timezones.html). If not specified this defaults to UTC.
+
+### workflow
+
+The following arguments are required:
+
+* `workflow_arn` - (Required) Amazon Resource Name (ARN) of the Image Builder Workflow.
+
+The following arguments are optional:
+
+* `on_failure` - (Optional) The action to take if the workflow fails. Must be one of `CONTINUE` or `ABORT`.
+* `parallel_group` - (Optional) The parallel group in which to run a test Workflow.
+* `parameter` - (Optional) Configuration block for the workflow parameters. Detailed below.
+
+### parameter
+
+The following arguments are required:
+
+* `name` - (Required) The name of the Workflow parameter.
+* `value` - (Required) The value of the Workflow parameter.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
This PR adds support for Image Builder workflows to Image Builder pipelines. Similar to https://github.com/hashicorp/terraform-provider-aws/pull/36953.

### Relations
Closes #35045.

### References
https://aws.amazon.com/about-aws/whats-new/2023/12/ec2-image-builder-image-workflows/
https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_CreateImagePipeline.html
https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_UpdateImagePipeline.html


### Output from Acceptance Testing
```console
% make testacc TESTARGS="-run=TestAccImageBuilderImagePipeline_workflow" PKG=imagebuilder
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/imagebuilder/... -v -count 1 -parallel 20  -run=TestAccImageBuilderImagePipeline_workflow -timeout 360m
=== RUN   TestAccImageBuilderImagePipeline_workflow
=== PAUSE TestAccImageBuilderImagePipeline_workflow
=== RUN   TestAccImageBuilderImagePipeline_workflowParameter
=== PAUSE TestAccImageBuilderImagePipeline_workflowParameter
=== CONT  TestAccImageBuilderImagePipeline_workflow
=== CONT  TestAccImageBuilderImagePipeline_workflowParameter
--- PASS: TestAccImageBuilderImagePipeline_workflow (43.19s)
--- PASS: TestAccImageBuilderImagePipeline_workflowParameter (43.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       48.232s
```
