### PR TITLE
resource/aws_securitylake_subscriber_notification: Fixes

### DIFF
--- a/.changelog/37332.txt
+++ b/.changelog/37332.txt
@@ -1,0 +1,19 @@
+```release-note:enhancement
+resource/aws_securitylake_subscriber_notification: Deprecates `endpoint_id` in favor of `subscriber_endpoint`
+```
+
+```release-note:bug
+resource/aws_securitylake_subscriber_notification: Requires value for `configuration.https_notification_configuration.endpoint`
+```
+
+```release-note:enhancement
+resource/aws_securitylake_subscriber_notification: Better handles importing resource
+```
+
+```release-note:enhancement
+resource/aws_securitylake_subscriber_notification: Handles `configuration.https_notification_configuration.authorization_api_key_value` as sensitive value
+```
+
+```release-note:bug
+resource/aws_securitylake_subscriber_notification: No longer recreates resource when not needed
+```

--- a/internal/service/securitylake/exports_test.go
+++ b/internal/service/securitylake/exports_test.go
@@ -11,10 +11,10 @@ var (
 	ResourceSubscriber             = newSubscriberResource
 	ResourceSubscriberNotification = newSubscriberNotificationResource
 
-	FindAWSLogSourceBySourceName           = findAWSLogSourceBySourceName
-	FindCustomLogSourceBySourceName        = findCustomLogSourceBySourceName
-	FindDataLakeByARN                      = findDataLakeByARN
-	FindDataLakes                          = findDataLakes
-	FindSubscriberByID                     = findSubscriberByID
-	FindSubscriberNotificationByEndPointID = findSubscriberNotificationByEndPointID
+	FindAWSLogSourceBySourceName             = findAWSLogSourceBySourceName
+	FindCustomLogSourceBySourceName          = findCustomLogSourceBySourceName
+	FindDataLakeByARN                        = findDataLakeByARN
+	FindDataLakes                            = findDataLakes
+	FindSubscriberByID                       = findSubscriberByID
+	FindSubscriberNotificationBySubscriberID = findSubscriberNotificationBySubscriberID
 )

--- a/internal/service/securitylake/securitylake_test.go
+++ b/internal/service/securitylake/securitylake_test.go
@@ -61,10 +61,12 @@ func TestAccSecurityLake_serial(t *testing.T) {
 			"migrateSource":   testAccSubscriber_migrate_source,
 		},
 		"SubscriberNotification": {
-			"disappears":  testAccSubscriberNotification_disappears,
-			"https_basic": testAccSubscriberNotification_https_basic,
-			"update":      testAccSubscriberNotification_update,
-			"sqs_basic":   testAccSubscriberNotification_sqs_basic,
+			"disappears":     testAccSubscriberNotification_disappears,
+			"https_basic":    testAccSubscriberNotification_https_basic,
+			"update":         testAccSubscriberNotification_update,
+			"sqs_basic":      testAccSubscriberNotification_sqs_basic,
+			"apiKeyNameOnly": testAccSubscriberNotification_https_apiKeyNameOnly,
+			"apiKey":         testAccSubscriberNotification_https_apiKey,
 		},
 	}
 

--- a/internal/service/securitylake/securitylake_test.go
+++ b/internal/service/securitylake/securitylake_test.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/securitylake"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/securitylake/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -94,7 +94,7 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 		t.Fatalf("getting current identity: %s", err)
 	}
 
-	if aws.StringValue(organization.MasterAccountId) == aws.StringValue(callerIdentity.Account) {
+	if aws.ToString(organization.MasterAccountId) == aws.ToString(callerIdentity.Account) {
 		t.Skip("this AWS account must not be the management account of an AWS Organization")
 	}
 

--- a/internal/service/securitylake/securitylake_test.go
+++ b/internal/service/securitylake/securitylake_test.go
@@ -61,10 +61,10 @@ func TestAccSecurityLake_serial(t *testing.T) {
 			"migrateSource":   testAccSubscriber_migrate_source,
 		},
 		"SubscriberNotification": {
-			"basic":      testAccSubscriberNotification_basic,
-			"https":      testAccSubscriberNotification_https,
-			"disappears": testAccSubscriberNotification_disappears,
-			"update":     testAccSubscriberNotification_update,
+			"sqs_basic":   testAccSubscriberNotification_sqs_basic,
+			"https_basic": testAccSubscriberNotification_https_basic,
+			"disappears":  testAccSubscriberNotification_disappears,
+			"update":      testAccSubscriberNotification_update,
 		},
 	}
 

--- a/internal/service/securitylake/securitylake_test.go
+++ b/internal/service/securitylake/securitylake_test.go
@@ -61,10 +61,10 @@ func TestAccSecurityLake_serial(t *testing.T) {
 			"migrateSource":   testAccSubscriber_migrate_source,
 		},
 		"SubscriberNotification": {
-			"sqs_basic":   testAccSubscriberNotification_sqs_basic,
-			"https_basic": testAccSubscriberNotification_https_basic,
 			"disappears":  testAccSubscriberNotification_disappears,
+			"https_basic": testAccSubscriberNotification_https_basic,
 			"update":      testAccSubscriberNotification_update,
+			"sqs_basic":   testAccSubscriberNotification_sqs_basic,
 		},
 	}
 

--- a/internal/service/securitylake/subscriber_notification.go
+++ b/internal/service/securitylake/subscriber_notification.go
@@ -97,7 +97,8 @@ func (r *subscriberNotificationResource) Schema(ctx context.Context, req resourc
 										Optional: true,
 									},
 									"authorization_api_key_value": schema.StringAttribute{
-										Optional: true,
+										Optional:  true,
+										Sensitive: true,
 									},
 									"endpoint": schema.StringAttribute{
 										Required: true,
@@ -199,6 +200,12 @@ func (r *subscriberNotificationResource) Read(ctx context.Context, request resou
 	if response.Diagnostics.HasError() {
 		return
 	}
+
+	// For HTTPS Configurations, only the `endpoint` value can be read back from the Security Lake API.
+	// `authorization_api_key_name` is configured on the EventBridge API Destination created by Security Lake
+	// `authorization_api_key_value` is configured in the Secrets Manager Secret used by the EventBridge API Destination
+	// Setting `http_method` does not seem to work, and it is not a parameter when using the Console, nor does it affect the EventBridge API Destination
+	// `target_role_arn` is used in an unknown location
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }

--- a/internal/service/securitylake/subscriber_notification.go
+++ b/internal/service/securitylake/subscriber_notification.go
@@ -154,7 +154,7 @@ func (r *subscriberNotificationResource) Create(ctx context.Context, request res
 		return
 	}
 
-	output, endpointID, err := findSubscriberNotificationByEndPointID(ctx, conn, data.SubscriberID.ValueString())
+	output, endpoint, err := findSubscriberNotificationBySubscriberID(ctx, conn, data.SubscriberID.ValueString())
 	if err != nil {
 		response.Diagnostics.AddError("creating Security Lake Subscriber Notification", err.Error())
 
@@ -169,7 +169,7 @@ func (r *subscriberNotificationResource) Create(ctx context.Context, request res
 
 	// Set values for unknowns.
 	data.SubscriberID = fwflex.StringToFramework(ctx, &parts[0])
-	data.EndpointID = fwflex.StringToFramework(ctx, endpointID)
+	data.EndpointID = fwflex.StringToFramework(ctx, endpoint)
 	data.setID()
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
@@ -190,7 +190,7 @@ func (r *subscriberNotificationResource) Read(ctx context.Context, request resou
 
 	conn := r.Meta().SecurityLakeClient(ctx)
 
-	output, endpointID, err := findSubscriberNotificationByEndPointID(ctx, conn, data.SubscriberID.ValueString())
+	output, endpoint, err := findSubscriberNotificationBySubscriberID(ctx, conn, data.SubscriberID.ValueString())
 
 	if tfresource.NotFound(err) || output == nil {
 		response.State.RemoveResource(ctx)
@@ -205,7 +205,7 @@ func (r *subscriberNotificationResource) Read(ctx context.Context, request resou
 	}
 
 	data.SubscriberID = fwflex.StringToFramework(ctx, &parts[0])
-	data.EndpointID = fwflex.StringToFramework(ctx, endpointID)
+	data.EndpointID = fwflex.StringToFramework(ctx, endpoint)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -286,7 +286,7 @@ func (r *subscriberNotificationResource) ImportState(ctx context.Context, req re
 	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrID), req, resp)
 }
 
-func findSubscriberNotificationByEndPointID(ctx context.Context, conn *securitylake.Client, subscriberID string) (*string, *string, error) {
+func findSubscriberNotificationBySubscriberID(ctx context.Context, conn *securitylake.Client, subscriberID string) (*string, *string, error) {
 	var resourceID string
 	output, err := findSubscriberByID(ctx, conn, subscriberID)
 

--- a/internal/service/securitylake/subscriber_notification.go
+++ b/internal/service/securitylake/subscriber_notification.go
@@ -98,7 +98,7 @@ func (r *subscriberNotificationResource) Schema(ctx context.Context, req resourc
 										Optional: true,
 									},
 									"endpoint": schema.StringAttribute{
-										Optional: true,
+										Required: true,
 									},
 									"http_method": schema.StringAttribute{
 										CustomType: fwtypes.StringEnumType[awstypes.HttpMethod](),
@@ -106,7 +106,7 @@ func (r *subscriberNotificationResource) Schema(ctx context.Context, req resourc
 									},
 									"target_role_arn": schema.StringAttribute{
 										CustomType: fwtypes.ARNType,
-										Optional:   true,
+										Required:   true,
 									},
 								},
 							},

--- a/internal/service/securitylake/subscriber_notification.go
+++ b/internal/service/securitylake/subscriber_notification.go
@@ -55,6 +55,10 @@ func (r *subscriberNotificationResource) Schema(ctx context.Context, req resourc
 		Attributes: map[string]schema.Attribute{
 			names.AttrID: framework.IDAttribute(),
 			"endpoint_id": schema.StringAttribute{
+				Computed:           true,
+				DeprecationMessage: "Use subscriber_endpoint instead",
+			},
+			"subscriber_endpoint": schema.StringAttribute{
 				Computed: true,
 			},
 			"subscriber_id": schema.StringAttribute{
@@ -170,6 +174,7 @@ func (r *subscriberNotificationResource) Create(ctx context.Context, request res
 	// Set values for unknowns.
 	data.SubscriberID = fwflex.StringToFramework(ctx, &parts[0])
 	data.EndpointID = fwflex.StringToFramework(ctx, endpoint)
+	data.SubscriberEndpoint = fwflex.StringToFramework(ctx, endpoint)
 	data.setID()
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
@@ -206,6 +211,7 @@ func (r *subscriberNotificationResource) Read(ctx context.Context, request resou
 
 	data.SubscriberID = fwflex.StringToFramework(ctx, &parts[0])
 	data.EndpointID = fwflex.StringToFramework(ctx, endpoint)
+	data.SubscriberEndpoint = fwflex.StringToFramework(ctx, endpoint)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -352,10 +358,11 @@ func expandSQSNotificationConfigurationModel(SQSNotifications []sqsNotificationC
 }
 
 type subscriberNotificationResourceModel struct {
-	Configuration fwtypes.ListNestedObjectValueOf[subscriberNotificationResourceConfigurationModel] `tfsdk:"configuration"`
-	EndpointID    types.String                                                                      `tfsdk:"endpoint_id"`
-	ID            types.String                                                                      `tfsdk:"id"`
-	SubscriberID  types.String                                                                      `tfsdk:"subscriber_id"`
+	Configuration      fwtypes.ListNestedObjectValueOf[subscriberNotificationResourceConfigurationModel] `tfsdk:"configuration"`
+	EndpointID         types.String                                                                      `tfsdk:"endpoint_id"`
+	ID                 types.String                                                                      `tfsdk:"id"`
+	SubscriberEndpoint types.String                                                                      `tfsdk:"subscriber_endpoint"`
+	SubscriberID       types.String                                                                      `tfsdk:"subscriber_id"`
 }
 
 const (

--- a/internal/service/securitylake/subscriber_notification_test.go
+++ b/internal/service/securitylake/subscriber_notification_test.go
@@ -35,7 +35,7 @@ func testAccSubscriberNotification_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriberNotificationConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -70,7 +70,7 @@ func testAccSubscriberNotification_https(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriberNotificationConfig_https(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -107,7 +107,7 @@ func testAccSubscriberNotification_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriberNotificationConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfsecuritylake.ResourceSubscriberNotification, resourceName),
 				),
@@ -134,7 +134,7 @@ func testAccSubscriberNotification_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriberNotificationConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 				),
 			},
@@ -146,7 +146,7 @@ func testAccSubscriberNotification_update(t *testing.T) {
 			},
 			{
 				Config: testAccSubscriberNotificationConfig_https(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
@@ -163,7 +163,7 @@ func testAccSubscriberNotification_update(t *testing.T) {
 			},
 			{
 				Config: testAccSubscriberNotificationConfig_https_update(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),

--- a/internal/service/securitylake/subscriber_notification_test.go
+++ b/internal/service/securitylake/subscriber_notification_test.go
@@ -90,15 +90,17 @@ func testAccSubscriberNotification_https_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.http_method"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.https_notification_configuration.0.target_role_arn", "aws_iam_role.event_bridge", names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.sqs_notification_configuration.#", "0"),
-					resource.TestCheckResourceAttrPair(resourceName, "endpoint_id", "aws_apigatewayv2_api.test", "api_endpoint"),
+					resource.TestCheckResourceAttrPair(resourceName, "endpoint_id", resourceName, "subscriber_endpoint"),
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_endpoint", "aws_apigatewayv2_api.test", "api_endpoint"),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"configuration"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"configuration.0.https_notification_configuration.0.target_role_arn",
+				},
 			},
 		},
 	})
@@ -151,7 +153,7 @@ func testAccSubscriberNotification_update(t *testing.T) {
 				Config: testAccSubscriberNotificationConfig_sqs_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.sqs_notification_configuration.#", "1"),
@@ -176,10 +178,13 @@ func testAccSubscriberNotification_update(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"configuration"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"configuration.0.https_notification_configuration.0.http_method",
+					"configuration.0.https_notification_configuration.0.target_role_arn",
+				},
 			},
 			{
 				Config: testAccSubscriberNotificationConfig_https_update(rName),
@@ -190,15 +195,18 @@ func testAccSubscriberNotification_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.https_notification_configuration.0.endpoint", "aws_apigatewayv2_api.test", "api_endpoint"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.https_notification_configuration.0.target_role_arn", "aws_iam_role.event_bridge", names.AttrARN),
-					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.http_method", "POST"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.http_method", "PUT"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.sqs_notification_configuration.#", "0"),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"configuration"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"configuration.0.https_notification_configuration.0.http_method",
+					"configuration.0.https_notification_configuration.0.target_role_arn",
+				},
 			},
 		},
 	})
@@ -406,7 +414,7 @@ resource "aws_securitylake_subscriber_notification" "test" {
     https_notification_configuration {
       endpoint        = aws_apigatewayv2_api.test.api_endpoint
       target_role_arn = aws_iam_role.event_bridge.arn
-      http_method     = "POST"
+      http_method     = "PUT"
     }
   }
 }

--- a/internal/service/securitylake/subscriber_notification_test.go
+++ b/internal/service/securitylake/subscriber_notification_test.go
@@ -578,7 +578,7 @@ resource "aws_securitylake_subscriber_notification" "test" {
     https_notification_configuration {
       endpoint                   = aws_apigatewayv2_api.test.api_endpoint
       target_role_arn            = aws_iam_role.event_bridge.arn
-	  authorization_api_key_name = %[2]q
+      authorization_api_key_name = %[2]q
     }
   }
 }
@@ -599,8 +599,8 @@ resource "aws_securitylake_subscriber_notification" "test" {
     https_notification_configuration {
       endpoint                    = aws_apigatewayv2_api.test.api_endpoint
       target_role_arn             = aws_iam_role.event_bridge.arn
-	  authorization_api_key_name  = %[2]q
-	  authorization_api_key_value = %[3]q
+      authorization_api_key_name  = %[2]q
+      authorization_api_key_value = %[3]q
     }
   }
 }

--- a/internal/service/securitylake/subscriber_notification_test.go
+++ b/internal/service/securitylake/subscriber_notification_test.go
@@ -44,6 +44,7 @@ func testAccSubscriberNotification_sqs_basic(t *testing.T) {
 					testAccCheckSubscriberExists(ctx, subscriberResourceName, &subscriber),
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.sqs_notification_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoint_id", resourceName, "subscriber_endpoint"),
 					func(s *terraform.State) error {
@@ -84,8 +85,12 @@ func testAccSubscriberNotification_https_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name"),
+					resource.TestCheckNoResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_value"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.https_notification_configuration.0.endpoint", "aws_apigatewayv2_api.test", "api_endpoint"),
+					resource.TestCheckNoResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.http_method"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.https_notification_configuration.0.target_role_arn", "aws_iam_role.event_bridge", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.sqs_notification_configuration.#", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoint_id", "aws_apigatewayv2_api.test", "api_endpoint"),
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_endpoint", "aws_apigatewayv2_api.test", "api_endpoint"),
 				),
@@ -147,6 +152,10 @@ func testAccSubscriberNotification_update(t *testing.T) {
 				Config: testAccSubscriberNotificationConfig_sqs_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.sqs_notification_configuration.#", "1"),
 				),
 			},
 			{
@@ -164,6 +173,8 @@ func testAccSubscriberNotification_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.https_notification_configuration.0.endpoint", "aws_apigatewayv2_api.test", "api_endpoint"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.https_notification_configuration.0.target_role_arn", "aws_iam_role.event_bridge", names.AttrARN),
+					resource.TestCheckNoResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.http_method"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.sqs_notification_configuration.#", "0"),
 				),
 			},
 			{
@@ -182,6 +193,7 @@ func testAccSubscriberNotification_update(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.https_notification_configuration.0.endpoint", "aws_apigatewayv2_api.test", "api_endpoint"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.https_notification_configuration.0.target_role_arn", "aws_iam_role.event_bridge", names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.http_method", "POST"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.sqs_notification_configuration.#", "0"),
 				),
 			},
 			{

--- a/internal/service/securitylake/subscriber_notification_test.go
+++ b/internal/service/securitylake/subscriber_notification_test.go
@@ -212,6 +212,149 @@ func testAccSubscriberNotification_update(t *testing.T) {
 	})
 }
 
+func testAccSubscriberNotification_https_apiKeyNameOnly(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_securitylake_subscriber_notification.test"
+	rName := randomCustomLogSourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SecurityLake)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecurityLakeServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSubscriberNotificationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSubscriberNotificationConfig_https_apiKeyNameOnly(rName, "example-key"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSubscriberNotificationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name", "example-key"),
+					resource.TestCheckNoResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_value"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"configuration.0.https_notification_configuration.0.authorization_api_key_name",
+					"configuration.0.https_notification_configuration.0.target_role_arn",
+				},
+			},
+			{
+				Config: testAccSubscriberNotificationConfig_https_apiKeyNameOnly(rName, "example-key-updated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSubscriberNotificationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name", "example-key-updated"),
+					resource.TestCheckNoResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_value"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"configuration.0.https_notification_configuration.0.authorization_api_key_name",
+					"configuration.0.https_notification_configuration.0.target_role_arn",
+				},
+			},
+		},
+	})
+}
+
+func testAccSubscriberNotification_https_apiKey(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_securitylake_subscriber_notification.test"
+	rName := randomCustomLogSourceName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.SecurityLake)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecurityLakeServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSubscriberNotificationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSubscriberNotificationConfig_https_apiKey(rName, "example-key", "example-value"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSubscriberNotificationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name", "example-key"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_value", "example-value"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"configuration.0.https_notification_configuration.0.authorization_api_key_name",
+					"configuration.0.https_notification_configuration.0.authorization_api_key_value",
+					"configuration.0.https_notification_configuration.0.target_role_arn",
+				},
+			},
+			{
+				Config: testAccSubscriberNotificationConfig_https_apiKey(rName, "example-key", "example-value-updated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSubscriberNotificationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name", "example-key"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_value", "example-value-updated"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"configuration.0.https_notification_configuration.0.authorization_api_key_name",
+					"configuration.0.https_notification_configuration.0.authorization_api_key_value",
+					"configuration.0.https_notification_configuration.0.target_role_arn",
+				},
+			},
+			{
+				Config: testAccSubscriberNotificationConfig_https_apiKey(rName, "example-key-updated", "example-value-three"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckSubscriberNotificationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name", "example-key-updated"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_value", "example-value-three"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"configuration.0.https_notification_configuration.0.authorization_api_key_name",
+					"configuration.0.https_notification_configuration.0.authorization_api_key_value",
+					"configuration.0.https_notification_configuration.0.target_role_arn",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckSubscriberNotificationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SecurityLakeClient(ctx)
@@ -424,4 +567,47 @@ resource "aws_apigatewayv2_api" "test" {
   protocol_type = "HTTP"
 }
 `, rName))
+}
+
+func testAccSubscriberNotificationConfig_https_apiKeyNameOnly(rName, keyName string) string {
+	return acctest.ConfigCompose(
+		testAccSubscriberNotification_config(rName), fmt.Sprintf(`
+resource "aws_securitylake_subscriber_notification" "test" {
+  subscriber_id = aws_securitylake_subscriber.test.id
+  configuration {
+    https_notification_configuration {
+      endpoint                   = aws_apigatewayv2_api.test.api_endpoint
+      target_role_arn            = aws_iam_role.event_bridge.arn
+	  authorization_api_key_name = %[2]q
+    }
+  }
+}
+
+resource "aws_apigatewayv2_api" "test" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+}
+`, rName, keyName))
+}
+
+func testAccSubscriberNotificationConfig_https_apiKey(rName, keyName, keyValue string) string {
+	return acctest.ConfigCompose(
+		testAccSubscriberNotification_config(rName), fmt.Sprintf(`
+resource "aws_securitylake_subscriber_notification" "test" {
+  subscriber_id = aws_securitylake_subscriber.test.id
+  configuration {
+    https_notification_configuration {
+      endpoint                    = aws_apigatewayv2_api.test.api_endpoint
+      target_role_arn             = aws_iam_role.event_bridge.arn
+	  authorization_api_key_name  = %[2]q
+	  authorization_api_key_value = %[3]q
+    }
+  }
+}
+
+resource "aws_apigatewayv2_api" "test" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+}
+`, rName, keyName, keyValue))
 }

--- a/internal/service/securitylake/subscriber_notification_test.go
+++ b/internal/service/securitylake/subscriber_notification_test.go
@@ -192,7 +192,7 @@ func testAccCheckSubscriberNotificationDestroy(ctx context.Context) resource.Tes
 				continue
 			}
 
-			_, _, err := tfsecuritylake.FindSubscriberNotificationByEndPointID(ctx, conn, rs.Primary.Attributes["subscriber_id"])
+			_, _, err := tfsecuritylake.FindSubscriberNotificationBySubscriberID(ctx, conn, rs.Primary.Attributes["subscriber_id"])
 
 			if tfresource.NotFound(err) {
 				continue
@@ -218,7 +218,7 @@ func testAccCheckSubscriberNotificationExists(ctx context.Context, n string) res
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SecurityLakeClient(ctx)
 
-		_, _, err := tfsecuritylake.FindSubscriberNotificationByEndPointID(ctx, conn, rs.Primary.Attributes["subscriber_id"])
+		_, _, err := tfsecuritylake.FindSubscriberNotificationBySubscriberID(ctx, conn, rs.Primary.Attributes["subscriber_id"])
 
 		return err
 	}

--- a/internal/service/securitylake/subscriber_notification_test.go
+++ b/internal/service/securitylake/subscriber_notification_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func testAccSubscriberNotification_basic(t *testing.T) {
+func testAccSubscriberNotification_sqs_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_securitylake_subscriber_notification.test"
@@ -34,7 +34,7 @@ func testAccSubscriberNotification_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckSubscriberNotificationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubscriberNotificationConfig_basic(rName),
+				Config: testAccSubscriberNotificationConfig_sqs_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
@@ -52,7 +52,7 @@ func testAccSubscriberNotification_basic(t *testing.T) {
 	})
 }
 
-func testAccSubscriberNotification_https(t *testing.T) {
+func testAccSubscriberNotification_https_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	resourceName := "aws_securitylake_subscriber_notification.test"
@@ -69,7 +69,7 @@ func testAccSubscriberNotification_https(t *testing.T) {
 		CheckDestroy:             testAccCheckSubscriberNotificationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubscriberNotificationConfig_https(rName),
+				Config: testAccSubscriberNotificationConfig_https_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
@@ -106,7 +106,7 @@ func testAccSubscriberNotification_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckSubscriberNotificationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubscriberNotificationConfig_basic(rName),
+				Config: testAccSubscriberNotificationConfig_sqs_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfsecuritylake.ResourceSubscriberNotification, resourceName),
@@ -133,7 +133,7 @@ func testAccSubscriberNotification_update(t *testing.T) {
 		CheckDestroy:             testAccCheckSubscriberNotificationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubscriberNotificationConfig_basic(rName),
+				Config: testAccSubscriberNotificationConfig_sqs_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 				),
@@ -145,7 +145,7 @@ func testAccSubscriberNotification_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"configuration"},
 			},
 			{
-				Config: testAccSubscriberNotificationConfig_https(rName),
+				Config: testAccSubscriberNotificationConfig_https_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),

--- a/internal/service/securitylake/subscriber_notification_test.go
+++ b/internal/service/securitylake/subscriber_notification_test.go
@@ -215,7 +215,7 @@ func testAccCheckSubscriberNotificationDestroy(ctx context.Context) resource.Tes
 				continue
 			}
 
-			_, _, err := tfsecuritylake.FindSubscriberNotificationBySubscriberID(ctx, conn, rs.Primary.Attributes["subscriber_id"])
+			_, err := tfsecuritylake.FindSubscriberNotificationBySubscriberID(ctx, conn, rs.Primary.Attributes["subscriber_id"])
 
 			if tfresource.NotFound(err) {
 				continue
@@ -241,7 +241,7 @@ func testAccCheckSubscriberNotificationExists(ctx context.Context, n string) res
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SecurityLakeClient(ctx)
 
-		_, _, err := tfsecuritylake.FindSubscriberNotificationBySubscriberID(ctx, conn, rs.Primary.Attributes["subscriber_id"])
+		_, err := tfsecuritylake.FindSubscriberNotificationBySubscriberID(ctx, conn, rs.Primary.Attributes["subscriber_id"])
 
 		return err
 	}

--- a/internal/service/securitylake/subscriber_notification_test.go
+++ b/internal/service/securitylake/subscriber_notification_test.go
@@ -53,10 +53,9 @@ func testAccSubscriberNotification_sqs_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"configuration"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -159,10 +158,9 @@ func testAccSubscriberNotification_update(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"configuration"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccSubscriberNotificationConfig_https_basic(rName),

--- a/internal/service/securitylake/subscriber_notification_test.go
+++ b/internal/service/securitylake/subscriber_notification_test.go
@@ -232,7 +232,7 @@ func testAccSubscriberNotification_https_apiKeyNameOnly(t *testing.T) {
 				Config: testAccSubscriberNotificationConfig_https_apiKeyNameOnly(rName, "example-key"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name", "example-key"),
@@ -252,7 +252,7 @@ func testAccSubscriberNotification_https_apiKeyNameOnly(t *testing.T) {
 				Config: testAccSubscriberNotificationConfig_https_apiKeyNameOnly(rName, "example-key-updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name", "example-key-updated"),
@@ -292,7 +292,7 @@ func testAccSubscriberNotification_https_apiKey(t *testing.T) {
 				Config: testAccSubscriberNotificationConfig_https_apiKey(rName, "example-key", "example-value"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name", "example-key"),
@@ -313,7 +313,7 @@ func testAccSubscriberNotification_https_apiKey(t *testing.T) {
 				Config: testAccSubscriberNotificationConfig_https_apiKey(rName, "example-key", "example-value-updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name", "example-key"),
@@ -334,7 +334,7 @@ func testAccSubscriberNotification_https_apiKey(t *testing.T) {
 				Config: testAccSubscriberNotificationConfig_https_apiKey(rName, "example-key-updated", "example-value-three"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSubscriberNotificationExists(ctx, resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subscriber_id", "aws_securitylake_subscriber.test", names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.https_notification_configuration.0.authorization_api_key_name", "example-key-updated"),

--- a/website/docs/r/securitylake_subscriber.html.markdown
+++ b/website/docs/r/securitylake_subscriber.html.markdown
@@ -69,6 +69,7 @@ Custom Log Source Resource support the following:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the Data Lake.
+* `id` - The Subscriber ID of the subscriber.
 * `s3_bucket_arn` - The ARN for the Amazon Security Lake Amazon S3 bucket.
 * `resource_share_arn` - The Amazon Resource Name (ARN) which uniquely defines the AWS RAM resource share. Before accepting the RAM resource share invitation, you can view details related to the RAM resource share.
 * `role_arn` - The Amazon Resource Name (ARN) specifying the role of the subscriber.

--- a/website/docs/r/securitylake_subscriber_notification.html.markdown
+++ b/website/docs/r/securitylake_subscriber_notification.html.markdown
@@ -45,6 +45,7 @@ HTTPS Notification Configuration support the following:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `endpoint_id` - (**Deprecated**) The subscriber endpoint to which exception messages are posted.
 * `subscriber_endpoint` - The subscriber endpoint to which exception messages are posted.
 
 ## Timeouts

--- a/website/docs/r/securitylake_subscriber_notification.html.markdown
+++ b/website/docs/r/securitylake_subscriber_notification.html.markdown
@@ -12,11 +12,27 @@ Terraform resource for managing an AWS Security Lake Subscriber Notification.
 
 ## Example Usage
 
+### SQS Notification
+
 ```terraform
-resource "aws_securitylake_subscriber_notification" "test" {
-  subscriber_id = aws_securitylake_subscriber.test.id
+resource "aws_securitylake_subscriber_notification" "example" {
+  subscriber_id = aws_securitylake_subscriber.example.id
   configuration {
     sqs_notification_configuration {}
+  }
+}
+```
+
+### HTTPS Notification
+
+```terraform
+resource "aws_securitylake_subscriber_notification" "example" {
+  subscriber_id = aws_securitylake_subscriber.example.id
+  configuration {
+    https_notification_configuration {
+      endpoint        = aws_apigatewayv2_api.test.api_endpoint
+      target_role_arn = aws_iam_role.event_bridge.arn
+    }
   }
 }
 ```
@@ -31,15 +47,19 @@ The following arguments are required:
 Configuration support the following:
 
 * `sqs_notification_configuration` - (Optional) The configurations for SQS subscriber notification.
+  There are no parameters within `sqs_notification_configuration`.
 * `https_notification_configuration` - (Optional) The configurations for HTTPS subscriber notification.
 
 HTTPS Notification Configuration support the following:
 
-* `endpoint` - (Required) The subscription endpoint in Security Lake. If you prefer notification with an HTTPs endpoint, populate this field.
-* `target_role_arn` - (Required) The Amazon Resource Name (ARN) of the EventBridge API destinations IAM role that you created. For more information about ARNs and how to use them in policies, see Managing data access and AWS Managed Policies in the Amazon Security Lake User Guide.
-* `authorization_api_key_name` - (Optional) The key name for the notification subscription.
-* `authorization_api_key_value` - (Optional) The key value for the notification subscription.
-* `http_method` - (Optional) The HTTPS method used for the notification subscription.
+* `endpoint` - (Required) The subscription endpoint in Security Lake.
+  If you prefer notification with an HTTPS endpoint, populate this field.
+* `target_role_arn` - (Required) The Amazon Resource Name (ARN) of the EventBridge API destinations IAM role that you created.
+  For more information about ARNs and how to use them in policies, see Managing data access and AWS Managed Policies in the Amazon Security Lake User Guide.
+* `authorization_api_key_name` - (Optional) The API key name for the notification subscription.
+* `authorization_api_key_value` - (Optional) The API key value for the notification subscription.
+* `http_method` - (Optional) The HTTP method used for the notification subscription.
+  Valid values are `POST` and `PUT`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

Various fixes to `aws_securitylake_subscriber_notification`:

* Deprecates `endpoint_id` and adds `subscriber_endpoint` to match documentation and API
* Requires value for `configuration.https_notification_configuration.endpoint`
* Better handles `import` by reading available data from API
* Marks `configuration.https_notification_configuration. authorization_api_key_value` as `Sensitive`
* Allows resource to be modified in-place

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #36325

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=securitylake TESTS=TestAccSecurityLake_serial/SubscriberNotification

--- PASS: TestAccSecurityLake_serial (481.97s)
    --- PASS: TestAccSecurityLake_serial/SubscriberNotification (481.97s)
        --- PASS: TestAccSecurityLake_serial/SubscriberNotification/sqs_basic (62.10s)
        --- PASS: TestAccSecurityLake_serial/SubscriberNotification/apiKeyNameOnly (79.17s)
        --- PASS: TestAccSecurityLake_serial/SubscriberNotification/apiKey (100.66s)
        --- PASS: TestAccSecurityLake_serial/SubscriberNotification/disappears (63.29s)
        --- PASS: TestAccSecurityLake_serial/SubscriberNotification/https_basic (62.37s)
        --- PASS: TestAccSecurityLake_serial/SubscriberNotification/update (114.37s)
```
