### PR TITLE
F add resource aws redshift idc application

### DIFF
--- a/internal/service/redshift/find.go
+++ b/internal/service/redshift/find.go
@@ -444,3 +444,32 @@ func findResourcePolicyByARN(ctx context.Context, conn *redshift.Redshift, arn s
 
 	return output.ResourcePolicy, nil
 }
+
+func FindIdcApplicationByArn(ctx context.Context, conn *redshift.Redshift, arn string) (*redshift.RedshiftIdcApplication, error) {
+	input := &redshift.DescribeRedshiftIdcApplicationsInput{
+		RedshiftIdcApplicationArn: aws.String(arn),
+	}
+
+	output, err := conn.DescribeRedshiftIdcApplicationsWithContext(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, redshift.ErrCodeRedshiftIdcApplicationNotExistsFault) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.RedshiftIdcApplications) == 0 || output.RedshiftIdcApplications[0] == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	if count := len(output.RedshiftIdcApplications); count > 1 {
+		return nil, tfresource.NewTooManyResultsError(count, input)
+	}
+
+	return output.RedshiftIdcApplications[0], nil
+}

--- a/internal/service/redshift/idc_application.go
+++ b/internal/service/redshift/idc_application.go
@@ -1,0 +1,428 @@
+package redshift
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_redshift_idc_application", name="IDC Application")
+// @Tags(identifierAttribute="arn")
+func ResourceIdcApplication() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceIdcApplicationCreate,
+		ReadWithoutTimeout:   resourceIdcApplicationRead,
+		UpdateWithoutTimeout: resourceIdcApplicationUpdate,
+		DeleteWithoutTimeout: resourceIdcApplicationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(75 * time.Minute),
+			Update: schema.DefaultTimeout(75 * time.Minute),
+			Delete: schema.DefaultTimeout(40 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"authorized_token_issuer_list": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"authorized_audiences_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"trusted_token_issuer_arn": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: verify.ValidARN,
+						},
+					},
+				},
+			},
+			"iam_role_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"idc_display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 127),
+				),
+			},
+			"idc_instance_arn": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidARN,
+			},
+			"identity_namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 127),
+				),
+			},
+			"redshift_idc_application_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 63),
+				),
+			},
+			"service_integrations": {
+				Optional: true,
+				Type:     schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"lake_formation": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"lake_formation_query": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Set: serviceIntegrationsHash,
+			},
+
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+		},
+
+		CustomizeDiff: verify.SetTagsDiff,
+	}
+}
+
+func resourceIdcApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RedshiftConn(ctx)
+
+	input := &redshift.CreateRedshiftIdcApplicationInput{
+		RedshiftIdcApplicationName: aws.String(d.Get("redshift_idc_application_name").(string)),
+		IamRoleArn:                 aws.String(d.Get("iam_role_arn").(string)),
+		IdcInstanceArn:             aws.String(d.Get("idc_instance_arn").(string)),
+		IdcDisplayName:             aws.String(d.Get("idc_display_name").(string)),
+	}
+
+	if v, ok := d.GetOk("authorized_token_issuer_list"); ok {
+		input.AuthorizedTokenIssuerList = expandAuthorizedTokenIssuerList(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("service_integrations"); ok {
+		input.ServiceIntegrations = expandServiceIntegrations(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("identity_namespace"); ok {
+		input.IdentityNamespace = aws.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] creating Redshift IDC Application: %s", input)
+	output, err := conn.CreateRedshiftIdcApplication(input)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Redshift IDC Application (%s): %s", "", err)
+	}
+	d.SetId(aws.StringValue(output.RedshiftIdcApplication.RedshiftIdcApplicationArn))
+
+	return append(diags, resourceIdcApplicationRead(ctx, d, meta)...)
+}
+
+func resourceIdcApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RedshiftConn(ctx)
+
+	rsIdc, err := FindIdcApplicationByArn(ctx, conn, d.Id())
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Redshift IDC Application (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Redshift IDC Application (%s): %s", d.Id(), err)
+	}
+	d.Set("authorized_token_issuer_list", flattenAuthorizedTokenIssuerList(rsIdc.AuthorizedTokenIssuerList))
+	d.Set("iam_role_arn", rsIdc.IamRoleArn)
+	d.Set("idc_display_name", rsIdc.IdcDisplayName)
+	d.Set("idc_instance_arn", rsIdc.IdcInstanceArn)
+	d.Set("identity_namespace", rsIdc.IdentityNamespace)
+	d.Set("redshift_idc_application_name", rsIdc.RedshiftIdcApplicationName)
+	d.Set("service_integrations", flatternServiceIntegrations(rsIdc.ServiceIntegrations))
+
+	d.Set("arn", rsIdc.RedshiftIdcApplicationArn)
+
+	return diags
+}
+
+func resourceIdcApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RedshiftConn(ctx)
+
+	input := &redshift.ModifyRedshiftIdcApplicationInput{
+		RedshiftIdcApplicationArn: aws.String(d.Id()),
+	}
+
+	if d.HasChange("authorized_token_issuer_list") {
+		input.AuthorizedTokenIssuerList = expandAuthorizedTokenIssuerList(d.Get("authorized_token_issuer_list").(*schema.Set).List())
+	}
+
+	if d.HasChange("iam_role_arn") {
+		input.IamRoleArn = aws.String(d.Get("iam_role_arn").(string))
+	}
+
+	if d.HasChange("idc_display_name") {
+		input.IdcDisplayName = aws.String(d.Get("idc_display_name").(string))
+	}
+
+	if d.HasChange("identity_namespace") {
+		input.IdentityNamespace = aws.String(d.Get("identity_namespace").(string))
+	}
+
+	if d.HasChange("service_integrations") {
+		input.ServiceIntegrations = expandServiceIntegrations(d.Get("service_integrations").(*schema.Set).List())
+	}
+
+	_, err := conn.ModifyRedshiftIdcApplicationWithContext(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating Redshift IDC Application (%s): %s", d.Id(), err)
+	}
+
+	return append(diags, resourceIdcApplicationRead(ctx, d, meta)...)
+}
+
+func resourceIdcApplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RedshiftConn(ctx)
+
+	log.Printf("[DEBUG] deleting Redshift IDC Application: %s", d.Id())
+	_, err := conn.DeleteRedshiftIdcApplicationWithContext(ctx, &redshift.DeleteRedshiftIdcApplicationInput{
+		RedshiftIdcApplicationArn: aws.String(d.Id()),
+	})
+
+	if tfawserr.ErrCodeEquals(err, redshift.ErrCodeRedshiftIdcApplicationNotExistsFault) {
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting Redshift IDC Application (%s): %s", d.Id(), err)
+	}
+
+	return diags
+}
+
+func expandAuthorizedTokenIssuerList(vAuthorizedTokenIssuerList []interface{}) []*redshift.AuthorizedTokenIssuer {
+	if len(vAuthorizedTokenIssuerList) == 0 || vAuthorizedTokenIssuerList[0] == nil {
+		return nil
+	}
+
+	authorizedTokenIssuerList := []*redshift.AuthorizedTokenIssuer{}
+
+	for _, v := range vAuthorizedTokenIssuerList {
+		authorizedTokenIssuer := &redshift.AuthorizedTokenIssuer{}
+		m := v.(map[string]interface{})
+		if v, ok := m["authorized_audiences_list"].([]interface{}); ok && len(v) > 0 && v[0] != "" {
+			authorizedTokenIssuer.AuthorizedAudiencesList = expandAuthorizedAudiences(v)
+		}
+		if vTrustedTokenIssuerArn, ok := m["trusted_token_issuer_arn"].(string); ok && vTrustedTokenIssuerArn != "" {
+			authorizedTokenIssuer.TrustedTokenIssuerArn = aws.String(vTrustedTokenIssuerArn)
+		}
+		authorizedTokenIssuerList = append(authorizedTokenIssuerList, authorizedTokenIssuer)
+	}
+	return authorizedTokenIssuerList
+}
+
+func expandAuthorizedAudiences(v []interface{}) []*string {
+	var authorizedAudiencesList []*string
+	for _, v := range v {
+		authorizedAudiencesList = append(authorizedAudiencesList, aws.String(v.(string)))
+	}
+	return authorizedAudiencesList
+}
+
+func flattenAuthorizedTokenIssuerList(v []*redshift.AuthorizedTokenIssuer) *schema.Set {
+	s := &schema.Set{F: authorizedTokenIssuerListHash}
+	if len(v) == 0 {
+		return nil
+	}
+
+	for _, v := range v {
+		var authorizedToeknIsuser interface{}
+		authorizedAudiences := flatternAuthorizedAudiences(v.AuthorizedAudiencesList)
+		authorizedToeknIsuser = map[string]interface{}{
+			"authorized_audiences_list": authorizedAudiences,
+			"trusted_token_issuer_arn":  aws.StringValue(v.TrustedTokenIssuerArn),
+		}
+
+		s.Add(authorizedToeknIsuser)
+	}
+
+	return s
+}
+
+func expandServiceIntegrations(v []interface{}) []*redshift.ServiceIntegrationsUnion {
+	if len(v) == 0 || v[0] == nil {
+		return nil
+	}
+
+	serviceIntegrations := []*redshift.ServiceIntegrationsUnion{}
+
+	for _, v := range v {
+		serviceIntegration := &redshift.ServiceIntegrationsUnion{}
+		m := v.(map[string]interface{})
+		if v, ok := m["lake_formation"].(*schema.Set); ok && v.Len() > 0 {
+			serviceIntegration.LakeFormation = expandLakeFormation(v.List())
+		}
+		serviceIntegrations = append(serviceIntegrations, serviceIntegration)
+	}
+	return serviceIntegrations
+}
+
+func expandLakeFormation(v []interface{}) []*redshift.LakeFormationScopeUnion {
+	if len(v) == 0 || v[0] == nil {
+		return nil
+	}
+
+	lakeFormation := []*redshift.LakeFormationScopeUnion{}
+	for _, v := range v {
+		lakeFormationScopeUnion := expandLakeFormationScopeUnion(v.(map[string]interface{}))
+		lakeFormation = append(lakeFormation, lakeFormationScopeUnion)
+	}
+	return lakeFormation
+}
+
+func expandLakeFormationScopeUnion(v map[string]interface{}) *redshift.LakeFormationScopeUnion {
+	lakeFormationScopeUnion := &redshift.LakeFormationScopeUnion{}
+	if v, ok := v["lake_formation_query"].(map[string]interface{}); ok {
+		lakeFormationScopeUnion.LakeFormationQuery = expandLakeFormationQuery(v)
+	}
+	return lakeFormationScopeUnion
+}
+
+func expandLakeFormationQuery(v map[string]interface{}) *redshift.LakeFormationQuery {
+	lakeFormationQuery := &redshift.LakeFormationQuery{}
+	if v, ok := v["authorization"].(string); ok && v != "" {
+		lakeFormationQuery.Authorization = aws.String(v)
+	}
+	return lakeFormationQuery
+}
+
+func flatternAuthorizedAudiences(v []*string) []interface{} {
+	var authorizedAudiencesList []interface{}
+	for _, v := range v {
+		authorizedAudiencesList = append(authorizedAudiencesList, v)
+	}
+	return authorizedAudiencesList
+}
+
+func flatternServiceIntegrations(v []*redshift.ServiceIntegrationsUnion) *schema.Set {
+	serviceIntegrations := []interface{}{}
+	if len(v) == 0 {
+		return nil
+	}
+
+	for _, v := range v {
+		serviceIntegrationsUnion := flatternServiceIntegrationsUnion(v)
+		serviceIntegrations = append(serviceIntegrations, serviceIntegrationsUnion)
+	}
+	return schema.NewSet(serviceIntegrationsHash, serviceIntegrations)
+}
+
+func flatternServiceIntegrationsUnion(v *redshift.ServiceIntegrationsUnion) map[string]interface{} {
+	mServiceIntegrationsUnion := make(map[string]interface{})
+	if lakeFormation := v.LakeFormation; lakeFormation != nil {
+		mServiceIntegrationsUnion["lake_formation"] = flatternLakeFormation(v.LakeFormation)
+	}
+	return mServiceIntegrationsUnion
+}
+
+func flatternLakeFormation(v []*redshift.LakeFormationScopeUnion) []interface{} {
+	lakeFormation := []interface{}{}
+	if len(v) == 0 {
+		return nil
+	}
+	for _, v := range v {
+		lakeFormationScopeUnion := flatternLakeFormationScopeUnion(v)
+		lakeFormation = append(lakeFormation, lakeFormationScopeUnion)
+	}
+
+	return lakeFormation
+}
+
+func flatternLakeFormationScopeUnion(v *redshift.LakeFormationScopeUnion) map[string]interface{} {
+	mLakeFormationScopeUnion := make(map[string]interface{})
+	if lakeFormationQuery := v.LakeFormationQuery; lakeFormationQuery != nil {
+		mLakeFormationScopeUnion["lake_formation_query"] = flatternLakeFormationQuery(v.LakeFormationQuery)
+	}
+	return mLakeFormationScopeUnion
+}
+
+func flatternLakeFormationQuery(v *redshift.LakeFormationQuery) map[string]interface{} {
+	lakeFormationQuery := make(map[string]interface{})
+	lakeFormationQuery["authorization"] = aws.StringValue(v.Authorization)
+
+	return lakeFormationQuery
+}
+
+func authorizedTokenIssuerListHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["authorized_audiences_list"].([]interface{})))
+	buf.WriteString(fmt.Sprintf("%s-", m["trusted_token_issuer_arn"].(string)))
+
+	return create.StringHashcode(buf.String())
+}
+
+func serviceIntegrationsHash(vServiceIntegrations interface{}) int {
+	var buf bytes.Buffer
+
+	if vLakeformation, ok := vServiceIntegrations.(map[string]interface{})["lake_formation"].([]map[string]interface{}); ok && len(vLakeformation) > 0 && vLakeformation[0] != nil {
+		for _, v := range vLakeformation {
+			if vLakeFormationQuery, ok := v["lake_formation_query"].(map[string]interface{}); ok && len(vLakeFormationQuery) > 0 {
+				if v, ok := vLakeFormationQuery["authorization"].(string); ok && v != "" {
+					buf.WriteString(fmt.Sprintf("%s-", v))
+				}
+			}
+		}
+	}
+
+	return create.StringHashcode(buf.String())
+}

--- a/internal/service/redshift/idc_application.go
+++ b/internal/service/redshift/idc_application.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
@@ -74,6 +75,7 @@ func ResourceIdcApplication() *schema.Resource {
 				Required: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 127),
+					validation.StringMatch(regexache.MustCompile(`[\w+=,.@-]+`), "must match [\\w+=,.@-]"),
 				),
 			},
 			"idc_instance_arn": {
@@ -88,6 +90,7 @@ func ResourceIdcApplication() *schema.Resource {
 				Computed: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 127),
+					validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9_+.#@$-]+$`), "must match ^[a-zA-Z0-9_+.#@$-]+$"),
 				),
 			},
 			"redshift_idc_application_name": {
@@ -96,6 +99,7 @@ func ResourceIdcApplication() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 63),
+					validation.StringMatch(regexache.MustCompile(`[a-z][a-z0-9]*(-[a-z0-9]+)*`), "must match [a-z][a-z0-9]*(-[a-z0-9]+)"),
 				),
 			},
 			"service_integrations": {

--- a/internal/service/redshift/idc_application_test.go
+++ b/internal/service/redshift/idc_application_test.go
@@ -1,0 +1,287 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package redshift_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfredshift "github.com/hashicorp/terraform-provider-aws/internal/service/redshift"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRedshiftIdcApplication_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_redshift_idc_application.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIdcApplicationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdcApplicationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdcApplicationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "iam_role_arn", "aws_iam_role.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "idc_display_name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "idc_instance_arn", "data.aws_ssoadmin_instances.test", "arns.0"),
+					resource.TestCheckResourceAttr(resourceName, "redshift_idc_application_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "identity_namespace", rName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccRedshiftIdcApplication_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_redshift_idc_application.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIdcApplicationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdcApplicationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdcApplicationExists(ctx, resourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfredshift.ResourceIdcApplication(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccRedshiftIdcApplication_authorizedTokenIssuerList(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_redshift_idc_application.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIdcApplicationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdcApplicationConfig_authorizedTokenIssuerList(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdcApplicationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "redshift_idc_application_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "authorized_token_issuer_list.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "authorized_token_issuer_list.0.trusted_token_issuer_arn", "aws_ssoadmin_trusted_token_issuer.test", "arn"),
+					resource.TestCheckResourceAttr(resourceName, "authorized_token_issuer_list.0.authorized_audiences_list.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "authorized_token_issuer_list.0.authorized_audiences_list.0", "client_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccRedshiftIdcApplication_serviceIntegrations(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_redshift_idc_application.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIdcApplicationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdcApplicationConfig_serviceIntegrations(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdcApplicationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "redshift_idc_application_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "service_integrations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "service_integrations.0.lake_formation.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "service_integrations.0.lake_formation.0.lake_formation_query.authorization", "Enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIdcApplicationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_redshift_idc_application" {
+				continue
+			}
+			_, err := tfredshift.FindIdcApplicationByArn(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Redshift IDC Application %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIdcApplicationExists(ctx context.Context, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Redshift IDC Application is not set")
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).RedshiftConn(ctx)
+
+		_, err := tfredshift.FindIdcApplicationByArn(ctx, conn, rs.Primary.ID)
+
+		return err
+	}
+}
+func testAccIdcApplicationConfig_baseIAMRole(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  path = "/service-role/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": [
+                    "redshift-serverless.amazonaws.com",
+                    "redshift.amazonaws.com"
+                ]
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role_policy_attachment" "test1" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSSSOMemberAccountAdministrator"
+}
+
+resource "aws_iam_role_policy_attachment" "test2" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonRedshiftFullAccess"
+}
+
+`, rName)
+}
+
+func testAccIdcApplicationConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccIdcApplicationConfig_baseIAMRole(rName), fmt.Sprintf(`
+
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_redshift_idc_application" "test" {
+  iam_role_arn = aws_iam_role.test.arn
+  idc_display_name = %[1]q
+  idc_instance_arn  = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  identity_namespace = %[1]q
+  redshift_idc_application_name = %[1]q
+}
+`, rName))
+}
+
+func testAccIdcApplicationConfig_authorizedTokenIssuerList(rName string) string {
+	return acctest.ConfigCompose(testAccIdcApplicationConfig_baseIAMRole(rName), fmt.Sprintf(`
+resource "aws_ssoadmin_trusted_token_issuer" "test" {
+  name                      = %[1]q
+  instance_arn              = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  trusted_token_issuer_type = "OIDC_JWT"
+
+  trusted_token_issuer_configuration {
+    oidc_jwt_configuration {
+      claim_attribute_path          = "email"
+      identity_store_attribute_path = "emails.value"
+      issuer_url                    = "https://example.com"
+      jwks_retrieval_option         = "OPEN_ID_DISCOVERY"
+    }
+  }
+}
+
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_redshift_idc_application" "test" {
+  authorized_token_issuer_list {
+	authorized_audiences_list = ["client_id"]
+	trusted_token_issuer_arn = aws_ssoadmin_trusted_token_issuer.test.arn
+  }
+  iam_role_arn = aws_iam_role.test.arn
+  idc_display_name = %[1]q
+  idc_instance_arn  = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+  redshift_idc_application_name = %[1]q
+}
+
+`, rName))
+}
+
+func testAccIdcApplicationConfig_serviceIntegrations(rName string) string {
+	return acctest.ConfigCompose(testAccIdcApplicationConfig_baseIAMRole(rName), fmt.Sprintf(`
+
+data "aws_ssoadmin_instances" "test" {}
+
+resource "aws_redshift_idc_application" "test" {
+	iam_role_arn = aws_iam_role.test.arn
+	idc_display_name = %[1]q
+	idc_instance_arn  = tolist(data.aws_ssoadmin_instances.test.arns)[0]
+	redshift_idc_application_name = %[1]q
+	  service_integrations {
+		lake_formation {
+			lake_formation_query = {
+				authorization = "Enabled"
+			}
+		}
+	}
+}
+
+`, rName))
+}

--- a/internal/service/redshift/service_package_gen.go
+++ b/internal/service/redshift/service_package_gen.go
@@ -146,7 +146,15 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  resourceParameterGroup,
+			Factory:  ResourceIdcApplication,
+			TypeName: "aws_redshift_idc_application",
+			Name:     "IDC Application",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: "arn",
+			},
+		},
+		{
+			Factory:  ResourceParameterGroup,
 			TypeName: "aws_redshift_parameter_group",
 			Name:     "Parameter Group",
 			Tags: &types.ServicePackageResourceTags{

--- a/website/docs/r/redshift_idc_application.html.markdown
+++ b/website/docs/r/redshift_idc_application.html.markdown
@@ -1,0 +1,79 @@
+---
+subcategory: "Redshift"
+layout: "aws"
+page_title: "AWS: aws_redshift_idc_application"
+description: |-
+  Provides a Redshift IDC Application resource.
+---
+
+# Resource: aws_redshift_idc_application
+
+Creates a new Amazon Redshift IDC application.
+
+## Example Usage
+
+```terraform
+resource "aws_redshift_idc_application" "example" {
+  iam_role_arn = aws_iam_role.example.arn
+  idc_display_name = "example
+  idc_instance_arn  = tolist(data.aws_ssoadmin_instances.example.arns)[0]
+  identity_namespace = "example"
+  redshift_idc_application_name = "example"
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `authorized_token_issuer_list` - (Optional) The token issuer list for the Amazon Redshift IAM Identity Center application instance. Documented below.
+* `iam_role_arn` - (Required) The IAM role ARN for the Amazon Redshift IAM Identity Center application instance.
+* `idc_display_name` - (Required) The display name for the Amazon Redshift IAM Identity Center application instance.
+* `idc_instance_arn` - (Required) The Amazon resource name (ARN) of the IAM Identity Center instance where Amazon Redshift creates a new managed application.
+* `identity_namespace` - (Optional) The namespace for the Amazon Redshift IAM Identity Center application instance.
+* `redshift_idc_application_name` - (Required) The name of the Redshift application in IAM Identity Center.
+* `service_integrations` - (Optional) A collection of service integrations for the Redshift IAM Identity Center application. Documented below.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - The ARN for the Redshift application that integrates with IAM Identity Center.
+* `authorized_token_issuer_list` - The authorized token issuer list for the Amazon Redshift IAM Identity Center application.
+* `iam_role_arn` - The ARN for the Amazon Redshift IAM Identity Center application.
+* `idc_display_name` - The display name for the Amazon Redshift IAM Identity Center application.
+* `identity_namespace` - The identity namespace for the Amazon Redshift IAM Identity Center application.
+* `redshift_idc_application_name` - The name of the Redshift application in IAM Identity Center.
+* `service_integrations` - A list of service integrations for the Redshift IAM Identity Center application.
+
+### AuthorizedTokenIssuerList
+
+* `authorized_audiences_list` - One or more network interfaces of the endpoint. Also known as an interface endpoint. See details below.
+* `trusted_token_issuer_arn` - The connection endpoint ID for connecting an Amazon Redshift cluster through the proxy.
+
+### ServiceIntegrations
+* `lake_formation` - (Optional) A list of scopes set up for Lake Formation integration.
+
+### LakeFormation
+* `lake_formation_query` - (Optional) The Lake Formation scope.
+
+### LakeFormationQuery
+* `authorization` - (Required) Determines whether the query scope is enabled or disabled.
+
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Redshift IDC Application using the `arn`. For example:
+
+```terraform
+import {
+  to = aws_redshift_idc_application.example
+  id = "example"
+}
+```
+
+Using `terraform import`, import Redshift endpoint access using the `arn`. For example:
+
+```console
+% terraform import aws_redshift_idc_application.example example
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Add `redshift_idc_application resource. `


<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #35829

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_CreateRedshiftIdcApplication.html
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_DescribeRedshiftIdcApplications.html
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_ModifyRedshiftIdcApplication.html
- https://docs.aws.amazon.com/redshift/latest/APIReference/API_DeleteRedshiftIdcApplication.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
# make testacc TESTS=TestAccRedshiftIdcApplication PKG=redshift
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/redshift/... -v -count 1 -parallel 20 -run='TestAccRedshiftIdcApplication'  -timeout 360m
=== RUN   TestAccRedshiftIdcApplication_basic
=== PAUSE TestAccRedshiftIdcApplication_basic
=== RUN   TestAccRedshiftIdcApplication_disappears
=== PAUSE TestAccRedshiftIdcApplication_disappears
=== RUN   TestAccRedshiftIdcApplication_authorizedTokenIssuerList
=== PAUSE TestAccRedshiftIdcApplication_authorizedTokenIssuerList
=== RUN   TestAccRedshiftIdcApplication_serviceIntegrations
=== PAUSE TestAccRedshiftIdcApplication_serviceIntegrations
=== CONT  TestAccRedshiftIdcApplication_basic
=== CONT  TestAccRedshiftIdcApplication_authorizedTokenIssuerList
=== CONT  TestAccRedshiftIdcApplication_disappears
=== CONT  TestAccRedshiftIdcApplication_serviceIntegrations
--- PASS: TestAccRedshiftIdcApplication_disappears (32.01s)
--- PASS: TestAccRedshiftIdcApplication_basic (33.63s)
--- PASS: TestAccRedshiftIdcApplication_serviceIntegrations (33.80s)
--- PASS: TestAccRedshiftIdcApplication_authorizedTokenIssuerList (33.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	34.108s
```
