### PR TITLE
Added `nil` check for `notification_property` on the `glue_job` resource

### DIFF
--- a/.changelog/37347.txt
+++ b/.changelog/37347.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_job: Fix `interface conversion: interface {} is nil, not map[string]interface {}` panic when `notify_delay_after` is empty (`null`)
+```

--- a/internal/service/glue/job.go
+++ b/internal/service/glue/job.go
@@ -235,8 +235,8 @@ func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		input.NonOverridableArguments = flex.ExpandStringMap(v.(map[string]interface{}))
 	}
 
-	if v, ok := d.GetOk("notification_property"); ok {
-		input.NotificationProperty = expandNotificationProperty(v.([]interface{}))
+	if v, ok := d.GetOk("notification_property"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.NotificationProperty = expandNotificationProperty(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("number_of_workers"); ok {
@@ -363,8 +363,8 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 			jobUpdate.NonOverridableArguments = flex.ExpandStringMap(kv.(map[string]interface{}))
 		}
 
-		if v, ok := d.GetOk("notification_property"); ok {
-			jobUpdate.NotificationProperty = expandNotificationProperty(v.([]interface{}))
+		if v, ok := d.GetOk("notification_property"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			jobUpdate.NotificationProperty = expandNotificationProperty(v.([]interface{})[0].(map[string]interface{}))
 		}
 
 		if v, ok := d.GetOk("number_of_workers"); ok {
@@ -451,11 +451,15 @@ func expandJobCommand(l []interface{}) *glue.JobCommand {
 	return jobCommand
 }
 
-func expandNotificationProperty(l []interface{}) *glue.NotificationProperty {
-	m := l[0].(map[string]interface{})
+func expandNotificationProperty(tfMap map[string]interface{}) *glue.NotificationProperty {
+	if tfMap == nil {
+		return nil
+	}
 
-	notificationProperty := &glue.NotificationProperty{
-		NotifyDelayAfter: aws.Int64(int64(m["notify_delay_after"].(int))),
+	notificationProperty := &glue.NotificationProperty{}
+
+	if v, ok := tfMap["notify_delay_after"].(int); ok && v != 0 {
+		notificationProperty.NotifyDelayAfter = aws.Int64(int64(v))
 	}
 
 	return notificationProperty


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Added a check for nil values.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/37325

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
➜  terraform-provider-aws git:(main) make testacc TESTARGS='-run=TestAccGlueJob_notificationProperty' PKG=glue
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/glue/... -v -count 1 -parallel 20  -run=TestAccGlueJob_notificationProperty -timeout 360m
=== RUN   TestAccGlueJob_notificationProperty
=== PAUSE TestAccGlueJob_notificationProperty
=== CONT  TestAccGlueJob_notificationProperty
--- PASS: TestAccGlueJob_notificationProperty (59.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       64.144s
```
