### PR TITLE
r/aws_bedrockagent_agent(test): fix test configuration

### DIFF
--- a/internal/service/bedrockagent/agent_action_group_test.go
+++ b/internal/service/bedrockagent/agent_action_group_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccBedrockAgentActionGroup_basic(t *testing.T) {
+func TestAccBedrockAgentAgentActionGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent_action_group.test"
@@ -48,7 +48,7 @@ func TestAccBedrockAgentActionGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgentActionGroup_s3APISchema(t *testing.T) {
+func TestAccBedrockAgentAgentActionGroup_s3APISchema(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent_action_group.test"
@@ -77,7 +77,7 @@ func TestAccBedrockAgentActionGroup_s3APISchema(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgentActionGroup_update(t *testing.T) {
+func TestAccBedrockAgentAgentActionGroup_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent_action_group.test"

--- a/internal/service/bedrockagent/agent_alias_test.go
+++ b/internal/service/bedrockagent/agent_alias_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccBedrockAgentAlias_basic(t *testing.T) {
+func TestAccBedrockAgentAgentAlias_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent_alias.test"
@@ -53,7 +53,7 @@ func TestAccBedrockAgentAlias_basic(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgentAlias_disappears(t *testing.T) {
+func TestAccBedrockAgentAgentAlias_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent_alias.test"
@@ -77,7 +77,7 @@ func TestAccBedrockAgentAlias_disappears(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgentAlias_update(t *testing.T) {
+func TestAccBedrockAgentAgentAlias_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	descriptionOld := "Agent Alias Before Update"
@@ -128,7 +128,7 @@ func TestAccBedrockAgentAlias_update(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgentAlias_routingUpdate(t *testing.T) {
+func TestAccBedrockAgentAgentAlias_routingUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent_alias.test"
@@ -178,7 +178,7 @@ func TestAccBedrockAgentAlias_routingUpdate(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgentAlias_tags(t *testing.T) {
+func TestAccBedrockAgentAgentAlias_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent_alias.test"

--- a/internal/service/bedrockagent/agent_test.go
+++ b/internal/service/bedrockagent/agent_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccBedrockAgent_basic(t *testing.T) {
+func TestAccBedrockAgentAgent_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent.test"
@@ -49,7 +49,7 @@ func TestAccBedrockAgent_basic(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgent_full(t *testing.T) {
+func TestAccBedrockAgentAgent_full(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent.test"
@@ -79,7 +79,7 @@ func TestAccBedrockAgent_full(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgent_update(t *testing.T) {
+func TestAccBedrockAgentAgent_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent.test"
@@ -127,7 +127,7 @@ func TestAccBedrockAgent_update(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgent_tags(t *testing.T) {
+func TestAccBedrockAgentAgent_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent.test"
@@ -258,8 +258,8 @@ data "aws_iam_policy_document" "test_agent_permissions" {
 }
 
 resource "aws_iam_role_policy" "test_agent" {
+  role   = aws_iam_role.test_agent.id
   policy = data.aws_iam_policy_document.test_agent_permissions.json
-  role   = aws_iam_role.test.id
 }
 
 resource "aws_iam_role_policy_attachment" "test_agent_s3" {


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes a broken IAM role reference in the base configuration shared by all acceptance tests.

Also aligns acceptance test names with the corresponding resources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #36851



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagent TESTS=TestAccBedrockAgentAgent_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentAgent_'  -timeout 360m

--- PASS: TestAccBedrockAgentAgent_full (19.72s)
--- PASS: TestAccBedrockAgentAgent_basic (23.29s)
--- PASS: TestAccBedrockAgentAgent_tags (35.97s)
--- PASS: TestAccBedrockAgentAgent_update (39.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       44.344s
```


```console
% make testacc PKG=bedrockagent TESTS=TestAccBedrockAgentAgentAlias_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentAgentAlias_'  -timeout 360m

--- PASS: TestAccBedrockAgentAgentAlias_disappears (26.80s)
--- PASS: TestAccBedrockAgentAgentAlias_basic (31.81s)
--- PASS: TestAccBedrockAgentAgentAlias_update (37.83s)
--- PASS: TestAccBedrockAgentAgentAlias_routingUpdate (45.00s)
--- PASS: TestAccBedrockAgentAgentAlias_tags (49.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       54.096s
```

```console
% make testacc PKG=bedrockagent TESTS=TestAccBedrockAgentAgentActionGroup_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentAgentActionGroup_'  -timeout 360m

--- PASS: TestAccBedrockAgentAgentActionGroup_s3APISchema (30.45s)
--- PASS: TestAccBedrockAgentAgentActionGroup_basic (41.60s)
--- PASS: TestAccBedrockAgentAgentActionGroup_update (48.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       53.900s
```