### PR TITLE
r/aws_opensearch_domain: handle unset auto_tune_options.rollback_on_disable

### DIFF
--- a/.changelog/37394.txt
+++ b/.changelog/37394.txt
@@ -1,0 +1,9 @@
+```release-note:bug
+resource/aws_opensearch_domain: Wait for `auto_tune_options` to be applied during creation
+```
+```release-note:bug
+resource/aws_opensearch_domain: Fix handling of unset `auto_tune_options.rollback_on_disable` argument
+```
+```release-note:bug
+resource/aws_elasticsearch_domain: Fix handling of unset `auto_tune_options.rollback_on_disable` argument
+```

--- a/internal/service/elasticsearch/domain_structure.go
+++ b/internal/service/elasticsearch/domain_structure.go
@@ -62,7 +62,9 @@ func expandAutoTuneOptions(tfMap map[string]interface{}) *elasticsearch.AutoTune
 	options.DesiredState = autoTuneOptionsInput.DesiredState
 	options.MaintenanceSchedules = autoTuneOptionsInput.MaintenanceSchedules
 
-	options.RollbackOnDisable = aws.String(tfMap["rollback_on_disable"].(string))
+	if v, ok := tfMap["rollback_on_disable"].(string); ok && v != "" {
+		options.RollbackOnDisable = aws.String(v)
+	}
 
 	return options
 }

--- a/internal/service/opensearch/domain_structure.go
+++ b/internal/service/opensearch/domain_structure.go
@@ -67,7 +67,9 @@ func expandAutoTuneOptions(tfMap map[string]interface{}) *opensearchservice.Auto
 	options.MaintenanceSchedules = autoTuneOptionsInput.MaintenanceSchedules
 	options.UseOffPeakWindow = autoTuneOptionsInput.UseOffPeakWindow
 
-	options.RollbackOnDisable = aws.String(tfMap["rollback_on_disable"].(string))
+	if v, ok := tfMap["rollback_on_disable"].(string); ok && v != "" {
+		options.RollbackOnDisable = aws.String(v)
+	}
 
 	return options
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously omitting this optional argument resulted in a failure when creating or updating the domain:

```
Error: modifying config for OpenSearch Domain: ValidationException: 1 validation error detected: Value '' at 'autoTuneOptions.rollbackOnDisable' failed to satisfy constraint: Member must satisfy enum value set: [DEFAULT_ROLLBACK, NO_ROLLBACK]
```

The `auto_tune_options` expander logic has been updated to properly handle cases where `rollback_on_disable` is unset. 

Also adds a missing waiter in create operation when `auto_tune_options` are configured.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37234

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=opensearch TESTS=TestAccOpenSearchDomain_autoTuneOptions
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchDomain_autoTuneOptions'  -timeout 360m

--- PASS: TestAccOpenSearchDomain_autoTuneOptions (1915.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 1920.265s
```

```console
% make testacc PKG=elasticsearch TESTS=TestAccElasticsearchDomain_AutoTuneOptions
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/elasticsearch/... -v -count 1 -parallel 20 -run='TestAccElasticsearchDomain_AutoTuneOptions'  -timeout 360m

--- PASS: TestAccElasticsearchDomain_AutoTuneOptions (2287.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticsearch      2292.708s
```
