### PR TITLE
r/aws_bedrockagent_agent: use configured `prepare_agent` value 

### DIFF
--- a/.changelog/37405.txt
+++ b/.changelog/37405.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagent_agent: Fix to use the configured `prepare_agent` value (or default value of `true` when omitted) for all create and update operations
+```

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -55,7 +56,6 @@ func newAgentResource(context.Context) (resource.ResourceWithConfigure, error) {
 
 type agentResource struct {
 	framework.ResourceWithConfigure
-	framework.WithImportByID
 	framework.WithTimeouts
 }
 
@@ -249,8 +249,6 @@ func (r *agentResource) Read(ctx context.Context, request resource.ReadRequest, 
 		return
 	}
 
-	data.PrepareAgent = types.BoolValue(agent.AgentStatus == awstypes.AgentStatusPrepared)
-
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
@@ -364,6 +362,12 @@ func (r *agentResource) Delete(ctx context.Context, request resource.DeleteReque
 
 		return
 	}
+}
+
+func (r *agentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.AttrID), req.ID)...)
+	// Set prepare_agent to default value on import
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("prepare_agent"), true)...)
 }
 
 func (r *agentResource) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {

--- a/internal/service/bedrockagent/agent_test.go
+++ b/internal/service/bedrockagent/agent_test.go
@@ -38,6 +38,7 @@ func TestAccBedrockAgentAgent_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "agent_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "prompt_override_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "basic claude"),
+					resource.TestCheckResourceAttr(resourceName, "prepare_agent", "true"),
 				),
 			},
 			{

--- a/website/docs/r/bedrockagent_agent.html.markdown
+++ b/website/docs/r/bedrockagent_agent.html.markdown
@@ -80,7 +80,8 @@ The following arguments are optional:
 * `description` - (Optional) Description of the agent.
 * `idle_session_ttl_in_seconds` - (Optional) TTL in seconds for the agent to idle.
 * `instruction` - (Optional) Instructions to tell agent what it should do.
-* `prompt_override_configuration` (Optional) Prompt Override Configuration
+* `prepare_agent` (Optional) Whether or not to prepare the agent after creation or modification. Defaults to `true`.
+* `prompt_override_configuration` (Optional) Prompt override configuration.
 * `tags` - (Optional) Key-value tags for the place index. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### prompt_override_configuration
@@ -105,7 +106,7 @@ The following arguments are required:
 * `parser_mode` - (Required) DEFAULT or OVERRIDDEN to control if the `override_lambda` is used.
 * `prompt_creation_mode` - (Required) DEFAULT or OVERRIDDEN to control if the default or provided `base_prompt_template` is used,
 * `prompt_state` - (Required) ENABLED or DISABLED to allow the agent to carry out the step in `prompt_type`.
-* `prompt_type` - (Required) The step this prompt applies to. PRE_PROCESSING | ORCHESTRATION | POST_PROCESSING | KNOWLEDGE_BASE_RESPONSE_GENERATION
+* `prompt_type` - (Required) The step this prompt applies to. Valid values are `PRE_PROCESSING`, `ORCHESTRATION`, `POST_PROCESSING`, and `KNOWLEDGE_BASE_RESPONSE_GENERATION`.
 * `inference_configuration` - (Required) Configures inference for the agent
 
 ### inference_configuration
@@ -126,6 +127,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `agent_arn` - ARN of the Agent.
 * `agent_id` - ID of the Agent.
+* `id` - ID of the Agent.
 * `agent_version` - Version of the Agent.
 
 ## Timeouts
@@ -138,17 +140,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Agents for Amazon Bedrock Agent using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Agents for Amazon Bedrock Agent using the `id`. For example:
 
 ```terraform
 import {
   to = aws_bedrockagent_agent.example
-  id = "abcdef1234"
+  id = "agent-abcd1234"
 }
 ```
 
-Using `terraform import`, import Agents for Amazon Bedrock Agent using the `abcdef1234`. For example:
+Using `terraform import`, import Agents for Amazon Bedrock Agent using the `id`. For example:
 
 ```console
-% terraform import aws_bedrockagent_agent.example abcdef1234
+% terraform import aws_bedrockagent_agent.example agent-abcd1234
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This changes removes logic in the read operation which adjusted the `prepare_agent` argument based on whether or not the agent status was `Prepared`. Now the configured `prepare_agent` value is always used, regardless of the status of the agent. If omitted, the default value of `true` is inherited, meaning that by default agents will always be prepared as part of the create or update operation. The `prepare_agent` value is now also set to `true` when an agent is imported.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37162

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_PrepareAgent.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagent TESTS=TestAccBedrockAgentAgent_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentAgent_'  -timeout 360m

--- PASS: TestAccBedrockAgentAgent_basic (19.66s)
--- PASS: TestAccBedrockAgentAgent_full (19.67s)
--- PASS: TestAccBedrockAgentAgent_tags (35.51s)
--- PASS: TestAccBedrockAgentAgent_update (37.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       42.493s
```