### PR TITLE
r/lakeformation_data_cells_filter: fix error when using `row_filter.all_rows_wildcard`

### DIFF
--- a/.changelog/37433.txt
+++ b/.changelog/37433.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lakeformation_data_cells_filter: Fix inconsistent `state` error when using `row_filter.all_rows_wildcard`
+```

--- a/internal/service/lakeformation/data_cells_filter_test.go
+++ b/internal/service/lakeformation/data_cells_filter_test.go
@@ -121,6 +121,57 @@ func testAccDataCellsFilter_disappears(t *testing.T) {
 	})
 }
 
+func testAccDataCellsFilter_rowFilter(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var datacellsfilter awstypes.DataCellsFilter
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lakeformation_data_cells_filter.test"
+
+	filterExpression := `
+  filter_expression = "my_column_23='testing'"
+`
+	allRowsildcard := `
+  all_rows_wildcard {}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LakeFormation)
+			testAccDataCellsFilterPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataCellsFilterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCellsFilterConfig_rowFilter(rName, filterExpression),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCellsFilterExists(ctx, resourceName, &datacellsfilter),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.table_name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "table_data.0.version_id"),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.column_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.row_filter.0.filter_expression", "my_column_23='testing'"),
+				),
+			},
+			{
+				Config: testAccDataCellsFilterConfig_rowFilter(rName, allRowsildcard),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataCellsFilterExists(ctx, resourceName, &datacellsfilter),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.database_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.table_name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "table_data.0.version_id"),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.column_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "table_data.0.row_filter.0.all_rows_wildcard.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDataCellsFilterDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationClient(ctx)
@@ -291,4 +342,27 @@ resource "aws_lakeformation_data_cells_filter" "test" {
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }
 `, rName, column))
+}
+
+func testAccDataCellsFilterConfig_rowFilter(rName, rowFilter string) string {
+	return acctest.ConfigCompose(
+		testAccDataCellsFilterConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_lakeformation_data_cells_filter" "test" {
+  table_data {
+    database_name    = aws_glue_catalog_database.test.name
+    name             = %[1]q
+    table_catalog_id = data.aws_caller_identity.current.account_id
+    table_name       = aws_glue_catalog_table.test.name
+
+    column_names = ["my_column_22"]
+
+    row_filter {
+%[2]s
+    }
+  }
+
+  depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+`, rName, rowFilter))
 }

--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -24,6 +24,7 @@ func TestAccLakeFormation_serial(t *testing.T) {
 			"basic":          testAccDataCellsFilter_basic,
 			"columnWildcard": testAccDataCellsFilter_columnWildcard,
 			"disappears":     testAccDataCellsFilter_disappears,
+			"rowFilter":      testAccDataCellsFilter_rowFilter,
 		},
 		"DataLakeSettingsDataSource": {
 			"basic":          testAccDataLakeSettingsDataSource_basic,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

Closes #36574

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccLakeFormation_serial/DataCellsFilter/" PKG=lakeformation

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/lakeformation/... -v -count 1 -parallel 20  -run=TestAccLakeFormation_serial/DataCellsFilter/ -timeout 360m
--- PASS: TestAccLakeFormation_serial (60.35s)
    --- PASS: TestAccLakeFormation_serial/DataCellsFilter (60.35s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/columnWildcard (12.59s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/disappears (12.74s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/rowFilter (20.37s)
        --- PASS: TestAccLakeFormation_serial/DataCellsFilter/basic (14.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	65.782s
```
