### PR TITLE
skaff: consistent tags, tags_all website descriptions

### DIFF
--- a/docs/resource-tagging.md
+++ b/docs/resource-tagging.md
@@ -578,7 +578,7 @@ Verify all acceptance testing passes for the resource (e.g., `make testacc TESTS
 In the resource documentation (e.g., `website/docs/r/service_example.html.markdown`), add the following to the arguments reference:
 
 ```markdown
-* `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 ```
 
 In the resource documentation (e.g., `website/docs/r/service_example.html.markdown`), add the following to the attribute reference:

--- a/skaff/datasource/websitedoc.tmpl
+++ b/skaff/datasource/websitedoc.tmpl
@@ -47,5 +47,5 @@ This data source exports the following attributes in addition to the arguments a
 * `arn` - ARN of the {{ .HumanDataSourceName }}. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
 * `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
 {{- if .IncludeTags }}
-* `tags` - Mapping of Key-Value tags for the resource.
+* `tags` - Map of tags assigned to the resource.
 {{- end }}

--- a/skaff/resource/websitedoc.tmpl
+++ b/skaff/resource/websitedoc.tmpl
@@ -39,7 +39,7 @@ The following arguments are optional:
 
 * `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
 {{- if .IncludeTags }}
-* `tags` - (Optional) A map of tags assigned to the WorkSpaces Connection Alias. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 {{- end }}
 
 ## Attribute Reference
@@ -49,7 +49,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - ARN of the {{ .HumanResourceName }}. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
 * `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
 {{- if .IncludeTags }}
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 {{- end }}
 
 ## Timeouts

--- a/website/docs/r/codeguruprofiler_profiling_group.html.markdown
+++ b/website/docs/r/codeguruprofiler_profiling_group.html.markdown
@@ -34,7 +34,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `compute_platform` - (Optional) Compute platform of the profiling group.
-* `tags` - (Optional) A map of tags assigned to the WorkSpaces Connection Alias. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 

--- a/website/docs/r/m2_application.html.markdown
+++ b/website/docs/r/m2_application.html.markdown
@@ -62,7 +62,7 @@ The following arguments are optional:
 * `definition` - (Optional) The application definition for this application. You can specify either inline JSON or an S3 bucket location.
 * `kms_key_id` - (Optional) KMS Key to use for the Application.
 * `role_arn` - (Optional) ARN of role for application to use to access AWS resources.
-* `tags` - (Optional) A map of tags assigned to the WorkSpaces Connection Alias. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## definition
 

--- a/website/docs/r/rekognition_collection.html.markdown
+++ b/website/docs/r/rekognition_collection.html.markdown
@@ -30,7 +30,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `tags` - (Optional) A map of tags assigned to the WorkSpaces Connection Alias. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updates the `skaff` website template to use generic descriptions for the `tags` and `tags_all` attributes. Previously a hardcoded workspace resource name was present in the description, which would need manually adjusted. Also updates the descriptions in the contributor documentation to match skaff, and fixes places where the errant hardcoded resource name was included in `skaff`-generated registry documentation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #32513

