### PR TITLE
Fix for default_tags and tags on EC2 block devices

### DIFF
--- a/.changelog/37441.txt
+++ b/.changelog/37441.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_instance: Fix issues with `root_block_device.*.tags` and `ebs_block_device.*.tags` when overlapping with default tags
+resource/aws_instance: Fixed issues with `volume_tags`, `root_block_device.*.tags`, and `ebs_block_device.*.tags` where tags overlapped with default tags. These are now handled consistently with top-level tags throughout the provider. Specifically, tags defined in both locations are no longer removed, preventing erroneous differences.
 ```

--- a/.changelog/37441.txt
+++ b/.changelog/37441.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Fix issues with `root_block_device.*.tags` and `ebs_block_device.*.tags` when overlapping with default tags
+```

--- a/internal/provider/intercept.go
+++ b/internal/provider/intercept.go
@@ -362,7 +362,7 @@ func (r tagsResourceInterceptor) run(ctx context.Context, d schemaResourceData, 
 			tags := tagsInContext.TagsOut.UnwrapOrDefault().IgnoreSystem(inContext.ServicePackageName).IgnoreConfig(tagsInContext.IgnoreConfig)
 
 			// The resource's configured tags can now include duplicate tags that have been configured on the provider.
-			if err := d.Set(names.AttrTags, tags.ResolveDuplicates(ctx, tagsInContext.DefaultConfig, tagsInContext.IgnoreConfig, d).Map()); err != nil {
+			if err := d.Set(names.AttrTags, tags.ResolveDuplicates(ctx, tagsInContext.DefaultConfig, tagsInContext.IgnoreConfig, d, names.AttrTags, nil).Map()); err != nil {
 				return ctx, sdkdiag.AppendErrorf(diags, "setting %s: %s", names.AttrTags, err)
 			}
 

--- a/internal/provider/tags_interceptor.go
+++ b/internal/provider/tags_interceptor.go
@@ -161,7 +161,7 @@ func tagsReadFunc(ctx context.Context, d schemaResourceData, sp conns.ServicePac
 	toAdd := tagsInContext.TagsOut.UnwrapOrDefault().IgnoreSystem(inContext.ServicePackageName).IgnoreConfig(tagsInContext.IgnoreConfig)
 
 	// The resource's configured tags can now include duplicate tags that have been configured on the provider.
-	if err := d.Set(names.AttrTags, toAdd.ResolveDuplicates(ctx, tagsInContext.DefaultConfig, tagsInContext.IgnoreConfig, d).Map()); err != nil {
+	if err := d.Set(names.AttrTags, toAdd.ResolveDuplicates(ctx, tagsInContext.DefaultConfig, tagsInContext.IgnoreConfig, d, names.AttrTags, nil).Map()); err != nil {
 		return ctx, sdkdiag.AppendErrorf(diags, "setting %s: %s", names.AttrTags, err)
 	}
 

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -44,7 +44,7 @@ func resourceEBSVolume() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		CustomizeDiff: customdiff.Sequence(

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -2363,9 +2363,7 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 			// default setup, in case we don't find config for the block device (don't resolve duplicates)
 			bd[names.AttrTags] = tags.Map()
 			bd[names.AttrTagsAll] = tags.Map()
-			//bd[names.AttrTags] = tags.RemoveDefaultConfig(defaultTagsConfig).Map()
-			// this is hardcoded for the attr name to test this out
-			//rbd := d.Get("root_block_device")
+
 			if v, ok := d.GetOk("ebs_block_device"); ok && v.(*schema.Set).Len() > 0 {
 				ebdList := v.(*schema.Set).List()
 				for _, ebd := range ebdList {

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1336,9 +1336,12 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 		ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 		tags := keyValueTags(ctx, volumeTags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-		if err := d.Set("volume_tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		if err := d.Set("volume_tags", tags.ResolveDuplicates(ctx, defaultTagsConfig, ignoreTagsConfig, d, "volume_tags", nil).Map()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting volume_tags: %s", err)
 		}
+		//if err := d.Set("volume_tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		//	return sdkdiag.AppendErrorf(diags, "setting volume_tags: %s", err)
+		//}
 	}
 
 	if err := readSecurityGroups(ctx, d, instance, conn); err != nil {

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -1331,10 +1332,11 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 			return sdkdiag.AppendErrorf(diags, "reading EC2 Instance (%s): %s", d.Id(), err)
 		}
 
+		defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 		ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 		tags := keyValueTags(ctx, volumeTags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-		if err := d.Set("volume_tags", tags.Map()); err != nil {
+		if err := d.Set("volume_tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting volume_tags: %s", err)
 		}
 	}
@@ -2318,6 +2320,7 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 		return nil, err
 	}
 
+	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	for _, vol := range volResp.Volumes {
@@ -2350,13 +2353,41 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 		if instanceBd.DeviceName != nil {
 			bd[names.AttrDeviceName] = aws.ToString(instanceBd.DeviceName)
 		}
-		if v, ok := d.GetOk("volume_tags"); !ok || v == nil || len(v.(map[string]interface{})) == 0 {
-			if ds {
-				bd[names.AttrTags] = keyValueTags(ctx, vol.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()
-			} else {
-				tags := keyValueTags(ctx, vol.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-				bd[names.AttrTags] = tags.Map()
-				bd[names.AttrTagsAll] = tags.Map()
+		if v, ok := d.GetOk("volume_tags"); (!ok || v == nil || len(v.(map[string]interface{})) == 0) && ds {
+			bd[names.AttrTags] = keyValueTags(ctx, vol.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()
+		}
+
+		if v, ok := d.GetOk("volume_tags"); (!ok || v == nil || len(v.(map[string]interface{})) == 0) && !ds {
+			tags := keyValueTags(ctx, vol.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+			// default setup, in case we don't find config for the block device (don't resolve duplicates)
+			bd[names.AttrTags] = tags.Map()
+			bd[names.AttrTagsAll] = tags.Map()
+			//bd[names.AttrTags] = tags.RemoveDefaultConfig(defaultTagsConfig).Map()
+			// this is hardcoded for the attr name to test this out
+			//rbd := d.Get("root_block_device")
+			if v, ok := d.GetOk("ebs_block_device"); ok && v.(*schema.Set).Len() > 0 {
+				ebdList := v.(*schema.Set).List()
+				for _, ebd := range ebdList {
+					ebd, ok := ebd.(map[string]interface{})
+					if !ok {
+						continue
+					}
+
+					if ebd[names.AttrDeviceName] == aws.ToString(instanceBd.DeviceName) {
+						bd[names.AttrTags] = tags.ResolveDuplicates(ctx, defaultTagsConfig, ignoreTagsConfig, d, fmt.Sprintf("ebs_block_device[%s].tags", aws.ToString(instanceBd.DeviceName)), func(attr string, val cty.Value) bool {
+							if val.GetAttr("device_name").AsString() == attr {
+								return true
+							}
+							return false
+						}).Map()
+						break
+					}
+				}
+			}
+
+			if v, ok := d.GetOk("root_block_device"); ok && len(v.([]interface{})) > 0 && blockDeviceIsRoot(instanceBd, instance) {
+				bd[names.AttrTags] = tags.ResolveDuplicates(ctx, defaultTagsConfig, ignoreTagsConfig, d, "root_block_device[0].tags", nil).Map()
 			}
 		}
 

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -2377,10 +2377,7 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 
 					if ebd[names.AttrDeviceName] == aws.ToString(instanceBd.DeviceName) {
 						bd[names.AttrTags] = tags.ResolveDuplicates(ctx, defaultTagsConfig, ignoreTagsConfig, d, fmt.Sprintf("ebs_block_device[%s].tags", aws.ToString(instanceBd.DeviceName)), func(attr string, val cty.Value) bool {
-							if val.GetAttr("device_name").AsString() == attr {
-								return true
-							}
-							return false
+							return val.GetAttr(names.AttrDeviceName).AsString() == attr
 						}).Map()
 						break
 					}

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1331,11 +1331,10 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 			return sdkdiag.AppendErrorf(diags, "reading EC2 Instance (%s): %s", d.Id(), err)
 		}
 
-		defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 		ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 		tags := keyValueTags(ctx, volumeTags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-		if err := d.Set("volume_tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
+		if err := d.Set("volume_tags", tags.Map()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting volume_tags: %s", err)
 		}
 	}
@@ -2319,7 +2318,6 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 		return nil, err
 	}
 
-	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	for _, vol := range volResp.Volumes {
@@ -2357,7 +2355,7 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 				bd[names.AttrTags] = keyValueTags(ctx, vol.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()
 			} else {
 				tags := keyValueTags(ctx, vol.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
-				bd[names.AttrTags] = tags.RemoveDefaultConfig(defaultTagsConfig).Map()
+				bd[names.AttrTags] = tags.Map()
 				bd[names.AttrTagsAll] = tags.Map()
 			}
 		}

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -1339,9 +1339,6 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 		if err := d.Set("volume_tags", tags.ResolveDuplicates(ctx, defaultTagsConfig, ignoreTagsConfig, d, "volume_tags", nil).Map()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting volume_tags: %s", err)
 		}
-		//if err := d.Set("volume_tags", tags.RemoveDefaultConfig(defaultTagsConfig).Map()); err != nil {
-		//	return sdkdiag.AppendErrorf(diags, "setting volume_tags: %s", err)
-		//}
 	}
 
 	if err := readSecurityGroups(ctx, d, instance, conn); err != nil {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -7165,6 +7165,7 @@ resource "aws_instance" "test" {
 }
 
 func testAccInstanceConfig_blockDeviceTagsDefault3EBS(defTg, ebsTg1, ebsTg2, ebsTg3 map[string]string) string {
+	//lintignore:AT004
 	return acctest.ConfigCompose(
 		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
 		fmt.Sprintf(`

--- a/internal/tags/key_value_tags.go
+++ b/internal/tags/key_value_tags.go
@@ -764,8 +764,16 @@ func GetAnyAttr(value cty.Value, attr string, shouldReturnSetElement func(string
 
 	// Handle indexed attribute
 	if strings.Contains(part, "[") && strings.Contains(part, "]") {
-		attrName := part[:strings.Index(part, "[")]
-		indexStr := part[strings.Index(part, "[")+1 : strings.Index(part, "]")]
+		attrNameEnd := strings.Index(part, "[")
+		indexStart := attrNameEnd + 1
+		indexEnd := strings.Index(part, "]")
+
+		if attrNameEnd == -1 || indexEnd == -1 {
+			return cty.NilVal, fmt.Errorf("invalid indexed attribute format: %s", part)
+		}
+
+		attrName := part[:attrNameEnd]
+		indexStr := part[indexStart:indexEnd]
 
 		if !value.Type().HasAttribute(attrName) {
 			return cty.NilVal, fmt.Errorf("attribute %s not found", attrName)

--- a/internal/tags/key_value_tags.go
+++ b/internal/tags/key_value_tags.go
@@ -833,7 +833,9 @@ func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *D
 	if configExists {
 		c, err := GetAnyAttr(cf, tagsAttr, setFunc)
 		if err != nil {
-			panic(fmt.Sprintf("failed to get attribute %s: %v", tagsAttr, err))
+			// in situations with imports and computed attributes where there's no
+			// matching config, return the tags unchanged
+			return tags
 		}
 
 		// if the config is null just return the incoming tags

--- a/internal/tags/key_value_tags.go
+++ b/internal/tags/key_value_tags.go
@@ -497,27 +497,6 @@ func (tags KeyValueTags) RemoveDefaultConfig(dc *DefaultConfig) KeyValueTags {
 	return result
 }
 
-// RemoveUniquelyDefaultConfig returns tags unique to the default config. In other words, if a tag is
-// present in both the default config and the tags, it will NOT be removed because it's defined in the
-// tags to avoid perpetual diffs. For example, if the default tags are A, B, C, D and the tags are C, D,
-// E, F, tags should be returned as C, D, E, F. If the default tags are A, B, C, D and the tags are A, B,
-// C, D, E, F, tags should be returned as C, D, E, F.
-func (tags KeyValueTags) RemoveUniquelyDefaultConfig(dc *DefaultConfig) KeyValueTags {
-	if dc == nil || dc.Tags == nil {
-		return tags
-	}
-
-	result := make(KeyValueTags)
-
-	for k, v := range tags {
-		if defaultVal, ok := dc.Tags[k]; !ok || !v.Equal(defaultVal) {
-			result[k] = v
-		}
-	}
-
-	return result
-}
-
 // String returns the default string representation of the KeyValueTags.
 func (tags KeyValueTags) String() string {
 	var builder strings.Builder
@@ -844,7 +823,6 @@ func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *D
 
 	configTags := make(map[string]configTag)
 	if configExists {
-		//c := cf.GetAttr(tagsAttr)
 		c, err := GetAnyAttr(cf, tagsAttr, setFunc)
 		if err != nil {
 			panic(fmt.Sprintf("failed to get attribute %s: %v", tagsAttr, err))
@@ -862,7 +840,6 @@ func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *D
 	}
 
 	if pl := d.GetRawPlan(); !pl.IsNull() && pl.IsKnown() {
-		//c := pl.GetAttr(tagsAttr)
 		c, err := GetAnyAttr(pl, tagsAttr, setFunc)
 		if err != nil {
 			panic(fmt.Sprintf("failed to get attribute %s: %v", tagsAttr, err))
@@ -873,7 +850,6 @@ func (tags KeyValueTags) ResolveDuplicates(ctx context.Context, defaultConfig *D
 	}
 
 	if st := d.GetRawState(); !st.IsNull() && st.IsKnown() {
-		//c := st.GetAttr(tagsAttr)
 		c, err := GetAnyAttr(st, tagsAttr, setFunc)
 		if err != nil {
 			panic(fmt.Sprintf("failed to get attribute %s: %v", tagsAttr, err))

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -58,7 +58,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 - `create` - (Default `5m`)
 - `update` - (Default `5m`)
-- `delete` - (Default `5m`)
+- `delete` - (Default `10m`)
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

`default_tags` support for EC2 root block devices was introduced in hashicorp/terraform-provider-aws#33769, which is great ... except it makes the mix of `default_tags` and `tags` on a `root_block_device` perpetually showing drift even when there is none.

The solution is to not remove the default tags config from the volume tags in ec2_instance.

This diff fixes hashicorp/terraform-provider-aws#36448 for us in our environment (which references hashicorp/terraform-provider-aws#33769 as the change that introduced this bug).

This diff possibly fixes hashicorp/terraform-provider-aws#36706 too, but we weren't hitting this issue.

### Relations

Relates #33769
Relates #36706
Closes #36448 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccEC2 PKG=ec2
<in progress>
```
