### PR TITLE
d/aws_bedrock_foundation_models(test): fix semgrep finding

### DIFF
--- a/internal/service/bedrock/foundation_models_data_source_test.go
+++ b/internal/service/bedrock/foundation_models_data_source_test.go
@@ -106,7 +106,7 @@ func TestAccBedrockFoundationModelsDataSource_byProvider(t *testing.T) {
 			{
 				Config: testAccFoundationModelsDataSourceConfig_byProvider(provider),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(datasourceName, "id"),
+					resource.TestCheckResourceAttrSet(datasourceName, names.AttrID),
 					acctest.CheckResourceAttrGreaterThanValue(datasourceName, "model_summaries.#", 0),
 				),
 			},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes a failing semgrep finding on `main`.

https://github.com/hashicorp/terraform-provider-aws/actions/runs/9062758632/job/24897300698

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #37306



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrock TESTS=TestAccBedrockFoundationModelsDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/bedrock/... -v -count 1 -parallel 20 -run='TestAccBedrockFoundationModelsDataSource_'  -timeout 360m

--- PASS: TestAccBedrockFoundationModelsDataSource_byCustomizationType (9.86s)
--- PASS: TestAccBedrockFoundationModelsDataSource_byInferenceType (10.17s)
--- PASS: TestAccBedrockFoundationModelsDataSource_byProvider (10.20s)
--- PASS: TestAccBedrockFoundationModelsDataSource_basic (10.24s)
--- PASS: TestAccBedrockFoundationModelsDataSource_byOutputModality (10.29s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrock    15.375s
```
