### PR TITLE
[DOCS] fix console command in developer environment setup instructions

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -39,7 +39,7 @@ make build
 This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```console
-ls -la ./$GOPATH/bin/terraform-provider-aws
+ls -la $GOPATH/bin/terraform-provider-aws
 ```
 
 ### Testing the Provider


### PR DESCRIPTION
### Description

While setting up the Terraform AWS provider locally I noticed an issue with the instructions.
I believe the original version contains a mistake, as executing the command leads to an error:

```console
$ ls -la ./$GOPATH/bin/terraform-provider-aws
ls: .//Users/<xyz_user>/go/bin/terraform-provider-aws: No such file or directory
```

Instead, when the fixed version of the command is run, the expected output is received:

```console
$ ls -la $GOPATH/bin/terraform-provider-aws
-rwxr-xr-x@ 1 <xyz_user>  user  709759170 May 13 21:05 /Users/<xyz_user>/go/bin/terraform-provider-aws
```

### Relations

Closes #37477

### References

Webpage with mistake:
https://hashicorp.github.io/terraform-provider-aws/development-environment/