### PR TITLE
Use single custom label in GHA jobs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,3 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of string
-  labels: [custom, small, medium, large, xl, custom-linux-medium]
+  labels: [custom-linux-xl, custom-linux-small, custom-linux-medium, custom-linux-large, custom-linux-xl]

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -37,7 +37,7 @@ jobs:
 
   tflint:
     name: Validate Acceptance Tests
-    runs-on: [custom, linux, xl]
+    runs-on: custom-linux-xl
     strategy:
       matrix:
         path: ['[a-f]', '[g-z]']

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -59,7 +59,7 @@ jobs:
           exit $exit_code
 
   validate-terraform:
-    runs-on: [custom, linux, large]
+    runs-on: custom-linux-large
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   golangci-linta:
     name: 1 of 2
-    runs-on: [custom, linux, large]
+    runs-on: custom-linux-large
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
@@ -42,7 +42,7 @@ jobs:
   golangci-lintb:
     name: 2 of 2
     needs: [golangci-linta]
-    runs-on: [custom, linux, xl]
+    runs-on: custom-linux-xl
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1

--- a/.github/workflows/goreleaser-ci.yml
+++ b/.github/workflows/goreleaser-ci.yml
@@ -55,7 +55,7 @@ jobs:
   build-32-bit:
     # Run a single compiler check for 32-bit architecture (FreeBSD/ARM)
     # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/8988
-    runs-on: [custom, linux, small]
+    runs-on: custom-linux-small
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -48,7 +48,7 @@ jobs:
   go_build:
     name: go build
     needs: [go_mod_download]
-    runs-on: [custom, linux, medium]
+    runs-on: custom-linux-medium
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
@@ -116,7 +116,7 @@ jobs:
   go_test:
     name: go test
     needs: [go_build]
-    runs-on: [custom, linux, xl]
+    runs-on: custom-linux-xl
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:
@@ -176,7 +176,7 @@ jobs:
   validate_sweepers_unlinked:
     name: Sweeper Functions Not Linked
     needs: [go_build]
-    runs-on: [custom, linux, medium]
+    runs-on: custom-linux-medium
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:

--- a/.github/workflows/providerlint.yml
+++ b/.github/workflows/providerlint.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   providerlint:
-    runs-on: [custom, linux, medium]
+    runs-on: custom-linux-medium
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -110,7 +110,7 @@ jobs:
       - run: terrafmt diff ./website --check --pattern '*.markdown'
 
   tflint:
-    runs-on: [custom, linux, xl]
+    runs-on: custom-linux-xl
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
         with:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
👋 Greetings! 

To align with Github’s removal of [custom labels on larger runners](https://github.blog/changelog/2023-02-15-github-actions-removal-of-additional-label-option-for-github-hosted-larger-runners/), this PR is updating the labels defined in your Github Action jobs. Moving forward, only one label (the name of GH runner type)  will be needed to ensure an appropriate runner is used for your GHA job.

Please review for accuracy and merge before May 27, 2024. Thank you!

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
