### PR TITLE
tools/awssdkpatch: add multiclient support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -85,7 +85,7 @@ awssdkpatch-gen: awssdkpatch ## Generate a patch file using awssdkpatch
 		echo "PKG=foo make awssdkpatch-gen" ; \
 		exit 1 ; \
 	fi
-	@awssdkpatch -service $(PKG)
+	@awssdkpatch $(AWSSDKPATCH_OPTS) -service $(PKG)
 
 awssdkpatch: prereq-go ## Install awssdkpatch
 	cd tools/awssdkpatch && $(GO_VER) install github.com/hashicorp/terraform-provider-aws/tools/awssdkpatch

--- a/docs/aws-go-sdk-migrations.md
+++ b/docs/aws-go-sdk-migrations.md
@@ -43,8 +43,16 @@ PKG=ec2 make awssdkpatch-apply
 You may also optionally generate the patch and use [`gopatch`](https://github.com/uber-go/gopatch) to preview differences before modfiying any files.
 
 ```console
-PKG=ec2 make awssdkpatch-gen
+make awssdkpatch-gen PKG=ec2
 gopatch -d -p awssdk.patch ./internal/service/ec2/...
+```
+
+#### Custom options
+
+To set additional `awssdkpatch` flags during patch generation, use the `AWSSDKPATCH_OPTS` environment variable.
+
+```console
+make awssdkpatch-gen PKG=ec2 AWSSDKPATCH_OPTS="-multiclient"
 ```
 
 ## Imports

--- a/tools/awssdkpatch/README.md
+++ b/tools/awssdkpatch/README.md
@@ -17,6 +17,8 @@ Usage: awssdkpatch [flags]
 Flags:
   -importalias string
         alias that the service package is imported as (optional)
+  -multiclient
+        whether the service supports both v1 and v2 clients (optional)
   -out string
         output file (optional) (default "awssdk.patch")
   -service string
@@ -50,4 +52,12 @@ If the service uses an import alias, include the `-importalias` flag when genera
 
 ```console
 awssdkpatch -service dms -importalias dms
+```
+
+### Multiple clients
+
+If the service supports both V1 and V2 AWS SDK clients (a common pattern in large services which are migrated in parts), include the `-multiclient` flag when generating the patch file:
+
+```console
+awssdkpatch -service ec2 -multiclient
 ```

--- a/tools/awssdkpatch/main.go
+++ b/tools/awssdkpatch/main.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	importalias string
+	multiclient bool
 	out         string
 	service     string
 
@@ -32,6 +33,7 @@ type TemplateData struct {
 	GoV1Package        string
 	GoV1ClientTypeName string
 	GoV2Package        string
+	MultiClient        bool
 	ImportAlias        string
 	ProviderPackage    string
 	InputOutputTypes   []string
@@ -48,6 +50,7 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.StringVar(&importalias, "importalias", "", "alias that the service package is imported as (optional)")
+	flag.BoolVar(&multiclient, "multiclient", false, "whether the service supports both v1 and v2 clients (optional)")
 	flag.StringVar(&out, "out", "awssdk.patch", "output file (optional)")
 	flag.StringVar(&service, "service", "", "service to migrate (required)")
 	flag.Parse()
@@ -113,6 +116,7 @@ func getPackageData(sd data.ServiceRecord) (TemplateData, error) {
 		GoV1ClientTypeName: sd.GoV1ClientTypeName(),
 		GoV2Package:        sd.GoV2Package(),
 		ImportAlias:        importalias,
+		MultiClient:        multiclient,
 		ProviderPackage:    providerPackage,
 	}
 

--- a/tools/awssdkpatch/patch.tmpl
+++ b/tools/awssdkpatch/patch.tmpl
@@ -176,3 +176,59 @@ var x identifier
 @@
 +import "github.com/hashicorp/terraform-provider-aws/internal/enum"
 enum.x
+
+{{- if .MultiClient }}
+# Replace generated Tags function with the V2 variant.
+@@
+@@
+-Tags(...)
++TagsV2(...)
+
+# Replace generated KeyValueTags function with the V2 variant.
+@@
+@@
+-KeyValueTags(...)
++keyValueTagsV2(...)
+
+# Replace generated getTagsIn function with the V2 variant.
+@@
+@@
+-getTagsIn(...)
++getTagsInV2(...)
+
+# Replace generated getTagSpecificationsIn function with the V2 variant.
+@@
+@@
+-getTagSpecificationsIn(...)
++getTagSpecificationsInV2(...)
+
+# Replace generated setTagsOut function with the V2 variant.
+@@
+@@
+-setTagsOut(...)
++setTagsOutV2(...)
+
+# Replace generated createTags function with the V2 variant.
+@@
+@@
+-createTags(...)
++createTagsV2(...)
+
+# Replace generated updateTags function with the V2 variant.
+@@
+@@
+-updateTags(...)
++updateTagsV2(...)
+
+# Replace generated newTagFilterList function with the V2 variant.
+@@
+@@
+-newTagFilterList(...)
++newTagFilterListV2(...)
+
+# Replace generated newCustomFilterList function with the V2 variant.
+@@
+@@
+-newCustomFilterList(...)
++newCustomFilterListV2(...)
+{{- end }}


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The new `-multiclient` flag supports services where both V1 and V2 AWS SDK clients are used simultaneously. This is a common pattern for large services (e.g. `ec2`), where the migration will take place in parts. When set, the generated patch file will include additional patches to migrate tagging and filter helper functions to the appropriate V2 variant.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/32976

