### PR TITLE
add support for api type in appsync api

### DIFF
--- a/internal/service/appsync/graphql_api.go
+++ b/internal/service/appsync/graphql_api.go
@@ -282,6 +282,11 @@ func ResourceGraphQLAPI() *schema.Resource {
 				Default:      appsync.GraphQLApiVisibilityGlobal,
 				ValidateFunc: validation.StringInSlice(appsync.GraphQLApiVisibility_Values(), false),
 			},
+			"api_type": {
+				Type:         schema.TypeString,
+				Required:     false,
+				ValidateFunc: validation.StringInSlice(appsync.GraphQLApiType_Values(), false),
+			},
 			"xray_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -343,6 +348,10 @@ func resourceGraphQLAPICreate(ctx context.Context, d *schema.ResourceData, meta 
 		input.Visibility = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("api_type"); ok {
+		input.ApiType = aws.String(v.(string))
+	}
+
 	output, err := conn.CreateGraphqlApiWithContext(ctx, input)
 
 	if err != nil {
@@ -399,6 +408,7 @@ func resourceGraphQLAPIRead(ctx context.Context, d *schema.ResourceData, meta in
 		return sdkdiag.AppendErrorf(diags, "setting user_pool_config: %s", err)
 	}
 	d.Set("visibility", api.Visibility)
+	d.Set("api_type", api.ApiType)
 	if err := d.Set("xray_enabled", api.XrayEnabled); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting xray_enabled: %s", err)
 	}

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -1407,8 +1407,9 @@ resource "aws_appsync_graphql_api" "test" {
 func testAccGraphQLAPIConfig_apiType(rName, apiType string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
-  api_type = %[1]q
-  name     = %[2]q
+  authentication_type = "API_KEY"
+  api_type            = %[1]q
+  name                = %[2]q
 }
 `, apiType, rName)
 }

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -1395,22 +1395,22 @@ func testAccCheckGraphQLAPITypeExists(ctx context.Context, n, typeName string) r
 	}
 }
 
-func testAccGraphQLAPIConfig_authenticationType(rName, apiType string) string {
+func testAccGraphQLAPIConfig_authenticationType(rName, authenticationType string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
   api_type            = %[1]q
   name                = %[2]q
 }
-`, apiType, rName)
+`, authenticationType, rName)
 }
 
-func testAccGraphQLAPIConfig_apiType(rName, authenticationType string) string {
+func testAccGraphQLAPIConfig_apiType(rName, apiType string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
   authentication_type = %[1]q
   name                = %[2]q
 }
-`, authenticationType, rName)
+`, apiType, rName)
 }
 
 func testAccGraphQLAPIConfig_visibility(rName, visibility string) string {

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -170,6 +170,41 @@ func testAccGraphQLAPI_authenticationType(t *testing.T) {
 	})
 }
 
+func testAccGraphQLAPI_apiType(t *testing.T) {
+	ctx := acctest.Context(t)
+	var api1, api2 appsync.GraphqlApi
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, appsync.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppSyncServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGraphQLAPIDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGraphQLAPIConfig_apiType(rName, "MERGED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGraphQLAPIExists(ctx, resourceName, &api1),
+					resource.TestCheckResourceAttr(resourceName, "api_type", "MERGED"),
+				),
+			},
+			{
+				Config: testAccGraphQLAPIConfig_apiType(rName, "GRAPHQL"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGraphQLAPIExists(ctx, resourceName, &api2),
+					resource.TestCheckResourceAttr(resourceName, "api_type", "GRAPHQL"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccGraphQLAPI_AuthenticationType_apiKey(t *testing.T) {
 	ctx := acctest.Context(t)
 	var api1 appsync.GraphqlApi
@@ -1360,7 +1395,16 @@ func testAccCheckGraphQLAPITypeExists(ctx context.Context, n, typeName string) r
 	}
 }
 
-func testAccGraphQLAPIConfig_authenticationType(rName, authenticationType string) string {
+func testAccGraphQLAPIConfig_authenticationType(rName, apiType string) string {
+	return fmt.Sprintf(`
+resource "aws_appsync_graphql_api" "test" {
+  api_type            = %[1]q
+  name                = %[2]q
+}
+`, apiType, rName)
+}
+
+func testAccGraphQLAPIConfig_apiType(rName, authenticationType string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
   authentication_type = %[1]q

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -1398,7 +1398,7 @@ func testAccCheckGraphQLAPITypeExists(ctx context.Context, n, typeName string) r
 func testAccGraphQLAPIConfig_authenticationType(rName, authenticationType string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
-  api_type            = %[1]q
+  authentication_type = %[1]q
   name                = %[2]q
 }
 `, authenticationType, rName)
@@ -1407,8 +1407,8 @@ resource "aws_appsync_graphql_api" "test" {
 func testAccGraphQLAPIConfig_apiType(rName, apiType string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
-  authentication_type = %[1]q
-  name                = %[2]q
+  api_type = %[1]q
+  name     = %[2]q
 }
 `, apiType, rName)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This adds support for the API type field in a aws_appsync_graphql_api resource


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appsync-graphqlapi.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
