### PR TITLE
Correct securityhub_configuration_policy_association import docs

### DIFF
--- a/website/docs/r/securityhub_configuration_policy_association.markdown
+++ b/website/docs/r/securityhub_configuration_policy_association.markdown
@@ -94,7 +94,7 @@ import {
 }
 ```
 
-Using `terraform import`, import an existing Security Hub enabled account using the universally unique identifier (UUID) of the policy. For example:
+Using `terraform import`, import an existing Security Hub enabled account using the target id. For example:
 
 ```console
 % terraform import aws_securityhub_configuration_policy_association.example_account_association 123456789012


### PR DESCRIPTION
### Description

Correct securityhub_configuration_policy_association import documentation.

Tested; also matches the other import documentation right above it.