### PR TITLE
docs!: remove al1 references from image_id for `aws_cloud9_environment_ec2`

### DIFF
--- a/website/docs/r/cloud9_environment_ec2.html.markdown
+++ b/website/docs/r/cloud9_environment_ec2.html.markdown
@@ -74,12 +74,10 @@ This resource supports the following arguments:
 * `name` - (Required) The name of the environment.
 * `instance_type` - (Required) The type of instance to connect to the environment, e.g., `t2.micro`.
 * `image_id` - (Required) The identifier for the Amazon Machine Image (AMI) that's used to create the EC2 instance. Valid values are
-    * `amazonlinux-1-x86_64`
     * `amazonlinux-2-x86_64`
     * `amazonlinux-2023-x86_64`
     * `ubuntu-18.04-x86_64`
     * `ubuntu-22.04-x86_64`
-    * `resolve:ssm:/aws/service/cloud9/amis/amazonlinux-1-x86_64`
     * `resolve:ssm:/aws/service/cloud9/amis/amazonlinux-2-x86_64`
     * `resolve:ssm:/aws/service/cloud9/amis/amazonlinux-2023-x86_64`
     * `resolve:ssm:/aws/service/cloud9/amis/ubuntu-18.04-x86_64`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
As mentioned in #37554, the AWS API docs for [CreateEnvironmentEC2](https://docs.aws.amazon.com/cloud9/latest/APIReference/API_CreateEnvironmentEC2.html#cloud9-CreateEnvironmentEC2-request-imageId) have been updated where `imageId` no longer specifies Amazon Linux 1. Probably because it has reached end of life.

Again as mentioned in the linked issue, it would be worth investigating if create a Cloud9 instance with Amazon Linux 1 via Terraform is even possible or would the API return an error but that should be tracked in another issue/pr.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37554

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/cloud9/latest/APIReference/API_CreateEnvironmentEC2.html#cloud9-CreateEnvironmentEC2-request-imageId

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/A
