### PR TITLE
add support for cloudfront invalidation resource fixes #13298

### DIFF
--- a/internal/service/cloudfront/invalidation.go
+++ b/internal/service/cloudfront/invalidation.go
@@ -1,0 +1,225 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource("aws_cloudfront_invalidation", name="Invalidation")
+func newResourceInvalidation(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceInvalidation{}
+
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameInvalidation = "Invalidation"
+)
+
+type resourceInvalidation struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceInvalidation) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_cloudfront_invalidation"
+}
+
+func (r *resourceInvalidation) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"distribution_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"paths": schema.ListAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrStatus: schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			names.AttrTriggers: schema.MapAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *resourceInvalidation) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().CloudFrontClient(ctx)
+
+	var plan resourceInvalidationData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var paths []string
+	for _, p := range flex.ExpandFrameworkStringList(ctx, plan.Paths) {
+		paths = append(paths, *p)
+	}
+
+	in := &cloudfront.CreateInvalidationInput{
+		DistributionId: aws.String(plan.DistributionID.ValueString()),
+		InvalidationBatch: &awstypes.InvalidationBatch{
+			CallerReference: aws.String(uuid.NewString()),
+			Paths: &awstypes.Paths{
+				Quantity: aws.Int32(int32(len(paths))),
+				Items:    paths,
+			},
+		},
+	}
+
+	out, err := conn.CreateInvalidation(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFront, create.ErrActionCreating, ResNameInvalidation, plan.DistributionID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil || out.Invalidation == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFront, create.ErrActionCreating, ResNameInvalidation, plan.DistributionID.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+	plan.ID = flex.StringToFramework(ctx, out.Invalidation.Id)
+
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	waiter := cloudfront.NewInvalidationCompletedWaiter(conn)
+	waitResp, err := waiter.WaitForOutput(ctx, &cloudfront.GetInvalidationInput{
+		DistributionId: aws.String(plan.DistributionID.ValueString()),
+		Id:             out.Invalidation.Id,
+	}, createTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFront, create.ErrActionWaitingForCreation, ResNameInvalidation, plan.DistributionID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	plan.Status = flex.StringToFramework(ctx, waitResp.Invalidation.Status)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceInvalidation) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().CloudFrontClient(ctx)
+
+	var state resourceInvalidationData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findInvalidationByID(ctx, conn, state.DistributionID.ValueString(), state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFront, create.ErrActionSetting, ResNameInvalidation, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ID = flex.StringToFramework(ctx, out.Id)
+	state.Status = flex.StringToFramework(ctx, out.Status)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// There is no update API, so this method is a no-op
+func (r *resourceInvalidation) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+// There is no update API, so this method is a no-op
+func (r *resourceInvalidation) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+func findInvalidationByID(ctx context.Context, conn *cloudfront.Client, distributionId, id string) (*awstypes.Invalidation, error) {
+	in := &cloudfront.GetInvalidationInput{
+		DistributionId: aws.String(distributionId),
+		Id:             aws.String(id),
+	}
+
+	out, err := conn.GetInvalidation(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.NoSuchInvalidation](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil || out.Invalidation == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out.Invalidation, nil
+}
+
+type resourceInvalidationData struct {
+	Paths          types.List     `tfsdk:"paths"`
+	ID             types.String   `tfsdk:"id"`
+	Status         types.String   `tfsdk:"status"`
+	DistributionID types.String   `tfsdk:"distribution_id"`
+	Timeouts       timeouts.Value `tfsdk:"timeouts"`
+}

--- a/internal/service/cloudfront/invalidation_test.go
+++ b/internal/service/cloudfront/invalidation_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfcloudfront "github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCloudFrontInvalidation_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var invalidation cloudfront.GetInvalidationOutput
+	resourceName := "aws_cloudfront_invalidation.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInvalidationConfig_basic(false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInvalidationExists(ctx, resourceName, &invalidation),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Completed"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckInvalidationExists(ctx context.Context, name string, invalidation *cloudfront.GetInvalidationOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.CloudFront, create.ErrActionCheckingExistence, tfcloudfront.ResNameInvalidation, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.CloudFront, create.ErrActionCheckingExistence, tfcloudfront.ResNameInvalidation, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudFrontClient(ctx)
+		resp, err := conn.GetInvalidation(ctx, &cloudfront.GetInvalidationInput{
+			DistributionId: aws.String(rs.Primary.Attributes["distribution_id"]),
+			Id:             aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return create.Error(names.CloudFront, create.ErrActionCheckingExistence, tfcloudfront.ResNameInvalidation, rs.Primary.ID, err)
+		}
+
+		*invalidation = *resp
+
+		return nil
+	}
+}
+
+func testAccInvalidationConfig_basic(enabled, retainOnDelete bool) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = %[1]t
+  retain_on_delete = %[2]t
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  lifecycle {
+    ignore_changes = [web_acl_id]
+  }
+}
+
+resource "aws_cloudfront_invalidation" "test" {
+  distribution_id = aws_cloudfront_distribution.test.id
+  paths = [
+    "/*",
+  ]
+}
+`, enabled, retainOnDelete)
+}

--- a/internal/service/cloudfront/service_package_gen.go
+++ b/internal/service/cloudfront/service_package_gen.go
@@ -28,6 +28,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Factory: newKeyValueStoreResource,
 			Name:    "Key Value Store",
 		},
+		{
+			Factory: newResourceInvalidation,
+			Name:    "Invalidation",
+		},
 	}
 }
 

--- a/website/docs/r/cloudfront_invalidation.html.markdown
+++ b/website/docs/r/cloudfront_invalidation.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_invalidation"
+description: |-
+  Terraform resource for managing an AWS CloudFront Invalidation.
+---
+
+# Resource: aws_cloudfront_invalidation
+
+Terraform resource for managing an AWS CloudFront Invalidations.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_cloudfront_invalidation" "example" {
+  distribution_id = aws_cloudfront_distribution.example.id
+  paths = [
+    "/*",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `distribution_id` - (Required) CloudFront Distribution ID.
+* `paths` - (Required) List of paths to invalidate.
+* `triggers` (Optional) Map of arbitrary keys and values that, when changed, will trigger a re-invocation. To force a re-invocation without changing these keys/values, use the [`terraform taint` command](https://www.terraform.io/docs/commands/taint.html).
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - ID of the invalidation.
+* `status` - Invalidation status.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)


### PR DESCRIPTION
### Description

Add resource for CloudFront Invalidation:

### Relations

Closes #13298

### Output from Acceptance Testing

```console
%  make testacc TESTS=TestAccCloudFrontInvalidation PKG=cloudfront
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontInvalidation'  -timeout 360m
=== RUN   TestAccCloudFrontInvalidation_basic
=== PAUSE TestAccCloudFrontInvalidation_basic
=== CONT  TestAccCloudFrontInvalidation_basic
--- PASS: TestAccCloudFrontInvalidation_basic (262.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 266.116s
```
