### PR TITLE
r/route53_record Check region set

### DIFF
--- a/.changelog/37565.txt
+++ b/.changelog/37565.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_record: Change region default to us-east-1
+```

--- a/internal/service/route53/service_package.go
+++ b/internal/service/route53/service_package.go
@@ -21,9 +21,8 @@ func (p *servicePackage) NewConn(ctx context.Context, m map[string]any) (*route5
 	// Force "global" services to correct Regions.
 	switch m["partition"].(string) {
 	case endpoints_sdkv1.AwsPartitionID:
-		if aws_sdkv1.StringValue(config.Endpoint) == "" {
-			config.Region = aws_sdkv1.String(endpoints_sdkv1.UsWest2RegionID)
-		}
+		// https://docs.aws.amazon.com/general/latest/gr/r53.html Setting default to us-east-1
+		config.Region = aws_sdkv1.String(endpoints_sdkv1.UsEast1RegionID)
 	case endpoints_sdkv1.AwsCnPartitionID:
 		// The AWS Go SDK is missing endpoint information for Route 53 in the AWS China partition.
 		// This can likely be removed in the future.

--- a/internal/service/route53/service_package.go
+++ b/internal/service/route53/service_package.go
@@ -21,7 +21,9 @@ func (p *servicePackage) NewConn(ctx context.Context, m map[string]any) (*route5
 	// Force "global" services to correct Regions.
 	switch m["partition"].(string) {
 	case endpoints_sdkv1.AwsPartitionID:
-		config.Region = aws_sdkv1.String(endpoints_sdkv1.UsWest2RegionID)
+		if aws_sdkv1.StringValue(config.Endpoint) == "" {
+			config.Region = aws_sdkv1.String(endpoints_sdkv1.UsWest2RegionID)
+		}
 	case endpoints_sdkv1.AwsCnPartitionID:
 		// The AWS Go SDK is missing endpoint information for Route 53 in the AWS China partition.
 		// This can likely be removed in the future.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Change `route53` region default to `us-east-1`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #34016

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
> make testacc TESTS=TestAccRoute53Record_ PKG=route53
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53Record_'  -timeout 360m
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_disappears
=== PAUSE TestAccRoute53Record_disappears
=== RUN   TestAccRoute53Record_Disappears_multipleRecords
=== PAUSE TestAccRoute53Record_Disappears_multipleRecords
=== RUN   TestAccRoute53Record_underscored
=== PAUSE TestAccRoute53Record_underscored
=== RUN   TestAccRoute53Record_fqdn
=== PAUSE TestAccRoute53Record_fqdn
=== RUN   TestAccRoute53Record_trailingPeriodAndZoneID
=== PAUSE TestAccRoute53Record_trailingPeriodAndZoneID
=== RUN   TestAccRoute53Record_Support_txt
=== PAUSE TestAccRoute53Record_Support_txt
=== RUN   TestAccRoute53Record_Support_spf
=== PAUSE TestAccRoute53Record_Support_spf
=== RUN   TestAccRoute53Record_Support_caa
=== PAUSE TestAccRoute53Record_Support_caa
=== RUN   TestAccRoute53Record_Support_ds
=== PAUSE TestAccRoute53Record_Support_ds
=== RUN   TestAccRoute53Record_generatesSuffix
=== PAUSE TestAccRoute53Record_generatesSuffix
=== RUN   TestAccRoute53Record_wildcard
=== PAUSE TestAccRoute53Record_wildcard
=== RUN   TestAccRoute53Record_failover
=== PAUSE TestAccRoute53Record_failover
=== RUN   TestAccRoute53Record_Weighted_basic
=== PAUSE TestAccRoute53Record_Weighted_basic
=== RUN   TestAccRoute53Record_WeightedToSimple_basic
=== PAUSE TestAccRoute53Record_WeightedToSimple_basic
=== RUN   TestAccRoute53Record_Alias_elb
=== PAUSE TestAccRoute53Record_Alias_elb
=== RUN   TestAccRoute53Record_Alias_s3
=== PAUSE TestAccRoute53Record_Alias_s3
=== RUN   TestAccRoute53Record_Alias_vpcEndpoint
=== PAUSE TestAccRoute53Record_Alias_vpcEndpoint
=== RUN   TestAccRoute53Record_Alias_uppercase
=== PAUSE TestAccRoute53Record_Alias_uppercase
=== RUN   TestAccRoute53Record_Weighted_alias
=== PAUSE TestAccRoute53Record_Weighted_alias
=== RUN   TestAccRoute53Record_cidr
=== PAUSE TestAccRoute53Record_cidr
=== RUN   TestAccRoute53Record_Geolocation_basic
=== PAUSE TestAccRoute53Record_Geolocation_basic
=== RUN   TestAccRoute53Record_Geoproximity_basic
=== PAUSE TestAccRoute53Record_Geoproximity_basic
=== RUN   TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== PAUSE TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== RUN   TestAccRoute53Record_HealthCheckID_typeChange
=== PAUSE TestAccRoute53Record_HealthCheckID_typeChange
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53Record_typeChange
=== PAUSE TestAccRoute53Record_typeChange
=== RUN   TestAccRoute53Record_nameChange
=== PAUSE TestAccRoute53Record_nameChange
=== RUN   TestAccRoute53Record_setIdentifierChangeBasicToWeighted
=== PAUSE TestAccRoute53Record_setIdentifierChangeBasicToWeighted
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationContinent
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationContinent
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified
=== RUN   TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision
=== RUN   TestAccRoute53Record_SetIdentifierRename_geoproximityRegion
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geoproximityRegion
=== RUN   TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup
=== RUN   TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates
=== PAUSE TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates
=== RUN   TestAccRoute53Record_SetIdentifierRename_failover
=== PAUSE TestAccRoute53Record_SetIdentifierRename_failover
=== RUN   TestAccRoute53Record_SetIdentifierRename_latency
=== PAUSE TestAccRoute53Record_SetIdentifierRename_latency
=== RUN   TestAccRoute53Record_SetIdentifierRename_multiValueAnswer
=== PAUSE TestAccRoute53Record_SetIdentifierRename_multiValueAnswer
=== RUN   TestAccRoute53Record_SetIdentifierRename_weighted
=== PAUSE TestAccRoute53Record_SetIdentifierRename_weighted
=== RUN   TestAccRoute53Record_Alias_change
=== PAUSE TestAccRoute53Record_Alias_change
=== RUN   TestAccRoute53Record_Alias_changeDualstack
=== PAUSE TestAccRoute53Record_Alias_changeDualstack
=== RUN   TestAccRoute53Record_empty
=== PAUSE TestAccRoute53Record_empty
=== RUN   TestAccRoute53Record_longTXTrecord
=== PAUSE TestAccRoute53Record_longTXTrecord
=== RUN   TestAccRoute53Record_MultiValueAnswer_basic
=== PAUSE TestAccRoute53Record_MultiValueAnswer_basic
=== RUN   TestAccRoute53Record_Allow_doNotOverwrite
=== PAUSE TestAccRoute53Record_Allow_doNotOverwrite
=== RUN   TestAccRoute53Record_Allow_overwrite
=== PAUSE TestAccRoute53Record_Allow_overwrite
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53Record_HealthCheckID_typeChange
=== CONT  TestAccRoute53Record_SetIdentifierRename_failover
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault
=== CONT  TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates
=== CONT  TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup
=== CONT  TestAccRoute53Record_SetIdentifierRename_geoproximityRegion
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified
=== CONT  TestAccRoute53Record_failover
=== CONT  TestAccRoute53Record_HealthCheckID_setIdentifierChange
=== CONT  TestAccRoute53Record_Geoproximity_basic
=== CONT  TestAccRoute53Record_Geolocation_basic
=== CONT  TestAccRoute53Record_cidr
=== CONT  TestAccRoute53Record_Weighted_alias
=== CONT  TestAccRoute53Record_Alias_uppercase
=== CONT  TestAccRoute53Record_Alias_vpcEndpoint
=== CONT  TestAccRoute53Record_Alias_s3
=== CONT  TestAccRoute53Record_Alias_elb
=== CONT  TestAccRoute53Record_WeightedToSimple_basic
--- PASS: TestAccRoute53Record_failover (189.35s)
=== CONT  TestAccRoute53Record_Weighted_basic
--- PASS: TestAccRoute53Record_Alias_s3 (199.72s)
=== CONT  TestAccRoute53Record_Support_txt
--- PASS: TestAccRoute53Record_basic (205.92s)
=== CONT  TestAccRoute53Record_wildcard
--- PASS: TestAccRoute53Record_Alias_uppercase (209.84s)
=== CONT  TestAccRoute53Record_generatesSuffix
--- PASS: TestAccRoute53Record_Geoproximity_basic (215.14s)
=== CONT  TestAccRoute53Record_Support_spf
--- PASS: TestAccRoute53Record_Alias_elb (216.46s)
=== CONT  TestAccRoute53Record_underscored
--- PASS: TestAccRoute53Record_Geolocation_basic (245.80s)
=== CONT  TestAccRoute53Record_trailingPeriodAndZoneID
=== CONT  TestAccRoute53Record_fqdn
--- PASS: TestAccRoute53Record_SetIdentifierRename_geoproximityLocalZoneGroup (252.51s)
--- PASS: TestAccRoute53Record_SetIdentifierRename_geoproximityCoordinates (255.61s)
=== CONT  TestAccRoute53Record_empty
--- PASS: TestAccRoute53Record_WeightedToSimple_basic (256.81s)
=== CONT  TestAccRoute53Record_Allow_overwrite
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationCountryDefault (257.34s)
=== CONT  TestAccRoute53Record_Allow_doNotOverwrite
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationCountrySpecified (261.49s)
=== CONT  TestAccRoute53Record_MultiValueAnswer_basic
--- PASS: TestAccRoute53Record_HealthCheckID_typeChange (261.83s)
=== CONT  TestAccRoute53Record_longTXTrecord
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationCountrySubdivision (268.94s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_weighted
--- PASS: TestAccRoute53Record_HealthCheckID_setIdentifierChange (273.45s)
=== CONT  TestAccRoute53Record_Alias_changeDualstack
=== CONT  TestAccRoute53Record_Alias_change
--- PASS: TestAccRoute53Record_SetIdentifierRename_geoproximityRegion (319.24s)
--- PASS: TestAccRoute53Record_SetIdentifierRename_failover (328.57s)
=== CONT  TestAccRoute53Record_Support_ds
--- PASS: TestAccRoute53Record_Weighted_alias (372.21s)
=== CONT  TestAccRoute53Record_nameChange
--- PASS: TestAccRoute53Record_Alias_vpcEndpoint (376.50s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_geolocationContinent
--- PASS: TestAccRoute53Record_generatesSuffix (174.22s)
=== CONT  TestAccRoute53Record_Support_caa
--- PASS: TestAccRoute53Record_cidr (386.68s)
=== CONT  TestAccRoute53Record_Disappears_multipleRecords
--- PASS: TestAccRoute53Record_Weighted_basic (202.91s)
=== CONT  TestAccRoute53Record_disappears
--- PASS: TestAccRoute53Record_underscored (177.97s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_multiValueAnswer
--- PASS: TestAccRoute53Record_Support_spf (181.46s)
=== CONT  TestAccRoute53Record_SetIdentifierRename_latency
--- PASS: TestAccRoute53Record_Support_txt (211.35s)
=== CONT  TestAccRoute53Record_typeChange
--- PASS: TestAccRoute53Record_fqdn (168.96s)
=== CONT  TestAccRoute53Record_Latency_basic
--- PASS: TestAccRoute53Record_empty (166.57s)
=== CONT  TestAccRoute53Record_setIdentifierChangeBasicToWeighted
--- PASS: TestAccRoute53Record_longTXTrecord (166.49s)
--- PASS: TestAccRoute53Record_MultiValueAnswer_basic (169.31s)
--- PASS: TestAccRoute53Record_trailingPeriodAndZoneID (189.48s)
--- PASS: TestAccRoute53Record_Allow_doNotOverwrite (180.13s)
--- PASS: TestAccRoute53Record_wildcard (249.75s)
--- PASS: TestAccRoute53Record_Allow_overwrite (204.26s)
--- PASS: TestAccRoute53Record_SetIdentifierRename_weighted (212.88s)
--- PASS: TestAccRoute53Record_Alias_changeDualstack (218.30s)
--- PASS: TestAccRoute53Record_Support_ds (177.72s)
--- PASS: TestAccRoute53Record_Alias_change (188.15s)
--- PASS: TestAccRoute53Record_disappears (151.63s)
--- PASS: TestAccRoute53Record_Support_caa (172.17s)
--- PASS: TestAccRoute53Record_SetIdentifierRename_geolocationContinent (199.20s)
--- PASS: TestAccRoute53Record_Latency_basic (155.95s)
--- PASS: TestAccRoute53Record_typeChange (178.69s)
--- PASS: TestAccRoute53Record_SetIdentifierRename_multiValueAnswer (215.40s)
--- PASS: TestAccRoute53Record_Disappears_multipleRecords (236.04s)
--- PASS: TestAccRoute53Record_SetIdentifierRename_latency (245.06s)
--- PASS: TestAccRoute53Record_nameChange (269.80s)
--- PASS: TestAccRoute53Record_setIdentifierChangeBasicToWeighted (241.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    668.635s
```
