### PR TITLE
r/aws_m2_deployment: set `deployment_id` on start/stop

### DIFF
--- a/.changelog/37581.txt
+++ b/.changelog/37581.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_m2_deployment: Fix `state` with `deployment_id` during start/stop update
+```

--- a/.changelog/37581.txt
+++ b/.changelog/37581.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_m2_deployment: Fix `state` with `deployment_id` during start/stop update
+resource/aws_m2_deployment: Fix `state` error on `deployment_id` during start/stop update
 ```

--- a/internal/service/m2/deployment_test.go
+++ b/internal/service/m2/deployment_test.go
@@ -85,7 +85,7 @@ func TestAccM2Deployment_disappears(t *testing.T) {
 	})
 }
 
-func TestAccM2Deployment_nostart(t *testing.T) {
+func TestAccM2Deployment_start(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -115,6 +115,13 @@ func TestAccM2Deployment_nostart(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDeploymentConfig_basic(rName, "bluage", 1, 1, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
+					resource.TestCheckResourceAttr(resourceName, "application_version", acctest.Ct1),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

**Before:**

```console
% make testacc TESTARGS="-run=TestAccM2Deployment_start" PKG=m2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/m2/... -v -count 1 -parallel 20  -run=TestAccM2Deployment_nostart -timeout 360m
=== RUN   TestAccM2Deployment_start
=== PAUSE TestAccM2Deployment_start
=== CONT  TestAccM2Deployment_start
    deployment_test.go:97: Step 3/3 error: Error running apply: exit status 1

        Error: Provider returned invalid result object after apply

        After the apply operation, the provider still indicated an unknown value for
        aws_m2_deployment.test.deployment_id. All values must be known after apply,
        so this is always a bug in the provider and should be reported in the
        provider's own repository. Terraform will still save the other known object
        values in the state.
    panic.go:626: Error running post-test destroy, there may be dangling resources: operation error m2: GetDeployment, serialization failed: serialization failed: input member deploymentId must not be empty
--- FAIL: TestAccM2Deployment_nostart (2831.37s)
FAIL
FAIL	[github.com/hashicorp/terraform-provider-aws/internal/service/m2](http://github.com/hashicorp/terraform-provider-aws/internal/service/m2)	2836.723s
FAIL
make: *** [testacc] Error 1
```
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**After:**
```console
% make testacc TESTARGS="-run=TestAccM2Deployment_" PKG=m2

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/m2/... -v -count 1 -parallel 20  -run=TestAccM2Deployment_ -timeout 360m
--- PASS: TestAccM2Deployment_start (2868.05s)
--- PASS: TestAccM2Deployment_disappears (2919.10s)
--- PASS: TestAccM2Deployment_basic (2997.56s)
--- PASS: TestAccM2Deployment_update (3291.45s)
PASS
ok  	[github.com/hashicorp/terraform-provider-aws/internal/service/m2](http://github.com/hashicorp/terraform-provider-aws/internal/service/m2)	3296.872s
--- PASS: TestAccAppStreamDirectoryConfig_basic (3851.45s)
PASS
ok  	[github.com/hashicorp/terraform-provider-aws/internal/service/appstream](http://github.com/hashicorp/terraform-provider-aws/internal/service/appstream)	3856.704s
```
