### PR TITLE
feat: modify update method to use api to add or remove client ids wit…

### DIFF
--- a/.changelog/37612.txt
+++ b/.changelog/37612.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iam_openid_connect_provider: Allow `client_id_list` to be updated in-place
+```

--- a/internal/service/iam/openid_connect_provider.go
+++ b/internal/service/iam/openid_connect_provider.go
@@ -163,33 +163,33 @@ func resourceOpenIDConnectProviderUpdate(ctx context.Context, d *schema.Resource
 
 	if d.HasChange("client_id_list") {
 		o, n := d.GetChange("client_id_list")
-		oldSet, newSet := o.(*schema.Set), n.(*schema.Set)
+		os, ns := o.(*schema.Set), n.(*schema.Set)
 
-		for _, v := range newSet.Difference(oldSet).List() {
-			clientIdToAdd := v.(string)
+		for _, v := range ns.Difference(os).List() {
+			v := v.(string)
 			input := &iam.AddClientIDToOpenIDConnectProviderInput{
+				ClientID:                 aws.String(v),
 				OpenIDConnectProviderArn: aws.String(d.Id()),
-				ClientID:                 aws.String(clientIdToAdd),
 			}
 
 			_, err := conn.AddClientIDToOpenIDConnectProvider(ctx, input)
 
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "adding clientID (%s) to IAM OIDC Provider: %s", clientIdToAdd, err)
+				return sdkdiag.AppendErrorf(diags, "adding IAM OIDC Provider (%s) client ID (%s): %s", d.Id(), v, err)
 			}
 		}
 
-		for _, v := range oldSet.Difference(newSet).List() {
-			clientIdToRemove := v.(string)
+		for _, v := range os.Difference(ns).List() {
+			v := v.(string)
 			input := &iam.RemoveClientIDFromOpenIDConnectProviderInput{
+				ClientID:                 aws.String(v),
 				OpenIDConnectProviderArn: aws.String(d.Id()),
-				ClientID:                 aws.String(clientIdToRemove),
 			}
 
 			_, err := conn.RemoveClientIDFromOpenIDConnectProvider(ctx, input)
 
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "removing clientID (%s) from IAM OIDC Provider: %s", clientIdToRemove, err)
+				return sdkdiag.AppendErrorf(diags, "removing IAM OIDC Provider (%s) client ID (%s): %s", d.Id(), v, err)
 			}
 		}
 	}

--- a/internal/service/iam/openid_connect_provider_test.go
+++ b/internal/service/iam/openid_connect_provider_test.go
@@ -118,6 +118,55 @@ func TestAccIAMOpenIDConnectProvider_clientIDListOrder(t *testing.T) {
 	})
 }
 
+func TestAccIAMOpenIDConnectProvider_clientIDModification(t *testing.T) {
+	ctx := acctest.Context(t)
+	rString := sdkacctest.RandString(5)
+	resourceName := "aws_iam_openid_connect_provider.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenIDConnectProviderConfig_clientIDList_first(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccOpenIDConnectProviderConfig_clientIDList_add(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", acctest.Ct4),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.0", "abc.testle.com"),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.3", "xyz.testle.com"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccOpenIDConnectProviderConfig_clientIDList_remove(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenIDConnectProviderExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.#", acctest.Ct3),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.0", "def.testle.com"),
+					resource.TestCheckResourceAttr(resourceName, "client_id_list.2", "xyz.testle.com"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckOpenIDConnectProviderDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
@@ -216,6 +265,39 @@ resource "aws_iam_openid_connect_provider" "test" {
     "def.testle.com",
     "ghi.testle.com",
     "abc.testle.com",
+  ]
+
+  thumbprint_list = ["oif8192f189fa2178f-testle.thumbprint.com"]
+}
+`, rName)
+}
+
+func testAccOpenIDConnectProviderConfig_clientIDList_add(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_openid_connect_provider" "test" {
+  url = "https://accounts.testle.com/%[1]s"
+
+  client_id_list = [
+    "abc.testle.com",
+    "def.testle.com",
+    "ghi.testle.com",
+    "xyz.testle.com",
+  ]
+
+  thumbprint_list = ["oif8192f189fa2178f-testle.thumbprint.com"]
+}
+`, rName)
+}
+
+func testAccOpenIDConnectProviderConfig_clientIDList_remove(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_openid_connect_provider" "test" {
+  url = "https://accounts.testle.com/%[1]s"
+
+  client_id_list = [
+    "def.testle.com",
+    "ghi.testle.com",
+    "xyz.testle.com",
   ]
 
   thumbprint_list = ["oif8192f189fa2178f-testle.thumbprint.com"]


### PR DESCRIPTION
…hout destroying openid connect provider


### Description
This PR adds option to not recreate openid connect on changes in client list ids, as recreation is causing short downtime for existing clients which makes maintenance with terraform configuration bit harder.
 
On update on client ids now its using dedicated APIs to ADD and to REMOVE diffs in client list ids. Those APIs are idempotent, so if you try to add same client id it wont fail or if you try to delete non existing client id. 

Added acceptance tests to cover new cases.

### Relations

Closes #23099

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
```
make testacc TESTS='TestAccIAMOpenIDConnectProvider_' PKG=iam 
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go1.22.2 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMOpenIDConnectProvider_'  -timeout 360m
=== RUN   TestAccIAMOpenIDConnectProvider_tags
=== PAUSE TestAccIAMOpenIDConnectProvider_tags
=== RUN   TestAccIAMOpenIDConnectProvider_tags_null
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_null
=== RUN   TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate
=== RUN   TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate
=== RUN   TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnCreate
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnCreate
=== RUN   TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccIAMOpenIDConnectProvider_basic
=== PAUSE TestAccIAMOpenIDConnectProvider_basic
=== RUN   TestAccIAMOpenIDConnectProvider_disappears
=== PAUSE TestAccIAMOpenIDConnectProvider_disappears
=== RUN   TestAccIAMOpenIDConnectProvider_clientIDListOrder
=== PAUSE TestAccIAMOpenIDConnectProvider_clientIDListOrder
=== RUN   TestAccIAMOpenIDConnectProvider_clientIDModification
=== PAUSE TestAccIAMOpenIDConnectProvider_clientIDModification
=== CONT  TestAccIAMOpenIDConnectProvider_tags
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly
=== CONT  TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Replace
=== CONT  TestAccIAMOpenIDConnectProvider_tags_null
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccIAMOpenIDConnectProvider_clientIDListOrder
=== CONT  TestAccIAMOpenIDConnectProvider_clientIDModification
=== CONT  TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate
=== CONT  TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Add
=== CONT  TestAccIAMOpenIDConnectProvider_disappears
=== CONT  TestAccIAMOpenIDConnectProvider_basic
=== CONT  TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnCreate
=== CONT  TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping
=== CONT  TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccIAMOpenIDConnectProvider_disappears (49.01s)
=== CONT  TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResourceTag (64.93s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag (65.38s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag (65.91s)
--- PASS: TestAccIAMOpenIDConnectProvider_clientIDListOrder (68.12s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnCreate (68.31s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_null (79.12s)
--- PASS: TestAccIAMOpenIDConnectProvider_basic (85.50s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly (86.04s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace (88.79s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly (89.50s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate (90.47s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Replace (94.58s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate (95.10s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Add (95.51s)
--- PASS: TestAccIAMOpenIDConnectProvider_clientIDModification (107.84s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add (108.95s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping (112.84s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags (127.10s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping (79.82s)
--- PASS: TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly (130.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        135.250s
```
