### PR TITLE
chore(route53): add traffic policy document endpoint type 'application-load-balancer'

### DIFF
--- a/.changelog/37618.txt
+++ b/.changelog/37618.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/route53_traffic_policy_document: Add `application-load-balancer` endpoint type
+```

--- a/.changelog/37618.txt
+++ b/.changelog/37618.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/route53_traffic_policy_document: Add `application-load-balancer` endpoint type
+data-source/aws_route53_traffic_policy_document: Add support for `application-load-balancer, `elastic-beanstalk` and `network-load-balancer` `endpoint.type` values
 ```

--- a/internal/service/route53/traffic_policy_document_model.go
+++ b/internal/service/route53/traffic_policy_document_model.go
@@ -6,20 +6,24 @@ package route53
 type trafficPolicyDocEndpointType string
 
 const (
-	trafficPolicyDocEndpointCloudFront trafficPolicyDocEndpointType = "cloudfront"
-	trafficPolicyDocEndpointElastic    trafficPolicyDocEndpointType = "elastic-load-balancer"
-	trafficPolicyDocEndpointS3         trafficPolicyDocEndpointType = "s3-website"
-	trafficPolicyDocEndpointValue      trafficPolicyDocEndpointType = "value" // nosemgrep:ci.literal-value-string-constant
-	trafficPolicyDocEndpointALB        trafficPolicyDocEndpointType = "application-load-balancer"
+	trafficPolicyDocEndpointALB              trafficPolicyDocEndpointType = "application-load-balancer"
+	trafficPolicyDocEndpointCloudFront       trafficPolicyDocEndpointType = "cloudfront"
+	trafficPolicyDocEndpointElasticBeanstalk trafficPolicyDocEndpointType = "elastic-beanstalk"
+	trafficPolicyDocEndpointELB              trafficPolicyDocEndpointType = "elastic-load-balancer"
+	trafficPolicyDocEndpointNLB              trafficPolicyDocEndpointType = "network-load-balancer"
+	trafficPolicyDocEndpointS3Website        trafficPolicyDocEndpointType = "s3-website"
+	trafficPolicyDocEndpointValue            trafficPolicyDocEndpointType = "value" // nosemgrep:ci.literal-value-string-constant
 )
 
 func (trafficPolicyDocEndpointType) Values() []trafficPolicyDocEndpointType {
 	return []trafficPolicyDocEndpointType{
-		trafficPolicyDocEndpointCloudFront,
-		trafficPolicyDocEndpointElastic,
-		trafficPolicyDocEndpointS3,
-		trafficPolicyDocEndpointValue, // nosemgrep:ci.literal-value-string-constant
 		trafficPolicyDocEndpointALB,
+		trafficPolicyDocEndpointCloudFront,
+		trafficPolicyDocEndpointElasticBeanstalk,
+		trafficPolicyDocEndpointELB,
+		trafficPolicyDocEndpointNLB,
+		trafficPolicyDocEndpointS3Website,
+		trafficPolicyDocEndpointValue, // nosemgrep:ci.literal-value-string-constant
 	}
 }
 

--- a/internal/service/route53/traffic_policy_document_model.go
+++ b/internal/service/route53/traffic_policy_document_model.go
@@ -10,6 +10,7 @@ const (
 	trafficPolicyDocEndpointElastic    trafficPolicyDocEndpointType = "elastic-load-balancer"
 	trafficPolicyDocEndpointS3         trafficPolicyDocEndpointType = "s3-website"
 	trafficPolicyDocEndpointValue      trafficPolicyDocEndpointType = "value" // nosemgrep:ci.literal-value-string-constant
+	trafficPolicyDocEndpointALB        trafficPolicyDocEndpointType = "application-load-balancer"
 )
 
 func (trafficPolicyDocEndpointType) Values() []trafficPolicyDocEndpointType {
@@ -18,6 +19,7 @@ func (trafficPolicyDocEndpointType) Values() []trafficPolicyDocEndpointType {
 		trafficPolicyDocEndpointElastic,
 		trafficPolicyDocEndpointS3,
 		trafficPolicyDocEndpointValue, // nosemgrep:ci.literal-value-string-constant
+		trafficPolicyDocEndpointALB,
 	}
 }
 

--- a/website/docs/cdktf/typescript/d/route53_traffic_policy_document.html.markdown
+++ b/website/docs/cdktf/typescript/d/route53_traffic_policy_document.html.markdown
@@ -185,7 +185,7 @@ The following arguments are optional:
 ### `endpoint`
 
 * `id` - (Required) ID of an endpoint you want to assign.
-* `type` - (Optional) Type of the endpoint. Valid values are `value` , `cloudfront` , `elastic-load-balancer`, `s3-website`
+* `type` - (Optional) Type of the endpoint. Valid values are `value` , `cloudfront` , `application-load-balancer`, `elastic-load-balancer`, `s3-website`
 * `region` - (Optional) To route traffic to an Amazon S3 bucket that is configured as a website endpoint, specify the region in which you created the bucket for `region`.
 * `value` - (Optional) Value of the `type`.
 

--- a/website/docs/d/route53_traffic_policy_document.html.markdown
+++ b/website/docs/d/route53_traffic_policy_document.html.markdown
@@ -152,7 +152,7 @@ The following arguments are optional:
 ### `endpoint`
 
 * `id` - (Required) ID of an endpoint you want to assign.
-* `type` - (Optional) Type of the endpoint. Valid values are `value` , `cloudfront` , `elastic-load-balancer`, `s3-website`
+* `type` - (Optional) Type of the endpoint. Valid values are `value`, `cloudfront`, `elastic-load-balancer`, `s3-website`, `application-load-balancer`, `network-load-balancer` and `elastic-beanstalk`
 * `region` - (Optional) To route traffic to an Amazon S3 bucket that is configured as a website endpoint, specify the region in which you created the bucket for `region`.
 * `value` - (Optional) Value of the `type`.
 


### PR DESCRIPTION
## Description

This PR adds application-load-balancer endpoint type according to https://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html to the traffic_policy_document_model.

Closes https://github.com/hashicorp/terraform-provider-aws/issues/34315.