### PR TITLE
[Docs]: Mark ip_address as required in aws_customer_gateway resource

### DIFF
--- a/website/docs/r/customer_gateway.html.markdown
+++ b/website/docs/r/customer_gateway.html.markdown
@@ -33,7 +33,7 @@ This resource supports the following arguments:
 * `bgp_asn` - (Required) The gateway's Border Gateway Protocol (BGP) Autonomous System Number (ASN).
 * `certificate_arn` - (Optional) The Amazon Resource Name (ARN) for the customer gateway certificate.
 * `device_name` - (Optional) A name for the customer gateway device.
-* `ip_address` - (Optional) The IPv4 address for the customer gateway device's outside interface.
+* `ip_address` - (Required) The IPv4 address for the customer gateway device's outside interface.
 * `type` - (Required) The type of customer gateway. The only type AWS
   supports at this time is "ipsec.1".
 * `tags` - (Optional) Tags to apply to the gateway. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.

--- a/website/docs/r/pipes_pipe.html.markdown
+++ b/website/docs/r/pipes_pipe.html.markdown
@@ -172,7 +172,7 @@ resource "aws_pipes_pipe" "example" {
 The following arguments are required:
 
 * `role_arn` - (Required) ARN of the role that allows the pipe to send data to the target.
-* `source` - (Required) Source resource of the pipe (typically an ARN).
+* `source` - (Required) Source resource of the pipe. This field typically requires an ARN (Amazon Resource Name). However, when using a self-managed Kafka cluster, you should use a different format. Instead of an ARN, use 'smk://' followed by the bootstrap server's address.
 * `target` - (Required) Target resource of the pipe (typically an ARN).
 
 The following arguments are optional:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This pull request addresses issue #37553.

The `ip_address` argument in the `aws_customer_gateway` resource was incorrectly marked as optional in the documentation. However, not specifying this parameter results in the following error:

**Error: creating EC2 Customer Gateway: MissingParameter: The request must contain the parameter ipAddress**


### Changes Made

- Updated the documentation to mark `ip_address` as a required argument.

### Testing

- Documentation changes only.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
