### PR TITLE
r/aws_lambda_function: re-implement replace_security_groups_on_destroy

### DIFF
--- a/.changelog/37624.txt
+++ b/.changelog/37624.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_function: Remove `replace_security_group_on_destroy` and `replacement_security_group_ids` deprecations, re-implement with alternate workflow
+```

--- a/internal/service/ec2/findv2.go
+++ b/internal/service/ec2/findv2.go
@@ -298,6 +298,19 @@ func findSecurityGroupsV2(ctx context.Context, conn *ec2.Client, input *ec2.Desc
 	return output, nil
 }
 
+// FindSecurityGroupByNameAndVPCIDV2 looks up a security group by name, VPC ID. Returns a retry.NotFoundError if not found.
+func FindSecurityGroupByNameAndVPCIDV2(ctx context.Context, conn *ec2.Client, name, vpcID string) (*awstypes.SecurityGroup, error) {
+	input := &ec2.DescribeSecurityGroupsInput{
+		Filters: newAttributeFilterListV2(
+			map[string]string{
+				"group-name": name,
+				"vpc-id":     vpcID,
+			},
+		),
+	}
+	return findSecurityGroupV2(ctx, conn, input)
+}
+
 func findIPAMPoolAllocationsV2(ctx context.Context, conn *ec2.Client, input *ec2.GetIpamPoolAllocationsInput) ([]awstypes.IpamPoolAllocation, error) {
 	var output []awstypes.IpamPoolAllocation
 

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -280,8 +280,12 @@ The following arguments are optional:
 * `package_type` - (Optional) Lambda deployment package type. Valid values are `Zip` and `Image`. Defaults to `Zip`.
 * `publish` - (Optional) Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
 * `reserved_concurrent_executions` - (Optional) Amount of reserved concurrent executions for this lambda function. A value of `0` disables lambda from being triggered and `-1` removes any concurrency limitations. Defaults to Unreserved Concurrency Limits `-1`. See [Managing Concurrency][9]
-* `replace_security_groups_on_destroy` - (Optional, **Deprecated**) **AWS no longer supports this operation. This attribute now has no effect and will be removed in a future major version.** Whether to replace the security groups on associated lambda network interfaces upon destruction. Removing these security groups from orphaned network interfaces can speed up security group deletion times by avoiding a dependency on AWS's internal cleanup operations. By default, the ENI security groups will be replaced with the `default` security group in the function's VPC. Set the `replacement_security_group_ids` attribute to use a custom list of security groups for replacement.
-* `replacement_security_group_ids` - (Optional, **Deprecated**) List of security group IDs to assign to orphaned Lambda function network interfaces upon destruction. `replace_security_groups_on_destroy` must be set to `true` to use this attribute.
+* `replace_security_groups_on_destroy` - (Optional) Whether to replace the security groups on the function's VPC configuration prior to destruction.
+Removing these security group associations prior to function destruction can speed up security group deletion times of AWS's internal cleanup operations.
+By default, the security groups will be replaced with the `default` security group in the function's configured VPC.
+Set the `replacement_security_group_ids` attribute to use a custom list of security groups for replacement.
+* `replacement_security_group_ids` - (Optional) List of security group IDs to assign to the function's VPC configuration prior to destruction.
+`replace_security_groups_on_destroy` must be set to `true` to use this attribute.
 * `runtime` - (Optional) Identifier of the function's runtime. See [Runtimes][6] for valid values.
 * `s3_bucket` - (Optional) S3 bucket location containing the function's deployment package. This bucket must reside in the same AWS region where you are creating the Lambda function. Exactly one of `filename`, `image_uri`, or `s3_bucket` must be specified. When `s3_bucket` is set, `s3_key` is required.
 * `s3_key` - (Optional) S3 key of an object containing the function's deployment package. When `s3_bucket` is set, `s3_key` is required.


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change implements an alternative approach for improving deletion times of security groups associated with deleted Lambda functions. Previously, the `replace_security_groups_on_destroy` and `replacement_security_group_ids` were deprecated as AWS began disallowing modification of the security groups assigned to orphaned ENI's left behind after destruction of a Lambda function.

The deprecations on these arguments will be removed with this re-implementation. Instead of attempting to modify orphaned ENI's after deletion of the function, this approach replaces the security groups assigned in the functions VPC configuration, waits for the configuration update to complete, and then deletes the function. This re-ordering allows for faster security group deletion as the lambda function ENI's left behind after deletion do not contain the configured security groups. This approach also does not violate AWS rules around mutability of Lambda function ENI's, as Lambda is handling replacement of the security groups associated with the ENI's internally. While improvements are not as significant as the previous approach, this option still offers a significant reduction in destroy time when compared to a configurations without this option enabled.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31911
Relates https://github.com/hashicorp/terraform-provider-aws/pull/31904
Relates https://github.com/hashicorp/terraform-provider-aws/issues/31520

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lambda TESTS="TestAccLambdaFunction_VPC_replaceSGWith"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_VPC_replaceSGWith'  -timeout 360m

--- PASS: TestAccLambdaFunction_VPC_replaceSGWithDefault (426.21s)
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithCustom (648.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     653.553s
```

```console
% make testacc PKG=lambda TESTS="TestAccLambdaFunction_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunction_'  -timeout 360m

--- PASS: TestAccLambdaFunction_expectFilenameAndS3Attributes (7.82s)
=== CONT  TestAccLambdaFunction_loggingConfig
--- PASS: TestAccLambdaFunction_nameValidation (8.23s)
=== CONT  TestAccLambdaFunction_ephemeralStorage
--- PASS: TestAccLambdaFunction_Zip_validation (13.86s)
=== CONT  TestAccLambdaFunction_architecturesWithLayer
--- PASS: TestAccLambdaFunction_versioned (49.69s)
=== CONT  TestAccLambdaFunction_architecturesUpdate
--- PASS: TestAccLambdaFunction_S3Update_unversioned (59.60s)
=== CONT  TestAccLambdaFunction_architectures
--- PASS: TestAccLambdaFunction_skipDestroyInconsistentPlan (60.70s)
=== CONT  TestAccLambdaFunction_EnvironmentVariables_noValue
--- PASS: TestAccLambdaFunction_S3Update_basic (62.64s)
=== CONT  TestAccLambdaFunction_tags
--- PASS: TestAccLambdaFunction_nilDeadLetter (68.23s)
=== CONT  TestAccLambdaFunction_unpublishedCodeUpdate
--- PASS: TestAccLambdaFunction_basic (71.08s)
=== CONT  TestAccLambdaFunction_envVariables
--- PASS: TestAccLambdaFunction_tracing (74.88s)
=== CONT  TestAccLambdaFunction_disappears
--- PASS: TestAccLambdaFunction_EnvironmentVariables_emptyUpgrade (76.27s)
=== CONT  TestAccLambdaFunction_disablePublish
--- PASS: TestAccLambdaFunction_skipDestroy (80.78s)
=== CONT  TestAccLambdaFunction_deadLetterUpdated
--- PASS: TestAccLambdaFunction_snapStart (81.34s)
=== CONT  TestAccLambdaFunction_deadLetter
--- PASS: TestAccLambdaFunction_concurrencyCycle (98.23s)
=== CONT  TestAccLambdaFunction_VPCPublishNo_changes
--- PASS: TestAccLambdaFunction_codeSigning (105.37s)
=== CONT  TestAccLambdaFunction_s3
--- PASS: TestAccLambdaFunction_ephemeralStorage (114.15s)
=== CONT  TestAccLambdaFunction_emptyVPC
--- PASS: TestAccLambdaFunction_s3 (26.56s)
=== CONT  TestAccLambdaFunction_VPC_replaceSGWithCustom
--- PASS: TestAccLambdaFunction_loggingConfig (126.46s)
=== CONT  TestAccLambdaFunction_VPC_replaceSGWithDefault
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (304.98s)
=== CONT  TestAccLambdaFunction_VPC_properIAMDependencies
--- PASS: TestAccLambdaFunction_localUpdate (310.81s)
=== CONT  TestAccLambdaFunction_VPCPublishHas_changes
--- PASS: TestAccLambdaFunction_EnvironmentVariables_noValue (273.32s)
=== CONT  TestAccLambdaFunction_enablePublish
--- PASS: TestAccLambdaFunction_architectures (276.70s)
=== CONT  TestAccLambdaFunction_versionedUpdate
--- PASS: TestAccLambdaFunction_disappears (281.36s)
=== CONT  TestAccLambdaFunction_encryptedEnvVariables
--- PASS: TestAccLambdaFunction_tags (297.75s)
=== CONT  TestAccLambdaFunction_vpc
--- PASS: TestAccLambdaFunction_disablePublish (297.83s)
=== CONT  TestAccLambdaFunction_VPC_withInvocation
--- PASS: TestAccLambdaFunction_deadLetterUpdated (309.54s)
=== CONT  TestAccLambdaFunction_vpcUpdate
--- PASS: TestAccLambdaFunction_deadLetter (310.61s)
=== CONT  TestAccLambdaFunction_vpcRemoval
--- PASS: TestAccLambdaFunction_envVariables (331.82s)
=== CONT  TestAccLambdaFunction_layers
--- PASS: TestAccLambdaFunction_runtimes (438.40s)
=== CONT  TestAccLambdaFunction_layersUpdate
--- PASS: TestAccLambdaFunction_architecturesWithLayer (562.33s)
=== CONT  TestAccLambdaFunction_concurrency
--- PASS: TestAccLambdaFunction_ipv6AllowedForDualStack (701.53s)
=== CONT  TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables
--- PASS: TestAccLambdaFunction_emptyVPC (643.83s)
--- PASS: TestAccLambdaFunction_fileSystem (907.72s)
--- PASS: TestAccLambdaFunction_VPCPublishNo_changes (938.12s)
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithCustom (1056.70s)
--- PASS: TestAccLambdaFunction_architecturesUpdate (1295.23s)
--- PASS: TestAccLambdaFunction_VPC_properIAMDependencies (1056.01s)
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithDefault (1226.73s)
--- PASS: TestAccLambdaFunction_enablePublish (1038.48s)
--- PASS: TestAccLambdaFunction_unpublishedCodeUpdate (1479.15s)
--- PASS: TestAccLambdaFunction_encryptedEnvVariables (1228.87s)
--- PASS: TestAccLambdaFunction_VPCPublishHas_changes (1424.59s)
--- PASS: TestAccLambdaFunction_vpc (1569.97s)
--- PASS: TestAccLambdaFunction_layers (1546.31s)
--- PASS: TestAccLambdaFunction_VPC_withInvocation (1588.27s)
--- PASS: TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables (1654.83s)
--- PASS: TestAccLambdaFunction_concurrency (1782.71s)
--- PASS: TestAccLambdaFunction_layersUpdate (1924.70s)
--- PASS: TestAccLambdaFunction_versionedUpdate (2040.51s)
--- PASS: TestAccLambdaFunction_vpcUpdate (2161.88s)
--- PASS: TestAccLambdaFunction_vpcRemoval (2161.44s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     2558.481s
```