### PR TITLE
Enable and fix semgrep `diags` checks for additional services: `w*`, `v*` and `t*`

### DIFF
--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-v]*
+        - internal/service/[o-t]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +14,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-v]*
+        - internal/service/[o-t]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +24,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[o-v]*
+        - internal/service/[o-t]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +34,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-v]*
+        - internal/service/[o-t]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +44,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-v]*
+        - internal/service/[o-t]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +54,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-v]*
+        - internal/service/[o-t]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -72,7 +72,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-v]*
+        - internal/service/[o-t]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -93,7 +93,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[o-v]*
+        - internal/service/[o-t]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-z]*
+        - internal/service/[o-v]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +14,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-z]*
+        - internal/service/[o-v]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +24,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[o-z]*
+        - internal/service/[o-v]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +34,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-z]*
+        - internal/service/[o-v]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +44,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-z]*
+        - internal/service/[o-v]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +54,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-z]*
+        - internal/service/[o-v]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -72,7 +72,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-z]*
+        - internal/service/[o-v]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -93,7 +93,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[o-z]*
+        - internal/service/[o-v]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-t]*
+        - internal/service/[o-s]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +14,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-t]*
+        - internal/service/[o-s]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +24,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[o-t]*
+        - internal/service/[o-s]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +34,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-t]*
+        - internal/service/[o-s]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +44,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-t]*
+        - internal/service/[o-s]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +54,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-t]*
+        - internal/service/[o-s]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -72,7 +72,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-t]*
+        - internal/service/[o-s]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -93,7 +93,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[o-t]*
+        - internal/service/[o-s]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/internal/service/timestreamwrite/database.go
+++ b/internal/service/timestreamwrite/database.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -73,6 +74,7 @@ func resourceDatabase() *schema.Resource {
 }
 
 func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).TimestreamWriteClient(ctx)
 
 	name := d.Get(names.AttrDatabaseName).(string)
@@ -88,15 +90,16 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 	output, err := conn.CreateDatabase(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Timestream Database (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Timestream Database (%s): %s", name, err)
 	}
 
 	d.SetId(aws.ToString(output.Database.DatabaseName))
 
-	return resourceDatabaseRead(ctx, d, meta)
+	return append(diags, resourceDatabaseRead(ctx, d, meta)...)
 }
 
 func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).TimestreamWriteClient(ctx)
 
 	db, err := findDatabaseByName(ctx, conn, d.Id())
@@ -104,11 +107,11 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Timestream Database %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Timestream Database (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Timestream Database (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, db.Arn)
@@ -116,10 +119,11 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set(names.AttrKMSKeyID, db.KmsKeyId)
 	d.Set("table_count", db.TableCount)
 
-	return nil
+	return diags
 }
 
 func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).TimestreamWriteClient(ctx)
 
 	if d.HasChange(names.AttrKMSKeyID) {
@@ -131,14 +135,15 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		_, err := conn.UpdateDatabase(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Timestream Database (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Timestream Database (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceDatabaseRead(ctx, d, meta)
+	return append(diags, resourceDatabaseRead(ctx, d, meta)...)
 }
 
 func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).TimestreamWriteClient(ctx)
 
 	log.Printf("[INFO] Deleting Timestream Database: %s", d.Id())
@@ -147,14 +152,14 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Timestream Database (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Timestream Database (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findDatabaseByName(ctx context.Context, conn *timestreamwrite.Client, name string) (*types.Database, error) {

--- a/internal/service/transcribe/medical_vocabulary.go
+++ b/internal/service/transcribe/medical_vocabulary.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -79,6 +80,7 @@ func ResourceMedicalVocabulary() *schema.Resource {
 }
 
 func resourceMedicalVocabularyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).TranscribeClient(ctx)
 
 	vocabularyName := d.Get("vocabulary_name").(string)
@@ -91,23 +93,24 @@ func resourceMedicalVocabularyCreate(ctx context.Context, d *schema.ResourceData
 
 	out, err := conn.CreateMedicalVocabulary(ctx, in)
 	if err != nil {
-		return diag.Errorf("creating Amazon Transcribe MedicalVocabulary (%s): %s", d.Get("vocabulary_name").(string), err)
+		return sdkdiag.AppendErrorf(diags, "creating Amazon Transcribe MedicalVocabulary (%s): %s", d.Get("vocabulary_name").(string), err)
 	}
 
 	if out == nil {
-		return diag.Errorf("creating Amazon Transcribe MedicalVocabulary (%s): empty output", d.Get(names.AttrName).(string))
+		return sdkdiag.AppendErrorf(diags, "creating Amazon Transcribe MedicalVocabulary (%s): empty output", d.Get(names.AttrName).(string))
 	}
 
 	d.SetId(aws.ToString(out.VocabularyName))
 
 	if _, err := waitMedicalVocabularyCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for Amazon Transcribe MedicalVocabulary (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Amazon Transcribe MedicalVocabulary (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceMedicalVocabularyRead(ctx, d, meta)
+	return append(diags, resourceMedicalVocabularyRead(ctx, d, meta)...)
 }
 
 func resourceMedicalVocabularyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).TranscribeClient(ctx)
 
 	out, err := FindMedicalVocabularyByName(ctx, conn, d.Id())
@@ -115,11 +118,11 @@ func resourceMedicalVocabularyRead(ctx context.Context, d *schema.ResourceData, 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Transcribe MedicalVocabulary (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Transcribe MedicalVocabulary (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Transcribe MedicalVocabulary (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{
@@ -135,10 +138,11 @@ func resourceMedicalVocabularyRead(ctx context.Context, d *schema.ResourceData, 
 	d.Set("vocabulary_name", out.VocabularyName)
 	d.Set(names.AttrLanguageCode, out.LanguageCode)
 
-	return nil
+	return diags
 }
 
 func resourceMedicalVocabularyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).TranscribeClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
@@ -154,18 +158,19 @@ func resourceMedicalVocabularyUpdate(ctx context.Context, d *schema.ResourceData
 		log.Printf("[DEBUG] Updating Transcribe MedicalVocabulary (%s): %#v", d.Id(), in)
 		_, err := conn.UpdateMedicalVocabulary(ctx, in)
 		if err != nil {
-			return diag.Errorf("updating Transcribe MedicalVocabulary (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Transcribe MedicalVocabulary (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitMedicalVocabularyUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Transcribe MedicalVocabulary (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Transcribe MedicalVocabulary (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceMedicalVocabularyRead(ctx, d, meta)
+	return append(diags, resourceMedicalVocabularyRead(ctx, d, meta)...)
 }
 
 func resourceMedicalVocabularyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).TranscribeClient(ctx)
 
 	log.Printf("[INFO] Deleting Transcribe MedicalVocabulary %s", d.Id())
@@ -176,18 +181,18 @@ func resourceMedicalVocabularyDelete(ctx context.Context, d *schema.ResourceData
 
 	var badRequestException *types.BadRequestException
 	if errors.As(err, &badRequestException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Transcribe MedicalVocabulary (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Transcribe MedicalVocabulary (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitMedicalVocabularyDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Transcribe MedicalVocabulary (%s) to be deleted: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Transcribe MedicalVocabulary (%s) to be deleted: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func waitMedicalVocabularyCreated(ctx context.Context, conn *transcribe.Client, id string, timeout time.Duration) (*transcribe.GetMedicalVocabularyOutput, error) {

--- a/internal/service/vpclattice/auth_policy.go
+++ b/internal/service/vpclattice/auth_policy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -71,12 +72,13 @@ const (
 )
 
 func resourceAuthPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 	resourceId := d.Get("resource_identifier").(string)
 
 	policy, err := structure.NormalizeJsonString(d.Get(names.AttrPolicy).(string))
 	if err != nil {
-		return diag.Errorf("policy (%s) is invalid JSON: %s", policy, err)
+		return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", policy, err)
 	}
 
 	in := &vpclattice.PutAuthPolicyInput{
@@ -88,15 +90,16 @@ func resourceAuthPolicyPut(ctx context.Context, d *schema.ResourceData, meta int
 
 	_, err = conn.PutAuthPolicy(ctx, in)
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameAuthPolicy, d.Get(names.AttrPolicy).(string), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameAuthPolicy, d.Get(names.AttrPolicy).(string), err)
 	}
 
 	d.SetId(resourceId)
 
-	return resourceAuthPolicyRead(ctx, d, meta)
+	return append(diags, resourceAuthPolicyRead(ctx, d, meta)...)
 }
 
 func resourceAuthPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 	resourceId := d.Id()
 
@@ -106,15 +109,15 @@ func resourceAuthPolicyRead(ctx context.Context, d *schema.ResourceData, meta in
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VPCLattice AuthPolicy (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameAuthPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameAuthPolicy, d.Id(), err)
 	}
 
 	if policy == nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameAuthPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameAuthPolicy, d.Id(), err)
 	}
 
 	d.Set("resource_identifier", resourceId)
@@ -122,15 +125,16 @@ func resourceAuthPolicyRead(ctx context.Context, d *schema.ResourceData, meta in
 	policyToSet, err := verify.PolicyToSet(d.Get(names.AttrPolicy).(string), aws.ToString(policy.Policy))
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameAuthPolicy, aws.ToString(policy.Policy), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameAuthPolicy, aws.ToString(policy.Policy), err)
 	}
 
 	d.Set(names.AttrPolicy, policyToSet)
 
-	return nil
+	return diags
 }
 
 func resourceAuthPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VPCLattice AuthPolicy: %s", d.Id())
@@ -141,13 +145,13 @@ func resourceAuthPolicyDelete(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.VPCLattice, create.ErrActionDeleting, ResNameAuthPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameAuthPolicy, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findAuthPolicy(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetAuthPolicyOutput, error) {

--- a/internal/service/vpclattice/auth_policy_data_source.go
+++ b/internal/service/vpclattice/auth_policy_data_source.go
@@ -45,13 +45,14 @@ const (
 )
 
 func dataSourceAuthPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	resourceID := d.Get("resource_identifier").(string)
 	out, err := findAuthPolicy(ctx, conn, resourceID)
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, DSNameAuthPolicy, resourceID, err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameAuthPolicy, resourceID, err)
 	}
 
 	d.SetId(resourceID)
@@ -62,15 +63,15 @@ func dataSourceAuthPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 	// TIP: Setting a JSON string to avoid errorneous diffs.
 	p, err := verify.SecondJSONUnlessEquivalent(d.Get(names.AttrPolicy).(string), aws.ToString(out.Policy))
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionSetting, DSNameAuthPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionSetting, DSNameAuthPolicy, d.Id(), err)
 	}
 
 	p, err = structure.NormalizeJsonString(p)
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, DSNameAuthPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameAuthPolicy, d.Id(), err)
 	}
 
 	d.Set(names.AttrPolicy, p)
 
-	return nil
+	return diags
 }

--- a/internal/service/vpclattice/listener_data_source.go
+++ b/internal/service/vpclattice/listener_data_source.go
@@ -125,6 +125,7 @@ const (
 )
 
 func dataSourceListenerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	serviceId := d.Get("service_identifier").(string)
@@ -132,7 +133,7 @@ func dataSourceListenerRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	out, err := findListenerByListenerIdAndServiceId(ctx, conn, listenerId, serviceId)
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, DSNameListener, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameListener, d.Id(), err)
 	}
 
 	// Set simple arguments
@@ -149,7 +150,7 @@ func dataSourceListenerRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	// Flatten complex default_action attribute - uses flatteners from listener.go
 	if err := d.Set(names.AttrDefaultAction, flattenListenerRuleActionsDataSource(out.DefaultAction)); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionSetting, DSNameListener, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionSetting, DSNameListener, d.Id(), err)
 	}
 
 	// Set tags
@@ -157,15 +158,15 @@ func dataSourceListenerRead(ctx context.Context, d *schema.ResourceData, meta in
 	tags, err := listTags(ctx, conn, aws.ToString(out.Arn))
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, DSNameListener, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameListener, d.Id(), err)
 	}
 
 	//lintignore:AWSR002
 	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionSetting, DSNameListener, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionSetting, DSNameListener, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findListenerByListenerIdAndServiceId(ctx context.Context, conn *vpclattice.Client, listener_id string, service_id string) (*vpclattice.GetListenerOutput, error) {

--- a/internal/service/vpclattice/resource_policy.go
+++ b/internal/service/vpclattice/resource_policy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -62,13 +63,14 @@ const (
 )
 
 func resourceResourcePolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 	resourceArn := d.Get(names.AttrResourceARN).(string)
 
 	policy, err := structure.NormalizeJsonString(d.Get(names.AttrPolicy).(string))
 
 	if err != nil {
-		return diag.Errorf("policy (%s) is invalid JSON: %s", policy, err)
+		return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", policy, err)
 	}
 
 	in := &vpclattice.PutResourcePolicyInput{
@@ -79,15 +81,16 @@ func resourceResourcePolicyPut(ctx context.Context, d *schema.ResourceData, meta
 	_, err = conn.PutResourcePolicy(ctx, in)
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameResourcePolicy, d.Get(names.AttrPolicy).(string), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameResourcePolicy, d.Get(names.AttrPolicy).(string), err)
 	}
 
 	d.SetId(resourceArn)
 
-	return resourceResourcePolicyRead(ctx, d, meta)
+	return append(diags, resourceResourcePolicyRead(ctx, d, meta)...)
 }
 
 func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	resourceArn := d.Id()
@@ -96,15 +99,15 @@ func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VPCLattice ResourcePolicy (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameResourcePolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameResourcePolicy, d.Id(), err)
 	}
 
 	if policy == nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameResourcePolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameResourcePolicy, d.Id(), err)
 	}
 
 	d.Set(names.AttrResourceARN, resourceArn)
@@ -112,15 +115,16 @@ func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, met
 	policyToSet, err := verify.PolicyToSet(d.Get(names.AttrPolicy).(string), aws.ToString(policy.Policy))
 
 	if err != nil {
-		return diag.Errorf("setting policy %s: %s", aws.ToString(policy.Policy), err)
+		return sdkdiag.AppendErrorf(diags, "setting policy %s: %s", aws.ToString(policy.Policy), err)
 	}
 
 	d.Set(names.AttrPolicy, policyToSet)
 
-	return nil
+	return diags
 }
 
 func resourceResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VPCLattice ResourcePolicy: %s", d.Id())
@@ -131,13 +135,13 @@ func resourceResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.VPCLattice, create.ErrActionDeleting, ResNameResourcePolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameResourcePolicy, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findResourcePolicyByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetResourcePolicyOutput, error) {

--- a/internal/service/vpclattice/resource_policy_data_source.go
+++ b/internal/service/vpclattice/resource_policy_data_source.go
@@ -38,21 +38,22 @@ const (
 )
 
 func dataSourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	resourceArn := d.Get(names.AttrResourceARN).(string)
 
 	out, err := findResourcePolicyByID(ctx, conn, resourceArn)
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, DSNameResourcePolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameResourcePolicy, d.Id(), err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, DSNameResourcePolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameResourcePolicy, d.Id(), err)
 	}
 
 	d.SetId(resourceArn)
 	d.Set(names.AttrPolicy, out.Policy)
 
-	return nil
+	return diags
 }

--- a/internal/service/vpclattice/service.go
+++ b/internal/service/vpclattice/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -107,6 +108,7 @@ const (
 )
 
 func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	in := &vpclattice.CreateServiceInput{
@@ -130,19 +132,20 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 	out, err := conn.CreateService(ctx, in)
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameService, d.Get(names.AttrName).(string), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameService, d.Get(names.AttrName).(string), err)
 	}
 
 	d.SetId(aws.ToString(out.Id))
 
 	if _, err := waitServiceCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForCreation, ResNameService, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForCreation, ResNameService, d.Id(), err)
 	}
 
-	return resourceServiceRead(ctx, d, meta)
+	return append(diags, resourceServiceRead(ctx, d, meta)...)
 }
 
 func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	out, err := findServiceByID(ctx, conn, d.Id())
@@ -150,11 +153,11 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VPCLattice Service (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameService, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameService, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
@@ -163,7 +166,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("custom_domain_name", out.CustomDomainName)
 	if out.DnsEntry != nil {
 		if err := d.Set("dns_entry", []interface{}{flattenDNSEntry(out.DnsEntry)}); err != nil {
-			return diag.Errorf("setting dns_entry: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting dns_entry: %s", err)
 		}
 	} else {
 		d.Set("dns_entry", nil)
@@ -171,10 +174,11 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set(names.AttrName, out.Name)
 	d.Set(names.AttrStatus, out.Status)
 
-	return nil
+	return diags
 }
 
 func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
@@ -193,14 +197,15 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		_, err := conn.UpdateService(ctx, in)
 
 		if err != nil {
-			return create.DiagError(names.VPCLattice, create.ErrActionUpdating, ResNameService, d.Id(), err)
+			return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionUpdating, ResNameService, d.Id(), err)
 		}
 	}
 
-	return resourceServiceRead(ctx, d, meta)
+	return append(diags, resourceServiceRead(ctx, d, meta)...)
 }
 
 func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VPC Lattice Service: %s", d.Id())
@@ -209,18 +214,18 @@ func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta int
 	})
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionDeleting, ResNameService, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameService, d.Id(), err)
 	}
 
 	if _, err := waitServiceDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameService, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameService, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func waitServiceCreated(ctx context.Context, conn *vpclattice.Client, id string, timeout time.Duration) (*vpclattice.GetServiceOutput, error) {

--- a/internal/service/vpclattice/service_data_source.go
+++ b/internal/service/vpclattice/service_data_source.go
@@ -119,7 +119,7 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("custom_domain_name", out.CustomDomainName)
 	if out.DnsEntry != nil {
 		if err := d.Set("dns_entry", []interface{}{flattenDNSEntry(out.DnsEntry)}); err != nil {
-			return diag.Errorf("setting dns_entry: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting dns_entry: %s", err)
 		}
 	} else {
 		d.Set("dns_entry", nil)
@@ -146,5 +146,5 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta int
 		setTagsOut(ctx, Tags(tags))
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/vpclattice/service_network.go
+++ b/internal/service/vpclattice/service_network.go
@@ -69,6 +69,7 @@ const (
 )
 
 func resourceServiceNetworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	in := &vpclattice.CreateServiceNetworkInput{
@@ -84,15 +85,16 @@ func resourceServiceNetworkCreate(ctx context.Context, d *schema.ResourceData, m
 	out, err := conn.CreateServiceNetwork(ctx, in)
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameServiceNetwork, d.Get(names.AttrName).(string), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameServiceNetwork, d.Get(names.AttrName).(string), err)
 	}
 
 	d.SetId(aws.ToString(out.Id))
 
-	return resourceServiceNetworkRead(ctx, d, meta)
+	return append(diags, resourceServiceNetworkRead(ctx, d, meta)...)
 }
 
 func resourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	out, err := findServiceNetworkByID(ctx, conn, d.Id())
@@ -100,21 +102,22 @@ func resourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VPCLattice ServiceNetwork (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameServiceNetwork, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameServiceNetwork, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
 	d.Set("auth_type", out.AuthType)
 	d.Set(names.AttrName, out.Name)
 
-	return nil
+	return diags
 }
 
 func resourceServiceNetworkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
@@ -129,14 +132,15 @@ func resourceServiceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m
 		_, err := conn.UpdateServiceNetwork(ctx, in)
 
 		if err != nil {
-			return create.DiagError(names.VPCLattice, create.ErrActionUpdating, ResNameServiceNetwork, d.Id(), err)
+			return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionUpdating, ResNameServiceNetwork, d.Id(), err)
 		}
 	}
 
-	return resourceServiceNetworkRead(ctx, d, meta)
+	return append(diags, resourceServiceNetworkRead(ctx, d, meta)...)
 }
 
 func resourceServiceNetworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VPC Lattice Service Network: %s", d.Id())
@@ -145,14 +149,14 @@ func resourceServiceNetworkDelete(ctx context.Context, d *schema.ResourceData, m
 	})
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionDeleting, ResNameServiceNetwork, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameServiceNetwork, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findServiceNetworkByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetServiceNetworkOutput, error) {

--- a/internal/service/vpclattice/service_network_service_association.go
+++ b/internal/service/vpclattice/service_network_service_association.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -103,6 +104,7 @@ const (
 )
 
 func resourceServiceNetworkServiceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	in := &vpclattice.CreateServiceNetworkServiceAssociationInput{
@@ -114,23 +116,24 @@ func resourceServiceNetworkServiceAssociationCreate(ctx context.Context, d *sche
 
 	out, err := conn.CreateServiceNetworkServiceAssociation(ctx, in)
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkAssociation, "", err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkAssociation, "", err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkAssociation, "", errors.New("empty output"))
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkAssociation, "", errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.Id))
 
 	if _, err := waitServiceNetworkServiceAssociationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForCreation, ResNameServiceNetworkAssociation, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForCreation, ResNameServiceNetworkAssociation, d.Id(), err)
 	}
 
-	return resourceServiceNetworkServiceAssociationRead(ctx, d, meta)
+	return append(diags, resourceServiceNetworkServiceAssociationRead(ctx, d, meta)...)
 }
 
 func resourceServiceNetworkServiceAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	out, err := findServiceNetworkServiceAssociationByID(ctx, conn, d.Id())
@@ -138,11 +141,11 @@ func resourceServiceNetworkServiceAssociationRead(ctx context.Context, d *schema
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VPCLattice Service Network Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameServiceNetworkAssociation, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameServiceNetworkAssociation, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
@@ -150,7 +153,7 @@ func resourceServiceNetworkServiceAssociationRead(ctx context.Context, d *schema
 	d.Set("custom_domain_name", out.CustomDomainName)
 	if out.DnsEntry != nil {
 		if err := d.Set("dns_entry", []interface{}{flattenDNSEntry(out.DnsEntry)}); err != nil {
-			return diag.Errorf("setting dns_entry: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting dns_entry: %s", err)
 		}
 	} else {
 		d.Set("dns_entry", nil)
@@ -159,7 +162,7 @@ func resourceServiceNetworkServiceAssociationRead(ctx context.Context, d *schema
 	d.Set("service_network_identifier", out.ServiceNetworkId)
 	d.Set(names.AttrStatus, out.Status)
 
-	return nil
+	return diags
 }
 
 func resourceServiceNetworkServiceAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -168,6 +171,7 @@ func resourceServiceNetworkServiceAssociationUpdate(ctx context.Context, d *sche
 }
 
 func resourceServiceNetworkServiceAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VPCLattice Service Network Association %s", d.Id())
@@ -177,18 +181,18 @@ func resourceServiceNetworkServiceAssociationDelete(ctx context.Context, d *sche
 	})
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionDeleting, ResNameServiceNetworkAssociation, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameServiceNetworkAssociation, d.Id(), err)
 	}
 
 	if _, err := waitServiceNetworkServiceAssociationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameServiceNetworkAssociation, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameServiceNetworkAssociation, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findServiceNetworkServiceAssociationByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetServiceNetworkServiceAssociationOutput, error) {

--- a/internal/service/vpclattice/target_group.go
+++ b/internal/service/vpclattice/target_group.go
@@ -213,6 +213,7 @@ const (
 )
 
 func resourceTargetGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -230,19 +231,20 @@ func resourceTargetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 	out, err := conn.CreateTargetGroup(ctx, in)
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionCreating, ResNameService, name, err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameService, name, err)
 	}
 
 	d.SetId(aws.ToString(out.Id))
 
 	if _, err := waitTargetGroupCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForCreation, ResNameTargetGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForCreation, ResNameTargetGroup, d.Id(), err)
 	}
 
-	return resourceTargetGroupRead(ctx, d, meta)
+	return append(diags, resourceTargetGroupRead(ctx, d, meta)...)
 }
 
 func resourceTargetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	out, err := FindTargetGroupByID(ctx, conn, d.Id())
@@ -250,17 +252,17 @@ func resourceTargetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VpcLattice Target Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionReading, ResNameTargetGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameTargetGroup, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
 	if out.Config != nil {
 		if err := d.Set("config", []interface{}{flattenTargetGroupConfig(out.Config)}); err != nil {
-			return create.DiagError(names.VPCLattice, create.ErrActionSetting, ResNameTargetGroup, d.Id(), err)
+			return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionSetting, ResNameTargetGroup, d.Id(), err)
 		}
 	} else {
 		d.Set("config", nil)
@@ -269,10 +271,11 @@ func resourceTargetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set(names.AttrStatus, out.Status)
 	d.Set(names.AttrType, out.Type)
 
-	return nil
+	return diags
 }
 
 func resourceTargetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
@@ -291,24 +294,25 @@ func resourceTargetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		if in.HealthCheck == nil {
-			return nil
+			return diags
 		}
 
 		out, err := conn.UpdateTargetGroup(ctx, in)
 
 		if err != nil {
-			return create.DiagError(names.VPCLattice, create.ErrActionUpdating, ResNameTargetGroup, d.Id(), err)
+			return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionUpdating, ResNameTargetGroup, d.Id(), err)
 		}
 
 		if _, err := waitTargetGroupUpdated(ctx, conn, aws.ToString(out.Id), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return create.DiagError(names.VPCLattice, create.ErrActionWaitingForUpdate, ResNameTargetGroup, d.Id(), err)
+			return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForUpdate, ResNameTargetGroup, d.Id(), err)
 		}
 	}
 
-	return resourceTargetGroupRead(ctx, d, meta)
+	return append(diags, resourceTargetGroupRead(ctx, d, meta)...)
 }
 
 func resourceTargetGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VpcLattice TargetGroup: %s", d.Id())
@@ -319,17 +323,17 @@ func resourceTargetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.VPCLattice, create.ErrActionDeleting, ResNameTargetGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameTargetGroup, d.Id(), err)
 	}
 
 	if _, err := waitTargetGroupDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameTargetGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameTargetGroup, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func waitTargetGroupCreated(ctx context.Context, conn *vpclattice.Client, id string, timeout time.Duration) (*vpclattice.CreateTargetGroupOutput, error) {

--- a/internal/service/waf/byte_match_set.go
+++ b/internal/service/waf/byte_match_set.go
@@ -114,11 +114,11 @@ func resourceByteMatchSetRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF ByteMatchSet (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF ByteMatchSet (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF ByteMatchSet (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("byte_match_tuples", flattenByteMatchTuples(byteMatchSet.ByteMatchTuples)); err != nil {

--- a/internal/service/waf/geo_match_set.go
+++ b/internal/service/waf/geo_match_set.go
@@ -96,11 +96,11 @@ func resourceGeoMatchSetRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF GeoMatchSet (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF GeoMatchSet (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF GeoMatchSet (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{

--- a/internal/service/waf/ipset.go
+++ b/internal/service/waf/ipset.go
@@ -106,11 +106,11 @@ func resourceIPSetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF IPSet (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF IPSet (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF IPSet (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{

--- a/internal/service/waf/regex_match_set.go
+++ b/internal/service/waf/regex_match_set.go
@@ -120,11 +120,11 @@ func resourceRegexMatchSetRead(ctx context.Context, d *schema.ResourceData, meta
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regex Match Set (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regex Match Set (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regex Match Set (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{

--- a/internal/service/waf/regex_pattern_set.go
+++ b/internal/service/waf/regex_pattern_set.go
@@ -86,11 +86,11 @@ func resourceRegexPatternSetRead(ctx context.Context, d *schema.ResourceData, me
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regex Pattern Set (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regex Pattern Set (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regex Pattern Set (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{

--- a/internal/service/waf/rule.go
+++ b/internal/service/waf/rule.go
@@ -128,11 +128,11 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Rule (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Rule (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Rule (%s): %s", d.Id(), err)
 	}
 
 	var predicates []map[string]interface{}

--- a/internal/service/waf/rule_group.go
+++ b/internal/service/waf/rule_group.go
@@ -136,11 +136,11 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Rule Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Rule Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Rule Group (%s): %s", d.Id(), err)
 	}
 
 	var activatedRules []awstypes.ActivatedRule

--- a/internal/service/waf/sql_injection_match_set.go
+++ b/internal/service/waf/sql_injection_match_set.go
@@ -104,11 +104,11 @@ func resourceSQLInjectionMatchSetRead(ctx context.Context, d *schema.ResourceDat
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF SqlInjectionMatchSet (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF SqlInjectionMatchSet (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF SqlInjectionMatchSet (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrName, sqlInjectionMatchSet.Name)

--- a/internal/service/waf/web_acl.go
+++ b/internal/service/waf/web_acl.go
@@ -232,11 +232,11 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Web ACL (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Web ACL (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Web ACL (%s): %s", d.Id(), err)
 	}
 
 	arn := aws.ToString(webACL.WebACLArn)

--- a/internal/service/waf/xss_match_set.go
+++ b/internal/service/waf/xss_match_set.go
@@ -118,11 +118,11 @@ func resourceXSSMatchSetRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF XSS Match Set (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF XSS Match Set (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF XSS Match Set (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{

--- a/internal/service/wafregional/byte_match_set.go
+++ b/internal/service/wafregional/byte_match_set.go
@@ -113,11 +113,11 @@ func resourceByteMatchSetRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regional Byte Set Match (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional Byte Set Match (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional Byte Set Match (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("byte_match_tuples", flattenByteMatchTuples(byteMatchSet.ByteMatchTuples)); err != nil {

--- a/internal/service/wafregional/geo_match_set.go
+++ b/internal/service/wafregional/geo_match_set.go
@@ -92,11 +92,11 @@ func resourceGeoMatchSetRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regional Geo Match Set (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional Geo Match Set (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional Geo Match Set (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("geo_match_constraint", flattenGeoMatchConstraint(geoMatchSet.GeoMatchConstraints)); err != nil {

--- a/internal/service/wafregional/ipset.go
+++ b/internal/service/wafregional/ipset.go
@@ -97,11 +97,11 @@ func resourceIPSetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regional IPSet (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{

--- a/internal/service/wafregional/regex_match_set.go
+++ b/internal/service/wafregional/regex_match_set.go
@@ -120,7 +120,7 @@ func resourceRegexMatchSetRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional Regex Match Set (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional Regex Match Set (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrName, regexMatchSet.Name)

--- a/internal/service/wafregional/regex_pattern_set.go
+++ b/internal/service/wafregional/regex_pattern_set.go
@@ -86,7 +86,7 @@ func resourceRegexPatternSetRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional Regex Pattern Set (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional Regex Pattern Set (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrName, regexPatternSet.Name)

--- a/internal/service/wafregional/rule.go
+++ b/internal/service/wafregional/rule.go
@@ -126,11 +126,11 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regional Rule (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional Rule (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional Rule (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{

--- a/internal/service/wafregional/rule_group.go
+++ b/internal/service/wafregional/rule_group.go
@@ -137,11 +137,11 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regional Rule Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional Rule Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional Rule Group (%s): %s", d.Id(), err)
 	}
 
 	var activatedRules []awstypes.ActivatedRule

--- a/internal/service/wafregional/sql_injection_match_set.go
+++ b/internal/service/wafregional/sql_injection_match_set.go
@@ -113,11 +113,11 @@ func resourceSQLInjectionMatchSetRead(ctx context.Context, d *schema.ResourceDat
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regional SQL Injection Match Set (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional SQL Injection Match Set (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional SQL Injection Match Set (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrName, sqlInjectionMatchSet.Name)

--- a/internal/service/wafregional/subscribed_rule_group_data_source.go
+++ b/internal/service/wafregional/subscribed_rule_group_data_source.go
@@ -75,7 +75,7 @@ func dataSourceSubscribedRuleGroupRead(ctx context.Context, d *schema.ResourceDa
 	d.Set(names.AttrMetricName, output.MetricName)
 	d.Set(names.AttrName, output.Name)
 
-	return nil
+	return diags
 }
 
 func findSubscribedRuleGroup(ctx context.Context, conn *wafregional.Client, input *wafregional.ListSubscribedRuleGroupsInput, filter tfslices.Predicate[*awstypes.SubscribedRuleGroupSummary]) (*awstypes.SubscribedRuleGroupSummary, error) {

--- a/internal/service/wafregional/web_acl.go
+++ b/internal/service/wafregional/web_acl.go
@@ -237,11 +237,11 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regional Web ACL (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional Web ACL (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional Web ACL (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{

--- a/internal/service/wafregional/web_acl_association.go
+++ b/internal/service/wafregional/web_acl_association.go
@@ -72,7 +72,7 @@ func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData
 	})
 
 	if err != nil {
-		return diag.Errorf("creating WAF Regional WebACL Association (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "creating WAF Regional WebACL Association (%s): %s", id, err)
 	}
 
 	d.SetId(id)
@@ -86,7 +86,7 @@ func resourceWebACLAssociationRead(ctx context.Context, d *schema.ResourceData, 
 
 	_, resourceARN, err := webACLAssociationParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	webACL, err := findWebACLByResourceARN(ctx, conn, resourceARN)
@@ -94,11 +94,11 @@ func resourceWebACLAssociationRead(ctx context.Context, d *schema.ResourceData, 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regional WebACL Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional WebACL Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional WebACL Association (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrResourceARN, resourceARN)
@@ -113,7 +113,7 @@ func resourceWebACLAssociationDelete(ctx context.Context, d *schema.ResourceData
 
 	_, resourceARN, err := webACLAssociationParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	_, err = conn.DisassociateWebACL(ctx, &wafregional.DisassociateWebACLInput{

--- a/internal/service/wafregional/xss_match_set.go
+++ b/internal/service/wafregional/xss_match_set.go
@@ -114,11 +114,11 @@ func resourceXSSMatchSetRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAF Regional XSS Match Set (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAF Regional XSS Match Set (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAF Regional XSS Match Set (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrName, xssMatchSet.Name)

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -394,7 +394,6 @@ func resourceWebACLDelete(ctx context.Context, d *schema.ResourceData, meta inte
 				return sdkdiag.AppendErrorf(diags, "deleting WAFv2 WebACL (%s), resource has changed since last refresh please run a new plan before applying again: %s", d.Id(), err)
 			}
 		}
-
 	}
 
 	if errs.IsA[*awstypes.WAFNonexistentItemException](err) {

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -21,17 +21,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
-)
-
-const (
-	webACLCreateTimeout = 5 * time.Minute
-	webACLUpdateTimeout = 5 * time.Minute
-	webACLDeleteTimeout = 5 * time.Minute
 )
 
 // @SDKResource("aws_wafv2_web_acl", name="Web ACL")
@@ -180,6 +175,7 @@ func resourceWebACL() *schema.Resource {
 }
 
 func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFV2Client(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -207,22 +203,26 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.TokenDomains = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, webACLCreateTimeout, func() (interface{}, error) {
+	const (
+		timeout = 5 * time.Minute
+	)
+	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, timeout, func() (interface{}, error) {
 		return conn.CreateWebACL(ctx, input)
 	})
 
 	if err != nil {
-		return diag.Errorf("creating WAFv2 WebACL (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating WAFv2 WebACL (%s): %s", name, err)
 	}
 
 	output := outputRaw.(*wafv2.CreateWebACLOutput)
 
 	d.SetId(aws.ToString(output.Summary.Id))
 
-	return resourceWebACLRead(ctx, d, meta)
+	return append(diags, resourceWebACLRead(ctx, d, meta)...)
 }
 
 func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFV2Client(ctx)
 
 	output, err := findWebACLByThreePartKey(ctx, conn, d.Id(), d.Get(names.AttrName).(string), d.Get(names.AttrScope).(string))
@@ -230,11 +230,11 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAFv2 WebACL (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAFv2 WebACL (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAFv2 WebACL (%s): %s", d.Id(), err)
 	}
 
 	webACL := output.WebACL
@@ -242,40 +242,40 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set(names.AttrARN, webACL.ARN)
 	d.Set("capacity", webACL.Capacity)
 	if err := d.Set("association_config", flattenAssociationConfig(webACL.AssociationConfig)); err != nil {
-		return diag.Errorf("setting association_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting association_config: %s", err)
 	}
 	if err := d.Set("captcha_config", flattenCaptchaConfig(webACL.CaptchaConfig)); err != nil {
-		return diag.Errorf("setting captcha_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting captcha_config: %s", err)
 	}
 	if err := d.Set("challenge_config", flattenChallengeConfig(webACL.ChallengeConfig)); err != nil {
-		return diag.Errorf("setting challenge_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting challenge_config: %s", err)
 	}
 	if err := d.Set("custom_response_body", flattenCustomResponseBodies(webACL.CustomResponseBodies)); err != nil {
-		return diag.Errorf("setting custom_response_body: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting custom_response_body: %s", err)
 	}
 	if err := d.Set(names.AttrDefaultAction, flattenDefaultAction(webACL.DefaultAction)); err != nil {
-		return diag.Errorf("setting default_action: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting default_action: %s", err)
 	}
 	d.Set(names.AttrDescription, webACL.Description)
 	d.Set("lock_token", output.LockToken)
 	d.Set(names.AttrName, webACL.Name)
 	rules := filterWebACLRules(webACL.Rules, expandWebACLRules(d.Get(names.AttrRule).(*schema.Set).List()))
 	if err := d.Set(names.AttrRule, flattenWebACLRules(rules)); err != nil {
-		return diag.Errorf("setting rule: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
 	}
 	d.Set("token_domains", aws.StringSlice(webACL.TokenDomains))
 	if err := d.Set("visibility_config", flattenVisibilityConfig(webACL.VisibilityConfig)); err != nil {
-		return diag.Errorf("setting visibility_config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting visibility_config: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFV2Client(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
-		aclID := d.Id()
 		aclName := d.Get(names.AttrName).(string)
 		aclScope := d.Get(names.AttrScope).(string)
 		aclLockToken := d.Get("lock_token").(string)
@@ -283,10 +283,12 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		// so that the provider will not remove the Shield rule when changes are applied to the WebACL.
 		rules := expandWebACLRules(d.Get(names.AttrRule).(*schema.Set).List())
 		if sr := findShieldRule(rules); len(sr) == 0 {
-			output, err := findWebACLByThreePartKey(ctx, conn, aclID, aclName, aclScope)
+			output, err := findWebACLByThreePartKey(ctx, conn, d.Id(), aclName, aclScope)
+
 			if err != nil {
-				return diag.Errorf("reading WAFv2 WebACL (%s): %s", aclID, err)
+				return sdkdiag.AppendErrorf(diags, "reading WAFv2 WebACL (%s): %s", d.Id(), err)
 			}
+
 			rules = append(rules, findShieldRule(output.WebACL.Rules)...)
 		}
 
@@ -295,7 +297,7 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			CaptchaConfig:     expandCaptchaConfig(d.Get("captcha_config").([]interface{})),
 			ChallengeConfig:   expandChallengeConfig(d.Get("challenge_config").([]interface{})),
 			DefaultAction:     expandDefaultAction(d.Get(names.AttrDefaultAction).([]interface{})),
-			Id:                aws.String(aclID),
+			Id:                aws.String(d.Id()),
 			LockToken:         aws.String(aclLockToken),
 			Name:              aws.String(aclName),
 			Rules:             rules,
@@ -315,96 +317,96 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			input.TokenDomains = flex.ExpandStringValueSet(v.(*schema.Set))
 		}
 
-		_, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, webACLUpdateTimeout, func() (interface{}, error) {
+		const (
+			timeout = 5 * time.Minute
+		)
+		_, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, timeout, func() (interface{}, error) {
 			return conn.UpdateWebACL(ctx, input)
 		})
 
 		if errs.IsA[*awstypes.WAFOptimisticLockException](err) {
-			return retryResourceWebACLUpdateOptmisticLockFailure(ctx, conn, aclID, aclName, aclScope, aclLockToken, input)
+			var output *wafv2.GetWebACLOutput
+			output, err = findWebACLByThreePartKey(ctx, conn, d.Id(), aclName, aclScope)
+
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "reading WAFv2 WebACL (%s): %s", d.Id(), err)
+			}
+
+			if newLockToken := aws.ToString(output.LockToken); newLockToken != aclLockToken {
+				// Retrieved a new lock token, retry due to other processes modifying the web acl out of band (See: https://docs.aws.amazon.com/sdk-for-go/api/service/shield/#Shield.EnableApplicationLayerAutomaticResponse)
+				input.LockToken = aws.String(newLockToken)
+				_, err = tfresource.RetryWhenIsOneOf2[*awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func() (interface{}, error) {
+					return conn.UpdateWebACL(ctx, input)
+				})
+
+				if errs.IsA[*awstypes.WAFOptimisticLockException](err) {
+					return sdkdiag.AppendErrorf(diags, "updating WAFv2 WebACL (%s), resource has changed since last refresh please run a new plan before applying again: %s", d.Id(), err)
+				}
+			}
 		}
 
 		if err != nil {
-			return diag.Errorf("updating WAFv2 WebACL (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating WAFv2 WebACL (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceWebACLRead(ctx, d, meta)
-}
-
-func retryResourceWebACLUpdateOptmisticLockFailure(ctx context.Context, conn *wafv2.Client, id, name, scope, lockToken string, input *wafv2.UpdateWebACLInput) diag.Diagnostics {
-	webAcl, err := findWebACLByThreePartKey(ctx, conn, id, name, scope)
-	if err != nil {
-		return diag.Errorf("refreshing WAFv2 WebACL (%s), attempting to refresh WAFv2 WebACL to retrieve new LockToken: %s", id, err)
-	} else if aws.ToString(webAcl.LockToken) != lockToken {
-		// Retrieved a new lock token, retry due to other processes modifying the web acl out of band (See: https://docs.aws.amazon.com/sdk-for-go/api/service/shield/#Shield.EnableApplicationLayerAutomaticResponse)
-		input.LockToken = webAcl.LockToken
-		_, err := tfresource.RetryWhenIsOneOf2[*awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, webACLDeleteTimeout, func() (interface{}, error) {
-			return conn.UpdateWebACL(ctx, input)
-		})
-
-		if errs.IsA[*awstypes.WAFOptimisticLockException](err) {
-			return diag.Errorf("updating WAFv2 WebACL (%s), resource has changed since last refresh please run a new plan before applying again: %s", id, err)
-		}
-		return nil
-	}
-	return nil
+	return append(diags, resourceWebACLRead(ctx, d, meta)...)
 }
 
 func resourceWebACLDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFV2Client(ctx)
 
-	aclId := d.Id()
 	aclName := d.Get(names.AttrName).(string)
 	aclScope := d.Get(names.AttrScope).(string)
 	aclLockToken := d.Get("lock_token").(string)
-
 	input := &wafv2.DeleteWebACLInput{
-		Id:        aws.String(aclId),
+		Id:        aws.String(d.Id()),
 		LockToken: aws.String(aclLockToken),
 		Name:      aws.String(aclName),
 		Scope:     awstypes.Scope(aclScope),
 	}
 
 	log.Printf("[INFO] Deleting WAFv2 WebACL: %s", d.Id())
-	_, err := tfresource.RetryWhenIsOneOf2[*awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, webACLDeleteTimeout, func() (interface{}, error) {
+	const (
+		timeout = 5 * time.Minute
+	)
+	_, err := tfresource.RetryWhenIsOneOf2[*awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func() (interface{}, error) {
 		return conn.DeleteWebACL(ctx, input)
 	})
 
 	if errs.IsA[*awstypes.WAFOptimisticLockException](err) {
-		return retryResourceWebACLDeleteOptmisticLockFailure(ctx, conn, aclId, aclName, aclScope, aclLockToken)
-	} else if errs.IsA[*awstypes.WAFNonexistentItemException](err) {
-		return nil
-	}
-
-	if err != nil {
-		return diag.Errorf("deleting WAFv2 WebACL (%s): %s", d.Id(), err)
-	}
-
-	return nil
-}
-
-func retryResourceWebACLDeleteOptmisticLockFailure(ctx context.Context, conn *wafv2.Client, id, name, scope, lockToken string) diag.Diagnostics {
-	webAcl, err := findWebACLByThreePartKey(ctx, conn, id, name, scope)
-	if err != nil {
-		return diag.Errorf("refreshing WAFv2 WebACL (%s), attempting to refresh WAFv2 WebACL to retrieve new LockToken: %s", id, err)
-	} else if aws.ToString(webAcl.LockToken) != lockToken {
-		// got a new lock token, retry due to other processes modifying the web acl out of band (See: https://docs.aws.amazon.com/sdk-for-go/api/service/shield/#Shield.EnableApplicationLayerAutomaticResponse)
-		retryInput := &wafv2.DeleteWebACLInput{
-			Id:        aws.String(id),
-			LockToken: webAcl.LockToken,
-			Name:      aws.String(name),
-			Scope:     awstypes.Scope(scope),
-		}
-		_, err := tfresource.RetryWhenIsOneOf2[*awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, webACLDeleteTimeout, func() (interface{}, error) {
-			return conn.DeleteWebACL(ctx, retryInput)
-		})
-
 		if errs.IsA[*awstypes.WAFOptimisticLockException](err) {
-			return diag.Errorf("deleting WAFv2 WebACL (%s), resource has changed since last refresh please run a new plan before applying again: %s", id, err)
+			var output *wafv2.GetWebACLOutput
+			output, err = findWebACLByThreePartKey(ctx, conn, d.Id(), aclName, aclScope)
+
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "reading WAFv2 WebACL (%s): %s", d.Id(), err)
+			}
+
+			if newLockToken := aws.ToString(output.LockToken); newLockToken != aclLockToken {
+				// Retrieved a new lock token, retry due to other processes modifying the web acl out of band (See: https://docs.aws.amazon.com/sdk-for-go/api/service/shield/#Shield.EnableApplicationLayerAutomaticResponse)
+				input.LockToken = aws.String(newLockToken)
+				_, err = tfresource.RetryWhenIsOneOf2[*awstypes.WAFAssociatedItemException, *awstypes.WAFUnavailableEntityException](ctx, timeout, func() (interface{}, error) {
+					return conn.DeleteWebACL(ctx, input)
+				})
+
+				if errs.IsA[*awstypes.WAFOptimisticLockException](err) {
+					return sdkdiag.AppendErrorf(diags, "deleting WAFv2 WebACL (%s), resource has changed since last refresh please run a new plan before applying again: %s", d.Id(), err)
+				}
+			}
 		}
-		return nil
 	}
-	return nil
+
+	if errs.IsA[*awstypes.WAFNonexistentItemException](err) {
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting WAFv2 WebACL (%s): %s", d.Id(), err)
+	}
+
+	return diags
 }
 
 func findWebACLByThreePartKey(ctx context.Context, conn *wafv2.Client, id, name, scope string) (*wafv2.GetWebACLOutput, error) {

--- a/internal/service/wafv2/web_acl_association.go
+++ b/internal/service/wafv2/web_acl_association.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -61,6 +62,7 @@ func resourceWebACLAssociation() *schema.Resource {
 }
 
 func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFV2Client(ctx)
 
 	webACLARN := d.Get("web_acl_arn").(string)
@@ -77,20 +79,21 @@ func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData
 	})
 
 	if err != nil {
-		return diag.Errorf("creating WAFv2 WebACL Association (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "creating WAFv2 WebACL Association (%s): %s", id, err)
 	}
 
 	d.SetId(id)
 
-	return resourceWebACLAssociationRead(ctx, d, meta)
+	return append(diags, resourceWebACLAssociationRead(ctx, d, meta)...)
 }
 
 func resourceWebACLAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFV2Client(ctx)
 
 	parts, err := flex.ExpandResourceId(d.Id(), webACLAssociationResourceIDPartCount, true)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	resourceARN := parts[1]
@@ -99,25 +102,26 @@ func resourceWebACLAssociationRead(ctx context.Context, d *schema.ResourceData, 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] WAFv2 WebACL Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAFv2 WebACL Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAFv2 WebACL Association (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrResourceARN, resourceARN)
 	d.Set("web_acl_arn", webACL.ARN)
 
-	return nil
+	return diags
 }
 
 func resourceWebACLAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFV2Client(ctx)
 
 	parts, err := flex.ExpandResourceId(d.Id(), webACLAssociationResourceIDPartCount, true)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	log.Printf("[INFO] Deleting WAFv2 WebACL Association: %s", d.Id())
@@ -127,14 +131,14 @@ func resourceWebACLAssociationDelete(ctx context.Context, d *schema.ResourceData
 	})
 
 	if errs.IsA[*awstypes.WAFNonexistentItemException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting WAFv2 WebACL Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting WAFv2 WebACL Association (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findWebACLByResourceARN(ctx context.Context, conn *wafv2.Client, arn string) (*awstypes.WebACL, error) {

--- a/internal/service/wafv2/web_acl_logging_configuration.go
+++ b/internal/service/wafv2/web_acl_logging_configuration.go
@@ -225,7 +225,7 @@ func resourceWebACLLoggingConfigurationRead(ctx context.Context, d *schema.Resou
 	}
 
 	if err != nil {
-		return diag.Errorf("reading WAFv2 WebACL Logging Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading WAFv2 WebACL Logging Configuration (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("log_destination_configs", flex.FlattenStringValueList(loggingConfig.LogDestinationConfigs)); err != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Enables and fixes semgrep `diags` checks for additional services.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/37569.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_DEFAULT_REGION=us-east-1 make testacc TESTARGS='-run=TestAccWAFV2WebACL_' PKG=wafv2 ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/wafv2/... -v -count 1 -parallel 3  -run=TestAccWAFV2WebACL_ -timeout 360m
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_Update_rule
=== PAUSE TestAccWAFV2WebACL_Update_rule
=== RUN   TestAccWAFV2WebACL_Update_ruleProperties
=== PAUSE TestAccWAFV2WebACL_Update_ruleProperties
=== RUN   TestAccWAFV2WebACL_Update_nameForceNew
=== PAUSE TestAccWAFV2WebACL_Update_nameForceNew
=== RUN   TestAccWAFV2WebACL_disappears
=== PAUSE TestAccWAFV2WebACL_disappears
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== RUN   TestAccWAFV2WebACL_minimal
=== PAUSE TestAccWAFV2WebACL_minimal
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_body
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_body
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== PAUSE TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== RUN   TestAccWAFV2WebACL_LabelMatchStatement
=== PAUSE TestAccWAFV2WebACL_LabelMatchStatement
=== RUN   TestAccWAFV2WebACL_RuleLabels
=== PAUSE TestAccWAFV2WebACL_RuleLabels
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== PAUSE TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== RUN   TestAccWAFV2WebACL_RateBased_customKeys
=== PAUSE TestAccWAFV2WebACL_RateBased_customKeys
=== RUN   TestAccWAFV2WebACL_RateBased_forwardedIP
=== PAUSE TestAccWAFV2WebACL_RateBased_forwardedIP
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== RUN   TestAccWAFV2WebACL_Custom_response
=== PAUSE TestAccWAFV2WebACL_Custom_response
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== RUN   TestAccWAFV2WebACL_RateBased_maxNested
=== PAUSE TestAccWAFV2WebACL_RateBased_maxNested
=== RUN   TestAccWAFV2WebACL_Operators_maxNested
=== PAUSE TestAccWAFV2WebACL_Operators_maxNested
=== RUN   TestAccWAFV2WebACL_tokenDomains
=== PAUSE TestAccWAFV2WebACL_tokenDomains
=== RUN   TestAccWAFV2WebACL_associationConfigCloudFront
=== PAUSE TestAccWAFV2WebACL_associationConfigCloudFront
=== RUN   TestAccWAFV2WebACL_associationConfigRegional
=== PAUSE TestAccWAFV2WebACL_associationConfigRegional
=== RUN   TestAccWAFV2WebACL_CloudFrontScope
=== PAUSE TestAccWAFV2WebACL_CloudFrontScope
=== CONT  TestAccWAFV2WebACL_basic
=== CONT  TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
--- PASS: TestAccWAFV2WebACL_basic (14.84s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion (25.77s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
--- PASS: TestAccWAFV2WebACL_GeoMatch_forwardedIP (27.97s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_body
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (24.91s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_headerOrder (25.24s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_body (25.56s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_jsonBody (25.62s)
=== CONT  TestAccWAFV2WebACL_RateBased_basic
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint (25.58s)
=== CONT  TestAccWAFV2WebACL_minimal
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (25.48s)
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
--- PASS: TestAccWAFV2WebACL_minimal (12.09s)
=== CONT  TestAccWAFV2WebACL_CloudFrontScope
--- PASS: TestAccWAFV2WebACL_RateBased_basic (25.75s)
=== CONT  TestAccWAFV2WebACL_associationConfigRegional
--- PASS: TestAccWAFV2WebACL_CloudFrontScope (15.10s)
=== CONT  TestAccWAFV2WebACL_associationConfigCloudFront
--- PASS: TestAccWAFV2WebACL_associationConfigRegional (14.12s)
=== CONT  TestAccWAFV2WebACL_tokenDomains
--- PASS: TestAccWAFV2WebACL_associationConfigCloudFront (14.13s)
=== CONT  TestAccWAFV2WebACL_Operators_maxNested
--- PASS: TestAccWAFV2WebACL_tokenDomains (14.17s)
=== CONT  TestAccWAFV2WebACL_RateBased_maxNested
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (45.72s)
=== CONT  TestAccWAFV2WebACL_tags
--- PASS: TestAccWAFV2WebACL_Operators_maxNested (16.03s)
=== CONT  TestAccWAFV2WebACL_Custom_response
--- PASS: TestAccWAFV2WebACL_RateBased_maxNested (17.60s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
--- PASS: TestAccWAFV2WebACL_tags (33.50s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
--- PASS: TestAccWAFV2WebACL_Custom_response (35.52s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (12.97s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (44.19s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet (25.56s)
=== CONT  TestAccWAFV2WebACL_RateBased_customKeys
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet (25.93s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig (25.67s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule (41.18s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation (48.28s)
=== CONT  TestAccWAFV2WebACL_RateBased_forwardedIP
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (35.53s)
=== CONT  TestAccWAFV2WebACL_Update_ruleProperties
--- PASS: TestAccWAFV2WebACL_RateBased_forwardedIP (25.54s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
--- PASS: TestAccWAFV2WebACL_RateBased_customKeys (100.10s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_forwardedIP
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (15.73s)
=== CONT  TestAccWAFV2WebACL_Update_rule
--- PASS: TestAccWAFV2WebACL_Update_ruleProperties (41.91s)
=== CONT  TestAccWAFV2WebACL_RuleLabels
--- PASS: TestAccWAFV2WebACL_Update_rule (27.05s)
=== CONT  TestAccWAFV2WebACL_Update_nameForceNew
--- PASS: TestAccWAFV2WebACL_RuleLabels (24.97s)
=== CONT  TestAccWAFV2WebACL_disappears
--- PASS: TestAccWAFV2WebACL_IPSetReference_forwardedIP (47.33s)
=== CONT  TestAccWAFV2WebACL_LabelMatchStatement
--- PASS: TestAccWAFV2WebACL_Update_nameForceNew (22.65s)
--- PASS: TestAccWAFV2WebACL_disappears (12.09s)
--- PASS: TestAccWAFV2WebACL_LabelMatchStatement (23.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	370.761s
```
