### PR TITLE
r/aws_lambda_runtime_management_config: new resource

### DIFF
--- a/.changelog/37643.txt
+++ b/.changelog/37643.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_lambda_runtime_management_config
+```

--- a/internal/service/lambda/exports_test.go
+++ b/internal/service/lambda/exports_test.go
@@ -27,6 +27,7 @@ var (
 	FindLayerVersionPolicyByTwoPartKey           = findLayerVersionPolicyByTwoPartKey
 	FindPolicyStatementByTwoPartKey              = findPolicyStatementByTwoPartKey
 	FindProvisionedConcurrencyConfigByTwoPartKey = findProvisionedConcurrencyConfigByTwoPartKey
+	FindRuntimeManagementConfigByTwoPartKey      = findRuntimeManagementConfigByTwoPartKey
 	FunctionEventInvokeConfigParseResourceID     = functionEventInvokeConfigParseResourceID
 	GetFunctionNameFromARN                       = getFunctionNameFromARN
 	GetQualifierFromAliasOrVersionARN            = getQualifierFromAliasOrVersionARN

--- a/internal/service/lambda/runtime_management_config.go
+++ b/internal/service/lambda/runtime_management_config.go
@@ -1,0 +1,250 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package lambda
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_lambda_runtime_management_config", name="Runtime Management Config")
+func newResourceRuntimeManagementConfig(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceRuntimeManagementConfig{}, nil
+}
+
+const (
+	ResNameRuntimeManagementConfig = "Runtime Management Config"
+	runtimeManagementConfigIDParts = 2
+)
+
+type resourceRuntimeManagementConfig struct {
+	framework.ResourceWithConfigure
+	framework.WithNoOpDelete
+}
+
+func (r *resourceRuntimeManagementConfig) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_lambda_runtime_management_config"
+}
+
+func (r *resourceRuntimeManagementConfig) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrFunctionARN: framework.ARNAttributeComputedOnly(),
+			"function_name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"qualifier": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"runtime_version_arn": schema.StringAttribute{
+				CustomType: fwtypes.ARNType,
+				Optional:   true,
+			},
+			"update_runtime_on": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.UpdateRuntimeOn](),
+				Optional:   true,
+			},
+		},
+	}
+}
+
+func (r *resourceRuntimeManagementConfig) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().LambdaClient(ctx)
+
+	var plan resourceRuntimeManagementConfigData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &lambda.PutRuntimeManagementConfigInput{}
+	resp.Diagnostics.Append(flex.Expand(ctx, plan, in)...)
+
+	out, err := conn.PutRuntimeManagementConfig(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Lambda, create.ErrActionCreating, ResNameRuntimeManagementConfig, plan.FunctionName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Lambda, create.ErrActionCreating, ResNameRuntimeManagementConfig, plan.FunctionName.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &plan)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceRuntimeManagementConfig) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().LambdaClient(ctx)
+
+	var state resourceRuntimeManagementConfigData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findRuntimeManagementConfigByTwoPartKey(ctx, conn, state.FunctionName.ValueString(), state.Qualifier.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Lambda, create.ErrActionSetting, ResNameRuntimeManagementConfig, state.FunctionName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceRuntimeManagementConfig) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().LambdaClient(ctx)
+
+	var plan, state resourceRuntimeManagementConfigData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.RuntimeVersionARN.Equal(state.RuntimeVersionARN) ||
+		!plan.UpdateRuntimeOn.Equal(state.UpdateRuntimeOn) {
+		in := &lambda.PutRuntimeManagementConfigInput{}
+		resp.Diagnostics.Append(flex.Expand(ctx, plan, in)...)
+
+		out, err := conn.PutRuntimeManagementConfig(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.Lambda, create.ErrActionUpdating, ResNameRuntimeManagementConfig, plan.FunctionName.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.Lambda, create.ErrActionUpdating, ResNameRuntimeManagementConfig, plan.FunctionName.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		resp.Diagnostics.Append(flex.Flatten(ctx, out, &plan)...)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceRuntimeManagementConfig) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().LambdaClient(ctx)
+
+	var state resourceRuntimeManagementConfigData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &lambda.PutRuntimeManagementConfigInput{
+		FunctionName:    aws.String(state.FunctionName.ValueString()),
+		UpdateRuntimeOn: awstypes.UpdateRuntimeOnAuto,
+	}
+	if !state.Qualifier.IsNull() && state.Qualifier.ValueString() != "" {
+		in.Qualifier = aws.String(state.Qualifier.ValueString())
+	}
+
+	_, err := conn.PutRuntimeManagementConfig(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Lambda, create.ErrActionDeleting, ResNameRuntimeManagementConfig, state.FunctionName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceRuntimeManagementConfig) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts, err := intflex.ExpandResourceId(req.ID, runtimeManagementConfigIDParts, true)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: function_name,qualifier. Got: %q", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("function_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("qualifier"), parts[1])...)
+}
+
+func findRuntimeManagementConfigByTwoPartKey(ctx context.Context, conn *lambda.Client, functionName, qualifier string) (*lambda.GetRuntimeManagementConfigOutput, error) {
+	in := &lambda.GetRuntimeManagementConfigInput{
+		FunctionName: aws.String(functionName),
+	}
+	if qualifier != "" {
+		in.Qualifier = aws.String(qualifier)
+	}
+
+	out, err := conn.GetRuntimeManagementConfig(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+type resourceRuntimeManagementConfigData struct {
+	FunctionARN       types.String                                 `tfsdk:"function_arn"`
+	FunctionName      types.String                                 `tfsdk:"function_name"`
+	Qualifier         types.String                                 `tfsdk:"qualifier"`
+	RuntimeVersionARN fwtypes.ARN                                  `tfsdk:"runtime_version_arn"`
+	UpdateRuntimeOn   fwtypes.StringEnum[awstypes.UpdateRuntimeOn] `tfsdk:"update_runtime_on"`
+}

--- a/internal/service/lambda/runtime_management_config_test.go
+++ b/internal/service/lambda/runtime_management_config_test.go
@@ -1,0 +1,235 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package lambda_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tflambda "github.com/hashicorp/terraform-provider-aws/internal/service/lambda"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccLambdaRuntimeManagementConfig_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var cfg lambda.GetRuntimeManagementConfigOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lambda_runtime_management_config.test"
+	functionResourceName := "aws_lambda_function.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LambdaEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuntimeManagementConfigDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuntimeManagementConfigConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuntimeManagementConfigExists(ctx, resourceName, &cfg),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "function_name"),
+					resource.TestCheckResourceAttr(resourceName, "update_runtime_on", string(types.UpdateRuntimeOnFunctionUpdate)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrFunctionARN, "lambda", regexache.MustCompile(`function:+.`)),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccRuntimeManagementConfigImportStateIdFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "function_name",
+				ImportStateVerifyIgnore: []string{
+					"qualifier",
+				},
+			},
+		},
+	})
+}
+
+func TestAccLambdaRuntimeManagementConfig_disappears_Function(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var cfg lambda.GetRuntimeManagementConfigOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lambda_runtime_management_config.test"
+	functionResourceName := "aws_lambda_function.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LambdaEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuntimeManagementConfigDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuntimeManagementConfigConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuntimeManagementConfigExists(ctx, resourceName, &cfg),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflambda.ResourceFunction(), functionResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccLambdaRuntimeManagementConfig_runtimeVersionARN(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var cfg lambda.GetRuntimeManagementConfigOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lambda_runtime_management_config.test"
+	functionResourceName := "aws_lambda_function.test"
+	// nodejs18.x version hash in us-west-2, commercial partition
+	runtimeVersion := "b475b23763329123d9e6f79f51886d0e1054f727f5b90ec945fcb2a3ec09afdd"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			// The runtime version ARN contains a hash unique to a partition/region.
+			// There is currently no API to retrieve this ARN, so we have to hard-code
+			// the value and restrict this test to us-west-2 in the standard commercial
+			// partition.
+			acctest.PreCheckPartition(t, names.StandardPartitionID)
+			acctest.PreCheckRegion(t, names.USWest2RegionID)
+			acctest.PreCheckPartitionHasService(t, names.LambdaEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuntimeManagementConfigDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuntimeManagementConfigConfig_runtimeVersionARN(rName, runtimeVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuntimeManagementConfigExists(ctx, resourceName, &cfg),
+					resource.TestCheckResourceAttrPair(resourceName, "function_name", functionResourceName, "function_name"),
+					resource.TestCheckResourceAttr(resourceName, "update_runtime_on", string(types.UpdateRuntimeOnManual)),
+					resource.TestMatchResourceAttr(resourceName, "runtime_version_arn", regexache.MustCompile(runtimeVersion)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrFunctionARN, "lambda", regexache.MustCompile(`function:+.`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckRuntimeManagementConfigDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_lambda_runtime_management_config" {
+				continue
+			}
+
+			functionName := rs.Primary.Attributes["function_name"]
+			qualifier := rs.Primary.Attributes["qualifier"]
+
+			_, err := tflambda.FindRuntimeManagementConfigByTwoPartKey(ctx, conn, functionName, qualifier)
+			if errs.IsA[*types.ResourceNotFoundException](err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.Lambda, create.ErrActionCheckingDestroyed, tflambda.ResNameRuntimeManagementConfig, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.Lambda, create.ErrActionCheckingDestroyed, tflambda.ResNameRuntimeManagementConfig, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckRuntimeManagementConfigExists(ctx context.Context, name string, cfg *lambda.GetRuntimeManagementConfigOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.Lambda, create.ErrActionCheckingExistence, tflambda.ResNameRuntimeManagementConfig, name, errors.New("not found"))
+		}
+
+		functionName := rs.Primary.Attributes["function_name"]
+		qualifier := rs.Primary.Attributes["qualifier"]
+		if functionName == "" {
+			return create.Error(names.Lambda, create.ErrActionCheckingExistence, tflambda.ResNameRuntimeManagementConfig, name, errors.New("function_name not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient(ctx)
+
+		out, err := tflambda.FindRuntimeManagementConfigByTwoPartKey(ctx, conn, functionName, qualifier)
+		if err != nil {
+			return create.Error(names.Lambda, create.ErrActionCheckingExistence, tflambda.ResNameRuntimeManagementConfig, functionName, err)
+		}
+
+		*cfg = *out
+
+		return nil
+	}
+}
+
+func testAccRuntimeManagementConfigImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s,%s", rs.Primary.Attributes["function_name"], rs.Primary.Attributes["qualifier"]), nil
+	}
+}
+
+func testAccRuntimeManagementConfigConfigBase(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs18.x"
+}
+`, rName))
+}
+
+func testAccRuntimeManagementConfigConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccRuntimeManagementConfigConfigBase(rName),
+		`
+resource "aws_lambda_runtime_management_config" "test" {
+  function_name     = aws_lambda_function.test.function_name
+  update_runtime_on = "FunctionUpdate"
+}
+`)
+}
+
+func testAccRuntimeManagementConfigConfig_runtimeVersionARN(rName, runtimeVersion string) string {
+	return acctest.ConfigCompose(
+		testAccRuntimeManagementConfigConfigBase(rName),
+		fmt.Sprintf(`
+data "aws_region" "current" {}
+
+resource "aws_lambda_runtime_management_config" "test" {
+  function_name       = aws_lambda_function.test.function_name
+  update_runtime_on   = "Manual"
+  runtime_version_arn = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.name}::runtime:%[1]s"
+}
+`, runtimeVersion))
+}

--- a/internal/service/lambda/service_package_gen.go
+++ b/internal/service/lambda/service_package_gen.go
@@ -19,7 +19,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceRuntimeManagementConfig,
+			Name:    "Runtime Management Config",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/website/docs/r/lambda_runtime_management_config.html.markdown
+++ b/website/docs/r/lambda_runtime_management_config.html.markdown
@@ -1,0 +1,78 @@
+---
+subcategory: "Lambda"
+layout: "aws"
+page_title: "AWS: aws_lambda_runtime_management_config"
+description: |-
+  Terraform resource for managing an AWS Lambda Runtime Management Config.
+---
+# Resource: aws_lambda_runtime_management_config
+
+Terraform resource for managing an AWS Lambda Runtime Management Config.
+
+Refer to the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) for supported runtimes.
+
+~> Deletion of this resource returns the runtime update mode to `Auto` (the default behavior).
+To leave the configured runtime management options in-place, use a [`removed` block](https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources) withe destroy lifecycle set to `false`.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_lambda_runtime_management_config" "example" {
+  function_name     = aws_lambda_function.test.function_name
+  update_runtime_on = "FunctionUpdate"
+}
+```
+
+### `Manual` Update
+
+```terraform
+resource "aws_lambda_runtime_management_config" "example" {
+  function_name     = aws_lambda_function.test.function_name
+  update_runtime_on = "Manual"
+
+  # Runtime version ARN's contain a hashed value (not the friendly runtime
+  # name). There are currently no API's to retrieve this ARN, but the value
+  # can be copied from the "Runtime settings" section of a function in the 
+  # AWS console.
+  runtime_version_arn = "arn:aws:lambda:us-east-1::runtime:abcd1234"
+}
+```
+
+~> Once the runtime update mode is set to `Manual`, the `aws_lambda_function` `runtime` cannot be updated. To upgrade a runtime, the `update_runtime_on` argument must be set to `Auto` or `FunctionUpdate` prior to changing the function's `runtime` argument.
+
+## Argument Reference
+
+The following arguments are required:
+
+* `function_name` - (Required) Name or ARN of the Lambda function.
+
+The following arguments are optional:
+
+* `qualifier` - (Optional) Version of the function. This can be `$LATEST` or a published version number. If omitted, this resource will manage the runtime configuration for `$LATEST`.
+* `runtime_version_arn` - (Optional) ARN of the runtime version. Only required when `update_runtime_on` is `Manual`.
+* `update_runtime_on` - (Optional) Runtime update mode. Valid values are `Auto`, `FunctionUpdate`, and `Manual`. When a function is created, the default mode is `Auto`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `function_arn` - ARN of the function.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lambda Runtime Management Config using a comma-delimited string combining `function_name` and `qualifier`. For example:
+
+```terraform
+import {
+  to = aws_lambda_runtime_management_config.example
+  id = "my-function,$LATEST"
+}
+```
+
+Using `terraform import`, import Lambda Runtime Management Config using a comma-delimited string combining `function_name` and `qualifier`. For example:
+
+```console
+% terraform import aws_lambda_runtime_management_config.example my-function,$LATEST
+```


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resource will allow practitioners to manage AWS Lambda runtime management configurations via Terraform.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Closes #29210
Closes #32138

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/lambda/latest/api/API_PutRuntimeManagementConfig.html
- https://docs.aws.amazon.com/lambda/latest/api/API_GetRuntimeManagementConfig.html
- https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lambda TESTS="TestAccLambdaRuntimeManagementConfig_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaRuntimeManagementConfig_'  -timeout 360m

--- PASS: TestAccLambdaRuntimeManagementConfig_disappears_Function (37.05s)
--- PASS: TestAccLambdaRuntimeManagementConfig_basic (38.77s)
--- PASS: TestAccLambdaRuntimeManagementConfig_runtimeVersionARN (40.33s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     45.265s
```
