### PR TITLE
[WIP] feat: Add delete options for aws_fsx_openzfs_file_system

### DIFF
--- a/.changelog/37651.txt
+++ b/.changelog/37651.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fsx_openzfs_file_system: Add `delete_options` and `final_backup_tags` arguments
+```

--- a/internal/service/fsx/openzfs_file_system.go
+++ b/internal/service/fsx/openzfs_file_system.go
@@ -86,6 +86,14 @@ func resourceOpenZFSFileSystem() *schema.Resource {
 					validation.StringMatch(regexache.MustCompile(`^([01]\d|2[0-3]):?([0-5]\d)$`), "must be in the format HH:MM"),
 				),
 			},
+			"delete_options": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice(fsx.DeleteFileSystemOpenZFSOption_Values(), false),
+				},
+			},
 			"deployment_type": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -126,6 +134,32 @@ func resourceOpenZFSFileSystem() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+			},
+			"final_backup_tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 1,
+				MaxItems: 50,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrKey: {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(1, 128),
+								validation.StringMatch(regexache.MustCompile(`^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$`), "must be a valid tag key"),
+							),
+						},
+						names.AttrValue: {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.All(
+								validation.StringLenBetween(0, 128),
+								validation.StringMatch(regexache.MustCompile(`^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$`), "must be a valid tag value"),
+							),
+						},
+					},
+				},
 			},
 			names.AttrKMSKeyID: {
 				Type:         schema.TypeString,
@@ -534,7 +568,13 @@ func resourceOpenZFSFileSystemUpdate(ctx context.Context, d *schema.ResourceData
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn(ctx)
 
-	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
+	if d.HasChangesExcept(
+		names.AttrTags,
+		names.AttrTagsAll,
+		"delete_options",
+		"final_backup_tags",
+		"skip_final_backup",
+	) {
 		input := &fsx.UpdateFileSystemInput{
 			ClientRequestToken:   aws.String(id.UniqueId()),
 			FileSystemId:         aws.String(d.Id()),
@@ -633,13 +673,23 @@ func resourceOpenZFSFileSystemDelete(ctx context.Context, d *schema.ResourceData
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxConn(ctx)
 
-	log.Printf("[DEBUG] Deleting FSx for OpenZFS File System: %s", d.Id())
-	_, err := conn.DeleteFileSystemWithContext(ctx, &fsx.DeleteFileSystemInput{
+	input := &fsx.DeleteFileSystemInput{
 		FileSystemId: aws.String(d.Id()),
 		OpenZFSConfiguration: &fsx.DeleteFileSystemOpenZFSConfiguration{
 			SkipFinalBackup: aws.Bool(d.Get("skip_final_backup").(bool)),
 		},
-	})
+	}
+
+	if v, ok := d.GetOk("delete_options"); ok {
+		input.OpenZFSConfiguration.Options = flex.ExpandStringSet(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("final_backup_tags"); ok {
+		input.OpenZFSConfiguration.FinalBackupTags = expandFinalBackupTags(v.(*schema.Set))
+	}
+
+	log.Printf("[DEBUG] Deleting FSx for OpenZFS File System: %s", d.Id())
+	_, err := conn.DeleteFileSystemWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, fsx.ErrCodeFileSystemNotFound) {
 		return diags
@@ -739,6 +789,32 @@ func expandUpdateOpenZFSVolumeConfiguration(cfg []interface{}) *fsx.UpdateOpenZF
 
 	if v, ok := conf["nfs_exports"].([]interface{}); ok {
 		out.NfsExports = expandOpenZFSNfsExports(v)
+	}
+
+	return &out
+}
+
+func expandFinalBackupTags(cfg *schema.Set) []*fsx.Tag {
+	tags := []*fsx.Tag{}
+
+	for _, tag := range cfg.List() {
+		expandedTag := expandFinalBackupTag(tag.(map[string]interface{}))
+		if expandedTag != nil {
+			tags = append(tags, expandedTag)
+		}
+	}
+
+	return tags
+}
+
+func expandFinalBackupTag(cfg map[string]interface{}) *fsx.Tag {
+	out := fsx.Tag{}
+
+	if v, ok := cfg[names.AttrKey].(string); ok {
+		out.Key = aws.String(v)
+	}
+	if v, ok := cfg[names.AttrValue].(string); ok {
+		out.Value = aws.String(v)
 	}
 
 	return &out

--- a/internal/service/fsx/openzfs_file_system_test.go
+++ b/internal/service/fsx/openzfs_file_system_test.go
@@ -6,6 +6,7 @@ package fsx_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -78,7 +79,7 @@ func TestAccFSxOpenZFSFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "root_volume_id"),
 					resource.TestCheckResourceAttr(resourceName, "route_table_ids.#", acctest.Ct0),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", acctest.Ct0),
-					resource.TestCheckResourceAttr(resourceName, "skip_final_backup", "false"),
+					resource.TestCheckResourceAttr(resourceName, "skip_final_backup", "true"),
 					resource.TestCheckResourceAttr(resourceName, "storage_capacity", "64"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStorageType, fsx.StorageTypeSsd),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", acctest.Ct1),
@@ -94,6 +95,8 @@ func TestAccFSxOpenZFSFileSystem_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -128,6 +131,8 @@ func TestAccFSxOpenZFSFileSystem_diskIops(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -218,6 +223,8 @@ func TestAccFSxOpenZFSFileSystem_rootVolume(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -379,6 +386,8 @@ func TestAccFSxOpenZFSFileSystem_securityGroupIDs(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -420,6 +429,8 @@ func TestAccFSxOpenZFSFileSystem_tags(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -474,6 +485,8 @@ func TestAccFSxOpenZFSFileSystem_copyTags(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -516,6 +529,8 @@ func TestAccFSxOpenZFSFileSystem_throughput(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -556,6 +571,8 @@ func TestAccFSxOpenZFSFileSystem_storageType(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -588,6 +605,8 @@ func TestAccFSxOpenZFSFileSystem_weeklyMaintenanceStartTime(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -628,6 +647,8 @@ func TestAccFSxOpenZFSFileSystem_automaticBackupRetentionDays(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -675,6 +696,8 @@ func TestAccFSxOpenZFSFileSystem_kmsKeyID(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -707,6 +730,8 @@ func TestAccFSxOpenZFSFileSystem_dailyAutomaticBackupStartTime(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -747,6 +772,8 @@ func TestAccFSxOpenZFSFileSystem_throughputCapacity(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -787,6 +814,8 @@ func TestAccFSxOpenZFSFileSystem_storageCapacity(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -828,6 +857,8 @@ func TestAccFSxOpenZFSFileSystem_deploymentType(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -909,6 +940,8 @@ func TestAccFSxOpenZFSFileSystem_multiAZ(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -942,6 +975,8 @@ func TestAccFSxOpenZFSFileSystem_routeTableIDs(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
 					"skip_final_backup",
 				},
 			},
@@ -961,6 +996,52 @@ func TestAccFSxOpenZFSFileSystem_routeTableIDs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "route_table_ids.#", acctest.Ct1),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "route_table_ids.*", "aws_route_table.test.0", names.AttrID),
 				),
+			},
+		},
+	})
+}
+
+func TestAccFSxOpenZFSFileSystem_deleteOptions(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	if os.Getenv("FSX_CREATE_FINAL_BACKUP") != "true" {
+		t.Skip("Environment variable FSX_CREATE_FINAL_BACKUP is not set to true")
+	}
+
+	var filesystem fsx.FileSystem
+	resourceName := "aws_fsx_openzfs_file_system.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, fsx.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FSxServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckOpenZFSFileSystemDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenZFSFileSystemConfig_deleteOptions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOpenZFSFileSystemExists(ctx, resourceName, &filesystem),
+					resource.TestCheckResourceAttr(resourceName, "delete_options.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "delete_options.0", "DELETE_CHILD_VOLUMES_AND_SNAPSHOTS"),
+					resource.TestCheckResourceAttr(resourceName, "final_backup_tags.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "final_backup_tags.0.key", "TFTestKVTagKey"),
+					resource.TestCheckResourceAttr(resourceName, "final_backup_tags.0.value", "TFTestKVTagValue"),
+					resource.TestCheckResourceAttr(resourceName, "final_backup_tags.1.key", "TFTestKeyOnlyTagKey"),
+					resource.TestCheckResourceAttr(resourceName, "final_backup_tags.1.value", ""),
+					resource.TestCheckResourceAttr(resourceName, "skip_final_backup", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrSecurityGroupIDs,
+					"delete_options",
+					"final_backup_tags",
+					"skip_final_backup",
+				},
 			},
 		},
 	})
@@ -1044,6 +1125,7 @@ func testAccOpenZFSFileSystemConfig_baseMultiAZ(rName string) string {
 func testAccOpenZFSFileSystemConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccOpenZFSFileSystemConfig_baseSingleAZ(rName), `
 resource "aws_fsx_openzfs_file_system" "test" {
+  skip_final_backup   = true
   storage_capacity    = 64
   subnet_ids          = aws_subnet.test[*].id
   deployment_type     = "SINGLE_AZ_1"
@@ -1658,4 +1740,25 @@ resource "aws_fsx_openzfs_file_system" "test" {
   }
 }
 `, rName, n))
+}
+
+func testAccOpenZFSFileSystemConfig_deleteOptions(rName string) string {
+	return acctest.ConfigCompose(testAccOpenZFSFileSystemConfig_baseSingleAZ(rName), `
+resource "aws_fsx_openzfs_file_system" "test" {
+  skip_final_backup   = false
+  storage_capacity    = 64
+  subnet_ids          = aws_subnet.test[*].id
+  deployment_type     = "SINGLE_AZ_1"
+  throughput_capacity = 64
+  delete_options      = ["DELETE_CHILD_VOLUMES_AND_SNAPSHOTS"]
+  final_backup_tags {
+    key   = "TFTestKeyOnlyTagKey"
+    value = ""
+  }
+  final_backup_tags {
+    key   = "TFTestKVTagKey"
+    value = "TFTestKVTagValue"
+  }
+}
+`)
 }

--- a/website/docs/r/fsx_openzfs_file_system.html.markdown
+++ b/website/docs/r/fsx_openzfs_file_system.html.markdown
@@ -26,7 +26,7 @@ resource "aws_fsx_openzfs_file_system" "test" {
 
 This resource supports the following arguments:
 
-* `deployment_type` - (Required) - The filesystem deployment type. Valid values: `SINGLE_AZ_1`, `SINGLE_AZ_2` and `MULTI_AZ_1`.
+* `deployment_type` - (Required) The filesystem deployment type. Valid values: `SINGLE_AZ_1`, `SINGLE_AZ_2` and `MULTI_AZ_1`.
 * `storage_capacity` - (Required) The storage capacity (GiB) of the file system. Valid values between `64` and `524288`.
 * `subnet_ids` - (Required) A list of IDs for the subnets that the file system will be accessible from.
 * `throughput_capacity` - (Required) Throughput (MB/s) of the file system. Valid values depend on `deployment_type`. Must be one of `64`, `128`, `256`, `512`, `1024`, `2048`, `3072`, `4096` for `SINGLE_AZ_1`. Must be one of `160`, `320`, `640`, `1280`, `2560`, `3840`, `5120`, `7680`, `10240` for `SINGLE_AZ_2`.
@@ -35,11 +35,13 @@ This resource supports the following arguments:
 * `copy_tags_to_backups` - (Optional) A boolean flag indicating whether tags for the file system should be copied to backups. The default value is false.
 * `copy_tags_to_volumes` - (Optional) A boolean flag indicating whether tags for the file system should be copied to snapshots. The default value is false.
 * `daily_automatic_backup_start_time` - (Optional) A recurring daily time, in the format HH:MM. HH is the zero-padded hour of the day (0-23), and MM is the zero-padded minute of the hour. For example, 05:00 specifies 5 AM daily. Requires `automatic_backup_retention_days` to be set.
-* `disk_iops_configuration` - (Optional) The SSD IOPS configuration for the Amazon FSx for OpenZFS file system. See [Disk Iops Configuration](#disk-iops-configuration) below.
+* `delete_options` - (Optional) List of delete options, which at present supports only one value that specifies whether to delete all child volumes and snapshots when the file system is deleted. Valid values: `DELETE_CHILD_VOLUMES_AND_SNAPSHOTS`.
+* `disk_iops_configuration` - (Optional) The SSD IOPS configuration for the Amazon FSx for OpenZFS file system. See [`disk_iops_configuration` Block](#disk_iops_configuration-block) for details.
 * `endpoint_ip_address_range` - (Optional) (Multi-AZ only) Specifies the IP address range in which the endpoints to access your file system will be created.
+* `final_backup_tags` - (Optional) List of tags to apply to the file system's final backup. Maximum of 50 items. See [`final_backup_tags` Block](#final_backup_tags-block) for details.
 * `kms_key_id` - (Optional) ARN for the KMS Key to encrypt the file system at rest, Defaults to an AWS managed KMS Key.
 * `preferred_subnet_id` - (Optional) (Multi-AZ only) Required when `deployment_type` is set to `MULTI_AZ_1`. This specifies the subnet in which you want the preferred file server to be located.
-* `root_volume_configuration` - (Optional) The configuration for the root volume of the file system. All other volumes are children or the root volume. See [Root Volume Configuration](#root-volume-configuration) below.
+* `root_volume_configuration` - (Optional) The configuration for the root volume of the file system. All other volumes are children or the root volume. See [`root_volume_configuration` Block](#root_volume_configuration-block) for details.
 * `route_table_ids` - (Optional) (Multi-AZ only) Specifies the route tables in which Amazon FSx creates the rules for routing traffic to the correct file server. You should specify all virtual private cloud (VPC) route tables associated with the subnets in which your clients are located. By default, Amazon FSx selects your VPC's default route table.
 * `security_group_ids` - (Optional) A list of IDs for the security groups that apply to the specified network interfaces created for file system access. These security groups will apply to all network interfaces.
 * `skip_final_backup` - (Optional) When enabled, will skip the default final backup taken when the file system is deleted. This configuration must be applied separately before attempting to delete the resource to have the desired behavior. Defaults to `false`.
@@ -47,34 +49,51 @@ This resource supports the following arguments:
 * `tags` - (Optional) A map of tags to assign to the file system. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `weekly_maintenance_start_time` - (Optional) The preferred start time (in `d:HH:MM` format) to perform weekly maintenance, in the UTC time zone.
 
-### Disk Iops Configuration
+### `disk_iops_configuration` Block
 
-* `iops` - (Optional) - The total number of SSD IOPS provisioned for the file system.
-* `mode` - (Optional) - Specifies whether the number of IOPS for the file system is using the system. Valid values are `AUTOMATIC` and `USER_PROVISIONED`. Default value is `AUTOMATIC`.
+The `disk_iops_configuration` configuration block supports the following arguments:
 
-### Root Volume Configuration
+* `iops` - (Optional) The total number of SSD IOPS provisioned for the file system.
+* `mode` - (Optional) Specifies whether the number of IOPS for the file system is using the system. Valid values are `AUTOMATIC` and `USER_PROVISIONED`. Default value is `AUTOMATIC`.
 
-* `copy_tags_to_snapshots` - (Optional) - A boolean flag indicating whether tags for the file system should be copied to snapshots. The default value is false.
-* `data_compression_type` - (Optional) - Method used to compress the data on the volume. Valid values are `LZ4`, `NONE` or `ZSTD`. Child volumes that don't specify compression option will inherit from parent volume. This option on file system applies to the root volume.
-* `nfs_exports` - (Optional) - NFS export configuration for the root volume. Exactly 1 item. See [NFS Exports](#nfs-exports) Below.
-* `read_only` - (Optional) - specifies whether the volume is read-only. Default is false.
-* `record_size_kib` - (Optional) - Specifies the record size of an OpenZFS root volume, in kibibytes (KiB). Valid values are `4`, `8`, `16`, `32`, `64`, `128`, `256`, `512`, or `1024` KiB. The default is `128` KiB.
-* `user_and_group_quotas` - (Optional) - Specify how much storage users or groups can use on the volume. Maximum of 100 items. See [User and Group Quotas](#user-and-group-quotas) Below.
+### `final_backup_tags` Block
 
-### NFS Exports
+The `final_backup_tags` configuration block supports the following arguments:
 
-* `client_configurations` - (Required) - A list of configuration objects that contain the client and options for mounting the OpenZFS file system. Maximum of 25 items. See [Client Configurations](#client configurations) Below.
+* `key` - (Required) The name of the tag.
+* `value` - (Required) The value assigned to the corresponding tag key. To create a key-only tag, use an empty string as the value.
 
-### Client Configurations
+### `root_volume_configuration` Block
 
-* `clients` - (Required) - A value that specifies who can mount the file system. You can provide a wildcard character (*), an IP address (0.0.0.0), or a CIDR address (192.0.2.0/24. By default, Amazon FSx uses the wildcard character when specifying the client.
-* `options` - (Required) -  The options to use when mounting the file system. Maximum of 20 items. See the [Linix NFS exports man page](https://linux.die.net/man/5/exports) for more information. `crossmount` and `sync` are used by default.
+The `root_volume_configuration` configuration block supports the following arguments:
 
-### User and Group Quotas
+* `copy_tags_to_snapshots` - (Optional) A boolean flag indicating whether tags for the file system should be copied to snapshots. The default value is false.
+* `data_compression_type` - (Optional) Method used to compress the data on the volume. Valid values are `LZ4`, `NONE` or `ZSTD`. Child volumes that don't specify compression option will inherit from parent volume. This option on file system applies to the root volume.
+* `nfs_exports` - (Optional) NFS export configuration for the root volume. Exactly 1 item. See [`nfs_exports` Block](#nfs_exports-block) for details.
+* `read_only` - (Optional) specifies whether the volume is read-only. Default is false.
+* `record_size_kib` - (Optional) Specifies the record size of an OpenZFS root volume, in kibibytes (KiB). Valid values are `4`, `8`, `16`, `32`, `64`, `128`, `256`, `512`, or `1024` KiB. The default is `128` KiB.
+* `user_and_group_quotas` - (Optional) Specify how much storage users or groups can use on the volume. Maximum of 100 items. See [`user_and_group_quotas` Block](#user_and_group_quotas-block) for details.
 
-* `id` - (Required) - The ID of the user or group. Valid values between `0` and `2147483647`
-* `storage_capacity_quota_gib` - (Required) - The amount of storage that the user or group can use in gibibytes (GiB). Valid values between `0` and `2147483647`
-* `type` - (Required) - A value that specifies whether the quota applies to a user or group. Valid values are `USER` or `GROUP`.
+### `nfs_exports` Block
+
+The `nfs_exports` configuration block supports the following arguments:
+
+* `client_configurations` - (Required) A list of configuration objects that contain the client and options for mounting the OpenZFS file system. Maximum of 25 items. See [`client_configurations` Block](#client_configurations-block) for details.
+
+### `client_configurations` Block
+
+The `client_configurations` configuration block supports the following arguments:
+
+* `clients` - (Required) A value that specifies who can mount the file system. You can provide a wildcard character (*), an IP address (0.0.0.0), or a CIDR address (192.0.2.0/24. By default, Amazon FSx uses the wildcard character when specifying the client.
+* `options` - (Required)  The options to use when mounting the file system. Maximum of 20 items. See the [Linix NFS exports man page](https://linux.die.net/man/5/exports) for more information. `crossmount` and `sync` are used by default.
+
+### `user_and_group_quotas` Block
+
+The `user_and_group_quotas` configuration block supports the following arguments:
+
+* `id` - (Required) The ID of the user or group. Valid values between `0` and `2147483647`
+* `storage_capacity_quota_gib` - (Required) The amount of storage that the user or group can use in gibibytes (GiB). Valid values between `0` and `2147483647`
+* `type` - (Required) A value that specifies whether the quota applies to a user or group. Valid values are `USER` or `GROUP`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds the `delete_options` and `final_backup_tags` arguments to the `aws_fsx_openzfs_file_system` resource.

For the acceptance tests, I added a new environment variable `FSX_CREATE_FINAL_BACKUP` to control whether the test cases that involve taking a final backup on file system deletion is run. The backups would remain after running unit tests so they must be deleted afterwards to avoid storage costs.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36399

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [DeleteFileSystem](https://docs.aws.amazon.com/fsx/latest/APIReference/API_DeleteFileSystem.html) specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ export FSX_CREATE_FINAL_BACKUP=true
$ TF_ACC=1 go1.22.2 test ./internal/service/fsx/... -v -count 1 -parallel 3 -run='TestAccFSxOpenZFSFileSystem_basic|TestAccFSxOpenZFSFileSystem_deleteOptions'  -timeout 360m
=== RUN   TestAccFSxOpenZFSFileSystem_basic
=== PAUSE TestAccFSxOpenZFSFileSystem_basic
=== RUN   TestAccFSxOpenZFSFileSystem_deleteOptions
=== PAUSE TestAccFSxOpenZFSFileSystem_deleteOptions
=== CONT  TestAccFSxOpenZFSFileSystem_basic
=== CONT  TestAccFSxOpenZFSFileSystem_deleteOptions
--- PASS: TestAccFSxOpenZFSFileSystem_basic (549.56s)
--- PASS: TestAccFSxOpenZFSFileSystem_deleteOptions (672.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        673.009s
```
