### PR TITLE
r/lambda_function: fix drift when `source_code_hash` does not match upstream value

### DIFF
--- a/.changelog/37669.txt
+++ b/.changelog/37669.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+resource/aws_lambda_function: Fix issue when `source_code_hash` forces causes drift even if source code has not changed
+```
+
+```release-note:enhancement
+resource/aws_lambda_function: Add `code_sha256` attribute
+```
+
+```release-note:enhancement
+data-source/aws_lambda_function: Add `code_sha256` attribute
+```
+
+```release-note:note
+data-source/aws_lambda_function: `source_code_hash` attribute has been deprecated in favor of `code_sha256`. Will be removed in a future major version
+```

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -77,6 +77,10 @@ func resourceFunction() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"code_sha256": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"code_signing_config_arn": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -642,6 +646,7 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("architectures", function.Architectures)
 	functionARN := aws.ToString(function.FunctionArn)
 	d.Set(names.AttrARN, functionARN)
+	d.Set("code_sha256", function.CodeSha256)
 	if function.DeadLetterConfig != nil && function.DeadLetterConfig.TargetArn != nil {
 		if err := d.Set("dead_letter_config", []interface{}{
 			map[string]interface{}{
@@ -695,7 +700,7 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if err := d.Set("snap_start", flattenSnapStart(function.SnapStart)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting snap_start: %s", err)
 	}
-	d.Set("source_code_hash", function.CodeSha256)
+	d.Set("source_code_hash", d.Get("source_code_hash"))
 	d.Set("source_code_size", function.CodeSize)
 	d.Set(names.AttrTimeout, function.Timeout)
 	tracingConfigMode := awstypes.TracingModePassThrough

--- a/internal/service/lambda/function_data_source.go
+++ b/internal/service/lambda/function_data_source.go
@@ -35,6 +35,10 @@ func dataSourceFunction() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"code_sha256": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"code_signing_config_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -186,8 +190,9 @@ func dataSourceFunction() *schema.Resource {
 				Computed: true,
 			},
 			"source_code_hash": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "This attribute is deprecated and will be removed in a future major version. Use `code_sha256` instead.",
 			},
 			"source_code_size": {
 				Type:     schema.TypeInt,
@@ -288,6 +293,7 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.SetId(functionName)
 	d.Set("architectures", function.Architectures)
 	d.Set(names.AttrARN, unqualifiedARN)
+	d.Set("code_sha256", function.CodeSha256)
 	if function.DeadLetterConfig != nil && function.DeadLetterConfig.TargetArn != nil {
 		if err := d.Set("dead_letter_config", []interface{}{
 			map[string]interface{}{

--- a/internal/service/lambda/function_data_source_test.go
+++ b/internal/service/lambda/function_data_source_test.go
@@ -29,6 +29,7 @@ func TestAccLambdaFunctionDataSource_basic(t *testing.T) {
 				Config: testAccFunctionDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "code_sha256", resourceName, "code_sha256"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "code_signing_config_arn", resourceName, "code_signing_config_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "dead_letter_config.#", resourceName, "dead_letter_config.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDescription, resourceName, names.AttrDescription),
@@ -51,7 +52,7 @@ func TestAccLambdaFunctionDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "runtime", resourceName, "runtime"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "signing_job_arn", resourceName, "signing_job_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "signing_profile_version_arn", resourceName, "signing_profile_version_arn"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "source_code_hash", resourceName, "source_code_hash"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "source_code_hash", resourceName, "code_sha256"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "source_code_size", resourceName, "source_code_size"),
 					resource.TestCheckResourceAttrPair(dataSourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrTimeout, resourceName, names.AttrTimeout),

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -66,6 +66,7 @@ func TestAccLambdaFunction_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "architectures.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "architectures.0", string(awstypes.ArchitectureX8664)),
 					acctest.CheckResourceAttrRegionalARN(resourceName, names.AttrARN, "lambda", fmt.Sprintf("function:%s", funcName)),
+					resource.TestCheckResourceAttrSet(resourceName, "code_sha256"),
 					resource.TestCheckResourceAttr(resourceName, "ephemeral_storage.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "ephemeral_storage.0.size", "512"),
 					resource.TestCheckResourceAttr(resourceName, "logging_config.#", acctest.Ct1),

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -1893,7 +1893,7 @@ func TestAccLambdaFunction_localUpdate(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"filename", "publish"},
+				ImportStateVerifyIgnore: []string{"filename", "publish", "source_code_hash"},
 			},
 			{
 				PreConfig: func() {

--- a/website/docs/d/lambda_function.html.markdown
+++ b/website/docs/d/lambda_function.html.markdown
@@ -35,6 +35,7 @@ This data source exports the following attributes in addition to the arguments a
 
 * `architectures` - Instruction set architecture for the Lambda function.
 * `arn` - Unqualified (no `:QUALIFIER` or `:VERSION` suffix) ARN identifying your Lambda Function. See also `qualified_arn`.
+* `code_sha256` - Base64-encoded representation of raw SHA-256 sum of the zip file.
 * `code_signing_config_arn` - ARN for a Code Signing Configuration.
 * `dead_letter_config` - Configure the function's *dead letter queue*.
 * `description` - Description of what your Lambda Function does.
@@ -56,7 +57,7 @@ This data source exports the following attributes in addition to the arguments a
 * `runtime` - Runtime environment for the Lambda function.
 * `signing_job_arn` - ARN of a signing job.
 * `signing_profile_version_arn` - The ARN for a signing profile version.
-* `source_code_hash` - Base64-encoded representation of raw SHA-256 sum of the zip file.
+* `source_code_hash` - (**Deprecated** use `code_sha256` instead) Base64-encoded representation of raw SHA-256 sum of the zip file.
 * `source_code_size` - Size in bytes of the function .zip file.
 * `timeout` - Function execution time at which Lambda should terminate the function.
 * `tracing_config` - Tracing settings of the function.

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -291,7 +291,7 @@ Set the `replacement_security_group_ids` attribute to use a custom list of secur
 * `s3_key` - (Optional) S3 key of an object containing the function's deployment package. When `s3_bucket` is set, `s3_key` is required.
 * `s3_object_version` - (Optional) Object version containing the function's deployment package. Conflicts with `filename` and `image_uri`.
 * `skip_destroy` - (Optional) Set to true if you do not wish the function to be deleted at destroy time, and instead just remove the function from the Terraform state.
-* `source_code_hash` - (Optional) Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `filebase64sha256("file.zip")` (Terraform 0.11.12 and later) or `base64sha256(file("file.zip"))` (Terraform 0.11.11 and earlier), where "file.zip" is the local filename of the lambda function source archive.
+* `source_code_hash` - (Optional) Virtual attribute used to trigger replacement when source code changes. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `filebase64sha256("file.zip")` (Terraform 0.11.12 and later) or `base64sha256(file("file.zip"))` (Terraform 0.11.11 and earlier), where "file.zip" is the local filename of the lambda function source archive.
 * `snap_start` - (Optional) Snap start settings block. Detailed below.
 * `tags` - (Optional) Map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `timeout` - (Optional) Amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5].
@@ -361,6 +361,7 @@ For network connectivity to AWS resources in a VPC, specify a list of security g
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - Amazon Resource Name (ARN) identifying your Lambda Function.
+* `code_sha256` - Base64-encoded representation of raw SHA-256 sum of the zip file.
 * `invoke_arn` - ARN to be used for invoking Lambda Function from API Gateway - to be used in [`aws_api_gateway_integration`](/docs/providers/aws/r/api_gateway_integration.html)'s `uri`.
 * `last_modified` - Date this resource was last modified.
 * `qualified_arn` - ARN identifying your Lambda Function Version (if versioning is enabled via `publish = true`).


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #17989
Relates #37646

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccLambdaFunction" PKG=lambda

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/lambda/... -v -count 1 -parallel 20  -run=TestAccLambdaFunction -timeout 360m
    function_test.go:977: Environment variable AWS_LAMBDA_IMAGE_LATEST_ID is not set
--- SKIP: TestAccLambdaFunction_image (0.00s)
--- PASS: TestAccLambdaFunctionDataSource_ephemeralStorage (43.30s)
--- PASS: TestAccLambdaFunctionDataSource_basic (56.38s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_QualifierFunctionName_arn (77.34s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Destination_swap (85.73s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_FunctionName_arn (91.51s)
--- PASS: TestAccLambdaFunction_disablePublish (93.58s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_maximumEventAgeInSeconds (103.04s)
--- PASS: TestAccLambdaFunction_KMSKeyARN_noEnvironmentVariables (117.72s)
    function_data_source_test.go:375: AWS_LAMBDA_IMAGE_LATEST_ID env var must be set for Lambda Function Data Source Image Support acceptance tests.
--- SKIP: TestAccLambdaFunctionDataSource_image (0.00s)
--- PASS: TestAccLambdaFunction_layers (127.15s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_DestinationOnSuccess_destination (127.15s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Destination_remove (136.06s)
--- PASS: TestAccLambdaFunction_VPC_properIAMDependencies (352.60s)
--- PASS: TestAccLambdaFunction_layersUpdate (557.08s)
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithDefault (734.81s)
--- PASS: TestAccLambdaFunction_vpcRemoval (1318.87s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Disappears_lambdaFunction (1625.28s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_disappears (1612.70s)
--- PASS: TestAccLambdaFunction_nameValidation (0.91s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_basic (1614.81s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_DestinationOnFailure_destination (1660.91s)
--- PASS: TestAccLambdaFunctionDataSource_architectures (1605.91s)
--- PASS: TestAccLambdaFunctionDataSource_loggingConfig (1638.41s)
--- PASS: TestAccLambdaFunction_expectFilenameAndS3Attributes (0.85s)
--- PASS: TestAccLambdaFunction_EnvironmentVariables_emptyUpgrade (108.57s)
--- PASS: TestAccLambdaFunction_VPC_withInvocation (1869.90s)
--- PASS: TestAccLambdaFunctionDataSource_environment (1784.68s)
--- PASS: TestAccLambdaFunctionDataSource_unpublishedVersion (1790.51s)
--- PASS: TestAccLambdaFunctionDataSource_layers (1790.15s)
--- PASS: TestAccLambdaFunction_vpc (1993.09s)
--- PASS: TestAccLambdaFunctionDataSource_alias (1775.79s)
--- PASS: TestAccLambdaFunction_versioned (482.45s)
--- PASS: TestAccLambdaFunctionDataSource_fileSystem (2053.63s)
--- PASS: TestAccLambdaFunction_EnvironmentVariables_noValue (475.63s)
--- PASS: TestAccLambdaFunction_concurrencyCycle (1631.56s)
--- PASS: TestAccLambdaFunction_disappears (460.51s)
--- PASS: TestAccLambdaFunction_enablePublish (1457.51s)
--- PASS: TestAccLambdaFunction_VPCPublishNo_changes (2226.40s)
--- PASS: TestAccLambdaFunction_concurrency (425.15s)
--- PASS: TestAccLambdaFunction_encryptedEnvVariables (544.35s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Qualifier_functionVersion (313.83s)
--- PASS: TestAccLambdaFunction_basic (257.42s)
--- PASS: TestAccLambdaFunction_codeSigning (383.24s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Qualifier_latest (127.37s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_Qualifier_aliasName (107.39s)
--- PASS: TestAccLambdaFunction_tags (365.36s)
--- PASS: TestAccLambdaFunction_envVariables (579.31s)
--- PASS: TestAccLambdaFunction_versionedUpdate (977.25s)
--- PASS: TestAccLambdaFunction_tracing (137.80s)
--- PASS: TestAccLambdaFunction_unpublishedCodeUpdate (406.35s)
--- PASS: TestAccLambdaFunctionDataSource_latestVersion (92.80s)
--- PASS: TestAccLambdaFunctionDataSource_version (93.34s)
--- PASS: TestAccLambdaFunction_ephemeralStorage (141.03s)
--- PASS: TestAccLambdaFunction_Zip_validation (6.45s)
--- PASS: TestAccLambdaFunctionsDataSource_basic (93.87s)
--- PASS: TestAccLambdaFunctionURL_TwoURLs (112.72s)
--- PASS: TestAccLambdaFunction_loggingConfig (192.94s)
--- PASS: TestAccLambdaFunctionEventInvokeConfig_maximumRetryAttempts (148.37s)
--- PASS: TestAccLambdaFunctionURL_invokeMode (151.01s)
--- PASS: TestAccLambdaFunction_S3Update_basic (89.65s)
--- PASS: TestAccLambdaFunction_skipDestroyInconsistentPlan (96.49s)
--- PASS: TestAccLambdaFunction_S3Update_unversioned (79.15s)
--- PASS: TestAccLambdaFunction_s3 (44.49s)
--- PASS: TestAccLambdaFunction_localUpdate (63.28s)
--- PASS: TestAccLambdaFunctionURL_Alias (290.46s)
--- PASS: TestAccLambdaFunction_architecturesUpdate (395.83s)
--- PASS: TestAccLambdaFunctionURL_basic (294.65s)
--- PASS: TestAccLambdaFunctionURLDataSource_basic (292.07s)
--- PASS: TestAccLambdaFunction_architecturesWithLayer (407.47s)
--- PASS: TestAccLambdaFunction_vpcUpdate (2606.61s)
--- PASS: TestAccLambdaFunction_skipDestroy (288.94s)
--- PASS: TestAccLambdaFunction_nilDeadLetter (240.68s)
--- PASS: TestAccLambdaFunctionURL_Cors (332.41s)
--- PASS: TestAccLambdaFunction_snapStart (313.87s)
--- PASS: TestAccLambdaFunction_architectures (271.68s)
--- PASS: TestAccLambdaFunction_emptyVPC (235.99s)
--- PASS: TestAccLambdaFunction_deadLetterUpdated (266.33s)
--- PASS: TestAccLambdaFunction_VPCPublishHas_changes (2795.87s)
--- PASS: TestAccLambdaFunction_deadLetter (321.92s)
--- PASS: TestAccLambdaFunction_LocalUpdate_nameOnly (635.93s)
--- PASS: TestAccLambdaFunction_fileSystem (847.25s)
--- PASS: TestAccLambdaFunctionDataSource_vpc (3142.63s)
--- PASS: TestAccLambdaFunction_runtimes (936.91s)
--- PASS: TestAccLambdaFunction_ipv6AllowedForDualStack (1861.74s)
--- PASS: TestAccLambdaFunction_VPC_replaceSGWithCustom (1769.98s)
PASS
ok	  github.com/hashicorp/terraform-provider-aws/internal/service/lambda	4337.695s
```
