### PR TITLE
fix: aws_lambda_function data source always returns -1 for reserved_concurrent_executions

### DIFF
--- a/internal/service/lambda/function_data_source.go
+++ b/internal/service/lambda/function_data_source.go
@@ -325,8 +325,15 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("memory_size", function.MemorySize)
 	d.Set("qualified_arn", qualifiedARN)
 	d.Set("qualified_invoke_arn", invokeARN(meta.(*conns.AWSClient), qualifiedARN))
-	if output.Concurrency != nil {
-		d.Set("reserved_concurrent_executions", output.Concurrency.ReservedConcurrentExecutions)
+	// Get the function concurrency settings
+	result, err := conn.GetFunctionConcurrency(ctx, &lambda.GetFunctionConcurrencyInput{
+		FunctionName: aws.String(functionName),
+	})
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Lambda Function concurrency (%s): %s", functionName, err)
+	}
+	if result.ReservedConcurrentExecutions != nil {
+		d.Set("reserved_concurrent_executions", *result.ReservedConcurrentExecutions)
 	} else {
 		d.Set("reserved_concurrent_executions", -1)
 	}

--- a/internal/service/lambda/function_data_source_test.go
+++ b/internal/service/lambda/function_data_source_test.go
@@ -369,6 +369,32 @@ func TestAccLambdaFunctionDataSource_loggingConfig(t *testing.T) {
 	})
 }
 
+func TestAccLambdaFunctionDataSource_reservedConcurrentExecutions(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_lambda_function.test"
+	resourceName := "aws_lambda_function.test"
+	checkFunc := resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttrPair(dataSourceName, "reserved_concurrent_executions", resourceName, "reserved_concurrent_executions"),
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionDataSourceConfig_reservedConcurrentExecutions(rName),
+				Check:  checkFunc,
+			},
+			{
+				Config: testAccFunctionDataSourceConfig_reservedConcurrentExecutionsUnset(rName),
+				Check:  checkFunc,
+			},
+		},
+	})
+}
+
 func testAccImageLatestPreCheck(t *testing.T) {
 	if os.Getenv("AWS_LAMBDA_IMAGE_LATEST_ID") == "" {
 		t.Skip("AWS_LAMBDA_IMAGE_LATEST_ID env var must be set for Lambda Function Data Source Image Support acceptance tests.")
@@ -801,4 +827,39 @@ data "aws_lambda_function" "test" {
   function_name = aws_lambda_function.test.function_name
 }
 `, rName, rName+"_custom"))
+}
+
+func testAccFunctionDataSourceConfig_reservedConcurrentExecutions(rName string) string {
+	return acctest.ConfigCompose(testAccFunctionDataSourceConfig_base(rName), fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename                       = "test-fixtures/lambdatest.zip"
+  function_name                  = %[1]q
+  handler                        = "exports.example"
+  publish                        = true
+  role                           = aws_iam_role.lambda.arn
+  runtime                        = "nodejs16.x"
+  reserved_concurrent_executions = 2
+}
+
+data "aws_lambda_function" "test" {
+  function_name = aws_lambda_function.test.function_name
+}
+`, rName))
+}
+
+func testAccFunctionDataSourceConfig_reservedConcurrentExecutionsUnset(rName string) string {
+	return acctest.ConfigCompose(testAccFunctionDataSourceConfig_base(rName), fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename      = "test-fixtures/lambdatest.zip"
+  function_name = %[1]q
+  handler       = "exports.example"
+  publish       = true
+  role          = aws_iam_role.lambda.arn
+  runtime       = "nodejs16.x"
+}
+
+data "aws_lambda_function" "test" {
+  function_name = aws_lambda_function.test.function_name
+}
+`, rName))
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR implements a call to `GetFunctionConcurrency` to fetch the Lambda reserved concurrent executions and adds tests to validate the behavior.
It appears that in the AWS SDK v2, the reserved concurrency for a Lambda function is retrieved using the `GetFunctionConcurrency` instead of being part of the `GetFunction` response.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37660

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Before calling `GetFunctionConcurrency`:

```shell
make testacc TESTS=TestAccLambdaFunctionDataSource_reservedConcurrentExecutions PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunctionDataSource_reservedConcurrentExecutions'  -timeout 360m
=== RUN   TestAccLambdaFunctionDataSource_reservedConcurrentExecutions
=== PAUSE TestAccLambdaFunctionDataSource_reservedConcurrentExecutions
=== CONT  TestAccLambdaFunctionDataSource_reservedConcurrentExecutions
    function_data_source_test.go:381: Step 1/2 error: Check failed: Check 1/1 error: data.aws_lambda_function.test: Attribute 'reserved_concurrent_executions' expected "2", got "-1"
--- FAIL: TestAccLambdaFunctionDataSource_reservedConcurrentExecutions (37.58s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	43.296s
FAIL
make: *** [testacc] Error 1
```

After implementing the fix:

```shell
make testacc TESTS=TestAccLambdaFunctionDataSource_reservedConcurrentExecutions PKG=lambda
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaFunctionDataSource_reservedConcurrentExecutions'  -timeout 360m
=== RUN   TestAccLambdaFunctionDataSource_reservedConcurrentExecutions
=== PAUSE TestAccLambdaFunctionDataSource_reservedConcurrentExecutions
=== CONT  TestAccLambdaFunctionDataSource_reservedConcurrentExecutions
--- PASS: TestAccLambdaFunctionDataSource_reservedConcurrentExecutions (71.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	77.104s
```
