### PR TITLE
r/aws_route53_zone: fix invalid `name_servers` values

### DIFF
--- a/.changelog/37685.txt
+++ b/.changelog/37685.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_route53_zone: Fix incorrect `name_servers` values
+```
+```release-note:bug
+data-source/aws_route53_zone: Fix incorrect `name_servers` values
+```

--- a/internal/service/route53/zone.go
+++ b/internal/service/route53/zone.go
@@ -430,9 +430,13 @@ func findNameServersByZone(ctx context.Context, conn *route53.Client, zoneID, zo
 	if err != nil {
 		return nil, err
 	}
+	if len(output) == 0 {
+		return nil, nil
+	}
+	records := output[0].ResourceRecords
 
-	ns := tfslices.ApplyToAll(output, func(v awstypes.ResourceRecordSet) string {
-		return aws.ToString(v.Name)
+	ns := tfslices.ApplyToAll(records, func(v awstypes.ResourceRecord) string {
+		return aws.ToString(v.Value)
 	})
 	slices.Sort(ns)
 


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The migration of route53 to AWS SDK V2 introduced a regression which caused the `name_servers` attribute to be set to a list of record sets, rather than a list of name servers. This change returns the value to a list of name servers.

Given a minimal configuration with an internal VPC and associated hosted zone, the `name_servers` output from `v5.51.0` is:

```
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

name_server = tolist([
  "jb-test.internal.",
  "jb-test.internal.",
])
```

After this patch is applied:

```
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

name_server = tolist([
  "ns-0.awsdns-00.com.",
  "ns-1024.awsdns-00.org.",
  "ns-1536.awsdns-00.co.uk.",
  "ns-512.awsdns-00.net.",
])
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37681
Relates #37510

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=route53 TESTS=TestAccRoute53Zone
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53Zone'  -timeout 360m

=== NAME  TestAccRoute53ZoneAssociation_crossAccountAndRegion
    zone_association_test.go:194: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRoute53ZoneAssociation_crossAccountAndRegion (0.42s)
=== CONT  TestAccRoute53ZoneDataSource_serviceDiscovery
=== NAME  TestAccRoute53ZoneAssociation_crossAccount
    zone_association_test.go:132: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccRoute53ZoneAssociation_crossAccount (0.42s)
=== CONT  TestAccRoute53ZoneDataSource_vpc
--- PASS: TestAccRoute53Zone_delegationSetID (84.84s)
=== CONT  TestAccRoute53ZoneAssociation_Disappears_vpc
--- PASS: TestAccRoute53Zone_disappears (100.18s)
=== CONT  TestAccRoute53ZoneAssociation_disappears
--- PASS: TestAccRoute53ZoneDataSource_name (104.72s)
--- PASS: TestAccRoute53Zone_tags (106.97s)
--- PASS: TestAccRoute53Zone_comment (109.89s)
--- PASS: TestAccRoute53ZoneDataSource_id (112.29s)
--- PASS: TestAccRoute53ZoneDataSource_serviceDiscovery (114.20s)
--- PASS: TestAccRoute53Zone_multiple (115.26s)
--- PASS: TestAccRoute53Zone_basic (118.37s)
--- PASS: TestAccRoute53Zone_VPC_single (143.43s)
--- PASS: TestAccRoute53ZoneDataSource_tags (146.51s)
--- PASS: TestAccRoute53ZoneDataSource_vpc (152.61s)
--- PASS: TestAccRoute53Zone_VPC_multiple (195.22s)
--- PASS: TestAccRoute53Zone_VPC_single_forceDestroy (213.78s)
--- PASS: TestAccRoute53ZoneAssociation_Disappears_zone (220.95s)
--- PASS: TestAccRoute53Zone_VPC_updates (267.84s)
--- PASS: TestAccRoute53Zone_forceDestroy (268.90s)
--- PASS: TestAccRoute53ZoneAssociation_basic (270.54s)
--- PASS: TestAccRoute53ZoneAssociation_crossRegion (274.63s)
--- PASS: TestAccRoute53Zone_ForceDestroy_trailingPeriod (295.21s)
--- PASS: TestAccRoute53ZoneAssociation_Disappears_vpc (242.63s)
--- PASS: TestAccRoute53ZoneAssociation_disappears (231.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    336.544s
```
