### PR TITLE
d/aws_route53_zone: permit both `name` and `zone_id` arguments

### DIFF
--- a/.changelog/37686.txt
+++ b/.changelog/37686.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_route53_zone: Permit both `name` and `zone_id` arguments when one is an empty string
+```

--- a/internal/service/route53/zone_data_source.go
+++ b/internal/service/route53/zone_data_source.go
@@ -47,10 +47,9 @@ func dataSourceZone() *schema.Resource {
 				Computed: true,
 			},
 			names.AttrName: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ExactlyOneOf: []string{"zone_id", names.AttrName},
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"name_servers": {
 				Type:     schema.TypeList,
@@ -77,10 +76,9 @@ func dataSourceZone() *schema.Resource {
 				Computed: true,
 			},
 			"zone_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ExactlyOneOf: []string{"zone_id", names.AttrName},
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 		},
 	}


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
As part of the migration of the `route53` service to AWS SDK V2, an `ExactlyOneOf` constraint was added to the `name` and `zone_id` arguments in the `aws_route53_zone` data source. This is technically a regression as the data source functioned correctly in earlier versions when `name` is set and `zone_id` is an empty string. This change reverts the constraint and adds an acceptance test to cover this potential configuration.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37683
Relates #37510 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->



```console
% make testacc PKG=route53 TESTS=TestAccRoute53ZoneDataSource_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53ZoneDataSource_'  -timeout 360m

--- PASS: TestAccRoute53ZoneDataSource_id (91.23s)
--- PASS: TestAccRoute53ZoneDataSource_name_idEmptyString (95.31s)
--- PASS: TestAccRoute53ZoneDataSource_name (101.49s)
--- PASS: TestAccRoute53ZoneDataSource_serviceDiscovery (102.80s)
--- PASS: TestAccRoute53ZoneDataSource_vpc (126.11s)
--- PASS: TestAccRoute53ZoneDataSource_tags (127.60s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    132.691s
```
