### PR TITLE
docs: Amend lightsail_instance, add ipv6 as possible ip_address_type

### DIFF
--- a/internal/service/lightsail/instance_test.go
+++ b/internal/service/lightsail/instance_test.go
@@ -201,6 +201,13 @@ func TestAccLightsailInstance_IPAddressType(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "dualstack"),
 				),
 			},
+			{
+				Config: testAccInstanceConfig_IPAddressType(rName, "ipv6"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ip_address_type", "ipv6"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/lightsail_instance.html.markdown
+++ b/website/docs/r/lightsail_instance.html.markdown
@@ -82,7 +82,7 @@ This resource supports the following arguments:
 * `key_pair_name` - (Optional) The name of your key pair. Created in the
 Lightsail console (cannot use `aws_key_pair` at this time)
 * `user_data` - (Optional) Single lined launch script as a string to configure server with additional user data
-* `ip_address_type` - (Optional) The IP address type of the Lightsail Instance. Valid Values: `dualstack` | `ipv4`.
+* `ip_address_type` - (Optional) The IP address type of the Lightsail Instance. Valid Values: `dualstack` | `ipv4` | `ipv6`.
 * `add_on` - (Optional) The add on configuration for the instance. [Detailed below](#add_on).
 * `tags` - (Optional) A map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
### Description

AWS now support IPv6 only instance bundles, and `ipv6` is an availabe ip_address_type. This MR is to update the document and the test.


### Relations

Relates #36284

### References

https://aws.amazon.com/cn/blogs/compute/announcing-ipv6-instance-bundles-and-pricing-update-on-amazon-lightsail/


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
