### PR TITLE
r/aws-lb: Add support for IPv6-only ALB

### DIFF
--- a/.changelog/37700.txt
+++ b/.changelog/37700.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lb: Add support for IPv6-only Application Load Balancers
+```

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -1028,6 +1028,13 @@ func TestAccELBV2LoadBalancer_updateIPAddressType(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrIPAddressType, "dualstack"),
 				),
 			},
+			{
+				Config: testAccLoadBalancerConfig_ipAddressType(rName, "dualstack-without-public-ipv4"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckLoadBalancerExists(ctx, resourceName, &post),
+					resource.TestCheckResourceAttr(resourceName, names.AttrIPAddressType, "dualstack-without-public-ipv4"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -117,7 +117,7 @@ This resource supports the following arguments:
 * `enforce_security_group_inbound_rules_on_private_link_traffic` - (Optional) Whether inbound security group rules are enforced for traffic originating from a PrivateLink. Only valid for Load Balancers of type `network`. The possible values are `on` and `off`.
 * `idle_timeout` - (Optional) Time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type `application`. Default: 60.
 * `internal` - (Optional) If true, the LB will be internal. Defaults to `false`.
-* `ip_address_type` - (Optional) Type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`.
+* `ip_address_type` - (Optional) Type of IP addresses used by the subnets for your load balancer. The possible values depend upon the load balancer type: `ipv4` (all load balancer types), `dualstack` (all load balancer types), and `dualstack-without-public-ipv4` (type `application` only).
 * `load_balancer_type` - (Optional) Type of load balancer to create. Possible values are `application`, `gateway`, or `network`. The default value is `application`.
 * `name` - (Optional) Name of the LB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. If not specified, Terraform will autogenerate a name beginning with `tf-lb`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Adds support for IPv6-only internet-facing Application Load Balancers (ALBs). These load balancers do not require IPv4 addresses and can be used for clients that can connect using just IPv6 addresses.

Note this was already technically supported in the provider as the `ip_address_type` attribute uses the `elbv2.IpAddressType_Values()` function, which was updated with the SDK. This PR adds an appropriate acceptance test and updates the resource documentation to reflect the change.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37695

### References
- What's New: https://aws.amazon.com/about-aws/whats-new/2024/05/application-load-balancer-ipv6-internet-clients/
- API reference: https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateLoadBalancer.html


### Output from Acceptance Testing



```console
$ make testacc TESTS='TestAccELBV2LoadBalancer_updateIPAddressType' PKG=elbv2                                                                           
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2LoadBalancer_updateIPAddressType'  -timeout 360m
=== RUN   TestAccELBV2LoadBalancer_updateIPAddressType
=== PAUSE TestAccELBV2LoadBalancer_updateIPAddressType
=== CONT  TestAccELBV2LoadBalancer_updateIPAddressType
--- PASS: TestAccELBV2LoadBalancer_updateIPAddressType (321.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      326.585s
```

Full acceptance tests:

```console
$ make testacc TESTS='TestAccELBV2LoadBalancer_' PKG=elbv2 ACCTEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/elbv2/... -v -count 1 -parallel 10 -run='TestAccELBV2LoadBalancer_'  -timeout 360m
=== RUN   TestAccELBV2LoadBalancer_ALB_basic
=== PAUSE TestAccELBV2LoadBalancer_ALB_basic
=== RUN   TestAccELBV2LoadBalancer_NLB_basic
=== PAUSE TestAccELBV2LoadBalancer_NLB_basic
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerType_gateway
=== RUN   TestAccELBV2LoadBalancer_disappears
=== PAUSE TestAccELBV2LoadBalancer_disappears
=== RUN   TestAccELBV2LoadBalancer_nameGenerated
=== PAUSE TestAccELBV2LoadBalancer_nameGenerated
=== RUN   TestAccELBV2LoadBalancer_nameGeneratedForZeroValue
=== PAUSE TestAccELBV2LoadBalancer_nameGeneratedForZeroValue
=== RUN   TestAccELBV2LoadBalancer_namePrefix
=== PAUSE TestAccELBV2LoadBalancer_namePrefix
=== RUN   TestAccELBV2LoadBalancer_duplicateName
=== PAUSE TestAccELBV2LoadBalancer_duplicateName
=== RUN   TestAccELBV2LoadBalancer_tags
=== PAUSE TestAccELBV2LoadBalancer_tags
=== RUN   TestAccELBV2LoadBalancer_Tags_EmptyTag_OnCreate
=== PAUSE TestAccELBV2LoadBalancer_Tags_EmptyTag_OnCreate
=== RUN   TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ipv6SubnetMapping
=== RUN   TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== PAUSE TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== RUN   TestAccELBV2LoadBalancer_ALB_outpost
=== PAUSE TestAccELBV2LoadBalancer_ALB_outpost
=== RUN   TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== PAUSE TestAccELBV2LoadBalancer_networkLoadBalancerEIP
=== RUN   TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== PAUSE TestAccELBV2LoadBalancer_NLB_privateIPv4Address
=== RUN   TestAccELBV2LoadBalancer_backwardsCompatibility
=== PAUSE TestAccELBV2LoadBalancer_backwardsCompatibility
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_clientKeepAlive
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_clientKeepAlive
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== RUN   TestAccELBV2LoadBalancer_updateIPAddressType
=== PAUSE TestAccELBV2LoadBalancer_updateIPAddressType
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs
=== RUN   TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping
=== PAUSE TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping
=== RUN   TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== PAUSE TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== RUN   TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== RUN   TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== RUN   TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== PAUSE TestAccELBV2LoadBalancer_ALB_updateXffClientPort
=== CONT  TestAccELBV2LoadBalancer_ALB_basic
=== CONT  TestAccELBV2LoadBalancer_updateIPAddressType
=== CONT  TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix
=== CONT  TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen
=== CONT  TestAccELBV2LoadBalancer_updateDesyncMitigationMode
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping
=== CONT  TestAccELBV2LoadBalancer_ALB_updateXffClientPort
--- PASS: TestAccELBV2LoadBalancer_ALB_basic (225.21s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerTypeGateway_enableCrossZoneLoadBalancing (244.18s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader
--- PASS: TestAccELBV2LoadBalancer_updateDesyncMitigationMode (316.22s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateWAFFailOpen (316.24s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_clientKeepAlive
--- PASS: TestAccELBV2LoadBalancer_ALB_updateTLSVersionAndCipherSuite (316.24s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogsPrefix (320.16s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone
--- PASS: TestAccELBV2LoadBalancer_ALB_updateXffClientPort (324.23s)
=== CONT  TestAccELBV2LoadBalancer_backwardsCompatibility
--- PASS: TestAccELBV2LoadBalancer_ALB_updateXffHeaderProcessingMode (332.68s)
=== CONT  TestAccELBV2LoadBalancer_NLB_privateIPv4Address
--- PASS: TestAccELBV2LoadBalancer_updateIPAddressType (333.43s)
=== CONT  TestAccELBV2LoadBalancer_networkLoadBalancerEIP
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnetMapping (484.82s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping
--- PASS: TestAccELBV2LoadBalancer_backwardsCompatibility (201.45s)
=== CONT  TestAccELBV2LoadBalancer_ALB_outpost
    load_balancer_test.go:572: skipping since no Outposts found
--- SKIP: TestAccELBV2LoadBalancer_ALB_outpost (0.40s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDeletionProtection (302.40s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatePreserveHostHeader (302.58s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup
--- PASS: TestAccELBV2LoadBalancer_NLB_privateIPv4Address (215.00s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink
--- PASS: TestAccELBV2LoadBalancer_networkLoadBalancerEIP (232.80s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateHTTP2 (284.40s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_clientKeepAlive (299.55s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updateDropInvalidHeaderFields (299.60s)
=== CONT  TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateCrossZone (296.02s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_noSecurityGroup (189.76s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnetMapping (294.21s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_addSubnet (345.62s)
=== CONT  TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_enforcePrivateLink (332.80s)
=== CONT  TestAccELBV2LoadBalancer_ipv6SubnetMapping
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogsPrefix (305.99s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateDNSRecordClientRoutingPolicy (321.58s)
=== CONT  TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_accessLogs (373.40s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_connectionLogs (344.88s)
=== CONT  TestAccELBV2LoadBalancer_nameGenerated
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_deleteSubnet (467.26s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogsPrefix (295.07s)
=== CONT  TestAccELBV2LoadBalancer_namePrefix
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_accessLogs (340.78s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet
--- PASS: TestAccELBV2LoadBalancer_ipv6SubnetMapping (249.19s)
=== CONT  TestAccELBV2LoadBalancer_nameGeneratedForZeroValue
--- PASS: TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Add (281.04s)
=== CONT  TestAccELBV2LoadBalancer_Tags_EmptyTag_OnCreate
--- PASS: TestAccELBV2LoadBalancer_nameGenerated (205.82s)
=== CONT  TestAccELBV2LoadBalancer_LoadBalancerType_gateway
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnetMapping (256.78s)
=== CONT  TestAccELBV2LoadBalancer_disappears
--- PASS: TestAccELBV2LoadBalancer_Tags_EmptyTag_OnUpdate_Replace (257.22s)
=== CONT  TestAccELBV2LoadBalancer_NLB_basic
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnetMapping (259.06s)
=== CONT  TestAccELBV2LoadBalancer_tags
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_addSubnet (256.22s)
=== CONT  TestAccELBV2LoadBalancer_duplicateName
--- PASS: TestAccELBV2LoadBalancer_NetworkLoadBalancer_updateSecurityGroups (714.21s)
=== CONT  TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups
--- PASS: TestAccELBV2LoadBalancer_nameGeneratedForZeroValue (211.83s)
--- PASS: TestAccELBV2LoadBalancer_Tags_EmptyTag_OnCreate (214.84s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_deleteSubnet (260.85s)
--- PASS: TestAccELBV2LoadBalancer_disappears (203.48s)
--- PASS: TestAccELBV2LoadBalancer_LoadBalancerType_gateway (217.95s)
--- PASS: TestAccELBV2LoadBalancer_NLB_basic (213.42s)
--- PASS: TestAccELBV2LoadBalancer_namePrefix (379.14s)
--- PASS: TestAccELBV2LoadBalancer_duplicateName (221.02s)
--- PASS: TestAccELBV2LoadBalancer_tags (310.99s)
--- PASS: TestAccELBV2LoadBalancer_ApplicationLoadBalancer_updatedSecurityGroups (260.58s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      1580.491s
```
