### PR TITLE
docs: add link to s3 access point naming convention

### DIFF
--- a/website/docs/r/s3_access_point.html.markdown
+++ b/website/docs/r/s3_access_point.html.markdown
@@ -58,7 +58,7 @@ resource "aws_vpc" "example" {
 The following arguments are required:
 
 * `bucket` - (Required) Name of an AWS Partition S3 General Purpose Bucket or the ARN of S3 on Outposts Bucket that you want to associate this access point with.
-* `name` - (Required) Name you want to assign to this access point. It must meet the conditions described [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-access-points.html?icmpid=docs_amazons3_console#access-points-names).
+* `name` - (Required) Name you want to assign to this access point. See the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-access-points.html?icmpid=docs_amazons3_console#access-points-names) for naming conditions.
 
 The following arguments are optional:
 

--- a/website/docs/r/s3_access_point.html.markdown
+++ b/website/docs/r/s3_access_point.html.markdown
@@ -58,7 +58,7 @@ resource "aws_vpc" "example" {
 The following arguments are required:
 
 * `bucket` - (Required) Name of an AWS Partition S3 General Purpose Bucket or the ARN of S3 on Outposts Bucket that you want to associate this access point with.
-* `name` - (Required) Name you want to assign to this access point.
+* `name` - (Required) Name you want to assign to this access point. It must meet the conditions described [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-access-points.html?icmpid=docs_amazons3_console#access-points-names).
 
 The following arguments are optional:
 


### PR DESCRIPTION
### Description

Add information about the naming convention  to the required argument `name`.

### Relations

Closes #37656 

### References

* [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-access-points.html?icmpid=docs_amazons3_console#access-points-names) to the naming convention for S3 access points.

### Output from Acceptance Testing

Not applicable