### PR TITLE
r/kinesisanalyticsv2_application: add `application_mode` attribute

### DIFF
--- a/.changelog/37714.txt
+++ b/.changelog/37714.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_kinesisanalyticsv2_application: Add `application_mode` argument
+```

--- a/internal/service/kinesisanalyticsv2/application.go
+++ b/internal/service/kinesisanalyticsv2/application.go
@@ -848,6 +848,14 @@ func ResourceApplication() *schema.Resource {
 				Computed: true,
 			},
 
+			"application_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(kinesisanalyticsv2.ApplicationMode_Values(), false),
+			},
+
 			"cloudwatch_logging_options": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -949,6 +957,10 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 		Tags:                     getTagsIn(ctx),
 	}
 
+	if v, ok := d.GetOk("application_mode"); ok {
+		input.ApplicationMode = aws.String(v.(string))
+	}
+
 	outputRaw, err := waitIAMPropagation(ctx, func() (interface{}, error) {
 		return conn.CreateApplicationWithContext(ctx, input)
 	})
@@ -992,6 +1004,7 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set(names.AttrARN, arn)
 	d.Set("create_timestamp", aws.TimeValue(application.CreateTimestamp).Format(time.RFC3339))
 	d.Set(names.AttrDescription, application.ApplicationDescription)
+	d.Set("application_mode", application.ApplicationMode)
 	d.Set("last_update_timestamp", aws.TimeValue(application.LastUpdateTimestamp).Format(time.RFC3339))
 	d.Set(names.AttrName, application.ApplicationName)
 	d.Set("runtime_environment", application.RuntimeEnvironment)

--- a/internal/service/kinesisanalyticsv2/application_test.go
+++ b/internal/service/kinesisanalyticsv2/application_test.go
@@ -336,6 +336,34 @@ func TestAccKinesisAnalyticsV2Application_basicSQLApplication(t *testing.T) {
 	})
 }
 
+func TestAccKinesisAnalyticsV2Application_applicationMode(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v kinesisanalyticsv2.ApplicationDetail
+	resourceName := "aws_kinesisanalyticsv2_application.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.KinesisAnalyticsV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationConfig_applicationMode(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "application_mode", "STREAMING"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccKinesisAnalyticsV2Application_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v kinesisanalyticsv2.ApplicationDetail
@@ -4482,6 +4510,19 @@ func testAccApplicationConfig_basicSQL(rName string) string {
 resource "aws_kinesisanalyticsv2_application" "test" {
   name                   = %[1]q
   runtime_environment    = "SQL-1_0"
+  service_execution_role = aws_iam_role.test[0].arn
+}
+`, rName))
+}
+
+func testAccApplicationConfig_applicationMode(rName string) string {
+	return acctest.ConfigCompose(
+		testAccApplicationConfig_baseServiceExecutionIAMRole(rName),
+		fmt.Sprintf(`
+resource "aws_kinesisanalyticsv2_application" "test" {
+  name                   = %[1]q
+  application_mode       = "STREAMING"
+  runtime_environment    = "FLINK-1_13"
   service_execution_role = aws_iam_role.test[0].arn
 }
 `, rName))

--- a/website/docs/r/kinesisanalyticsv2_application.html.markdown
+++ b/website/docs/r/kinesisanalyticsv2_application.html.markdown
@@ -259,6 +259,7 @@ This resource supports the following arguments:
 * `runtime_environment` - (Required) The runtime environment for the application. Valid values: `SQL-1_0`, `FLINK-1_6`, `FLINK-1_8`, `FLINK-1_11`, `FLINK-1_13`, `FLINK-1_15`, `FLINK-1_18`.
 * `service_execution_role` - (Required) The ARN of the [IAM role](/docs/providers/aws/r/iam_role.html) used by the application to access Kinesis data streams, Kinesis Data Firehose delivery streams, Amazon S3 objects, and other external resources.
 * `application_configuration` - (Optional) The application's configuration
+* `application_mode` - (Optional) The application's mode. Valid values are `STREAMING`, `INTERACTIVE`.
 * `cloudwatch_logging_options` - (Optional) A [CloudWatch log stream](/docs/providers/aws/r/cloudwatch_log_stream.html) to monitor application configuration errors.
 * `description` - (Optional) A summary description of the application.
 * `force_stop` - (Optional) Whether to force stop an unresponsive Flink-based application.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31130

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccKinesisAnalyticsV2Application_applicationMode PKG=kinesisanalyticsv2
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/kinesisanalyticsv2/... -v -count 1 -parallel 20 -run='TestAccKinesisAnalyticsV2Application_applicationMode'  -timeout 360m
=== RUN   TestAccKinesisAnalyticsV2Application_applicationMode
=== PAUSE TestAccKinesisAnalyticsV2Application_applicationMode
=== CONT  TestAccKinesisAnalyticsV2Application_applicationMode
--- PASS: TestAccKinesisAnalyticsV2Application_applicationMode (52.05s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kinesisanalyticsv2	71.031s

--- PASS: TestAccKinesisAnalyticsV2Application_FlinkApplicationStartApplication_onCreate (355.22s)
--- PASS: TestAccKinesisAnalyticsV2Application_applicationMode (141.00s)
--- PASS: TestAccKinesisAnalyticsV2Application_CloudWatchLoggingOptions_add (235.50s)
--- PASS: TestAccKinesisAnalyticsV2Application_EnvironmentProperties_update (365.02s)
--- PASS: TestAccKinesisAnalyticsV2Application_SQLApplicationVPC_delete (214.10s)
--- PASS: TestAccKinesisAnalyticsV2Application_disappears (85.00s)
--- PASS: TestAccKinesisAnalyticsV2Application_basicSQLApplication (92.06s)
--- PASS: TestAccKinesisAnalyticsV2Application_basicFlinkApplication (422.95s)
--- PASS: TestAccKinesisAnalyticsV2Application_tags (137.03s)
--- PASS: TestAccKinesisAnalyticsV2Application_FlinkApplicationStartApplication_onUpdate (342.06s)
--- PASS: TestAccKinesisAnalyticsV2Application_RunConfiguration_Update (582.36s)
--- PASS: TestAccKinesisAnalyticsV2Application_FlinkApplication_updateRunning (418.99s)
--- PASS: TestAccKinesisAnalyticsV2Application_FlinkApplication_restoreFromSnapshot (622.65s)
--- PASS: TestAccKinesisAnalyticsV2Application_SQLApplicationVPC_add (295.24s)
--- PASS: TestAccKinesisAnalyticsV2Application_FlinkApplicationEnvironmentProperties_update (293.61s)
--- PASS: TestAccKinesisAnalyticsV2Application_SQLApplicationVPC_update (294.20s)
--- PASS: TestAccKinesisAnalyticsV2Application_FlinkApplication_update (294.61s)
--- PASS: TestAccKinesisAnalyticsV2Application_CloudWatchLoggingOptions_delete (204.91s)
--- PASS: TestAccKinesisAnalyticsV2Application_CloudWatchLoggingOptions_update (205.37s)
--- PASS: TestAccKinesisAnalyticsV2Application_ServiceExecutionRole_update (219.36s)
--- PASS: TestAccKinesisAnalyticsV2Application_ApplicationCode_update (219.68s)

...
```
