### PR TITLE
fix wrong argument name in example and a  typo

### DIFF
--- a/website/docs/d/chatbot_slack_workspace.html.markdown
+++ b/website/docs/d/chatbot_slack_workspace.html.markdown
@@ -16,7 +16,7 @@ Terraform data source for managing an AWS Chatbot Slack Workspace.
 
 ```terraform
 data "aws_chatbot_slack_workspace" "example" {
-  team_slack_name = "abc"
+  slack_team_name = "abc"
 }
 ```
 
@@ -24,7 +24,7 @@ data "aws_chatbot_slack_workspace" "example" {
 
 The following arguments are required:
 
-* `slack_team_name` - (Required) Slack workspace name configured with AWS Chabot.
+* `slack_team_name` - (Required) Slack workspace name configured with AWS Chatbot.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
When trying to use the new data source, I copied the example from the docs and found out that the argument is referenced incorrectly. This tiny PR fixes it

As per the [guidelines](https://hashicorp.github.io/terraform-provider-aws/changelog-process/) no changelog is required for documentation changes 

