### PR TITLE
fix: Increase instruction arg max length to 4000 for aws_bedrockagent_agent

### DIFF
--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -118,7 +118,7 @@ func (r *agentResource) Schema(ctx context.Context, request resource.SchemaReque
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{
-					stringvalidator.LengthBetween(40, 1200),
+					stringvalidator.LengthBetween(40, 4000),
 				},
 			},
 			"prompt_override_configuration": schema.ListAttribute{ // proto5 Optional+Computed nested block.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The PR is to increase the maximum length of the `instruction` argument to 4000 for the `aws_bedrockagent_agent` resource as per the API.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37757

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Checked [CreateAgent](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_CreateAgent.html#bedrock-agent_CreateAgent-request-instruction) for spec.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccBedrockAgentAgent_basic PKG=bedrockagent
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentAgent_basic'  -timeout 360m
=== RUN   TestAccBedrockAgentAgent_basic
=== PAUSE TestAccBedrockAgentAgent_basic
=== CONT  TestAccBedrockAgentAgent_basic
--- PASS: TestAccBedrockAgentAgent_basic (26.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       26.320s
```
