### PR TITLE
fix: change route53_traffic_policy update to create new version

### DIFF
--- a/.changelog/37759.txt
+++ b/.changelog/37759.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/route53_traffic_policy: Create new version of policy instead of recreating on `document` change.
+```

--- a/internal/service/route53/traffic_policy.go
+++ b/internal/service/route53/traffic_policy.go
@@ -63,7 +63,7 @@ func resourceTrafficPolicy() *schema.Resource {
 			"document": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
+				ForceNew:     false,
 				ValidateFunc: validation.StringLenBetween(0, 102400),
 			},
 			names.AttrName: {

--- a/internal/service/route53/traffic_policy.go
+++ b/internal/service/route53/traffic_policy.go
@@ -30,7 +30,7 @@ func resourceTrafficPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTrafficPolicyCreate,
 		ReadWithoutTimeout:   resourceTrafficPolicyRead,
-		UpdateWithoutTimeout: resourceTrafficPolicyUpdate,
+		UpdateWithoutTimeout: resourceTrafficPolicyVersionCreate,
 		DeleteWithoutTimeout: resourceTrafficPolicyDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -136,23 +136,20 @@ func resourceTrafficPolicyRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceTrafficPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficPolicyVersionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53Client(ctx)
 
-	input := &route53.UpdateTrafficPolicyCommentInput{
-		Id:      aws.String(d.Id()),
-		Version: aws.Int32(int32(d.Get(names.AttrVersion).(int))),
+	input := &route53.CreateTrafficPolicyVersionInput{
+		Document: aws.String(d.Get("document").(string)),
+		Id:       aws.String(d.Id()),
+		Comment:  aws.String(d.Get(names.AttrComment).(string)),
 	}
 
-	if d.HasChange(names.AttrComment) {
-		input.Comment = aws.String(d.Get(names.AttrComment).(string))
-	}
-
-	_, err := conn.UpdateTrafficPolicyComment(ctx, input)
+	_, err := conn.CreateTrafficPolicyVersion(ctx, input)
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating Route53 Traffic Policy (%s) comment: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "Creating new Route53 Traffic Policy version (%s) comment: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceTrafficPolicyRead(ctx, d, meta)...)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR changes route53_traffic_policy update method from updating current version to creating new version of policy.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #27767

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccRoute53TrafficPolicy_update PKG=route53
cat: .go-version: No such file or directory
cat: .go-version: No such file or directory
cat: .go-version: No such file or directory
cat: .go-version: No such file or directory
cat: .go-version: No such file or directory
cat: .go-version: No such file or directory
==> Checking that code complies with gofmt requirements...
cat: .go-version: No such file or directory
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53TrafficPolicy_update'  -timeout 360m
=== RUN   TestAccRoute53TrafficPolicy_update
=== PAUSE TestAccRoute53TrafficPolicy_update
=== CONT  TestAccRoute53TrafficPolicy_update
--- PASS: TestAccRoute53TrafficPolicy_update (36.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	41.859s
...
```
