### PR TITLE
b/aws_lambda_function: When the image_uri is set, the package_type must be explicitly set to 'Image' to avoid errors

### DIFF
--- a/.changelog/37780.txt
+++ b/.changelog/37780.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+* resource/aws_lambda_function: Permit `package_type` to be empty when `image_uri` is set ([#37780](https://github.com/hashicorp/terraform-provider-aws/issues/37780))
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ BUG FIXES:
 * resource/aws_lightsail_instance: Fix crash when reading a resource that has a key-only tag ([#37587](https://github.com/hashicorp/terraform-provider-aws/issues/37587))
 * resource/aws_lightsail_key_pair: Prevent destroy failure when resource is already deleted outside Terraform ([#37711](https://github.com/hashicorp/terraform-provider-aws/issues/37711))
 * resource/aws_lightsail_lb: Prevent destroy failure when resource is already deleted outside Terraform ([#37711](https://github.com/hashicorp/terraform-provider-aws/issues/37711))
+* resource/aws_lambda_function: Permit `package_type` to be empty when `image_uri` is set ([#37780](https://github.com/hashicorp/terraform-provider-aws/issues/37780))
 
 ## 5.51.1 (May 24, 2024)
 

--- a/website/docs/cdktf/python/r/lambda_function.html.markdown
+++ b/website/docs/cdktf/python/r/lambda_function.html.markdown
@@ -309,7 +309,7 @@ The following arguments are optional:
 * `layers` - (Optional) List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. See [Lambda Layers][10]
 * `logging_config` - (Optional) Configuration block used to specify advanced logging settings. Detailed below.
 * `memory_size` - (Optional) Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits][5]
-* `package_type` - (Optional) Lambda deployment package type. Valid values are `Zip` and `Image`. Defaults to `Zip`.
+* `package_type` - (Optional) Lambda deployment package type. Valid values are `Zip` and `Image`. Defaults to `Zip`. If `image_uri` is set, this defaults to `Image`.
 * `publish` - (Optional) Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
 * `reserved_concurrent_executions` - (Optional) Amount of reserved concurrent executions for this lambda function. A value of `0` disables lambda from being triggered and `-1` removes any concurrency limitations. Defaults to Unreserved Concurrency Limits `-1`. See [Managing Concurrency][9]
 * `replace_security_groups_on_destroy` - (Optional) Whether to replace the security groups on the function's VPC configuration prior to destruction.

--- a/website/docs/cdktf/typescript/r/lambda_function.html.markdown
+++ b/website/docs/cdktf/typescript/r/lambda_function.html.markdown
@@ -352,7 +352,7 @@ The following arguments are optional:
 * `layers` - (Optional) List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. See [Lambda Layers][10]
 * `loggingConfig` - (Optional) Configuration block used to specify advanced logging settings. Detailed below.
 * `memorySize` - (Optional) Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits][5]
-* `packageType` - (Optional) Lambda deployment package type. Valid values are `Zip` and `Image`. Defaults to `Zip`.
+* `packageType` - (Optional) Lambda deployment package type. Valid values are `Zip` and `Image`. Defaults to `Zip`. If `image_uri` is set, this defaults to `Image`.
 * `publish` - (Optional) Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
 * `reservedConcurrentExecutions` - (Optional) Amount of reserved concurrent executions for this lambda function. A value of `0` disables lambda from being triggered and `-1` removes any concurrency limitations. Defaults to Unreserved Concurrency Limits `-1`. See [Managing Concurrency][9]
 * `replaceSecurityGroupsOnDestroy` - (Optional) Whether to replace the security groups on the function's VPC configuration prior to destruction.

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -277,7 +277,7 @@ The following arguments are optional:
 * `layers` - (Optional) List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function. See [Lambda Layers][10]
 * `logging_config` - (Optional) Configuration block used to specify advanced logging settings. Detailed below.
 * `memory_size` - (Optional) Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits][5]
-* `package_type` - (Optional) Lambda deployment package type. Valid values are `Zip` and `Image`. Defaults to `Zip`.
+* `package_type` - (Optional) Lambda deployment package type. Valid values are `Zip` and `Image`. Defaults to `Zip`. If `image_uri` is set, this defaults to `Image`.
 * `publish` - (Optional) Whether to publish creation/change as new Lambda Function Version. Defaults to `false`.
 * `reserved_concurrent_executions` - (Optional) Amount of reserved concurrent executions for this lambda function. A value of `0` disables lambda from being triggered and `-1` removes any concurrency limitations. Defaults to Unreserved Concurrency Limits `-1`. See [Managing Concurrency][9]
 * `replace_security_groups_on_destroy` - (Optional) Whether to replace the security groups on the function's VPC configuration prior to destruction.


### PR DESCRIPTION
### Description
This PR introduces changes that allow the `package_type` parameter in AWS Lambda functions to be empty when `image_uri` is set. Accordingly, the parameter now defaults to `Image` if `image_uri` is set. The necessary tests have been added to verify this behaviour and the documentation has been updated to reflect this change. Modifications have been made internally to validate the `package_type` and `image_uri` combination.



### Relations
Closes #37784

### References
It seems to be a very common mistake.
https://github.com/hashicorp/terraform-provider-aws/issues/21864
https://github.com/hashicorp/terraform-provider-aws/pull/19514
https://stackoverflow.com/questions/76862775/what-is-this-terraform-error-trying-to-tell-me-about-image-configuration-blocks

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
