### PR TITLE
feat(dynamo): add arg to set deletion protection for table replica

### DIFF
--- a/internal/service/dynamodb/table_replica.go
+++ b/internal/service/dynamodb/table_replica.go
@@ -90,6 +90,10 @@ func resourceTableReplica() *schema.Resource {
 				ForceNew:         true,
 				ValidateDiagFunc: enum.Validate[awstypes.TableClass](),
 			},
+			"deletion_protection_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			names.AttrTags:    tftags.TagsSchema(),         // direct to replica
 			names.AttrTagsAll: tftags.TagsSchemaComputed(), // direct to replica
 		},
@@ -315,6 +319,10 @@ func resourceTableReplicaReadReplica(ctx context.Context, d *schema.ResourceData
 
 	setTagsOut(ctx, Tags(tags))
 
+	if table.DeletionProtectionEnabled != nil {
+		d.Set("deletion_protection_enabled", table.DeletionProtectionEnabled)
+	}
+
 	return diags
 }
 
@@ -403,7 +411,8 @@ func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, met
 	// handled direct to replica
 	// * point_in_time_recovery
 	// * tags
-	if d.HasChanges("point_in_time_recovery", names.AttrTagsAll) {
+	// * deletion_protection_enabled
+	if d.HasChanges("point_in_time_recovery", names.AttrTagsAll, "deletion_protection_enabled") {
 		if d.HasChange(names.AttrTagsAll) {
 			o, n := d.GetChange(names.AttrTagsAll)
 			if err := updateTags(ctx, conn, d.Get(names.AttrARN).(string), o, n); err != nil {
@@ -414,6 +423,22 @@ func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, met
 		if d.HasChange("point_in_time_recovery") {
 			if err := updatePITR(ctx, conn, tableName, d.Get("point_in_time_recovery").(bool), replicaRegion, d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTableReplica, d.Id(), err)
+			}
+		}
+
+		if d.HasChange("deletion_protection_enabled") {
+			log.Printf("[DEBUG] Updating DynamoDB Table Replica deletion protection: %v", d.Get("deletion_protection_enabled").(bool))
+			_, err := conn.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+				TableName:                 aws.String(tableName),
+				DeletionProtectionEnabled: aws.Bool(d.Get("deletion_protection_enabled").(bool)),
+			})
+			if err != nil {
+				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTableReplica, d.Id(), err)
+			}
+			// Deletion protection change is reflected only on table status, and not in replicas status field
+			// There is certain lag after attr update and table status change so doing it with delay
+			if _, err := waitTableActiveAfterDeletionProtectionChange(ctx, conn, tableName, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionWaitingForUpdate, resNameTable, d.Id(), err)
 			}
 		}
 

--- a/internal/service/dynamodb/table_replica_test.go
+++ b/internal/service/dynamodb/table_replica_test.go
@@ -404,6 +404,42 @@ func testAccCheckTableReplicaExists(ctx context.Context, n string) resource.Test
 	}
 }
 
+func TestAccDynamoDBTableReplica_deletion_protection(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	resourceName := "aws_dynamodb_table_replica.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckMultipleRegion(t, 2) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 3),
+		CheckDestroy:             testAccCheckTableReplicaDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableReplicaConfig_enable_deletion_protection(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTableReplicaExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "deletion_protection_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// disable deletion protection for the sweeper to work
+			{
+				Config: testAccTableReplicaConfig_disable_deletion_protection(rName),
+				Check:  resource.TestCheckResourceAttr(resourceName, "deletion_protection_enabled", "false"),
+			},
+		},
+	})
+}
+
 func testAccTableReplicaConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(3),
@@ -758,4 +794,62 @@ resource "aws_dynamodb_table_replica" "test" {
   point_in_time_recovery = true
 }
 `, rName, key))
+}
+
+func testAccTableReplicaConfig_enable_deletion_protection(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  lifecycle {
+    ignore_changes = [replica]
+  }
+}
+
+resource "aws_dynamodb_table_replica" "test" {
+  provider                    = "awsalternate"
+  global_table_arn            = aws_dynamodb_table.test.arn
+  deletion_protection_enabled = true
+}
+`, rName))
+}
+
+func testAccTableReplicaConfig_disable_deletion_protection(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  lifecycle {
+    ignore_changes = [replica]
+  }
+}
+
+resource "aws_dynamodb_table_replica" "test" {
+  provider                    = "awsalternate"
+  global_table_arn            = aws_dynamodb_table.test.arn
+  deletion_protection_enabled = false
+}
+`, rName))
 }


### PR DESCRIPTION
### Description
Adds support to enable/disable deletion protection when creating/updating a dynamodb table replica.

### Relations
Closes #30213 


### Output from Acceptance Testing


```console
make testacc TESTS=TestAccDynamoDBTableReplica_deletion_protection PKG=dynamodb  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTableReplica_deletion_protection'  -timeout 360m
=== RUN   TestAccDynamoDBTableReplica_deletion_protection
=== PAUSE TestAccDynamoDBTableReplica_deletion_protection
=== CONT  TestAccDynamoDBTableReplica_deletion_protection
--- PASS: TestAccDynamoDBTableReplica_deletion_protection (371.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   377.910s
```

```console
make testacc TESTS=TestAccDynamoDBTableReplica_basic PKG=dynamodb                
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTableReplica_basic'  -timeout 360m
=== RUN   TestAccDynamoDBTableReplica_basic
=== PAUSE TestAccDynamoDBTableReplica_basic
=== CONT  TestAccDynamoDBTableReplica_basic
--- PASS: TestAccDynamoDBTableReplica_basic (203.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   209.721s
```