### PR TITLE
aws_dx_gateway_association docs: Add a note for multi region setup

### DIFF
--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -93,6 +93,8 @@ A full example of how to create a VPN Gateway in one AWS account, create a Direc
 
 ~> **NOTE:** `dx_gateway_id` and `associated_gateway_id` must be specified for single account Direct Connect gateway associations.
 
+~> **NOTE:** If the `associated_gateway_id` is in another region, an [alias](https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations) in a new provider block for that region should be specified. 
+
 This argument supports the following arguments:
 
 * `dx_gateway_id` - (Required) The ID of the Direct Connect gateway.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
In multi-region setups, if the `associated_gateway_id` argument of `aws_dx_gateway_association` is located in a region outside of the current provider being used, it will result in the error below:

```
│ Error: accepting Direct Connect Gateway Association Proposal (XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXXX): DirectConnectClientException: The VirtualGateway vgw-0b116aa861f787XXX does not exist.
│ 
│   with aws_dx_gateway_association.example,
│   on main.tf line 53, in resource "aws_dx_gateway_association" "example":
│   53: resource "aws_dx_gateway_association" "example" {
```

This PR will add a note in the documentation to account for this use-case.

