### PR TITLE
Tech debt: Use `findTag` as default generated `GetTag` function name

### DIFF
--- a/internal/generate/common/generator.go
+++ b/internal/generate/common/generator.go
@@ -11,6 +11,8 @@ import (
 	"path"
 	"strings"
 	"text/template"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/hashicorp/cli"
 	"golang.org/x/text/cases"
@@ -144,6 +146,15 @@ func (d *baseDestination) WriteTemplate(templateName, templateBody string, templ
 
 func parseTemplate(templateName, templateBody string, templateData any) ([]byte, error) {
 	funcMap := template.FuncMap{
+		// FirstUpper returns a string with the first character as upper case.
+		"FirstUpper": func(s string) string {
+			if s == "" {
+				return ""
+			}
+			r, n := utf8.DecodeRuneInString(s)
+			return string(unicode.ToUpper(r)) + s[n:]
+		},
+		// Title returns a string with the first character of each word as upper case.
 		"Title": cases.Title(language.Und, cases.NoLower).String,
 	}
 	tmpl, err := template.New(templateName).Funcs(funcMap).Parse(templateBody)

--- a/internal/generate/tagresource/main.go
+++ b/internal/generate/tagresource/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	getTagFunc     = flag.String("GetTagFunc", "GetTag", "getTagFunc")
+	getTagFunc     = flag.String("GetTagFunc", "findTag", "getTagFunc")
 	idAttribName   = flag.String("IDAttribName", "resource_arn", "idAttribName")
 	updateTagsFunc = flag.String("UpdateTagsFunc", "updateTags", "updateTagsFunc")
 )

--- a/internal/generate/tagresource/tests.tmpl
+++ b/internal/generate/tagresource/tests.tmpl
@@ -30,7 +30,7 @@ func testAccCheckTagDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			_, err = tf{{ .ServicePackage }}.{{ .GetTagFunc }}(ctx, conn, identifier, key)
+			_, err = tf{{ .ServicePackage }}.{{ .GetTagFunc | FirstUpper }}(ctx, conn, identifier, key)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -61,7 +61,7 @@ func testAccCheckTagExists(ctx context.Context, n string) resource.TestCheckFunc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).{{ .AWSServiceUpper }}Client(ctx)
 
-		_, err = tf{{ .ServicePackage }}.{{ .GetTagFunc }}(ctx, conn, identifier, key)
+		_, err = tf{{ .ServicePackage }}.{{ .GetTagFunc | FirstUpper }}(ctx, conn, identifier, key)
 
 		return err
 	}

--- a/internal/generate/tags/main.go
+++ b/internal/generate/tags/main.go
@@ -43,7 +43,7 @@ var (
 	waitForPropagation       = flag.Bool("Wait", false, "whether to generate WaitTagsPropagated")
 
 	createTagsFunc             = flag.String("CreateTagsFunc", "createTags", "createTagsFunc")
-	getTagFunc                 = flag.String("GetTagFunc", "GetTag", "getTagFunc")
+	getTagFunc                 = flag.String("GetTagFunc", "findTag", "getTagFunc")
 	getTagsInFunc              = flag.String("GetTagsInFunc", "getTagsIn", "getTagsInFunc")
 	keyValueTagsFunc           = flag.String("KeyValueTagsFunc", "KeyValueTags", "keyValueTagsFunc")
 	listTagsFunc               = flag.String("ListTagsFunc", defaultListTagsFunc, "listTagsFunc")

--- a/internal/service/autoscaling/generate.go
+++ b/internal/service/autoscaling/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -GetTag -GetTagFunc=findTag -ListTags -ListTagsOp=DescribeTags -ListTagsOpPaginated -ListTagsInFiltIDName=auto-scaling-group -ServiceTagsSlice -TagOp=CreateOrUpdateTags -TagResTypeElem=ResourceType -TagType2=TagDescription -TagTypeAddBoolElem=PropagateAtLaunch -TagTypeIDElem=ResourceId -UntagOp=DeleteTags -UntagInNeedTagType -UntagInTagsElem=Tags -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -GetTag -ListTags -ListTagsOp=DescribeTags -ListTagsOpPaginated -ListTagsInFiltIDName=auto-scaling-group -ServiceTagsSlice -TagOp=CreateOrUpdateTags -TagResTypeElem=ResourceType -TagType2=TagDescription -TagTypeAddBoolElem=PropagateAtLaunch -TagTypeIDElem=ResourceId -UntagOp=DeleteTags -UntagInNeedTagType -UntagInTagsElem=Tags -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/dynamodb/exports_test.go
+++ b/internal/service/dynamodb/exports_test.go
@@ -26,6 +26,7 @@ var (
 	FindTableByName                              = findTableByName
 	FindTableExportByARN                         = findTableExportByARN
 	FindTableItemByTwoPartKey                    = findTableItemByTwoPartKey
+	FindTag                                      = findTag
 	FlattenTableItemAttributes                   = flattenTableItemAttributes
 	ListTags                                     = listTags
 	RegionFromARN                                = regionFromARN

--- a/internal/service/dynamodb/tag_gen.go
+++ b/internal/service/dynamodb/tag_gen.go
@@ -72,7 +72,7 @@ func resourceTagRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	value, err := GetTag(ctx, conn, identifier, key)
+	value, err := findTag(ctx, conn, identifier, key)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] %s resource (%s) tag (%s) not found, removing from state", names.DynamoDB, identifier, key)

--- a/internal/service/dynamodb/tag_gen_test.go
+++ b/internal/service/dynamodb/tag_gen_test.go
@@ -30,7 +30,7 @@ func testAccCheckTagDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			_, err = tfdynamodb.findTag(ctx, conn, identifier, key)
+			_, err = tfdynamodb.FindTag(ctx, conn, identifier, key)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -61,7 +61,7 @@ func testAccCheckTagExists(ctx context.Context, n string) resource.TestCheckFunc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBClient(ctx)
 
-		_, err = tfdynamodb.findTag(ctx, conn, identifier, key)
+		_, err = tfdynamodb.FindTag(ctx, conn, identifier, key)
 
 		return err
 	}

--- a/internal/service/dynamodb/tag_gen_test.go
+++ b/internal/service/dynamodb/tag_gen_test.go
@@ -30,7 +30,7 @@ func testAccCheckTagDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			_, err = tfdynamodb.GetTag(ctx, conn, identifier, key)
+			_, err = tfdynamodb.findTag(ctx, conn, identifier, key)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -61,7 +61,7 @@ func testAccCheckTagExists(ctx context.Context, n string) resource.TestCheckFunc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).DynamoDBClient(ctx)
 
-		_, err = tfdynamodb.GetTag(ctx, conn, identifier, key)
+		_, err = tfdynamodb.findTag(ctx, conn, identifier, key)
 
 		return err
 	}

--- a/internal/service/dynamodb/tags_gen.go
+++ b/internal/service/dynamodb/tags_gen.go
@@ -19,12 +19,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// GetTag fetches an individual dynamodb service tag for a resource.
+// findTag fetches an individual dynamodb service tag for a resource.
 // Returns whether the key value and any errors. A NotFoundError is used to signal that no value was found.
 // This function will optimise the handling over listTags, if possible.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func GetTag(ctx context.Context, conn *dynamodb.Client, identifier, key string, optFns ...func(*dynamodb.Options)) (*string, error) {
+func findTag(ctx context.Context, conn *dynamodb.Client, identifier, key string, optFns ...func(*dynamodb.Options)) (*string, error) {
 	listTags, err := listTags(ctx, conn, identifier, optFns...)
 
 	if err != nil {

--- a/internal/service/ec2/exports_test.go
+++ b/internal/service/ec2/exports_test.go
@@ -76,6 +76,7 @@ var (
 	FindRouteByPrefixListIDDestinationV2                   = findRouteByPrefixListIDDestination
 	FindRouteTableAssociationByIDV2                        = findRouteTableAssociationByID
 	FindRouteTableByIDV2                                   = findRouteTableByID
+	FindTag                                                = findTag
 	FindVolumeAttachmentInstanceByID                       = findVolumeAttachmentInstanceByID
 	FindVPCEndpointConnectionByServiceIDAndVPCEndpointIDV2 = findVPCEndpointConnectionByServiceIDAndVPCEndpointIDV2
 	FindVPCEndpointConnectionNotificationByIDV2            = findVPCEndpointConnectionNotificationByIDV2

--- a/internal/service/ec2/tag_gen.go
+++ b/internal/service/ec2/tag_gen.go
@@ -72,7 +72,7 @@ func resourceTagRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	value, err := GetTag(ctx, conn, identifier, key)
+	value, err := findTag(ctx, conn, identifier, key)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] %s resource (%s) tag (%s) not found, removing from state", names.EC2, identifier, key)

--- a/internal/service/ec2/tag_gen_test.go
+++ b/internal/service/ec2/tag_gen_test.go
@@ -30,7 +30,7 @@ func testAccCheckTagDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			_, err = tfec2.GetTag(ctx, conn, identifier, key)
+			_, err = tfec2.findTag(ctx, conn, identifier, key)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -61,7 +61,7 @@ func testAccCheckTagExists(ctx context.Context, n string) resource.TestCheckFunc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
 
-		_, err = tfec2.GetTag(ctx, conn, identifier, key)
+		_, err = tfec2.findTag(ctx, conn, identifier, key)
 
 		return err
 	}

--- a/internal/service/ec2/tag_gen_test.go
+++ b/internal/service/ec2/tag_gen_test.go
@@ -30,7 +30,7 @@ func testAccCheckTagDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			_, err = tfec2.findTag(ctx, conn, identifier, key)
+			_, err = tfec2.FindTag(ctx, conn, identifier, key)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -61,7 +61,7 @@ func testAccCheckTagExists(ctx context.Context, n string) resource.TestCheckFunc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
 
-		_, err = tfec2.findTag(ctx, conn, identifier, key)
+		_, err = tfec2.FindTag(ctx, conn, identifier, key)
 
 		return err
 	}

--- a/internal/service/ec2/tagsv2_gen.go
+++ b/internal/service/ec2/tagsv2_gen.go
@@ -16,12 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// GetTag fetches an individual ec2 service tag for a resource.
+// findTag fetches an individual ec2 service tag for a resource.
 // Returns whether the key value and any errors. A NotFoundError is used to signal that no value was found.
 // This function will optimise the handling over listTags, if possible.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func GetTag(ctx context.Context, conn *ec2.Client, identifier, key string, optFns ...func(*ec2.Options)) (*string, error) {
+func findTag(ctx context.Context, conn *ec2.Client, identifier, key string, optFns ...func(*ec2.Options)) (*string, error) {
 	input := &ec2.DescribeTagsInput{
 		Filters: []awstypes.Filter{
 			{

--- a/internal/service/ecs/exports_test.go
+++ b/internal/service/ecs/exports_test.go
@@ -6,4 +6,6 @@ package ecs
 // Exports for use in tests only.
 var (
 	ResourceTag = resourceTag
+
+	FindTag = findTag
 )

--- a/internal/service/ecs/tag_gen.go
+++ b/internal/service/ecs/tag_gen.go
@@ -72,7 +72,7 @@ func resourceTagRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	value, err := GetTag(ctx, conn, identifier, key)
+	value, err := findTag(ctx, conn, identifier, key)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] %s resource (%s) tag (%s) not found, removing from state", names.ECS, identifier, key)

--- a/internal/service/ecs/tag_gen_test.go
+++ b/internal/service/ecs/tag_gen_test.go
@@ -30,7 +30,7 @@ func testAccCheckTagDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			_, err = tfecs.GetTag(ctx, conn, identifier, key)
+			_, err = tfecs.findTag(ctx, conn, identifier, key)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -61,7 +61,7 @@ func testAccCheckTagExists(ctx context.Context, n string) resource.TestCheckFunc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ECSClient(ctx)
 
-		_, err = tfecs.GetTag(ctx, conn, identifier, key)
+		_, err = tfecs.findTag(ctx, conn, identifier, key)
 
 		return err
 	}

--- a/internal/service/ecs/tag_gen_test.go
+++ b/internal/service/ecs/tag_gen_test.go
@@ -30,7 +30,7 @@ func testAccCheckTagDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			_, err = tfecs.findTag(ctx, conn, identifier, key)
+			_, err = tfecs.FindTag(ctx, conn, identifier, key)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -61,7 +61,7 @@ func testAccCheckTagExists(ctx context.Context, n string) resource.TestCheckFunc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ECSClient(ctx)
 
-		_, err = tfecs.findTag(ctx, conn, identifier, key)
+		_, err = tfecs.FindTag(ctx, conn, identifier, key)
 
 		return err
 	}

--- a/internal/service/ecs/tagsv2_gen.go
+++ b/internal/service/ecs/tagsv2_gen.go
@@ -18,12 +18,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// GetTag fetches an individual ecs service tag for a resource.
+// findTag fetches an individual ecs service tag for a resource.
 // Returns whether the key value and any errors. A NotFoundError is used to signal that no value was found.
 // This function will optimise the handling over listTagsV2, if possible.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func GetTag(ctx context.Context, conn *ecs.Client, identifier, key string, optFns ...func(*ecs.Options)) (*string, error) {
+func findTag(ctx context.Context, conn *ecs.Client, identifier, key string, optFns ...func(*ecs.Options)) (*string, error) {
 	listTags, err := listTagsV2(ctx, conn, identifier, optFns...)
 
 	if err != nil {

--- a/internal/service/route53domains/generate.go
+++ b/internal/service/route53domains/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ListTagsOp=ListTagsForDomain -ListTagsInIDElem=DomainName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -UpdateTags -UntagOp=DeleteTagsForDomain -UntagInTagsElem=TagsToDelete -TagOp=UpdateTagsForDomain -TagInTagsElem=TagsToUpdate -TagInIDElem=DomainName -GetTag
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ListTagsOp=ListTagsForDomain -ListTagsInIDElem=DomainName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -UpdateTags -UntagOp=DeleteTagsForDomain -UntagInTagsElem=TagsToDelete -TagOp=UpdateTagsForDomain -TagInTagsElem=TagsToUpdate -TagInIDElem=DomainName
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/route53domains/tags_gen.go
+++ b/internal/service/route53domains/tags_gen.go
@@ -17,12 +17,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// GetTag fetches an individual route53domains service tag for a resource.
+// findTag fetches an individual route53domains service tag for a resource.
 // Returns whether the key value and any errors. A NotFoundError is used to signal that no value was found.
 // This function will optimise the handling over listTags, if possible.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func GetTag(ctx context.Context, conn *route53domains.Client, identifier, key string, optFns ...func(*route53domains.Options)) (*string, error) {
+func findTag(ctx context.Context, conn *route53domains.Client, identifier, key string, optFns ...func(*route53domains.Options)) (*string, error) {
 	listTags, err := listTags(ctx, conn, identifier, optFns...)
 
 	if err != nil {

--- a/internal/service/route53domains/tags_gen.go
+++ b/internal/service/route53domains/tags_gen.go
@@ -12,29 +12,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/types/option"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
-
-// findTag fetches an individual route53domains service tag for a resource.
-// Returns whether the key value and any errors. A NotFoundError is used to signal that no value was found.
-// This function will optimise the handling over listTags, if possible.
-// The identifier is typically the Amazon Resource Name (ARN), although
-// it may also be a different identifier depending on the service.
-func findTag(ctx context.Context, conn *route53domains.Client, identifier, key string, optFns ...func(*route53domains.Options)) (*string, error) {
-	listTags, err := listTags(ctx, conn, identifier, optFns...)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if !listTags.KeyExists(key) {
-		return nil, tfresource.NewEmptyResultError(nil)
-	}
-
-	return listTags.KeyValue(key), nil
-}
 
 // listTags lists route53domains service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although

--- a/internal/service/route53resolver/generate.go
+++ b/internal/service/route53resolver/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -GetTag -ListTags -ServiceTagsSlice -UpdateTags
+//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsSlice -UpdateTags
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/route53resolver/tags_gen.go
+++ b/internal/service/route53resolver/tags_gen.go
@@ -12,29 +12,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/types/option"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
-
-// findTag fetches an individual route53resolver service tag for a resource.
-// Returns whether the key value and any errors. A NotFoundError is used to signal that no value was found.
-// This function will optimise the handling over listTags, if possible.
-// The identifier is typically the Amazon Resource Name (ARN), although
-// it may also be a different identifier depending on the service.
-func findTag(ctx context.Context, conn route53resolveriface.Route53ResolverAPI, identifier, key string) (*string, error) {
-	listTags, err := listTags(ctx, conn, identifier)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if !listTags.KeyExists(key) {
-		return nil, tfresource.NewEmptyResultError(nil)
-	}
-
-	return listTags.KeyValue(key), nil
-}
 
 // listTags lists route53resolver service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although

--- a/internal/service/route53resolver/tags_gen.go
+++ b/internal/service/route53resolver/tags_gen.go
@@ -17,12 +17,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// GetTag fetches an individual route53resolver service tag for a resource.
+// findTag fetches an individual route53resolver service tag for a resource.
 // Returns whether the key value and any errors. A NotFoundError is used to signal that no value was found.
 // This function will optimise the handling over listTags, if possible.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func GetTag(ctx context.Context, conn route53resolveriface.Route53ResolverAPI, identifier, key string) (*string, error) {
+func findTag(ctx context.Context, conn route53resolveriface.Route53ResolverAPI, identifier, key string) (*string, error) {
 	listTags, err := listTags(ctx, conn, identifier)
 
 	if err != nil {

--- a/internal/service/transfer/exports_test.go
+++ b/internal/service/transfer/exports_test.go
@@ -22,6 +22,7 @@ var (
 	FindConnectorByID            = findConnectorByID
 	FindProfileByID              = findProfileByID
 	FindServerByID               = findServerByID
+	FindTag                      = findTag
 	FindUserByTwoPartKey         = findUserByTwoPartKey
 	FindUserSSHKeyByThreePartKey = findUserSSHKeyByThreePartKey
 	FindWorkflowByID             = findWorkflowByID

--- a/internal/service/transfer/tag_gen.go
+++ b/internal/service/transfer/tag_gen.go
@@ -72,7 +72,7 @@ func resourceTagRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	value, err := GetTag(ctx, conn, identifier, key)
+	value, err := findTag(ctx, conn, identifier, key)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] %s resource (%s) tag (%s) not found, removing from state", names.Transfer, identifier, key)

--- a/internal/service/transfer/tag_gen_test.go
+++ b/internal/service/transfer/tag_gen_test.go
@@ -30,7 +30,7 @@ func testAccCheckTagDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			_, err = tftransfer.findTag(ctx, conn, identifier, key)
+			_, err = tftransfer.FindTag(ctx, conn, identifier, key)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -61,7 +61,7 @@ func testAccCheckTagExists(ctx context.Context, n string) resource.TestCheckFunc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).TransferClient(ctx)
 
-		_, err = tftransfer.findTag(ctx, conn, identifier, key)
+		_, err = tftransfer.FindTag(ctx, conn, identifier, key)
 
 		return err
 	}

--- a/internal/service/transfer/tag_gen_test.go
+++ b/internal/service/transfer/tag_gen_test.go
@@ -30,7 +30,7 @@ func testAccCheckTagDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			_, err = tftransfer.GetTag(ctx, conn, identifier, key)
+			_, err = tftransfer.findTag(ctx, conn, identifier, key)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -61,7 +61,7 @@ func testAccCheckTagExists(ctx context.Context, n string) resource.TestCheckFunc
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).TransferClient(ctx)
 
-		_, err = tftransfer.GetTag(ctx, conn, identifier, key)
+		_, err = tftransfer.findTag(ctx, conn, identifier, key)
 
 		return err
 	}

--- a/internal/service/transfer/tags_gen.go
+++ b/internal/service/transfer/tags_gen.go
@@ -17,12 +17,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// GetTag fetches an individual transfer service tag for a resource.
+// findTag fetches an individual transfer service tag for a resource.
 // Returns whether the key value and any errors. A NotFoundError is used to signal that no value was found.
 // This function will optimise the handling over listTags, if possible.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func GetTag(ctx context.Context, conn *transfer.Client, identifier, key string, optFns ...func(*transfer.Options)) (*string, error) {
+func findTag(ctx context.Context, conn *transfer.Client, identifier, key string, optFns ...func(*transfer.Options)) (*string, error) {
 	listTags, err := listTags(ctx, conn, identifier, optFns...)
 
 	if err != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Uses a lowercase function name to reduce visibility.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/35700.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccECSTag_' PKG=ecs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/ecs/... -v -count 1 -parallel 20  -run=TestAccECSTag_ -timeout 360m
=== RUN   TestAccECSTag_basic
=== PAUSE TestAccECSTag_basic
=== RUN   TestAccECSTag_disappears
=== PAUSE TestAccECSTag_disappears
=== RUN   TestAccECSTag_ResourceARN_batchComputeEnvironment
=== PAUSE TestAccECSTag_ResourceARN_batchComputeEnvironment
=== RUN   TestAccECSTag_value
=== PAUSE TestAccECSTag_value
=== CONT  TestAccECSTag_basic
=== CONT  TestAccECSTag_ResourceARN_batchComputeEnvironment
=== CONT  TestAccECSTag_value
=== CONT  TestAccECSTag_disappears
--- PASS: TestAccECSTag_disappears (24.26s)
--- PASS: TestAccECSTag_basic (26.43s)
--- PASS: TestAccECSTag_ResourceARN_batchComputeEnvironment (30.44s)
--- PASS: TestAccECSTag_value (35.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	39.693s
```
```console
% make testacc TESTARGS='-run=TestAccAutoScalingGroupTag_' PKG=autoscaling
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/autoscaling/... -v -count 1 -parallel 20  -run=TestAccAutoScalingGroupTag_ -timeout 360m
=== RUN   TestAccAutoScalingGroupTag_basic
=== PAUSE TestAccAutoScalingGroupTag_basic
=== RUN   TestAccAutoScalingGroupTag_disappears
=== PAUSE TestAccAutoScalingGroupTag_disappears
=== RUN   TestAccAutoScalingGroupTag_value
=== PAUSE TestAccAutoScalingGroupTag_value
=== CONT  TestAccAutoScalingGroupTag_basic
=== CONT  TestAccAutoScalingGroupTag_value
=== CONT  TestAccAutoScalingGroupTag_disappears
--- PASS: TestAccAutoScalingGroupTag_basic (47.10s)
--- PASS: TestAccAutoScalingGroupTag_disappears (56.64s)
--- PASS: TestAccAutoScalingGroupTag_value (90.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	94.855s
```
