### PR TITLE
[WIP] Enable and fix semgrep `diags` checks for all services

### DIFF
--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-r]*
+        - internal/service/[o-p]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +14,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-r]*
+        - internal/service/[o-p]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +24,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[o-r]*
+        - internal/service/[o-p]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +34,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-r]*
+        - internal/service/[o-p]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +44,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-r]*
+        - internal/service/[o-p]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +54,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-r]*
+        - internal/service/[o-p]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -72,7 +72,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-r]*
+        - internal/service/[o-p]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -93,7 +93,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[o-r]*
+        - internal/service/[o-p]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -2,9 +2,6 @@ rules:
   - id: avoid-return-diag_FromErr
     languages: [go]
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
-    paths:
-      exclude:
-        - internal/service/o*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -12,9 +9,6 @@ rules:
   - id: avoid-append-diag_FromErr
     languages: [go]
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
-    paths:
-      exclude:
-        - internal/service/o*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -22,9 +16,6 @@ rules:
   - id: avoid-diag_Errorf
     languages: [go]
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
-    paths:
-      exclude:
-        - internal/service/o*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -32,9 +23,6 @@ rules:
   - id: avoid-return-create_DiagError
     languages: [go]
     message: Prefer `create.AppendDiagError` to `create.DiagError`
-    paths:
-      exclude:
-        - internal/service/o*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -42,9 +30,6 @@ rules:
   - id: avoid-append-create_DiagError
     languages: [go]
     message: Prefer `create.AppendDiagError` to `create.DiagError`
-    paths:
-      exclude:
-        - internal/service/o*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -52,9 +37,6 @@ rules:
   - id: append-Read-to-diags
     languages: [go]
     message: Append results of $READFN to diags instead of returning directly
-    paths:
-      exclude:
-        - internal/service/o*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -70,9 +52,6 @@ rules:
   - id: append-Update-to-diags
     languages: [go]
     message: Append results of $UPDATEFN to diags instead of returning directly
-    paths:
-      exclude:
-        - internal/service/o*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-s]*
+        - internal/service/[o-r]*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +14,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-s]*
+        - internal/service/[o-r]*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +24,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[o-s]*
+        - internal/service/[o-r]*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +34,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-s]*
+        - internal/service/[o-r]*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +44,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-s]*
+        - internal/service/[o-r]*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +54,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-s]*
+        - internal/service/[o-r]*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -72,7 +72,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-s]*
+        - internal/service/[o-r]*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -93,7 +93,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[o-s]*
+        - internal/service/[o-r]*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/.ci/semgrep/pluginsdk/diags.yml
+++ b/.ci/semgrep/pluginsdk/diags.yml
@@ -4,7 +4,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-p]*
+        - internal/service/o*
     pattern: return diag.FromErr($ERR)
     fix: return sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -14,7 +14,7 @@ rules:
     message: Prefer `sdkdiag.AppendFromErr` to `diag.FromErr`
     paths:
       exclude:
-        - internal/service/[o-p]*
+        - internal/service/o*
     pattern: append(diags, diag.FromErr($ERR)...)
     fix: sdkdiag.AppendFromErr(diags, $ERR)
     severity: WARNING
@@ -24,7 +24,7 @@ rules:
     message: Prefer `sdkdiag.AppendErrorf` to `diag.Errorf`
     paths:
       exclude:
-        - internal/service/[o-p]*
+        - internal/service/o*
     pattern: diag.Errorf($...ARGS)
     fix: sdkdiag.AppendErrorf(diags, $...ARGS)
     severity: WARNING
@@ -34,7 +34,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-p]*
+        - internal/service/o*
     pattern: return create.DiagError($...ARGS)
     fix: return create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -44,7 +44,7 @@ rules:
     message: Prefer `create.AppendDiagError` to `create.DiagError`
     paths:
       exclude:
-        - internal/service/[o-p]*
+        - internal/service/o*
     pattern: append(diags, create.DiagError($...ARGS)...)
     fix: create.AppendDiagError(diags, $...ARGS)
     severity: WARNING
@@ -54,7 +54,7 @@ rules:
     message: Append results of $READFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-p]*
+        - internal/service/o*
     patterns:
       - pattern: return $READFN($...ARGS)
       - metavariable-regex:
@@ -72,7 +72,7 @@ rules:
     message: Append results of $UPDATEFN to diags instead of returning directly
     paths:
       exclude:
-        - internal/service/[o-p]*
+        - internal/service/o*
     patterns:
       - pattern: return $UPDATEFN($...ARGS)
       - metavariable-regex:
@@ -93,7 +93,7 @@ rules:
       include:
         - internal/service
       exclude:
-        - internal/service/[o-p]*
+        - internal/service/o*
     patterns:
       - pattern: return nil
       - pattern-not-inside: |

--- a/internal/service/oam/link.go
+++ b/internal/service/oam/link.go
@@ -94,6 +94,7 @@ const (
 )
 
 func resourceLinkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	in := &oam.CreateLinkInput{
@@ -105,19 +106,20 @@ func resourceLinkCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	out, err := conn.CreateLink(ctx, in)
 	if err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionCreating, ResNameLink, d.Get("sink_identifier").(string), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionCreating, ResNameLink, d.Get("sink_identifier").(string), err)
 	}
 
 	if out == nil || out.Id == nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionCreating, ResNameLink, d.Get("sink_identifier").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionCreating, ResNameLink, d.Get("sink_identifier").(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.Arn))
 
-	return resourceLinkRead(ctx, d, meta)
+	return append(diags, resourceLinkRead(ctx, d, meta)...)
 }
 
 func resourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	out, err := findLinkByID(ctx, conn, d.Id())
@@ -129,7 +131,7 @@ func resourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	if err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, ResNameLink, d.Id(), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionReading, ResNameLink, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
@@ -144,6 +146,7 @@ func resourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interfac
 }
 
 func resourceLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	update := false
@@ -161,14 +164,15 @@ func resourceLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		log.Printf("[DEBUG] Updating ObservabilityAccessManager Link (%s): %#v", d.Id(), in)
 		_, err := conn.UpdateLink(ctx, in)
 		if err != nil {
-			return create.DiagError(names.ObservabilityAccessManager, create.ErrActionUpdating, ResNameLink, d.Id(), err)
+			return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionUpdating, ResNameLink, d.Id(), err)
 		}
 	}
 
-	return resourceLinkRead(ctx, d, meta)
+	return append(diags, resourceLinkRead(ctx, d, meta)...)
 }
 
 func resourceLinkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	log.Printf("[INFO] Deleting ObservabilityAccessManager Link %s", d.Id())
@@ -183,7 +187,7 @@ func resourceLinkDelete(ctx context.Context, d *schema.ResourceData, meta interf
 			return nil
 		}
 
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionDeleting, ResNameLink, d.Id(), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionDeleting, ResNameLink, d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/oam/link_data_source.go
+++ b/internal/service/oam/link_data_source.go
@@ -63,13 +63,14 @@ const (
 )
 
 func dataSourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	linkIdentifier := d.Get("link_identifier").(string)
 
 	out, err := findLinkByID(ctx, conn, linkIdentifier)
 	if err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, DSNameLink, linkIdentifier, err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionReading, DSNameLink, linkIdentifier, err)
 	}
 
 	d.SetId(aws.ToString(out.Arn))
@@ -83,13 +84,13 @@ func dataSourceLinkRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	tags, err := listTags(ctx, conn, d.Id())
 	if err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, DSNameLink, d.Id(), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionReading, DSNameLink, d.Id(), err)
 	}
 
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionSetting, DSNameLink, d.Id(), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionSetting, DSNameLink, d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/oam/links_data_source.go
+++ b/internal/service/oam/links_data_source.go
@@ -35,9 +35,10 @@ const (
 )
 
 func dataSourceLinksRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
-	listLinksInput := &oam.ListLinksInput{}
 
+	listLinksInput := &oam.ListLinksInput{}
 	paginator := oam.NewListLinksPaginator(conn, listLinksInput)
 	var arns []string
 
@@ -45,7 +46,7 @@ func dataSourceLinksRead(ctx context.Context, d *schema.ResourceData, meta inter
 		page, err := paginator.NextPage(ctx)
 
 		if err != nil {
-			return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, DSNameLinks, "", err)
+			return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionReading, DSNameLinks, "", err)
 		}
 
 		for _, listLinksItem := range page.Items {

--- a/internal/service/oam/sink.go
+++ b/internal/service/oam/sink.go
@@ -69,6 +69,7 @@ const (
 )
 
 func resourceSinkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	in := &oam.CreateSinkInput{
@@ -78,19 +79,20 @@ func resourceSinkCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	out, err := conn.CreateSink(ctx, in)
 	if err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionCreating, ResNameSink, d.Get(names.AttrName).(string), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionCreating, ResNameSink, d.Get(names.AttrName).(string), err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionCreating, ResNameSink, d.Get(names.AttrName).(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionCreating, ResNameSink, d.Get(names.AttrName).(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.Arn))
 
-	return resourceSinkRead(ctx, d, meta)
+	return append(diags, resourceSinkRead(ctx, d, meta)...)
 }
 
 func resourceSinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	out, err := findSinkByID(ctx, conn, d.Id())
@@ -102,7 +104,7 @@ func resourceSinkRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	if err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, ResNameSink, d.Id(), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionReading, ResNameSink, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
@@ -118,6 +120,7 @@ func resourceSinkUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func resourceSinkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	log.Printf("[INFO] Deleting ObservabilityAccessManager Sink %s", d.Id())
@@ -132,7 +135,7 @@ func resourceSinkDelete(ctx context.Context, d *schema.ResourceData, meta interf
 			return nil
 		}
 
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionDeleting, ResNameSink, d.Id(), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionDeleting, ResNameSink, d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/oam/sink_data_source.go
+++ b/internal/service/oam/sink_data_source.go
@@ -47,13 +47,14 @@ const (
 )
 
 func dataSourceSinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	sinkIdentifier := d.Get("sink_identifier").(string)
 
 	out, err := findSinkByID(ctx, conn, sinkIdentifier)
 	if err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, DSNameSink, sinkIdentifier, err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionReading, DSNameSink, sinkIdentifier, err)
 	}
 
 	d.SetId(aws.ToString(out.Arn))
@@ -64,13 +65,13 @@ func dataSourceSinkRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	tags, err := listTags(ctx, conn, d.Id())
 	if err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, DSNameSink, d.Id(), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionReading, DSNameSink, d.Id(), err)
 	}
 
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionSetting, DSNameSink, d.Id(), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionSetting, DSNameSink, d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/oam/sink_policy.go
+++ b/internal/service/oam/sink_policy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -76,13 +77,14 @@ const (
 )
 
 func resourceSinkPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	sinkIdentifier := d.Get("sink_identifier").(string)
 	policy, err := structure.NormalizeJsonString(d.Get(names.AttrPolicy).(string))
 
 	if err != nil {
-		return diag.Errorf("policy (%s) is invalid JSON: %s", d.Get(names.AttrPolicy).(string), err)
+		return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", d.Get(names.AttrPolicy).(string), err)
 	}
 
 	in := &oam.PutSinkPolicyInput{
@@ -92,17 +94,18 @@ func resourceSinkPolicyPut(ctx context.Context, d *schema.ResourceData, meta int
 
 	_, err = conn.PutSinkPolicy(ctx, in)
 	if err != nil {
-		return diag.Errorf("putting ObservabilityAccessManager Sink Policy (%s): %s", sinkIdentifier, err)
+		return sdkdiag.AppendErrorf(diags, "putting ObservabilityAccessManager Sink Policy (%s): %s", sinkIdentifier, err)
 	}
 
 	if d.IsNewResource() {
 		d.SetId(sinkIdentifier)
 	}
 
-	return resourceSinkPolicyRead(ctx, d, meta)
+	return append(diags, resourceSinkPolicyRead(ctx, d, meta)...)
 }
 
 func resourceSinkPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 
 	out, err := findSinkPolicyByID(ctx, conn, d.Id())
@@ -114,7 +117,7 @@ func resourceSinkPolicyRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err != nil {
-		return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, ResNameSinkPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionReading, ResNameSinkPolicy, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.SinkArn)
@@ -123,7 +126,7 @@ func resourceSinkPolicyRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	policyToSet, err := verify.PolicyToSet(d.Get(names.AttrPolicy).(string), aws.ToString(out.Policy))
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	d.Set(names.AttrPolicy, policyToSet)

--- a/internal/service/oam/sinks_data_source.go
+++ b/internal/service/oam/sinks_data_source.go
@@ -35,6 +35,7 @@ const (
 )
 
 func dataSourceSinksRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ObservabilityAccessManagerClient(ctx)
 	listSinksInput := &oam.ListSinksInput{}
 
@@ -45,7 +46,7 @@ func dataSourceSinksRead(ctx context.Context, d *schema.ResourceData, meta inter
 		page, err := paginator.NextPage(ctx)
 
 		if err != nil {
-			return create.DiagError(names.ObservabilityAccessManager, create.ErrActionReading, DSNameSinks, "", err)
+			return create.AppendDiagError(diags, names.ObservabilityAccessManager, create.ErrActionReading, DSNameSinks, "", err)
 		}
 
 		for _, listSinksItem := range page.Items {

--- a/internal/service/opensearch/outbound_connection.go
+++ b/internal/service/opensearch/outbound_connection.go
@@ -17,40 +17,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_opensearch_outbound_connection")
 func ResourceOutboundConnection() *schema.Resource {
-	outboundConnectionDomainInfoSchema := func() *schema.Schema {
-		return &schema.Schema{
-			Type:     schema.TypeList,
-			Required: true,
-			ForceNew: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					names.AttrDomainName: {
-						Type:     schema.TypeString,
-						Required: true,
-						ForceNew: true,
-					},
-					names.AttrOwnerID: {
-						Type:     schema.TypeString,
-						Required: true,
-						ForceNew: true,
-					},
-					names.AttrRegion: {
-						Type:     schema.TypeString,
-						Required: true,
-						ForceNew: true,
-					},
-				},
-			},
-		}
-	}
-
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceOutboundConnectionCreate,
 		ReadWithoutTimeout:   resourceOutboundConnectionRead,
@@ -65,64 +38,95 @@ func ResourceOutboundConnection() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"accept_connection": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  false,
-			},
-			"connection_alias": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"connection_mode": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(opensearchservice.ConnectionMode_Values(), false),
-			},
-			"connection_properties": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"cross_cluster_search": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"skip_unavailable": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
+		SchemaFunc: func() map[string]*schema.Schema {
+			outboundConnectionDomainInfoSchema := func() *schema.Schema {
+				return &schema.Schema{
+					Type:     schema.TypeList,
+					Required: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrDomainName: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							names.AttrOwnerID: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							names.AttrRegion: {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+						},
+					},
+				}
+			}
+
+			return map[string]*schema.Schema{
+				"accept_connection": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+					Default:  false,
+				},
+				"connection_alias": {
+					Type:     schema.TypeString,
+					Required: true,
+					ForceNew: true,
+				},
+				"connection_mode": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringInSlice(opensearchservice.ConnectionMode_Values(), false),
+				},
+				"connection_properties": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"cross_cluster_search": {
+								Type:     schema.TypeList,
+								Optional: true,
+								ForceNew: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"skip_unavailable": {
+											Type:     schema.TypeString,
+											Optional: true,
+											ForceNew: true,
+										},
 									},
 								},
 							},
-						},
-						names.AttrEndpoint: {
-							Type:     schema.TypeString,
-							Computed: true,
+							names.AttrEndpoint: {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
 						},
 					},
 				},
-			},
-			"connection_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"local_domain_info":  outboundConnectionDomainInfoSchema(),
-			"remote_domain_info": outboundConnectionDomainInfoSchema(),
+				"connection_status": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"local_domain_info":  outboundConnectionDomainInfoSchema(),
+				"remote_domain_info": outboundConnectionDomainInfoSchema(),
+			}
 		},
 	}
 }
 
 func resourceOutboundConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpenSearchConn(ctx)
 
 	connectionAlias := d.Get("connection_alias").(string)
@@ -137,13 +141,13 @@ func resourceOutboundConnectionCreate(ctx context.Context, d *schema.ResourceDat
 	output, err := conn.CreateOutboundConnectionWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating OpenSearch Outbound Connection (%s): %s", connectionAlias, err)
+		return sdkdiag.AppendErrorf(diags, "creating OpenSearch Outbound Connection (%s): %s", connectionAlias, err)
 	}
 
 	d.SetId(aws.StringValue(output.ConnectionId))
 
 	if _, err := waitOutboundConnectionCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for OpenSearch Outbound Connection (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for OpenSearch Outbound Connection (%s) create: %s", d.Id(), err)
 	}
 
 	if d.Get("accept_connection").(bool) {
@@ -154,18 +158,19 @@ func resourceOutboundConnectionCreate(ctx context.Context, d *schema.ResourceDat
 		_, err := conn.AcceptInboundConnectionWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("accepting OpenSearch Inbound Connection (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "accepting OpenSearch Inbound Connection (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitInboundConnectionAccepted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-			return diag.Errorf("waiting for OpenSearch Inbound Connection (%s) accept: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for OpenSearch Inbound Connection (%s) accept: %s", d.Id(), err)
 		}
 	}
 
-	return resourceOutboundConnectionRead(ctx, d, meta)
+	return append(diags, resourceOutboundConnectionRead(ctx, d, meta)...)
 }
 
 func resourceOutboundConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpenSearchConn(ctx)
 
 	connection, err := FindOutboundConnectionByID(ctx, conn, d.Id())
@@ -177,7 +182,7 @@ func resourceOutboundConnectionRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err != nil {
-		return diag.Errorf("reading OpenSearch Outbound Connection (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading OpenSearch Outbound Connection (%s): %s", d.Id(), err)
 	}
 
 	d.Set("connection_alias", connection.ConnectionAlias)
@@ -191,6 +196,7 @@ func resourceOutboundConnectionRead(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceOutboundConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpenSearchConn(ctx)
 
 	log.Printf("[DEBUG] Deleting OpenSearch Outbound Connection: %s", d.Id())
@@ -203,11 +209,11 @@ func resourceOutboundConnectionDelete(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting OpenSearch Outbound Connection (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting OpenSearch Outbound Connection (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitOutboundConnectionDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for OpenSearch Outbound Connection (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for OpenSearch Outbound Connection (%s) delete: %s", d.Id(), err)
 	}
 
 	return nil

--- a/internal/service/opensearch/vpc_endpoint.go
+++ b/internal/service/opensearch/vpc_endpoint.go
@@ -129,7 +129,7 @@ func resourceVPCEndpointRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set(names.AttrEndpoint, endpoint.Endpoint)
 	if endpoint.VpcOptions != nil {
 		if err := d.Set("vpc_options", []interface{}{flattenVPCDerivedInfo(endpoint.VpcOptions)}); err != nil {
-			return diag.Errorf("setting vpc_options: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting vpc_options: %s", err)
 		}
 	} else {
 		d.Set("vpc_options", nil)

--- a/internal/service/opsworks/layers.go
+++ b/internal/service/opsworks/layers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tfmaps "github.com/hashicorp/terraform-provider-aws/internal/maps"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -470,12 +471,13 @@ func (lt *opsworksLayerType) resourceSchema() *schema.Resource {
 }
 
 func (lt *opsworksLayerType) Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
 
 	attributes, err := lt.Attributes.resourceDataToAPIAttributes(d)
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	name := d.Get(names.AttrName).(string)
@@ -559,7 +561,7 @@ func (lt *opsworksLayerType) Create(ctx context.Context, d *schema.ResourceData,
 		})
 
 		if err != nil {
-			return diag.Errorf("registering OpsWorks Layer (%s) ECS Cluster (%s): %s", name, arn, err)
+			return sdkdiag.AppendErrorf(diags, "registering OpsWorks Layer (%s) ECS Cluster (%s): %s", name, arn, err)
 		}
 	}
 
@@ -567,7 +569,7 @@ func (lt *opsworksLayerType) Create(ctx context.Context, d *schema.ResourceData,
 	output, err := conn.CreateLayerWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating OpsWorks Layer (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating OpsWorks Layer (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.LayerId))
@@ -580,7 +582,7 @@ func (lt *opsworksLayerType) Create(ctx context.Context, d *schema.ResourceData,
 		})
 
 		if err != nil {
-			return diag.Errorf("attaching OpsWorks Layer (%s) load balancer (%s): %s", d.Id(), v, err)
+			return sdkdiag.AppendErrorf(diags, "attaching OpsWorks Layer (%s) load balancer (%s): %s", d.Id(), v, err)
 		}
 	}
 
@@ -591,7 +593,7 @@ func (lt *opsworksLayerType) Create(ctx context.Context, d *schema.ResourceData,
 		_, err := conn.SetLoadBasedAutoScalingWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("setting OpsWorks Layer (%s) load-based auto scaling configuration: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "setting OpsWorks Layer (%s) load-based auto scaling configuration: %s", d.Id(), err)
 		}
 	}
 
@@ -599,19 +601,20 @@ func (lt *opsworksLayerType) Create(ctx context.Context, d *schema.ResourceData,
 		layer, err := FindLayerByID(ctx, conn, d.Id())
 
 		if err != nil {
-			return diag.Errorf("reading OpsWorks Layer (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading OpsWorks Layer (%s): %s", d.Id(), err)
 		}
 
 		arn := aws.StringValue(layer.Arn)
 		if err := updateTags(ctx, conn, arn, nil, tags); err != nil {
-			return diag.Errorf("adding OpsWorks Layer (%s) tags: %s", arn, err)
+			return sdkdiag.AppendErrorf(diags, "adding OpsWorks Layer (%s) tags: %s", arn, err)
 		}
 	}
 
-	return lt.Read(ctx, d, meta)
+	return append(diags, lt.Read(ctx, d, meta)...)
 }
 
 func (lt *opsworksLayerType) Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
 
 	layer, err := FindLayerByID(ctx, conn, d.Id())
@@ -623,7 +626,7 @@ func (lt *opsworksLayerType) Read(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return diag.Errorf("reading OpsWorks Layer (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading OpsWorks Layer (%s): %s", d.Id(), err)
 	}
 
 	arn := aws.StringValue(layer.Arn)
@@ -633,7 +636,7 @@ func (lt *opsworksLayerType) Read(ctx context.Context, d *schema.ResourceData, m
 	d.Set("auto_healing", layer.EnableAutoHealing)
 	if layer.CloudWatchLogsConfiguration != nil {
 		if err := d.Set("cloudwatch_configuration", []interface{}{flattenCloudWatchLogsConfiguration(layer.CloudWatchLogsConfiguration)}); err != nil {
-			return diag.Errorf("setting cloudwatch_configuration: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting cloudwatch_configuration: %s", err)
 		}
 	} else {
 		d.Set("cloudwatch_configuration", nil)
@@ -657,7 +660,7 @@ func (lt *opsworksLayerType) Read(ctx context.Context, d *schema.ResourceData, m
 	} else {
 		policy, err := structure.NormalizeJsonString(aws.StringValue(layer.CustomJson))
 		if err != nil {
-			return diag.Errorf("policy contains an invalid JSON: %s", err)
+			return sdkdiag.AppendErrorf(diags, "policy contains an invalid JSON: %s", err)
 		}
 		d.Set("custom_json", policy)
 	}
@@ -670,7 +673,7 @@ func (lt *opsworksLayerType) Read(ctx context.Context, d *schema.ResourceData, m
 		d.Set("instance_shutdown_timeout", layer.LifecycleEventConfiguration.Shutdown.ExecutionTimeout)
 	}
 	if err := d.Set("ebs_volume", flattenVolumeConfigurations(layer.VolumeConfigurations)); err != nil {
-		return diag.Errorf("setting ebs_volume: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting ebs_volume: %s", err)
 	}
 	d.Set("install_updates_on_boot", layer.InstallUpdatesOnBoot)
 	d.Set(names.AttrName, layer.Name)
@@ -682,7 +685,7 @@ func (lt *opsworksLayerType) Read(ctx context.Context, d *schema.ResourceData, m
 	d.Set("use_ebs_optimized_instances", layer.UseEbsOptimizedInstances)
 
 	if err := lt.Attributes.apiAttributesToResourceData(aws.StringValueMap(layer.Attributes), d); err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	loadBalancer, err := findElasticLoadBalancerByLayerID(ctx, conn, d.Id())
@@ -692,25 +695,26 @@ func (lt *opsworksLayerType) Read(ctx context.Context, d *schema.ResourceData, m
 	} else if tfresource.NotFound(err) {
 		d.Set("elastic_load_balancer", nil)
 	} else {
-		return diag.Errorf("reading OpsWorks Layer (%s) load balancers: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading OpsWorks Layer (%s) load balancers: %s", d.Id(), err)
 	}
 
 	loadBasedAutoScalingConfiguration, err := findLoadBasedAutoScalingConfigurationByLayerID(ctx, conn, d.Id())
 
 	if err == nil {
 		if err := d.Set("load_based_auto_scaling", []interface{}{flattenLoadBasedAutoScalingConfiguration(loadBasedAutoScalingConfiguration)}); err != nil {
-			return diag.Errorf("setting load_based_auto_scaling: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting load_based_auto_scaling: %s", err)
 		}
 	} else if tfresource.NotFound(err) {
 		d.Set("load_based_auto_scaling", nil)
 	} else {
-		return diag.Errorf("reading OpsWorks Layer (%s) load-based auto scaling configurations: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading OpsWorks Layer (%s) load-based auto scaling configurations: %s", d.Id(), err)
 	}
 
 	return nil
 }
 
 func (lt *opsworksLayerType) Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
 
 	if d.HasChangesExcept("elastic_load_balancer", "load_based_auto_scaling", names.AttrTags, names.AttrTagsAll) {
@@ -722,7 +726,7 @@ func (lt *opsworksLayerType) Update(ctx context.Context, d *schema.ResourceData,
 			attributes, err := lt.Attributes.resourceDataToAPIAttributes(d)
 
 			if err != nil {
-				return diag.FromErr(err)
+				return sdkdiag.AppendFromErr(diags, err)
 			}
 
 			input.Attributes = aws.StringMap(attributes)
@@ -823,7 +827,7 @@ func (lt *opsworksLayerType) Update(ctx context.Context, d *schema.ResourceData,
 		_, err := conn.UpdateLayerWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating OpsWorks Layer (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating OpsWorks Layer (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -837,7 +841,7 @@ func (lt *opsworksLayerType) Update(ctx context.Context, d *schema.ResourceData,
 			})
 
 			if err != nil {
-				return diag.Errorf("detaching OpsWorks Layer (%s) load balancer (%s): %s", d.Id(), v, err)
+				return sdkdiag.AppendErrorf(diags, "detaching OpsWorks Layer (%s) load balancer (%s): %s", d.Id(), v, err)
 			}
 		}
 
@@ -848,7 +852,7 @@ func (lt *opsworksLayerType) Update(ctx context.Context, d *schema.ResourceData,
 			})
 
 			if err != nil {
-				return diag.Errorf("attaching OpsWorks Layer (%s) load balancer (%s): %s", d.Id(), v, err)
+				return sdkdiag.AppendErrorf(diags, "attaching OpsWorks Layer (%s) load balancer (%s): %s", d.Id(), v, err)
 			}
 		}
 	}
@@ -860,14 +864,15 @@ func (lt *opsworksLayerType) Update(ctx context.Context, d *schema.ResourceData,
 		_, err := conn.SetLoadBasedAutoScalingWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("setting OpsWorks Layer (%s) load-based auto scaling configuration: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "setting OpsWorks Layer (%s) load-based auto scaling configuration: %s", d.Id(), err)
 		}
 	}
 
-	return lt.Read(ctx, d, meta)
+	return append(diags, lt.Read(ctx, d, meta)...)
 }
 
 func (lt *opsworksLayerType) Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
 
 	log.Printf("[DEBUG] Deleting OpsWorks Layer: %s", d.Id())
@@ -880,7 +885,7 @@ func (lt *opsworksLayerType) Delete(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting OpsWorks Layer (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting OpsWorks Layer (%s): %s", d.Id(), err)
 	}
 
 	if v, ok := d.GetOk("ecs_cluster_arn"); ok {
@@ -890,7 +895,7 @@ func (lt *opsworksLayerType) Delete(ctx context.Context, d *schema.ResourceData,
 		})
 
 		if err != nil {
-			return diag.Errorf("deregistering OpsWorks Layer (%s) ECS Cluster (%s): %s", d.Id(), arn, err)
+			return sdkdiag.AppendErrorf(diags, "deregistering OpsWorks Layer (%s) ECS Cluster (%s): %s", d.Id(), arn, err)
 		}
 	}
 

--- a/internal/service/organizations/delegated_administrators_data_source.go
+++ b/internal/service/organizations/delegated_administrators_data_source.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -74,6 +75,7 @@ func dataSourceDelegatedAdministrators() *schema.Resource {
 }
 
 func dataSourceDelegatedAdministratorsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OrganizationsClient(ctx)
 
 	input := &organizations.ListDelegatedAdministratorsInput{}
@@ -85,12 +87,12 @@ func dataSourceDelegatedAdministratorsRead(ctx context.Context, d *schema.Resour
 	output, err := findDelegatedAdministrators(ctx, conn, input, tfslices.PredicateTrue[*awstypes.DelegatedAdministrator]())
 
 	if err != nil {
-		return diag.Errorf("reading Organizations Delegated Administrators: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading Organizations Delegated Administrators: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).AccountID)
 	if err = d.Set("delegated_administrators", flattenDelegatedAdministrators(output)); err != nil {
-		return diag.Errorf("setting delegated_administrators: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting delegated_administrators: %s", err)
 	}
 
 	return nil

--- a/internal/service/organizations/delegated_services_data_source.go
+++ b/internal/service/organizations/delegated_services_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -48,18 +49,19 @@ func dataSourceDelegatedServices() *schema.Resource {
 }
 
 func dataSourceDelegatedServicesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OrganizationsClient(ctx)
 
 	accountID := d.Get(names.AttrAccountID).(string)
 	output, err := findDelegatedServicesByAccountID(ctx, conn, accountID)
 
 	if err != nil {
-		return diag.Errorf("reading Organizations Delegated Services (%s): %s", accountID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Organizations Delegated Services (%s): %s", accountID, err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).AccountID)
 	if err = d.Set("delegated_services", flattenDelegatedServices(output)); err != nil {
-		return diag.Errorf("setting delegated_services: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting delegated_services: %s", err)
 	}
 
 	return nil

--- a/internal/service/qldb/ledger_data_source.go
+++ b/internal/service/qldb/ledger_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -52,6 +53,7 @@ func dataSourceLedger() *schema.Resource {
 }
 
 func dataSourceLedgerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QLDBClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -59,7 +61,7 @@ func dataSourceLedgerRead(ctx context.Context, d *schema.ResourceData, meta inte
 	ledger, err := findLedgerByName(ctx, conn, name)
 
 	if err != nil {
-		return diag.Errorf("reading QLDB Ledger (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "reading QLDB Ledger (%s): %s", name, err)
 	}
 
 	d.SetId(aws.ToString(ledger.Name))
@@ -76,12 +78,12 @@ func dataSourceLedgerRead(ctx context.Context, d *schema.ResourceData, meta inte
 	tags, err := listTags(ctx, conn, d.Get(names.AttrARN).(string))
 
 	if err != nil {
-		return diag.Errorf("listing tags for QLDB Ledger (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for QLDB Ledger (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/quicksight/account_subscription.go
+++ b/internal/service/quicksight/account_subscription.go
@@ -139,6 +139,7 @@ const (
 )
 
 func resourceAccountSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId := meta.(*conns.AWSClient).AccountID
@@ -196,23 +197,24 @@ func resourceAccountSubscriptionCreate(ctx context.Context, d *schema.ResourceDa
 
 	out, err := conn.CreateAccountSubscriptionWithContext(ctx, in)
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionCreating, ResNameAccountSubscription, d.Get("account_name").(string), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionCreating, ResNameAccountSubscription, d.Get("account_name").(string), err)
 	}
 
 	if out == nil || out.SignupResponse == nil {
-		return create.DiagError(names.QuickSight, create.ErrActionCreating, ResNameAccountSubscription, d.Get("account_name").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionCreating, ResNameAccountSubscription, d.Get("account_name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(awsAccountId)
 
 	if _, err := waitAccountSubscriptionCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionWaitingForCreation, ResNameAccountSubscription, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionWaitingForCreation, ResNameAccountSubscription, d.Id(), err)
 	}
 
-	return resourceAccountSubscriptionRead(ctx, d, meta)
+	return append(diags, resourceAccountSubscriptionRead(ctx, d, meta)...)
 }
 
 func resourceAccountSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	out, err := FindAccountSubscriptionByID(ctx, conn, d.Id())
@@ -220,17 +222,17 @@ func resourceAccountSubscriptionRead(ctx context.Context, d *schema.ResourceData
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] QuickSight AccountSubscription (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 	// Ressource is logically deleted with UNSUBSCRIBED status
 	if !d.IsNewResource() && aws.StringValue(out.AccountSubscriptionStatus) == statusUnsuscribed {
 		log.Printf("[WARN] QuickSight AccountSubscription (%s) unsuscribed, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionReading, ResNameAccountSubscription, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionReading, ResNameAccountSubscription, d.Id(), err)
 	}
 
 	d.Set("account_name", out.AccountName)
@@ -238,10 +240,11 @@ func resourceAccountSubscriptionRead(ctx context.Context, d *schema.ResourceData
 	d.Set("notification_email", out.NotificationEmail)
 	d.Set("account_subscription_status", out.AccountSubscriptionStatus)
 
-	return nil
+	return diags
 }
 
 func resourceAccountSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	log.Printf("[INFO] Deleting QuickSight AccountSubscription %s", d.Id())
@@ -251,18 +254,18 @@ func resourceAccountSubscriptionDelete(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionDeleting, ResNameAccountSubscription, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionDeleting, ResNameAccountSubscription, d.Id(), err)
 	}
 
 	if _, err := waitAccountSubscriptionDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionWaitingForDeletion, ResNameAccountSubscription, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionWaitingForDeletion, ResNameAccountSubscription, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 // Not documented on AWS

--- a/internal/service/quicksight/dashboard.go
+++ b/internal/service/quicksight/dashboard.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	quicksightschema "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -143,6 +144,7 @@ const (
 )
 
 func resourceDashboardCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId := meta.(*conns.AWSClient).AccountID
@@ -186,22 +188,23 @@ func resourceDashboardCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	_, err := conn.CreateDashboardWithContext(ctx, input)
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionCreating, ResNameDashboard, d.Get(names.AttrName).(string), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionCreating, ResNameDashboard, d.Get(names.AttrName).(string), err)
 	}
 
 	if _, err := waitDashboardCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionWaitingForCreation, ResNameDashboard, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionWaitingForCreation, ResNameDashboard, d.Id(), err)
 	}
 
-	return resourceDashboardRead(ctx, d, meta)
+	return append(diags, resourceDashboardRead(ctx, d, meta)...)
 }
 
 func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, dashboardId, err := ParseDashboardId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	out, err := FindDashboardByID(ctx, conn, d.Id(), DashboardLatestVersion)
@@ -209,11 +212,11 @@ func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta int
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] QuickSight Dashboard (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionReading, ResNameDashboard, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionReading, ResNameDashboard, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
@@ -234,15 +237,15 @@ func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta int
 	})
 
 	if err != nil {
-		return diag.Errorf("describing QuickSight Dashboard (%s) Definition: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Dashboard (%s) Definition: %s", d.Id(), err)
 	}
 
 	if err := d.Set("definition", quicksightschema.FlattenDashboardDefinition(descResp.Definition)); err != nil {
-		return diag.Errorf("setting definition: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting definition: %s", err)
 	}
 
 	if err := d.Set("dashboard_publish_options", quicksightschema.FlattenDashboardPublishOptions(descResp.DashboardPublishOptions)); err != nil {
-		return diag.Errorf("setting dashboard_publish_options: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting dashboard_publish_options: %s", err)
 	}
 
 	permsResp, err := conn.DescribeDashboardPermissionsWithContext(ctx, &quicksight.DescribeDashboardPermissionsInput{
@@ -251,22 +254,23 @@ func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta int
 	})
 
 	if err != nil {
-		return diag.Errorf("describing QuickSight Dashboard (%s) Permissions: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Dashboard (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set(names.AttrPermissions, flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("setting permissions: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting permissions: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, dashboardId, err := ParseDashboardId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	if d.HasChangesExcept(names.AttrPermissions, names.AttrTags, names.AttrTagsAll) {
@@ -295,12 +299,12 @@ func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		log.Printf("[DEBUG] Updating QuickSight Dashboard (%s): %#v", d.Id(), in)
 		out, err := conn.UpdateDashboardWithContext(ctx, in)
 		if err != nil {
-			return create.DiagError(names.QuickSight, create.ErrActionUpdating, ResNameDashboard, d.Id(), err)
+			return create.AppendDiagError(diags, names.QuickSight, create.ErrActionUpdating, ResNameDashboard, d.Id(), err)
 		}
 
 		updatedVersionNumber := extractVersionFromARN(aws.StringValue(out.VersionArn))
 		if _, err := waitDashboardUpdated(ctx, conn, d.Id(), updatedVersionNumber, d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return create.DiagError(names.QuickSight, create.ErrActionWaitingForUpdate, ResNameDashboard, d.Id(), err)
+			return create.AppendDiagError(diags, names.QuickSight, create.ErrActionWaitingForUpdate, ResNameDashboard, d.Id(), err)
 		}
 
 		publishVersion := &quicksight.UpdateDashboardPublishedVersionInput{
@@ -310,7 +314,7 @@ func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 		_, err = conn.UpdateDashboardPublishedVersionWithContext(ctx, publishVersion)
 		if err != nil {
-			return create.DiagError(names.QuickSight, create.ErrActionUpdating, ResNameDashboard, d.Id(), err)
+			return create.AppendDiagError(diags, names.QuickSight, create.ErrActionUpdating, ResNameDashboard, d.Id(), err)
 		}
 	}
 
@@ -337,19 +341,20 @@ func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		_, err = conn.UpdateDashboardPermissionsWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("updating QuickSight Dashboard (%s) permissions: %s", dashboardId, err)
+			return sdkdiag.AppendErrorf(diags, "updating QuickSight Dashboard (%s) permissions: %s", dashboardId, err)
 		}
 	}
 
-	return resourceDashboardRead(ctx, d, meta)
+	return append(diags, resourceDashboardRead(ctx, d, meta)...)
 }
 
 func resourceDashboardDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, dashboardId, err := ParseDashboardId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	log.Printf("[INFO] Deleting QuickSight Dashboard %s", d.Id())
@@ -359,14 +364,14 @@ func resourceDashboardDelete(ctx context.Context, d *schema.ResourceData, meta i
 	})
 
 	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionDeleting, ResNameDashboard, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionDeleting, ResNameDashboard, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 // Pass version as DashboardLatestVersion for latest published version, or specify a specific version if required

--- a/internal/service/quicksight/data_set.go
+++ b/internal/service/quicksight/data_set.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -838,6 +839,7 @@ func physicalTableMapSchema() *schema.Resource {
 }
 
 func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId := meta.(*conns.AWSClient).AccountID
@@ -891,7 +893,7 @@ func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	_, err := conn.CreateDataSetWithContext(ctx, input)
 	if err != nil {
-		return diag.Errorf("creating QuickSight Data Set: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating QuickSight Data Set: %s", err)
 	}
 
 	if v, ok := d.GetOk("refresh_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
@@ -903,19 +905,20 @@ func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, err := conn.PutDataSetRefreshPropertiesWithContext(ctx, input)
 		if err != nil {
-			return diag.Errorf("putting QuickSight Data Set Refresh Properties: %s", err)
+			return sdkdiag.AppendErrorf(diags, "putting QuickSight Data Set Refresh Properties: %s", err)
 		}
 	}
 
-	return resourceDataSetRead(ctx, d, meta)
+	return append(diags, resourceDataSetRead(ctx, d, meta)...)
 }
 
 func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, dataSetId, err := ParseDataSetID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	descOpts := &quicksight.DescribeDataSetInput{
@@ -928,15 +931,15 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] QuickSight Data Set (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("describing QuickSight Data Set (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Data Set (%s): %s", d.Id(), err)
 	}
 
 	if output == nil || output.DataSet == nil {
-		return diag.Errorf("describing QuickSight Data Set (%s): empty output", d.Id())
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Data Set (%s): empty output", d.Id())
 	}
 
 	dataSet := output.DataSet
@@ -948,39 +951,39 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("import_mode", dataSet.ImportMode)
 
 	if err := d.Set("column_groups", flattenColumnGroups(dataSet.ColumnGroups)); err != nil {
-		return diag.Errorf("setting column_groups: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting column_groups: %s", err)
 	}
 
 	if err := d.Set("column_level_permission_rules", flattenColumnLevelPermissionRules(dataSet.ColumnLevelPermissionRules)); err != nil {
-		return diag.Errorf("setting column_level_permission_rules: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting column_level_permission_rules: %s", err)
 	}
 
 	if err := d.Set("data_set_usage_configuration", flattenDataSetUsageConfiguration(dataSet.DataSetUsageConfiguration)); err != nil {
-		return diag.Errorf("setting data_set_usage_configuration: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting data_set_usage_configuration: %s", err)
 	}
 
 	if err := d.Set("field_folders", flattenFieldFolders(dataSet.FieldFolders)); err != nil {
-		return diag.Errorf("setting field_folders: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting field_folders: %s", err)
 	}
 
 	if err := d.Set("logical_table_map", flattenLogicalTableMap(dataSet.LogicalTableMap, logicalTableMapSchema())); err != nil {
-		return diag.Errorf("setting logical_table_map: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting logical_table_map: %s", err)
 	}
 
 	if err := d.Set("output_columns", flattenOutputColumns(dataSet.OutputColumns)); err != nil {
-		return diag.Errorf("setting output_columns: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting output_columns: %s", err)
 	}
 
 	if err := d.Set("physical_table_map", flattenPhysicalTableMap(dataSet.PhysicalTableMap, physicalTableMapSchema())); err != nil {
-		return diag.Errorf("setting physical_table_map: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting physical_table_map: %s", err)
 	}
 
 	if err := d.Set("row_level_permission_data_set", flattenRowLevelPermissionDataSet(dataSet.RowLevelPermissionDataSet)); err != nil {
-		return diag.Errorf("setting row_level_permission_data_set: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting row_level_permission_data_set: %s", err)
 	}
 
 	if err := d.Set("row_level_permission_tag_configuration", flattenRowLevelPermissionTagConfiguration(dataSet.RowLevelPermissionTagConfiguration)); err != nil {
-		return diag.Errorf("setting row_level_permission_tag_configuration: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting row_level_permission_tag_configuration: %s", err)
 	}
 
 	permsResp, err := conn.DescribeDataSetPermissionsWithContext(ctx, &quicksight.DescribeDataSetPermissionsInput{
@@ -989,11 +992,11 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if err != nil {
-		return diag.Errorf("describing QuickSight Data Source (%s) Permissions: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Data Source (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set(names.AttrPermissions, flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("setting permissions: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting permissions: %s", err)
 	}
 
 	propsResp, err := conn.DescribeDataSetRefreshPropertiesWithContext(ctx, &quicksight.DescribeDataSetRefreshPropertiesInput{
@@ -1002,25 +1005,26 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if err != nil && !(tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) || tfawserr.ErrMessageContains(err, quicksight.ErrCodeInvalidParameterValueException, "not a SPICE dataset")) {
-		return diag.Errorf("describing refresh properties (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing refresh properties (%s): %s", d.Id(), err)
 	}
 
 	if err == nil {
 		if err := d.Set("refresh_properties", flattenRefreshProperties(propsResp.DataSetRefreshProperties)); err != nil {
-			return diag.Errorf("setting refresh properties: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting refresh properties: %s", err)
 		}
 	}
 
-	return nil
+	return diags
 }
 
 func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	if d.HasChangesExcept(names.AttrPermissions, names.AttrTags, names.AttrTagsAll, "refresh_properties") {
 		awsAccountId, dataSetId, err := ParseDataSetID(d.Id())
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		params := &quicksight.UpdateDataSetInput{
@@ -1047,14 +1051,14 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		_, err = conn.UpdateDataSetWithContext(ctx, params)
 		if err != nil {
-			return diag.Errorf("updating QuickSight Data Set (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating QuickSight Data Set (%s): %s", d.Id(), err)
 		}
 	}
 
 	if d.HasChange(names.AttrPermissions) {
 		awsAccountId, dataSetId, err := ParseDataSetID(d.Id())
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		oraw, nraw := d.GetChange(names.AttrPermissions)
@@ -1079,14 +1083,14 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		_, err = conn.UpdateDataSetPermissionsWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("updating QuickSight Data Set (%s) permissions: %s", dataSetId, err)
+			return sdkdiag.AppendErrorf(diags, "updating QuickSight Data Set (%s) permissions: %s", dataSetId, err)
 		}
 	}
 
 	if d.HasChange("refresh_properties") {
 		awsAccountId, dataSetId, err := ParseDataSetID(d.Id())
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		oldraw, newraw := d.GetChange("refresh_properties")
@@ -1098,7 +1102,7 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				DataSetId:    aws.String(dataSetId),
 			})
 			if err != nil {
-				return diag.Errorf("deleting QuickSight Data Set Refresh Properties (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "deleting QuickSight Data Set Refresh Properties (%s): %s", d.Id(), err)
 			}
 		} else {
 			_, err = conn.PutDataSetRefreshPropertiesWithContext(ctx, &quicksight.PutDataSetRefreshPropertiesInput{
@@ -1107,21 +1111,22 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				DataSetRefreshProperties: expandDataSetRefreshProperties(d.Get("refresh_properties").([]interface{})),
 			})
 			if err != nil {
-				return diag.Errorf("updating QuickSight Data Set Refresh Properties (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating QuickSight Data Set Refresh Properties (%s): %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceDataSetRead(ctx, d, meta)
+	return append(diags, resourceDataSetRead(ctx, d, meta)...)
 }
 
 func resourceDataSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	log.Printf("[INFO] Deleting QuickSight Data Set %s", d.Id())
 	awsAccountId, dataSetId, err := ParseDataSetID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	deleteOpts := &quicksight.DeleteDataSetInput{
@@ -1132,14 +1137,14 @@ func resourceDataSetDelete(ctx context.Context, d *schema.ResourceData, meta int
 	_, err = conn.DeleteDataSetWithContext(ctx, deleteOpts)
 
 	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting QuickSight Data Set (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting QuickSight Data Set (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func expandDataSetColumnGroups(tfList []interface{}) []*quicksight.ColumnGroup {

--- a/internal/service/quicksight/data_source.go
+++ b/internal/service/quicksight/data_source.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -610,6 +611,7 @@ func ResourceDataSource() *schema.Resource {
 }
 
 func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId := meta.(*conns.AWSClient).AccountID
@@ -646,24 +648,25 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	_, err := conn.CreateDataSourceWithContext(ctx, params)
 	if err != nil {
-		return diag.Errorf("creating QuickSight Data Source: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating QuickSight Data Source: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", awsAccountId, id))
 
 	if _, err := waitCreated(ctx, conn, awsAccountId, id); err != nil {
-		return diag.Errorf("waiting from QuickSight Data Source (%s) creation: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting from QuickSight Data Source (%s) creation: %s", d.Id(), err)
 	}
 
-	return resourceDataSourceRead(ctx, d, meta)
+	return append(diags, resourceDataSourceRead(ctx, d, meta)...)
 }
 
 func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, dataSourceId, err := ParseDataSourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	descOpts := &quicksight.DescribeDataSourceInput{
@@ -676,15 +679,15 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
 		log.Printf("[WARN] QuickSight Data Source (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("describing QuickSight Data Source (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Data Source (%s): %s", d.Id(), err)
 	}
 
 	if output == nil || output.DataSource == nil {
-		return diag.Errorf("describing QuickSight Data Source (%s): empty output", d.Id())
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Data Source (%s): empty output", d.Id())
 	}
 
 	dataSource := output.DataSource
@@ -695,17 +698,17 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set(names.AttrName, dataSource.Name)
 
 	if err := d.Set(names.AttrParameters, flattenParameters(dataSource.DataSourceParameters)); err != nil {
-		return diag.Errorf("setting parameters: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting parameters: %s", err)
 	}
 
 	if err := d.Set("ssl_properties", flattenSSLProperties(dataSource.SslProperties)); err != nil {
-		return diag.Errorf("setting ssl_properties: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting ssl_properties: %s", err)
 	}
 
 	d.Set(names.AttrType, dataSource.Type)
 
 	if err := d.Set("vpc_connection_properties", flattenVPCConnectionProperties(dataSource.VpcConnectionProperties)); err != nil {
-		return diag.Errorf("setting vpc_connection_properties: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting vpc_connection_properties: %s", err)
 	}
 
 	permsResp, err := conn.DescribeDataSourcePermissionsWithContext(ctx, &quicksight.DescribeDataSourcePermissionsInput{
@@ -714,23 +717,24 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if err != nil {
-		return diag.Errorf("describing QuickSight Data Source (%s) Permissions: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Data Source (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set("permission", flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("setting permission: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting permission: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	if d.HasChangesExcept("permission", names.AttrTags, names.AttrTagsAll) {
 		awsAccountId, dataSourceId, err := ParseDataSourceID(d.Id())
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		params := &quicksight.UpdateDataSourceInput{
@@ -758,18 +762,18 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		_, err = conn.UpdateDataSourceWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("updating QuickSight Data Source (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating QuickSight Data Source (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitUpdated(ctx, conn, awsAccountId, dataSourceId); err != nil {
-			return diag.Errorf("waiting for QuickSight Data Source (%s) to update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for QuickSight Data Source (%s) to update: %s", d.Id(), err)
 		}
 	}
 
 	if d.HasChange("permission") {
 		awsAccountId, dataSourceId, err := ParseDataSourceID(d.Id())
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		oraw, nraw := d.GetChange("permission")
@@ -794,19 +798,20 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		_, err = conn.UpdateDataSourcePermissionsWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("updating QuickSight Data Source (%s) permissions: %s", dataSourceId, err)
+			return sdkdiag.AppendErrorf(diags, "updating QuickSight Data Source (%s) permissions: %s", dataSourceId, err)
 		}
 	}
 
-	return resourceDataSourceRead(ctx, d, meta)
+	return append(diags, resourceDataSourceRead(ctx, d, meta)...)
 }
 
 func resourceDataSourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, dataSourceId, err := ParseDataSourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	deleteOpts := &quicksight.DeleteDataSourceInput{
@@ -817,14 +822,14 @@ func resourceDataSourceDelete(ctx context.Context, d *schema.ResourceData, meta 
 	_, err = conn.DeleteDataSourceWithContext(ctx, deleteOpts)
 
 	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting QuickSight Data Source (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting QuickSight Data Source (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func expandDataSourceCredentials(tfList []interface{}) *quicksight.DataSourceCredentials {

--- a/internal/service/quicksight/folder.go
+++ b/internal/service/quicksight/folder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -137,6 +138,7 @@ const (
 )
 
 func resourceFolderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId := meta.(*conns.AWSClient).AccountID
@@ -169,33 +171,34 @@ func resourceFolderCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	out, err := conn.CreateFolderWithContext(ctx, in)
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionCreating, ResNameFolder, d.Get(names.AttrName).(string), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionCreating, ResNameFolder, d.Get(names.AttrName).(string), err)
 	}
 
 	if out == nil || out.Arn == nil {
-		return create.DiagError(names.QuickSight, create.ErrActionCreating, ResNameFolder, d.Get(names.AttrName).(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionCreating, ResNameFolder, d.Get(names.AttrName).(string), errors.New("empty output"))
 	}
 
-	return resourceFolderRead(ctx, d, meta)
+	return append(diags, resourceFolderRead(ctx, d, meta)...)
 }
 
 func resourceFolderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, folderId, err := ParseFolderId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	out, err := FindFolderByID(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] QuickSight Folder (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionReading, ResNameFolder, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionReading, ResNameFolder, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
@@ -211,7 +214,7 @@ func resourceFolderRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err := d.Set("folder_path", flex.FlattenStringList(out.FolderPath)); err != nil {
-		return diag.Errorf("setting folder_path: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting folder_path: %s", err)
 	}
 
 	permsResp, err := conn.DescribeFolderPermissionsWithContext(ctx, &quicksight.DescribeFolderPermissionsInput{
@@ -220,21 +223,22 @@ func resourceFolderRead(ctx context.Context, d *schema.ResourceData, meta interf
 	})
 
 	if err != nil {
-		return diag.Errorf("describing QuickSight Folder (%s) Permissions: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Folder (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set(names.AttrPermissions, flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("setting permissions: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting permissions: %s", err)
 	}
-	return nil
+	return diags
 }
 
 func resourceFolderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, folderId, err := ParseFolderId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	if d.HasChangesExcept("permission", names.AttrTags, names.AttrTagsAll) {
@@ -247,7 +251,7 @@ func resourceFolderUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		log.Printf("[DEBUG] Updating QuickSight Folder (%s): %#v", d.Id(), in)
 		_, err = conn.UpdateFolderWithContext(ctx, in)
 		if err != nil {
-			return create.DiagError(names.QuickSight, create.ErrActionUpdating, ResNameFolder, d.Id(), err)
+			return create.AppendDiagError(diags, names.QuickSight, create.ErrActionUpdating, ResNameFolder, d.Id(), err)
 		}
 	}
 
@@ -274,21 +278,22 @@ func resourceFolderUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		_, err = conn.UpdateFolderPermissionsWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("updating QuickSight Folder (%s) permissions: %s", folderId, err)
+			return sdkdiag.AppendErrorf(diags, "updating QuickSight Folder (%s) permissions: %s", folderId, err)
 		}
 	}
 
-	return resourceFolderRead(ctx, d, meta)
+	return append(diags, resourceFolderRead(ctx, d, meta)...)
 }
 
 func resourceFolderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	log.Printf("[INFO] Deleting QuickSight Folder %s", d.Id())
 
 	awsAccountId, folderId, err := ParseFolderId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	_, err = conn.DeleteFolderWithContext(ctx, &quicksight.DeleteFolderInput{
@@ -297,14 +302,14 @@ func resourceFolderDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	})
 
 	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionDeleting, ResNameFolder, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionDeleting, ResNameFolder, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindFolderByID(ctx context.Context, conn *quicksight.QuickSight, id string) (*quicksight.Folder, error) {

--- a/internal/service/quicksight/template.go
+++ b/internal/service/quicksight/template.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	quicksightschema "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -131,6 +132,7 @@ const (
 )
 
 func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId := meta.(*conns.AWSClient).AccountID
@@ -166,22 +168,23 @@ func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	_, err := conn.CreateTemplateWithContext(ctx, input)
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionCreating, ResNameTemplate, d.Get(names.AttrName).(string), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionCreating, ResNameTemplate, d.Get(names.AttrName).(string), err)
 	}
 
 	if _, err := waitTemplateCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionWaitingForCreation, ResNameTemplate, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionWaitingForCreation, ResNameTemplate, d.Id(), err)
 	}
 
-	return resourceTemplateRead(ctx, d, meta)
+	return append(diags, resourceTemplateRead(ctx, d, meta)...)
 }
 
 func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, templateId, err := ParseTemplateId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	out, err := FindTemplateByID(ctx, conn, d.Id())
@@ -189,11 +192,11 @@ func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] QuickSight Template (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionReading, ResNameTemplate, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionReading, ResNameTemplate, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
@@ -214,11 +217,11 @@ func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta inte
 	})
 
 	if err != nil {
-		return diag.Errorf("describing QuickSight Template (%s) Definition: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Template (%s) Definition: %s", d.Id(), err)
 	}
 
 	if err := d.Set("definition", quicksightschema.FlattenTemplateDefinition(descResp.Definition)); err != nil {
-		return diag.Errorf("setting definition: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting definition: %s", err)
 	}
 
 	permsResp, err := conn.DescribeTemplatePermissionsWithContext(ctx, &quicksight.DescribeTemplatePermissionsInput{
@@ -227,22 +230,23 @@ func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta inte
 	})
 
 	if err != nil {
-		return diag.Errorf("describing QuickSight Template (%s) Permissions: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Template (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set(names.AttrPermissions, flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("setting permissions: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting permissions: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, templateId, err := ParseTemplateId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	if d.HasChangesExcept(names.AttrPermissions, names.AttrTags, names.AttrTagsAll) {
@@ -263,11 +267,11 @@ func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		log.Printf("[DEBUG] Updating QuickSight Template (%s): %#v", d.Id(), in)
 		_, err := conn.UpdateTemplateWithContext(ctx, in)
 		if err != nil {
-			return create.DiagError(names.QuickSight, create.ErrActionUpdating, ResNameTemplate, d.Id(), err)
+			return create.AppendDiagError(diags, names.QuickSight, create.ErrActionUpdating, ResNameTemplate, d.Id(), err)
 		}
 
 		if _, err := waitTemplateUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return create.DiagError(names.QuickSight, create.ErrActionWaitingForUpdate, ResNameTemplate, d.Id(), err)
+			return create.AppendDiagError(diags, names.QuickSight, create.ErrActionWaitingForUpdate, ResNameTemplate, d.Id(), err)
 		}
 	}
 
@@ -294,19 +298,20 @@ func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		_, err = conn.UpdateTemplatePermissionsWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("updating QuickSight Template (%s) permissions: %s", templateId, err)
+			return sdkdiag.AppendErrorf(diags, "updating QuickSight Template (%s) permissions: %s", templateId, err)
 		}
 	}
 
-	return resourceTemplateRead(ctx, d, meta)
+	return append(diags, resourceTemplateRead(ctx, d, meta)...)
 }
 
 func resourceTemplateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, templateId, err := ParseTemplateId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	log.Printf("[INFO] Deleting QuickSight Template %s", d.Id())
@@ -316,14 +321,14 @@ func resourceTemplateDelete(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionDeleting, ResNameTemplate, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionDeleting, ResNameTemplate, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindTemplateByID(ctx context.Context, conn *quicksight.QuickSight, id string) (*quicksight.Template, error) {

--- a/internal/service/quicksight/theme.go
+++ b/internal/service/quicksight/theme.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -350,6 +351,7 @@ const (
 )
 
 func resourceThemeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId := meta.(*conns.AWSClient).AccountID
@@ -382,22 +384,23 @@ func resourceThemeCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	_, err := conn.CreateThemeWithContext(ctx, input)
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionCreating, ResNameTheme, d.Get(names.AttrName).(string), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionCreating, ResNameTheme, d.Get(names.AttrName).(string), err)
 	}
 
 	if _, err := waitThemeCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionWaitingForCreation, ResNameTheme, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionWaitingForCreation, ResNameTheme, d.Id(), err)
 	}
 
-	return resourceThemeRead(ctx, d, meta)
+	return append(diags, resourceThemeRead(ctx, d, meta)...)
 }
 
 func resourceThemeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, themeId, err := ParseThemeId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	out, err := FindThemeByID(ctx, conn, d.Id())
@@ -405,11 +408,11 @@ func resourceThemeRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] QuickSight Theme (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionReading, ResNameTheme, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionReading, ResNameTheme, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
@@ -424,7 +427,7 @@ func resourceThemeRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("version_number", out.Version.VersionNumber)
 
 	if err := d.Set(names.AttrConfiguration, flattenThemeConfiguration(out.Version.Configuration)); err != nil {
-		return diag.Errorf("setting configuration: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting configuration: %s", err)
 	}
 
 	permsResp, err := conn.DescribeThemePermissionsWithContext(ctx, &quicksight.DescribeThemePermissionsInput{
@@ -433,22 +436,23 @@ func resourceThemeRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	})
 
 	if err != nil {
-		return diag.Errorf("describing QuickSight Theme (%s) Permissions: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "describing QuickSight Theme (%s) Permissions: %s", d.Id(), err)
 	}
 
 	if err := d.Set(names.AttrPermissions, flattenPermissions(permsResp.Permissions)); err != nil {
-		return diag.Errorf("setting permissions: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting permissions: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceThemeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, themeId, err := ParseThemeId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	if d.HasChangesExcept(names.AttrPermissions, names.AttrTags, names.AttrTagsAll) {
@@ -466,11 +470,11 @@ func resourceThemeUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		log.Printf("[DEBUG] Updating QuickSight Theme (%s): %#v", d.Id(), in)
 		_, err := conn.UpdateThemeWithContext(ctx, in)
 		if err != nil {
-			return create.DiagError(names.QuickSight, create.ErrActionUpdating, ResNameTheme, d.Id(), err)
+			return create.AppendDiagError(diags, names.QuickSight, create.ErrActionUpdating, ResNameTheme, d.Id(), err)
 		}
 
 		if _, err := waitThemeUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return create.DiagError(names.QuickSight, create.ErrActionWaitingForUpdate, ResNameTheme, d.Id(), err)
+			return create.AppendDiagError(diags, names.QuickSight, create.ErrActionWaitingForUpdate, ResNameTheme, d.Id(), err)
 		}
 	}
 
@@ -497,19 +501,20 @@ func resourceThemeUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		_, err = conn.UpdateThemePermissionsWithContext(ctx, params)
 
 		if err != nil {
-			return diag.Errorf("updating QuickSight Theme (%s) permissions: %s", themeId, err)
+			return sdkdiag.AppendErrorf(diags, "updating QuickSight Theme (%s) permissions: %s", themeId, err)
 		}
 	}
 
-	return resourceThemeRead(ctx, d, meta)
+	return append(diags, resourceThemeRead(ctx, d, meta)...)
 }
 
 func resourceThemeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightConn(ctx)
 
 	awsAccountId, themeId, err := ParseThemeId(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &quicksight.DeleteThemeInput{
@@ -521,14 +526,14 @@ func resourceThemeDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	_, err = conn.DeleteThemeWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, quicksight.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.QuickSight, create.ErrActionDeleting, ResNameTheme, d.Id(), err)
+		return create.AppendDiagError(diags, names.QuickSight, create.ErrActionDeleting, ResNameTheme, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindThemeByID(ctx context.Context, conn *quicksight.QuickSight, id string) (*quicksight.Theme, error) {

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1160,7 +1160,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] RDS Cluster (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
@@ -1283,7 +1283,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	setTagsOut(ctx, dbc.TagList)
 
-	return nil
+	return diags
 }
 
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -1618,7 +1618,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	)
 
 	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBClusterNotFoundFault) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
@@ -1629,7 +1629,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS Cluster (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceClusterImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -363,7 +363,7 @@ func resourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, me
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] RDS Cluster Instance (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading RDS Cluster Instance (%s): %s", d.Id(), err)
@@ -430,7 +430,7 @@ func resourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, me
 
 	setTagsOut(ctx, db.TagList)
 
-	return nil
+	return diags
 }
 
 func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
@@ -538,7 +538,7 @@ func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 		rds.ErrCodeInvalidDBClusterStateFault, "Delete the replica cluster before deleting")
 
 	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBInstanceNotFoundFault) {
-		return nil
+		return diags
 	}
 
 	if err != nil && !tfawserr.ErrMessageContains(err, rds.ErrCodeInvalidDBInstanceStateFault, "is already being deleted") {
@@ -549,7 +549,7 @@ func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS Cluster Instance (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func clusterSetResourceDataEngineVersionFromClusterInstance(d *schema.ResourceData, c *rds.DBInstance) {

--- a/internal/service/rds/cluster_snapshot.go
+++ b/internal/service/rds/cluster_snapshot.go
@@ -161,7 +161,7 @@ func resourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, me
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] RDS DB Cluster Snapshot (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/rds/clusters_data_source.go
+++ b/internal/service/rds/clusters_data_source.go
@@ -42,6 +42,7 @@ const (
 )
 
 func dataSourceClustersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSConn(ctx)
 
 	input := &rds.DescribeDBClustersInput{}
@@ -70,12 +71,12 @@ func dataSourceClustersRead(ctx context.Context, d *schema.ResourceData, meta in
 		return !lastPage
 	})
 	if err != nil {
-		return create.DiagError(names.RDS, create.ErrActionReading, DSNameClusters, "", err)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionReading, DSNameClusters, "", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("cluster_arns", clusterArns)
 	d.Set("cluster_identifiers", clusterIdentifiers)
 
-	return nil
+	return diags
 }

--- a/internal/service/rds/custom_db_engine_version.go
+++ b/internal/service/rds/custom_db_engine_version.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -204,7 +205,7 @@ func resourceCustomDBEngineVersionCreate(ctx context.Context, d *schema.Resource
 		defer conns.GlobalMutexKV.Unlock(cevMutexKey)
 		file, err := resourceCustomDBEngineVersionLoadFileContent(filename)
 		if err != nil {
-			return diag.Errorf("unable to load %q: %s", filename, err)
+			return sdkdiag.AppendErrorf(diags, "unable to load %q: %s", filename, err)
 		}
 		input.Manifest = aws.String(file)
 	} else if v, ok := d.GetOk("manifest"); ok {
@@ -213,13 +214,13 @@ func resourceCustomDBEngineVersionCreate(ctx context.Context, d *schema.Resource
 
 	output, err := conn.CreateCustomDBEngineVersionWithContext(ctx, &input)
 	if err != nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionCreating, ResNameCustomDBEngineVersion, fmt.Sprintf("%s:%s", aws.StringValue(output.Engine), aws.StringValue(output.EngineVersion)), err)...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionCreating, ResNameCustomDBEngineVersion, fmt.Sprintf("%s:%s", aws.StringValue(output.Engine), aws.StringValue(output.EngineVersion)), err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", aws.StringValue(output.Engine), aws.StringValue(output.EngineVersion)))
 
 	if _, err := waitCustomDBEngineVersionCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionWaitingForCreation, ResNameCustomDBEngineVersion, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionWaitingForCreation, ResNameCustomDBEngineVersion, d.Id(), err)
 	}
 
 	return append(diags, resourceCustomDBEngineVersionRead(ctx, d, meta)...)
@@ -237,7 +238,7 @@ func resourceCustomDBEngineVersionRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionReading, ResNameCustomDBEngineVersion, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionReading, ResNameCustomDBEngineVersion, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.DBEngineVersionArn)
@@ -266,13 +267,13 @@ func resourceCustomDBEngineVersionUpdate(ctx context.Context, d *schema.Resource
 	conn := meta.(*conns.AWSClient).RDSConn(ctx)
 
 	if d.HasChangesExcept(names.AttrDescription, names.AttrStatus) {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionUpdating, ResNameCustomDBEngineVersion, d.Id(), errors.New("only description and status can be updated"))...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionUpdating, ResNameCustomDBEngineVersion, d.Id(), errors.New("only description and status can be updated"))
 	}
 
 	update := false
 	engine, engineVersion, e := customEngineVersionParseID(d.Id())
 	if e != nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionUpdating, ResNameCustomDBEngineVersion, d.Id(), e)...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionUpdating, ResNameCustomDBEngineVersion, d.Id(), e)
 	}
 	input := &rds.ModifyCustomDBEngineVersionInput{
 		Engine:        aws.String(engine),
@@ -295,14 +296,14 @@ func resourceCustomDBEngineVersionUpdate(ctx context.Context, d *schema.Resource
 	log.Printf("[DEBUG] Updating RDS CustomDBEngineVersion (%s): %#v", d.Id(), input)
 	output, err := conn.ModifyCustomDBEngineVersionWithContext(ctx, input)
 	if err != nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionUpdating, ResNameCustomDBEngineVersion, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionUpdating, ResNameCustomDBEngineVersion, d.Id(), err)
 	}
 	if output == nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionUpdating, ResNameCustomDBEngineVersion, d.Id(), errors.New("empty output"))...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionUpdating, ResNameCustomDBEngineVersion, d.Id(), errors.New("empty output"))
 	}
 
 	if _, err := waitCustomDBEngineVersionUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionWaitingForUpdate, ResNameCustomDBEngineVersion, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionWaitingForUpdate, ResNameCustomDBEngineVersion, d.Id(), err)
 	}
 
 	return append(diags, resourceCustomDBEngineVersionRead(ctx, d, meta)...)
@@ -316,7 +317,7 @@ func resourceCustomDBEngineVersionDelete(ctx context.Context, d *schema.Resource
 
 	engine, engineVersion, e := customEngineVersionParseID(d.Id())
 	if e != nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionUpdating, ResNameCustomDBEngineVersion, d.Id(), e)...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionUpdating, ResNameCustomDBEngineVersion, d.Id(), e)
 	}
 	_, err := conn.DeleteCustomDBEngineVersionWithContext(ctx, &rds.DeleteCustomDBEngineVersionInput{
 		Engine:        aws.String(engine),
@@ -328,11 +329,11 @@ func resourceCustomDBEngineVersionDelete(ctx context.Context, d *schema.Resource
 	}
 
 	if err != nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionDeleting, ResNameCustomDBEngineVersion, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionDeleting, ResNameCustomDBEngineVersion, d.Id(), err)
 	}
 
 	if _, err := waitCustomDBEngineVersionDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return append(diags, create.DiagError(names.RDS, create.ErrActionWaitingForDeletion, ResNameCustomDBEngineVersion, d.Id(), err)...)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionWaitingForDeletion, ResNameCustomDBEngineVersion, d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1824,7 +1824,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 			if tfresource.NotFound(err) {
 				log.Printf("[WARN] RDS DB Instance (%s) not found, removing from state", d.Get(names.AttrIdentifier).(string))
 				d.SetId("")
-				return nil
+				return diags
 			}
 		}
 	}
@@ -2518,7 +2518,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if tfawserr.ErrCodeEquals(err, rds.ErrCodeDBInstanceNotFoundFault) {
-		return nil
+		return diags
 	}
 
 	if err != nil && !tfawserr.ErrMessageContains(err, rds.ErrCodeInvalidDBInstanceStateFault, "is already being deleted") {
@@ -2529,7 +2529,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) delete: %s", d.Get(names.AttrIdentifier).(string), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceInstanceImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/internal/service/rds/parameter_group.go
+++ b/internal/service/rds/parameter_group.go
@@ -339,7 +339,7 @@ func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting RDS DB Parameter Group (%s): %s", d.Id(), err)
 	}
-	return nil
+	return diags
 }
 
 func FindDBParameterGroupByName(ctx context.Context, conn *rds.RDS, name string) (*rds.DBParameterGroup, error) {

--- a/internal/service/rds/parameter_group_data_source.go
+++ b/internal/service/rds/parameter_group_data_source.go
@@ -68,5 +68,5 @@ func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set(names.AttrFamily, output.DBParameterGroups[0].DBParameterGroupFamily)
 	d.Set(names.AttrDescription, output.DBParameterGroups[0].Description)
 
-	return nil
+	return diags
 }

--- a/internal/service/rds/reserved_instance.go
+++ b/internal/service/rds/reserved_instance.go
@@ -133,6 +133,7 @@ func ResourceReservedInstance() *schema.Resource {
 }
 
 func resourceReservedInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSConn(ctx)
 
 	input := &rds.PurchaseReservedDBInstancesOfferingInput{
@@ -150,19 +151,20 @@ func resourceReservedInstanceCreate(ctx context.Context, d *schema.ResourceData,
 
 	resp, err := conn.PurchaseReservedDBInstancesOfferingWithContext(ctx, input)
 	if err != nil {
-		return create.DiagError(names.RDS, create.ErrActionCreating, ResNameReservedInstance, fmt.Sprintf("offering_id: %s, reservation_id: %s", d.Get("offering_id").(string), d.Get("reservation_id").(string)), err)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionCreating, ResNameReservedInstance, fmt.Sprintf("offering_id: %s, reservation_id: %s", d.Get("offering_id").(string), d.Get("reservation_id").(string)), err)
 	}
 
 	d.SetId(aws.ToString(resp.ReservedDBInstance.ReservedDBInstanceId))
 
 	if err := waitReservedInstanceCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.RDS, create.ErrActionWaitingForCreation, ResNameReservedInstance, d.Id(), err)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionWaitingForCreation, ResNameReservedInstance, d.Id(), err)
 	}
 
-	return resourceReservedInstanceRead(ctx, d, meta)
+	return append(diags, resourceReservedInstanceRead(ctx, d, meta)...)
 }
 
 func resourceReservedInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSConn(ctx)
 
 	reservation, err := FindReservedDBInstanceByID(ctx, conn, d.Id())
@@ -170,11 +172,11 @@ func resourceReservedInstanceRead(ctx context.Context, d *schema.ResourceData, m
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		create.LogNotFoundRemoveState(names.RDS, create.ErrActionReading, ResNameReservedInstance, d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.RDS, create.ErrActionReading, ResNameReservedInstance, d.Id(), err)
+		return create.AppendDiagError(diags, names.RDS, create.ErrActionReading, ResNameReservedInstance, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, reservation.ReservedDBInstanceArn)
@@ -194,7 +196,7 @@ func resourceReservedInstanceRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set(names.AttrState, reservation.State)
 	d.Set("usage_price", reservation.UsagePrice)
 
-	return nil
+	return diags
 }
 
 func resourceReservedInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/rds/snapshot_copy.go
+++ b/internal/service/rds/snapshot_copy.go
@@ -201,7 +201,7 @@ func resourceSnapshotCopyRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] RDS DB Snapshot (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/resourcegroups/group.go
+++ b/internal/service/resourcegroups/group.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -117,6 +118,7 @@ func resourceGroup() *schema.Resource {
 }
 
 func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ResourceGroupsClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -141,21 +143,22 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	output, err := conn.CreateGroup(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Resource Groups Group (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Resource Groups Group (%s): %s", name, err)
 	}
 
 	d.SetId(aws.ToString(output.Group.Name))
 
 	if waitForConfigurationAttached {
 		if _, err := waitGroupConfigurationUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-			return diag.Errorf("waiting for Resource Groups Group (%s) configuration update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Resource Groups Group (%s) configuration update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceGroupRead(ctx, d, meta)
+	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
 func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ResourceGroupsClient(ctx)
 
 	group, err := findGroupByName(ctx, conn, d.Id())
@@ -163,11 +166,11 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Resource Groups Group %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Resource Groups Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Resource Groups Group (%s): %s", d.Id(), err)
 	}
 
 	arn := aws.ToString(group.GroupArn)
@@ -185,7 +188,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 			// Attempting to get the query on a configuration group returns BadRequestException.
 			hasQuery = false
 		} else {
-			return diag.Errorf("reading Resource Groups Group (%s) resource query: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading Resource Groups Group (%s) resource query: %s", d.Id(), err)
 		}
 	}
 
@@ -197,7 +200,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 			// Attempting to get configuration on a query group returns BadRequestException.
 			hasConfiguration = false
 		} else {
-			return diag.Errorf("reading Resource Groups Group (%s) configuration: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading Resource Groups Group (%s) configuration: %s", d.Id(), err)
 		}
 	}
 
@@ -206,24 +209,25 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		resultQuery["query"] = aws.ToString(q.GroupQuery.ResourceQuery.Query)
 		resultQuery[names.AttrType] = q.GroupQuery.ResourceQuery.Type
 		if err := d.Set("resource_query", []map[string]interface{}{resultQuery}); err != nil {
-			return diag.Errorf("setting resource_query: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting resource_query: %s", err)
 		}
 	}
 	if hasConfiguration {
 		if err := d.Set(names.AttrConfiguration, flattenGroupConfigurationItems(groupCfg.Configuration)); err != nil {
-			return diag.Errorf("setting configuration: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting configuration: %s", err)
 		}
 	}
 
-	return nil
+	return diags
 }
 
 func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ResourceGroupsClient(ctx)
 
 	// Conversion between a resource-query and configuration group is not possible and vice-versa
 	if d.HasChange(names.AttrConfiguration) && d.HasChange("resource_query") {
-		return diag.Errorf("conversion between resource-query and configuration group types is not possible")
+		return sdkdiag.AppendErrorf(diags, "conversion between resource-query and configuration group types is not possible")
 	}
 
 	if d.HasChange(names.AttrDescription) {
@@ -235,7 +239,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		_, err := conn.UpdateGroup(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Resource Groups Group (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Resource Groups Group (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -248,7 +252,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		_, err := conn.UpdateGroupQuery(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Resource Groups Group (%s) resource query: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Resource Groups Group (%s) resource query: %s", d.Id(), err)
 		}
 	}
 
@@ -261,18 +265,19 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		_, err := conn.PutGroupConfiguration(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Resource Groups Group (%s) configuration: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Resource Groups Group (%s) configuration: %s", d.Id(), err)
 		}
 
 		if _, err := waitGroupConfigurationUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return diag.Errorf("waiting for Resource Groups Group (%s) configuration update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Resource Groups Group (%s) configuration update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceGroupRead(ctx, d, meta)
+	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
 func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ResourceGroupsClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Resource Groups Group: %s", d.Id())
@@ -281,14 +286,14 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Resource Groups Group (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Resource Groups Group (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findGroupByName(ctx context.Context, conn *resourcegroups.Client, name string) (*types.Group, error) {

--- a/internal/service/rolesanywhere/profile.go
+++ b/internal/service/rolesanywhere/profile.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -80,6 +81,7 @@ func ResourceProfile() *schema.Resource {
 }
 
 func resourceProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -113,15 +115,16 @@ func resourceProfileCreate(ctx context.Context, d *schema.ResourceData, meta int
 	output, err := conn.CreateProfile(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating RolesAnywhere Profile (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating RolesAnywhere Profile (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.Profile.ProfileId))
 
-	return resourceProfileRead(ctx, d, meta)
+	return append(diags, resourceProfileRead(ctx, d, meta)...)
 }
 
 func resourceProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
 	profile, err := FindProfileByID(ctx, conn, d.Id())
@@ -129,11 +132,11 @@ func resourceProfileRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] RolesAnywhere Profile (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading RolesAnywhere Profile (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading RolesAnywhere Profile (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, profile.ProfileArn)
@@ -145,13 +148,14 @@ func resourceProfileRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("role_arns", profile.RoleArns)
 	d.Set("session_policy", profile.SessionPolicy)
 
-	return nil
+	return diags
 }
 
 func resourceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
-	if d.HasChangesExcept(names.AttrEnabled, names.AttrTagsAll) {
+	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
 		input := &rolesanywhere.UpdateProfileInput{
 			ProfileId: aws.String(d.Id()),
 		}
@@ -179,7 +183,7 @@ func resourceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		log.Printf("[DEBUG] Updating RolesAnywhere Profile (%s): %#v", d.Id(), input)
 		_, err := conn.UpdateProfile(ctx, input)
 		if err != nil {
-			return diag.Errorf("updating RolesAnywhere Profile (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating RolesAnywhere Profile (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -188,20 +192,21 @@ func resourceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		if n == true {
 			err := enableProfile(ctx, d.Id(), meta)
 			if err != nil {
-				diag.Errorf("enabling RolesAnywhere Profile (%s): %s", d.Id(), err)
+				sdkdiag.AppendErrorf(diags, "enabling RolesAnywhere Profile (%s): %s", d.Id(), err)
 			}
 		} else {
 			err := disableProfile(ctx, d.Id(), meta)
 			if err != nil {
-				diag.Errorf("disabling RolesAnywhere Profile (%s): %s", d.Id(), err)
+				sdkdiag.AppendErrorf(diags, "disabling RolesAnywhere Profile (%s): %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceProfileRead(ctx, d, meta)
+	return append(diags, resourceProfileRead(ctx, d, meta)...)
 }
 
 func resourceProfileDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
 	log.Printf("[DEBUG] Deleting RolesAnywhere Profile (%s)", d.Id())
@@ -211,14 +216,14 @@ func resourceProfileDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	var resourceNotFoundException *types.ResourceNotFoundException
 	if errors.As(err, &resourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting RolesAnywhere Profile: (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting RolesAnywhere Profile: (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func disableProfile(ctx context.Context, profileId string, meta interface{}) error {

--- a/internal/service/rolesanywhere/trust_anchor.go
+++ b/internal/service/rolesanywhere/trust_anchor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -91,6 +92,7 @@ func ResourceTrustAnchor() *schema.Resource {
 }
 
 func resourceTrustAnchorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -105,15 +107,16 @@ func resourceTrustAnchorCreate(ctx context.Context, d *schema.ResourceData, meta
 	output, err := conn.CreateTrustAnchor(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating RolesAnywhere Trust Anchor (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating RolesAnywhere Trust Anchor (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.TrustAnchor.TrustAnchorId))
 
-	return resourceTrustAnchorRead(ctx, d, meta)
+	return append(diags, resourceTrustAnchorRead(ctx, d, meta)...)
 }
 
 func resourceTrustAnchorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
 	trustAnchor, err := FindTrustAnchorByID(ctx, conn, d.Id())
@@ -121,11 +124,11 @@ func resourceTrustAnchorRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] RolesAnywhere Trust Anchor (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, trustAnchor.TrustAnchorArn)
@@ -133,13 +136,14 @@ func resourceTrustAnchorRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set(names.AttrName, trustAnchor.Name)
 
 	if err := d.Set(names.AttrSource, flattenSource(trustAnchor.Source)); err != nil {
-		return diag.Errorf("setting source: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting source: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceTrustAnchorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
@@ -153,27 +157,28 @@ func resourceTrustAnchorUpdate(ctx context.Context, d *schema.ResourceData, meta
 		_, err := conn.UpdateTrustAnchor(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
 		}
 
 		if d.HasChange(names.AttrEnabled) {
 			_, n := d.GetChange(names.AttrEnabled)
 			if n == true {
 				if err := enableTrustAnchor(ctx, d.Id(), meta); err != nil {
-					diag.Errorf("enabling RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
+					sdkdiag.AppendErrorf(diags, "enabling RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
 				}
 			} else {
 				if err := disableTrustAnchor(ctx, d.Id(), meta); err != nil {
-					diag.Errorf("disabling RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
+					sdkdiag.AppendErrorf(diags, "disabling RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
 				}
 			}
 		}
 	}
 
-	return resourceTrustAnchorRead(ctx, d, meta)
+	return append(diags, resourceTrustAnchorRead(ctx, d, meta)...)
 }
 
 func resourceTrustAnchorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RolesAnywhereClient(ctx)
 
 	log.Printf("[DEBUG] Deleting RolesAnywhere Trust Anchor (%s)", d.Id())
@@ -183,14 +188,14 @@ func resourceTrustAnchorDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	var resourceNotFoundException *types.ResourceNotFoundException
 	if errors.As(err, &resourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func flattenSource(apiObject *types.Source) []interface{} {

--- a/internal/service/route53/query_log.go
+++ b/internal/service/route53/query_log.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -53,6 +54,7 @@ func resourceQueryLog() *schema.Resource {
 }
 
 func resourceQueryLogCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53Client(ctx)
 
 	input := &route53.CreateQueryLoggingConfigInput{
@@ -63,15 +65,16 @@ func resourceQueryLogCreate(ctx context.Context, d *schema.ResourceData, meta in
 	output, err := conn.CreateQueryLoggingConfig(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Route53 Query Logging Config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Route53 Query Logging Config: %s", err)
 	}
 
 	d.SetId(aws.ToString(output.QueryLoggingConfig.Id))
 
-	return resourceQueryLogRead(ctx, d, meta)
+	return append(diags, resourceQueryLogRead(ctx, d, meta)...)
 }
 
 func resourceQueryLogRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53Client(ctx)
 
 	output, err := findQueryLoggingConfigByID(ctx, conn, d.Id())
@@ -79,11 +82,11 @@ func resourceQueryLogRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Route53 Query Logging Config %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Route53 Query Logging Config (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Query Logging Config (%s): %s", d.Id(), err)
 	}
 
 	arn := arn.ARN{
@@ -95,10 +98,11 @@ func resourceQueryLogRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set(names.AttrCloudWatchLogGroupARN, output.CloudWatchLogsLogGroupArn)
 	d.Set("zone_id", output.HostedZoneId)
 
-	return nil
+	return diags
 }
 
 func resourceQueryLogDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53Client(ctx)
 
 	log.Printf("[DEBUG] Deleting Route53 Query Logging Config: %s", d.Id())
@@ -107,14 +111,14 @@ func resourceQueryLogDelete(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if errs.IsA[*awstypes.NoSuchQueryLoggingConfig](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Route53 Query Logging Config (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Route53 Query Logging Config (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findQueryLoggingConfigByID(ctx context.Context, conn *route53.Client, id string) (*awstypes.QueryLoggingConfig, error) {

--- a/internal/service/route53/traffic_policy_document_data_source.go
+++ b/internal/service/route53/traffic_policy_document_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -266,6 +267,7 @@ func dataSourceTrafficPolicyDocument() *schema.Resource {
 }
 
 func dataSourceTrafficPolicyDocumentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	trafficDoc := &route53TrafficPolicyDoc{}
 
 	if v, ok := d.GetOk(names.AttrEndpoint); ok {
@@ -289,7 +291,7 @@ func dataSourceTrafficPolicyDocumentRead(ctx context.Context, d *schema.Resource
 
 	jsonDoc, err := json.Marshal(trafficDoc)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 	jsonString := string(jsonDoc)
 
@@ -297,7 +299,7 @@ func dataSourceTrafficPolicyDocumentRead(ctx context.Context, d *schema.Resource
 
 	d.SetId(strconv.Itoa(schema.HashString(jsonString)))
 
-	return nil
+	return diags
 }
 
 func expandDataTrafficPolicyEndpointDoc(tfMap map[string]interface{}) *trafficPolicyEndpoint {

--- a/internal/service/route53domains/registered_domain.go
+++ b/internal/service/route53domains/registered_domain.go
@@ -361,7 +361,7 @@ func resourceRegisteredDomainRead(ctx context.Context, d *schema.ResourceData, m
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Route 53 Domains Domain %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/route53resolver/config.go
+++ b/internal/service/route53resolver/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -51,6 +52,7 @@ func ResourceConfig() *schema.Resource {
 }
 
 func resourceConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	autodefinedReverseFlag := d.Get("autodefined_reverse_flag").(string)
@@ -62,19 +64,20 @@ func resourceConfigCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	output, err := conn.UpdateResolverConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Route53 Resolver Config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Route53 Resolver Config: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.ResolverConfig.Id))
 
 	if _, err = waitAutodefinedReverseUpdated(ctx, conn, d.Id(), autodefinedReverseFlag); err != nil {
-		return diag.Errorf("waiting for Route53 Resolver Config (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Route53 Resolver Config (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceConfigRead(ctx, d, meta)
+	return append(diags, resourceConfigRead(ctx, d, meta)...)
 }
 
 func resourceConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	resolverConfig, err := FindResolverConfigByID(ctx, conn, d.Id())
@@ -82,11 +85,11 @@ func resourceConfigRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Route53 Resolver Config (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Route53 Resolver Config (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Resolver Config (%s): %s", d.Id(), err)
 	}
 
 	var autodefinedReverseFlag string
@@ -99,10 +102,11 @@ func resourceConfigRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set(names.AttrOwnerID, resolverConfig.OwnerId)
 	d.Set(names.AttrResourceID, resolverConfig.ResourceId)
 
-	return nil
+	return diags
 }
 
 func resourceConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	autodefinedReverseFlag := d.Get("autodefined_reverse_flag").(string)
@@ -114,14 +118,14 @@ func resourceConfigUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	_, err := conn.UpdateResolverConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating Route53 Resolver Config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "updating Route53 Resolver Config: %s", err)
 	}
 
 	if _, err = waitAutodefinedReverseUpdated(ctx, conn, d.Id(), autodefinedReverseFlag); err != nil {
-		return diag.Errorf("waiting for Route53 Resolver Config (%s) update: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Route53 Resolver Config (%s) update: %s", d.Id(), err)
 	}
 
-	return resourceConfigRead(ctx, d, meta)
+	return append(diags, resourceConfigRead(ctx, d, meta)...)
 }
 
 func FindResolverConfigByID(ctx context.Context, conn *route53resolver.Route53Resolver, id string) (*route53resolver.ResolverConfig, error) {

--- a/internal/service/route53resolver/dnssec_config.go
+++ b/internal/service/route53resolver/dnssec_config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -55,6 +56,7 @@ func ResourceDNSSECConfig() *schema.Resource {
 }
 
 func resourceDNSSECConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	input := &route53resolver.UpdateResolverDnssecConfigInput{
@@ -65,19 +67,20 @@ func resourceDNSSECConfigCreate(ctx context.Context, d *schema.ResourceData, met
 	output, err := conn.UpdateResolverDnssecConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Route53 Resolver DNSSEC Config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Route53 Resolver DNSSEC Config: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.ResolverDNSSECConfig.Id))
 
 	if _, err := waitDNSSECConfigCreated(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("waiting for Route53 Resolver DNSSEC Config (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Route53 Resolver DNSSEC Config (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceDNSSECConfigRead(ctx, d, meta)
+	return append(diags, resourceDNSSECConfigRead(ctx, d, meta)...)
 }
 
 func resourceDNSSECConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	dnssecConfig, err := FindResolverDNSSECConfigByID(ctx, conn, d.Id())
@@ -85,11 +88,11 @@ func resourceDNSSECConfigRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Route53 Resolver DNSSEC Config (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Route53 Resolver DNSSEC Config (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Resolver DNSSEC Config (%s): %s", d.Id(), err)
 	}
 
 	ownerID := aws.StringValue(dnssecConfig.OwnerId)
@@ -106,10 +109,11 @@ func resourceDNSSECConfigRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set(names.AttrResourceID, resourceID)
 	d.Set("validation_status", dnssecConfig.ValidationStatus)
 
-	return nil
+	return diags
 }
 
 func resourceDNSSECConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	log.Printf("[DEBUG] Deleting Route53 Resolver DNSSEC Config: %s", d.Id())
@@ -120,18 +124,18 @@ func resourceDNSSECConfigDelete(ctx context.Context, d *schema.ResourceData, met
 
 	if tfawserr.ErrCodeEquals(err, route53resolver.ErrCodeAccessDeniedException) {
 		// VPC doesn't exist.
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Route53 Resolver DNSSEC Config (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Route53 Resolver DNSSEC Config (%s): %s", d.Id(), err)
 	}
 
 	if _, err = waitDNSSECConfigDeleted(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("waiting for Route53 Resolver DNSSEC Config (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Route53 Resolver DNSSEC Config (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindResolverDNSSECConfigByID(ctx context.Context, conn *route53resolver.Route53Resolver, id string) (*route53resolver.ResolverDnssecConfig, error) {

--- a/internal/service/route53resolver/firewall_config.go
+++ b/internal/service/route53resolver/firewall_config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -51,6 +52,7 @@ func ResourceFirewallConfig() *schema.Resource {
 }
 
 func resourceFirewallConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	input := &route53resolver.UpdateFirewallConfigInput{
@@ -64,15 +66,16 @@ func resourceFirewallConfigCreate(ctx context.Context, d *schema.ResourceData, m
 	output, err := conn.UpdateFirewallConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Route53 Resolver Firewall Config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "creating Route53 Resolver Firewall Config: %s", err)
 	}
 
 	d.SetId(aws.StringValue(output.FirewallConfig.Id))
 
-	return resourceFirewallConfigRead(ctx, d, meta)
+	return append(diags, resourceFirewallConfigRead(ctx, d, meta)...)
 }
 
 func resourceFirewallConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	firewallConfig, err := FindFirewallConfigByID(ctx, conn, d.Id())
@@ -80,21 +83,22 @@ func resourceFirewallConfigRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Route53 Resolver Firewall Config (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Route53 Resolver Firewall Config (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Resolver Firewall Config (%s): %s", d.Id(), err)
 	}
 
 	d.Set("firewall_fail_open", firewallConfig.FirewallFailOpen)
 	d.Set(names.AttrOwnerID, firewallConfig.OwnerId)
 	d.Set(names.AttrResourceID, firewallConfig.ResourceId)
 
-	return nil
+	return diags
 }
 
 func resourceFirewallConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	input := &route53resolver.UpdateFirewallConfigInput{
@@ -108,13 +112,14 @@ func resourceFirewallConfigUpdate(ctx context.Context, d *schema.ResourceData, m
 	_, err := conn.UpdateFirewallConfigWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating Route53 Resolver Firewall Config: %s", err)
+		return sdkdiag.AppendErrorf(diags, "updating Route53 Resolver Firewall Config: %s", err)
 	}
 
-	return resourceFirewallConfigRead(ctx, d, meta)
+	return append(diags, resourceFirewallConfigRead(ctx, d, meta)...)
 }
 
 func resourceFirewallConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	log.Printf("[DEBUG] Deleting Route53 Resolver Firewall Config: %s", d.Id())
@@ -124,10 +129,10 @@ func resourceFirewallConfigDelete(ctx context.Context, d *schema.ResourceData, m
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting Route53 Resolver Firewall Config (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Route53 Resolver Firewall Config (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindFirewallConfigByID(ctx context.Context, conn *route53resolver.Route53Resolver, id string) (*route53resolver.FirewallConfig, error) {

--- a/internal/service/route53resolver/firewall_config_data_source.go
+++ b/internal/service/route53resolver/firewall_config_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -40,13 +41,14 @@ func DataSourceFirewallConfig() *schema.Resource {
 }
 
 func dataSourceFirewallConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	id := d.Get(names.AttrResourceID).(string)
 	firewallConfig, err := findFirewallConfigByResourceID(ctx, conn, id)
 
 	if err != nil {
-		return diag.Errorf("reading Route53 Resolver Firewall Config (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Resolver Firewall Config (%s): %s", id, err)
 	}
 
 	d.SetId(aws.StringValue(firewallConfig.Id))
@@ -54,7 +56,7 @@ func dataSourceFirewallConfigRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set(names.AttrOwnerID, firewallConfig.OwnerId)
 	d.Set(names.AttrResourceID, firewallConfig.ResourceId)
 
-	return nil
+	return diags
 }
 
 func findFirewallConfigByResourceID(ctx context.Context, conn *route53resolver.Route53Resolver, id string) (*route53resolver.FirewallConfig, error) {

--- a/internal/service/route53resolver/firewall_domain_list_data_source.go
+++ b/internal/service/route53resolver/firewall_domain_list_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -64,13 +65,14 @@ func DataSourceFirewallDomainList() *schema.Resource {
 }
 
 func dataSourceFirewallDomainListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	id := d.Get("firewall_domain_list_id").(string)
 	firewallDomainList, err := FindFirewallDomainListByID(ctx, conn, id)
 
 	if err != nil {
-		return diag.Errorf("reading Route53 Resolver Firewall Domain List (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Resolver Firewall Domain List (%s): %s", id, err)
 	}
 
 	d.SetId(aws.StringValue(firewallDomainList.Id))
@@ -85,5 +87,5 @@ func dataSourceFirewallDomainListRead(ctx context.Context, d *schema.ResourceDat
 	d.Set(names.AttrStatus, firewallDomainList.Status)
 	d.Set(names.AttrStatusMessage, firewallDomainList.StatusMessage)
 
-	return nil
+	return diags
 }

--- a/internal/service/route53resolver/firewall_rule.go
+++ b/internal/service/route53resolver/firewall_rule.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -86,6 +87,7 @@ func ResourceFirewallRule() *schema.Resource {
 }
 
 func resourceFirewallRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	firewallDomainListID := d.Get("firewall_domain_list_id").(string)
@@ -120,21 +122,22 @@ func resourceFirewallRuleCreate(ctx context.Context, d *schema.ResourceData, met
 	_, err := conn.CreateFirewallRuleWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Route53 Resolver Firewall Rule (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Route53 Resolver Firewall Rule (%s): %s", name, err)
 	}
 
 	d.SetId(ruleID)
 
-	return resourceFirewallRuleRead(ctx, d, meta)
+	return append(diags, resourceFirewallRuleRead(ctx, d, meta)...)
 }
 
 func resourceFirewallRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	firewallRuleGroupID, firewallDomainListID, err := FirewallRuleParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	firewallRule, err := FindFirewallRuleByTwoPartKey(ctx, conn, firewallRuleGroupID, firewallDomainListID)
@@ -142,11 +145,11 @@ func resourceFirewallRuleRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Route53 Resolver Firewall Rule (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Route53 Resolver Firewall Rule (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Resolver Firewall Rule (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrAction, firewallRule.Action)
@@ -159,16 +162,17 @@ func resourceFirewallRuleRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set(names.AttrName, firewallRule.Name)
 	d.Set(names.AttrPriority, firewallRule.Priority)
 
-	return nil
+	return diags
 }
 
 func resourceFirewallRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	firewallRuleGroupID, firewallDomainListID, err := FirewallRuleParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &route53resolver.UpdateFirewallRuleInput{
@@ -198,19 +202,20 @@ func resourceFirewallRuleUpdate(ctx context.Context, d *schema.ResourceData, met
 	_, err = conn.UpdateFirewallRuleWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating Route53 Resolver Firewall Rule (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Route53 Resolver Firewall Rule (%s): %s", d.Id(), err)
 	}
 
-	return resourceFirewallRuleRead(ctx, d, meta)
+	return append(diags, resourceFirewallRuleRead(ctx, d, meta)...)
 }
 
 func resourceFirewallRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	firewallRuleGroupID, firewallDomainListID, err := FirewallRuleParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	log.Printf("[DEBUG] Deleting Route53 Resolver Firewall Rule: %s", d.Id())
@@ -220,14 +225,14 @@ func resourceFirewallRuleDelete(ctx context.Context, d *schema.ResourceData, met
 	})
 
 	if tfawserr.ErrCodeEquals(err, route53resolver.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Route53 Resolver Firewall Rule (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Route53 Resolver Firewall Rule (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 const firewallRuleIDSeparator = ":"

--- a/internal/service/route53resolver/firewall_rule_group_association.go
+++ b/internal/service/route53resolver/firewall_rule_group_association.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -76,6 +77,7 @@ func ResourceFirewallRuleGroupAssociation() *schema.Resource {
 }
 
 func resourceFirewallRuleGroupAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -95,19 +97,20 @@ func resourceFirewallRuleGroupAssociationCreate(ctx context.Context, d *schema.R
 	output, err := conn.AssociateFirewallRuleGroupWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Route53 Resolver Firewall Rule Group Association (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Route53 Resolver Firewall Rule Group Association (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.FirewallRuleGroupAssociation.Id))
 
 	if _, err := waitFirewallRuleGroupAssociationCreated(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("waiting for Route53 Resolver Firewall Rule Group Association (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Route53 Resolver Firewall Rule Group Association (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceFirewallRuleGroupAssociationRead(ctx, d, meta)
+	return append(diags, resourceFirewallRuleGroupAssociationRead(ctx, d, meta)...)
 }
 
 func resourceFirewallRuleGroupAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	ruleGroupAssociation, err := FindFirewallRuleGroupAssociationByID(ctx, conn, d.Id())
@@ -115,11 +118,11 @@ func resourceFirewallRuleGroupAssociationRead(ctx context.Context, d *schema.Res
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Route53 Resolver Firewall Rule Group Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Route53 Resolver Firewall Rule Group Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Resolver Firewall Rule Group Association (%s): %s", d.Id(), err)
 	}
 
 	arn := aws.StringValue(ruleGroupAssociation.Arn)
@@ -130,10 +133,11 @@ func resourceFirewallRuleGroupAssociationRead(ctx context.Context, d *schema.Res
 	d.Set(names.AttrPriority, ruleGroupAssociation.Priority)
 	d.Set(names.AttrVPCID, ruleGroupAssociation.VpcId)
 
-	return nil
+	return diags
 }
 
 func resourceFirewallRuleGroupAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	if d.HasChanges(names.AttrName, "mutation_protection", names.AttrPriority) {
@@ -150,18 +154,19 @@ func resourceFirewallRuleGroupAssociationUpdate(ctx context.Context, d *schema.R
 		_, err := conn.UpdateFirewallRuleGroupAssociationWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Route53 Resolver Firewall Rule Group Association (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Route53 Resolver Firewall Rule Group Association (%s): %s", d.Id(), err)
 		}
 
 		if _, err := waitFirewallRuleGroupAssociationUpdated(ctx, conn, d.Id()); err != nil {
-			return diag.Errorf("waiting for Route53 Resolver Firewall Rule Group Association (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Route53 Resolver Firewall Rule Group Association (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceFirewallRuleGroupAssociationRead(ctx, d, meta)
+	return append(diags, resourceFirewallRuleGroupAssociationRead(ctx, d, meta)...)
 }
 
 func resourceFirewallRuleGroupAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	log.Printf("[DEBUG] Deleting Route53 Resolver Firewall Rule Group Association: %s", d.Id())
@@ -170,18 +175,18 @@ func resourceFirewallRuleGroupAssociationDelete(ctx context.Context, d *schema.R
 	})
 
 	if tfawserr.ErrCodeEquals(err, route53resolver.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Route53 Resolver Firewall Rule Group Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Route53 Resolver Firewall Rule Group Association (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitFirewallRuleGroupAssociationDeleted(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("waiting for Route53 Resolver Firewall Rule Group Association (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Route53 Resolver Firewall Rule Group Association (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindFirewallRuleGroupAssociationByID(ctx context.Context, conn *route53resolver.Route53Resolver, id string) (*route53resolver.FirewallRuleGroupAssociation, error) {

--- a/internal/service/route53resolver/firewall_rule_group_association_data_source.go
+++ b/internal/service/route53resolver/firewall_rule_group_association_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -76,13 +77,14 @@ func DataSourceFirewallRuleGroupAssociation() *schema.Resource {
 }
 
 func dataSourceRuleGroupAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	id := d.Get("firewall_rule_group_association_id").(string)
 	ruleGroupAssociation, err := FindFirewallRuleGroupAssociationByID(ctx, conn, id)
 
 	if err != nil {
-		return diag.Errorf("reading Route53 Resolver Firewall Rule Group Association (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Resolver Firewall Rule Group Association (%s): %s", id, err)
 	}
 
 	d.SetId(aws.StringValue(ruleGroupAssociation.Id))
@@ -100,5 +102,5 @@ func dataSourceRuleGroupAssociationRead(ctx context.Context, d *schema.ResourceD
 	d.Set(names.AttrStatusMessage, ruleGroupAssociation.StatusMessage)
 	d.Set(names.AttrVPCID, ruleGroupAssociation.VpcId)
 
-	return nil
+	return diags
 }

--- a/internal/service/route53resolver/firewall_rule_group_data_source.go
+++ b/internal/service/route53resolver/firewall_rule_group_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -68,13 +69,14 @@ func DataSourceFirewallRuleGroup() *schema.Resource {
 }
 
 func dataSourceFirewallRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	id := d.Get("firewall_rule_group_id").(string)
 	ruleGroup, err := FindFirewallRuleGroupByID(ctx, conn, id)
 
 	if err != nil {
-		return diag.Errorf("reading Route53 Resolver Firewall Rule Group (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "reading Route53 Resolver Firewall Rule Group (%s): %s", id, err)
 	}
 
 	d.SetId(aws.StringValue(ruleGroup.Id))
@@ -90,5 +92,5 @@ func dataSourceFirewallRuleGroupRead(ctx context.Context, d *schema.ResourceData
 	d.Set(names.AttrStatus, ruleGroup.Status)
 	d.Set(names.AttrStatusMessage, ruleGroup.StatusMessage)
 
-	return nil
+	return diags
 }

--- a/internal/service/route53resolver/rules_data_source.go
+++ b/internal/service/route53resolver/rules_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -61,6 +62,7 @@ func DataSourceRules() *schema.Resource {
 }
 
 func dataSourceRulesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).Route53ResolverConn(ctx)
 
 	input := &route53resolver.ListResolverRulesInput{}
@@ -91,12 +93,12 @@ func dataSourceRulesRead(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if err != nil {
-		return diag.Errorf("listing Route53 Resolver Rules: %s", err)
+		return sdkdiag.AppendErrorf(diags, "listing Route53 Resolver Rules: %s", err)
 	}
 
 	d.SetId(meta.(*conns.AWSClient).Region)
 
 	d.Set("resolver_rule_ids", aws.StringValueSlice(ruleIDs))
 
-	return nil
+	return diags
 }

--- a/internal/service/rum/app_monitor.go
+++ b/internal/service/rum/app_monitor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -149,6 +150,7 @@ func ResourceAppMonitor() *schema.Resource {
 }
 
 func resourceAppMonitorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RUMConn(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -170,15 +172,16 @@ func resourceAppMonitorCreate(ctx context.Context, d *schema.ResourceData, meta 
 	_, err := conn.CreateAppMonitorWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating CloudWatch RUM App Monitor (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating CloudWatch RUM App Monitor (%s): %s", name, err)
 	}
 
 	d.SetId(name)
 
-	return resourceAppMonitorRead(ctx, d, meta)
+	return append(diags, resourceAppMonitorRead(ctx, d, meta)...)
 }
 
 func resourceAppMonitorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RUMConn(ctx)
 
 	appMon, err := FindAppMonitorByName(ctx, conn, d.Id())
@@ -186,19 +189,19 @@ func resourceAppMonitorRead(ctx context.Context, d *schema.ResourceData, meta in
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] CloudWatch RUM App Monitor %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading CloudWatch RUM App Monitor (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading CloudWatch RUM App Monitor (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set("app_monitor_configuration", []interface{}{flattenAppMonitorConfiguration(appMon.AppMonitorConfiguration)}); err != nil {
-		return diag.Errorf("setting app_monitor_configuration: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting app_monitor_configuration: %s", err)
 	}
 
 	if err := d.Set("custom_events", []interface{}{flattenCustomEvents(appMon.CustomEvents)}); err != nil {
-		return diag.Errorf("setting custom_events: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting custom_events: %s", err)
 	}
 
 	d.Set("app_monitor_id", appMon.Id)
@@ -217,10 +220,11 @@ func resourceAppMonitorRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	setTagsOut(ctx, appMon.Tags)
 
-	return nil
+	return diags
 }
 
 func resourceAppMonitorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RUMConn(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
@@ -247,14 +251,15 @@ func resourceAppMonitorUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		_, err := conn.UpdateAppMonitorWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating CloudWatch RUM App Monitor (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating CloudWatch RUM App Monitor (%s): %s", d.Id(), err)
 		}
 	}
 
-	return resourceAppMonitorRead(ctx, d, meta)
+	return append(diags, resourceAppMonitorRead(ctx, d, meta)...)
 }
 
 func resourceAppMonitorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RUMConn(ctx)
 
 	log.Printf("[DEBUG] Deleting CloudWatch RUM App Monitor: %s", d.Id())
@@ -263,14 +268,14 @@ func resourceAppMonitorDelete(ctx context.Context, d *schema.ResourceData, meta 
 	})
 
 	if tfawserr.ErrCodeEquals(err, cloudwatchrum.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting CloudWatch RUM App Monitor (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting CloudWatch RUM App Monitor (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindAppMonitorByName(ctx context.Context, conn *cloudwatchrum.CloudWatchRUM, name string) (*cloudwatchrum.AppMonitor, error) {

--- a/internal/service/rum/metrics_destination.go
+++ b/internal/service/rum/metrics_destination.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -57,6 +58,7 @@ func ResourceMetricsDestination() *schema.Resource {
 }
 
 func resourceMetricsDestinationPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RUMConn(ctx)
 
 	name := d.Get("app_monitor_name").(string)
@@ -76,17 +78,18 @@ func resourceMetricsDestinationPut(ctx context.Context, d *schema.ResourceData, 
 	_, err := conn.PutRumMetricsDestinationWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("putting CloudWatch RUM Metrics Destination (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "putting CloudWatch RUM Metrics Destination (%s): %s", name, err)
 	}
 
 	if d.IsNewResource() {
 		d.SetId(name)
 	}
 
-	return resourceMetricsDestinationRead(ctx, d, meta)
+	return append(diags, resourceMetricsDestinationRead(ctx, d, meta)...)
 }
 
 func resourceMetricsDestinationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RUMConn(ctx)
 
 	dest, err := FindMetricsDestinationByName(ctx, conn, d.Id())
@@ -94,11 +97,11 @@ func resourceMetricsDestinationRead(ctx context.Context, d *schema.ResourceData,
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] CloudWatch RUM Metrics Destination %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading CloudWatch RUM Metrics Destination (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading CloudWatch RUM Metrics Destination (%s): %s", d.Id(), err)
 	}
 
 	d.Set("app_monitor_name", d.Id())
@@ -106,10 +109,11 @@ func resourceMetricsDestinationRead(ctx context.Context, d *schema.ResourceData,
 	d.Set(names.AttrDestinationARN, dest.DestinationArn)
 	d.Set(names.AttrIAMRoleARN, dest.IamRoleArn)
 
-	return nil
+	return diags
 }
 
 func resourceMetricsDestinationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RUMConn(ctx)
 
 	input := &cloudwatchrum.DeleteRumMetricsDestinationInput{
@@ -125,14 +129,14 @@ func resourceMetricsDestinationDelete(ctx context.Context, d *schema.ResourceDat
 	_, err := conn.DeleteRumMetricsDestinationWithContext(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, cloudwatchrum.ErrCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting CloudWatch RUM Metrics Destination (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting CloudWatch RUM Metrics Destination (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindMetricsDestinationByName(ctx context.Context, conn *cloudwatchrum.CloudWatchRUM, name string) (*cloudwatchrum.MetricDestinationSummary, error) {

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -835,7 +835,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented):
 		d.Set(names.AttrPolicy, nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) policy: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) policy: %s", d.Id(), err)
 	}
 
 	//
@@ -859,7 +859,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented):
 		d.Set("grant", nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) ACL: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) ACL: %s", d.Id(), err)
 	}
 
 	//
@@ -883,7 +883,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeNoSuchCORSConfiguration, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented):
 		d.Set("cors_rule", nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) CORS configuration: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) CORS configuration: %s", d.Id(), err)
 	}
 
 	//
@@ -911,7 +911,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented):
 		d.Set("website", nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) website configuration: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) website configuration: %s", d.Id(), err)
 	}
 
 	//
@@ -935,7 +935,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented):
 		d.Set("versioning", nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) versioning: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) versioning: %s", d.Id(), err)
 	}
 
 	//
@@ -957,7 +957,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented, errCodeUnsupportedArgument, errCodeUnsupportedOperation):
 		d.Set("acceleration_status", nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) accelerate configuration: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) accelerate configuration: %s", d.Id(), err)
 	}
 
 	//
@@ -979,7 +979,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented):
 		d.Set("request_payer", nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) request payment configuration: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) request payment configuration: %s", d.Id(), err)
 	}
 
 	//
@@ -1003,7 +1003,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented):
 		d.Set("logging", nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) logging: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) logging: %s", d.Id(), err)
 	}
 
 	//
@@ -1027,7 +1027,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented):
 		d.Set("lifecycle_rule", nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) lifecycle configuration: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) lifecycle configuration: %s", d.Id(), err)
 	}
 
 	//
@@ -1051,7 +1051,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented):
 		d.Set("replication_configuration", nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) replication configuration: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) replication configuration: %s", d.Id(), err)
 	}
 
 	//
@@ -1075,7 +1075,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	case tfresource.NotFound(err), tfawserr.ErrCodeEquals(err, errCodeMethodNotAllowed, errCodeNotImplemented, errCodeXNotImplemented, errCodeUnsupportedOperation):
 		d.Set("server_side_encryption_configuration", nil)
 	default:
-		return diag.Errorf("reading S3 Bucket (%s) server-side encryption configuration: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) server-side encryption configuration: %s", d.Id(), err)
 	}
 
 	//
@@ -1102,7 +1102,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 		d.Set("object_lock_enabled", nil)
 	default:
 		if partition := meta.(*conns.AWSClient).Partition; partition == names.StandardPartitionID || partition == names.USGovCloudPartitionID {
-			return diag.Errorf("reading S3 Bucket (%s) object lock configuration: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) object lock configuration: %s", d.Id(), err)
 		}
 		log.Printf("[WARN] Unable to read S3 Bucket (%s) Object Lock Configuration: %s", d.Id(), err)
 		d.Set("object_lock_configuration", nil)
@@ -1566,7 +1566,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 
 			if n, err := emptyBucket(ctx, conn, d.Id(), objectLockEnabled); err != nil {
-				return diag.Errorf("emptying S3 Bucket (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "emptying S3 Bucket (%s): %s", d.Id(), err)
 			} else {
 				log.Printf("[DEBUG] Deleted %d S3 objects", n)
 			}

--- a/internal/service/s3/bucket_analytics_configuration.go
+++ b/internal/service/s3/bucket_analytics_configuration.go
@@ -164,7 +164,7 @@ func resourceBucketAnalyticsConfigurationPut(ctx context.Context, d *schema.Reso
 	}
 
 	if err != nil {
-		return diag.Errorf("creating S3 Bucket (%s) Analytics Configuration (%s): %s", bucket, name, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Bucket (%s) Analytics Configuration (%s): %s", bucket, name, err)
 	}
 
 	if d.IsNewResource() {
@@ -196,11 +196,11 @@ func resourceBucketAnalyticsConfigurationRead(ctx context.Context, d *schema.Res
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket Analytics Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Bucket Analytics Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Analytics Configuration (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrBucket, bucket)
@@ -246,7 +246,7 @@ func resourceBucketAnalyticsConfigurationDelete(ctx context.Context, d *schema.R
 		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Analytics Configuration (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func BucketAnalyticsConfigurationParseID(id string) (string, string, error) {

--- a/internal/service/s3/bucket_cors_configuration.go
+++ b/internal/service/s3/bucket_cors_configuration.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -90,6 +91,7 @@ func resourceBucketCorsConfiguration() *schema.Resource {
 }
 
 func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket := d.Get(names.AttrBucket).(string)
@@ -113,7 +115,7 @@ func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.Resour
 	}
 
 	if err != nil {
-		return diag.Errorf("creating S3 Bucket (%s) CORS Configuration: %s", bucket, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Bucket (%s) CORS Configuration: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -123,18 +125,19 @@ func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.Resour
 	})
 
 	if err != nil {
-		return diag.Errorf("waiting for S3 Bucket CORS Configuration (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket CORS Configuration (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceBucketCorsConfigurationRead(ctx, d, meta)
+	return append(diags, resourceBucketCorsConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceBucketCorsConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	corsRules, err := findCORSRules(ctx, conn, bucket, expectedBucketOwner)
@@ -142,28 +145,29 @@ func resourceBucketCorsConfigurationRead(ctx context.Context, d *schema.Resource
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket CORS Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Bucket CORS Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket CORS Configuration (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrBucket, bucket)
 	if err := d.Set("cors_rule", flattenCORSRules(corsRules)); err != nil {
-		return diag.Errorf("setting cors_rule: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting cors_rule: %s", err)
 	}
 	d.Set(names.AttrExpectedBucketOwner, expectedBucketOwner)
 
-	return nil
+	return diags
 }
 
 func resourceBucketCorsConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &s3.PutBucketCorsInput{
@@ -179,18 +183,19 @@ func resourceBucketCorsConfigurationUpdate(ctx context.Context, d *schema.Resour
 	_, err = conn.PutBucketCors(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating S3 Bucket CORS Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating S3 Bucket CORS Configuration (%s): %s", d.Id(), err)
 	}
 
-	return resourceBucketCorsConfigurationRead(ctx, d, meta)
+	return append(diags, resourceBucketCorsConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceBucketCorsConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &s3.DeleteBucketCorsInput{
@@ -203,11 +208,11 @@ func resourceBucketCorsConfigurationDelete(ctx context.Context, d *schema.Resour
 	_, err = conn.DeleteBucketCors(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket, errCodeNoSuchCORSConfiguration) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting S3 Bucket CORS Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket CORS Configuration (%s): %s", d.Id(), err)
 	}
 
 	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
@@ -215,10 +220,10 @@ func resourceBucketCorsConfigurationDelete(ctx context.Context, d *schema.Resour
 	})
 
 	if err != nil {
-		return diag.Errorf("waiting for S3 Bucket CORS Configuration (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket CORS Configuration (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findCORSRules(ctx context.Context, conn *s3.Client, bucket, expectedBucketOwner string) ([]types.CORSRule, error) {

--- a/internal/service/s3/bucket_inventory.go
+++ b/internal/service/s3/bucket_inventory.go
@@ -225,7 +225,7 @@ func resourceBucketInventoryPut(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err != nil {
-		return diag.Errorf("creating S3 Bucket (%s) Inventory: %s", bucket, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Bucket (%s) Inventory: %s", bucket, err)
 	}
 
 	if d.IsNewResource() {
@@ -257,11 +257,11 @@ func resourceBucketInventoryRead(ctx context.Context, d *schema.ResourceData, me
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket Inventory (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Bucket Inventory (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Inventory (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrBucket, bucket)

--- a/internal/service/s3/bucket_logging.go
+++ b/internal/service/s3/bucket_logging.go
@@ -182,10 +182,10 @@ func resourceBucketLoggingCreate(ctx context.Context, d *schema.ResourceData, me
 	})
 
 	if err != nil {
-		return diag.Errorf("waiting for S3 Bucket Logging (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Logging (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceBucketLoggingRead(ctx, d, meta)
+	return append(diags, resourceBucketLoggingRead(ctx, d, meta)...)
 }
 
 func resourceBucketLoggingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -263,7 +263,7 @@ func resourceBucketLoggingUpdate(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "updating S3 Bucket Logging (%s): %s", d.Id(), err)
 	}
 
-	return resourceBucketLoggingRead(ctx, d, meta)
+	return append(diags, resourceBucketLoggingRead(ctx, d, meta)...)
 }
 
 func resourceBucketLoggingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -286,7 +286,7 @@ func resourceBucketLoggingDelete(ctx context.Context, d *schema.ResourceData, me
 	_, err = conn.PutBucketLogging(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
@@ -295,7 +295,7 @@ func resourceBucketLoggingDelete(ctx context.Context, d *schema.ResourceData, me
 
 	// Don't wait for the logging to disappear as it still exists after update.
 
-	return nil
+	return diags
 }
 
 func findLoggingEnabled(ctx context.Context, conn *s3.Client, bucketName, expectedBucketOwner string) (*types.LoggingEnabled, error) {

--- a/internal/service/s3/bucket_metric.go
+++ b/internal/service/s3/bucket_metric.go
@@ -142,11 +142,11 @@ func resourceBucketMetricRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket Metric (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Bucket Metric (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Metric (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrBucket, bucket)

--- a/internal/service/s3/bucket_notification.go
+++ b/internal/service/s3/bucket_notification.go
@@ -313,7 +313,7 @@ func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if err != nil {
-		return diag.Errorf("creating S3 Bucket (%s) Notification: %s", bucket, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Bucket (%s) Notification: %s", bucket, err)
 	}
 
 	if d.IsNewResource() {
@@ -324,7 +324,7 @@ func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, 
 		})
 
 		if err != nil {
-			return diag.Errorf("waiting for S3 Bucket Notification (%s) create: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Notification (%s) create: %s", d.Id(), err)
 		}
 	}
 
@@ -375,11 +375,11 @@ func resourceBucketNotificationDelete(ctx context.Context, d *schema.ResourceDat
 	_, err := conn.PutBucketNotificationConfiguration(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting S3 Bucket Notification (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Notification (%s): %s", d.Id(), err)
 	}
 
 	// Don't wait for the notification configuration to disappear as it still exists after update.

--- a/internal/service/s3/bucket_object_lock_configuration.go
+++ b/internal/service/s3/bucket_object_lock_configuration.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -98,6 +99,7 @@ func resourceBucketObjectLockConfiguration() *schema.Resource {
 }
 
 func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket := d.Get(names.AttrBucket).(string)
@@ -132,7 +134,7 @@ func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.
 	}
 
 	if err != nil {
-		return diag.Errorf("creating S3 Bucket (%s) Object Lock Configuration: %s", bucket, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Bucket (%s) Object Lock Configuration: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -142,18 +144,19 @@ func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.
 	})
 
 	if err != nil {
-		return diag.Errorf("waiting for S3 Bucket Object Lock Configuration (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Object Lock Configuration (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceBucketObjectLockConfigurationRead(ctx, d, meta)
+	return append(diags, resourceBucketObjectLockConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceBucketObjectLockConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	objLockConfig, err := findObjectLockConfiguration(ctx, conn, bucket, expectedBucketOwner)
@@ -161,29 +164,30 @@ func resourceBucketObjectLockConfigurationRead(ctx context.Context, d *schema.Re
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket Object Lock Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Bucket Object Lock Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Object Lock Configuration (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrBucket, bucket)
 	d.Set(names.AttrExpectedBucketOwner, expectedBucketOwner)
 	d.Set("object_lock_enabled", objLockConfig.ObjectLockEnabled)
 	if err := d.Set(names.AttrRule, flattenObjectLockRule(objLockConfig.Rule)); err != nil {
-		return diag.Errorf("setting rule: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceBucketObjectLockConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &s3.PutObjectLockConfigurationInput{
@@ -210,18 +214,19 @@ func resourceBucketObjectLockConfigurationUpdate(ctx context.Context, d *schema.
 	_, err = conn.PutObjectLockConfiguration(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating S3 Bucket Object Lock Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating S3 Bucket Object Lock Configuration (%s): %s", d.Id(), err)
 	}
 
-	return resourceBucketObjectLockConfigurationRead(ctx, d, meta)
+	return append(diags, resourceBucketObjectLockConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceBucketObjectLockConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &s3.PutObjectLockConfigurationInput{
@@ -243,16 +248,16 @@ func resourceBucketObjectLockConfigurationDelete(ctx context.Context, d *schema.
 	_, err = conn.PutObjectLockConfiguration(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket, errCodeObjectLockConfigurationNotFoundError) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting S3 Bucket Object Lock Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Object Lock Configuration (%s): %s", d.Id(), err)
 	}
 
 	// Don't wait for the object lock configuration to disappear as may still exist.
 
-	return nil
+	return diags
 }
 
 func findObjectLockConfiguration(ctx context.Context, conn *s3.Client, bucket, expectedBucketOwner string) (*types.ObjectLockConfiguration, error) {

--- a/internal/service/s3/bucket_policy.go
+++ b/internal/service/s3/bucket_policy.go
@@ -112,7 +112,7 @@ func resourceBucketPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Bucket Policy (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Policy (%s): %s", d.Id(), err)
 	}
 
 	policy, err = verify.PolicyToSet(d.Get(names.AttrPolicy).(string), policy)

--- a/internal/service/s3/bucket_policy_data_source.go
+++ b/internal/service/s3/bucket_policy_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -32,23 +33,23 @@ func dataSourceBucketPolicy() *schema.Resource {
 }
 
 func dataSourceBucketPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	name := d.Get(names.AttrBucket).(string)
-
 	policy, err := findBucketPolicy(ctx, conn, name)
 
 	if err != nil {
-		return diag.Errorf("reading S3 Bucket (%s) Policy: %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) Policy: %s", name, err)
 	}
 
 	policy, err = structure.NormalizeJsonString(policy)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	d.SetId(name)
 	d.Set(names.AttrPolicy, policy)
 
-	return nil
+	return diags
 }

--- a/internal/service/s3/bucket_server_side_encryption_configuration.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -82,6 +83,7 @@ func resourceBucketServerSideEncryptionConfiguration() *schema.Resource {
 }
 
 func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket := d.Get(names.AttrBucket).(string)
@@ -105,7 +107,7 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 	}
 
 	if err != nil {
-		return diag.Errorf("creating S3 Bucket (%s) Server-side Encryption Configuration: %s", bucket, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Bucket (%s) Server-side Encryption Configuration: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -115,18 +117,19 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 	})
 
 	if err != nil {
-		return diag.Errorf("waiting for S3 Bucket Server-side Encryption Configuration (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Server-side Encryption Configuration (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceBucketServerSideEncryptionConfigurationRead(ctx, d, meta)
+	return append(diags, resourceBucketServerSideEncryptionConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	sse, err := findServerSideEncryptionConfiguration(ctx, conn, bucket, expectedBucketOwner)
@@ -134,28 +137,29 @@ func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket Server-side Encryption Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Bucket Server-side Encryption Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Server-side Encryption Configuration (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrBucket, bucket)
 	d.Set(names.AttrExpectedBucketOwner, expectedBucketOwner)
 	if err := d.Set(names.AttrRule, flattenServerSideEncryptionRules(sse.Rules)); err != nil {
-		return diag.Errorf("setting rule: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &s3.PutBucketEncryptionInput{
@@ -173,18 +177,19 @@ func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, 
 	}, errCodeNoSuchBucket, errCodeOperationAborted)
 
 	if err != nil {
-		return diag.Errorf("updating S3 Bucket Server-side Encryption Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating S3 Bucket Server-side Encryption Configuration (%s): %s", d.Id(), err)
 	}
 
-	return resourceBucketServerSideEncryptionConfigurationRead(ctx, d, meta)
+	return append(diags, resourceBucketServerSideEncryptionConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceBucketServerSideEncryptionConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &s3.DeleteBucketEncryptionInput{
@@ -197,16 +202,16 @@ func resourceBucketServerSideEncryptionConfigurationDelete(ctx context.Context, 
 	_, err = conn.DeleteBucketEncryption(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket, errCodeServerSideEncryptionConfigurationNotFound) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting S3 Bucket Server-side Encryption Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Server-side Encryption Configuration (%s): %s", d.Id(), err)
 	}
 
 	// Don't wait for the SSE configuration to disappear as the bucket now always has one.
 
-	return nil
+	return diags
 }
 
 func findServerSideEncryptionConfiguration(ctx context.Context, conn *s3.Client, bucketName, expectedBucketOwner string) (*types.ServerSideEncryptionConfiguration, error) {

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -180,6 +181,7 @@ func resourceBucketWebsiteConfiguration() *schema.Resource {
 }
 
 func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	websiteConfig := &types.WebsiteConfiguration{}
@@ -203,7 +205,7 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 	if v, ok := d.GetOk("routing_rules"); ok {
 		var unmarshalledRules []types.RoutingRule
 		if err := json.Unmarshal([]byte(v.(string)), &unmarshalledRules); err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 		websiteConfig.RoutingRules = unmarshalledRules
 	}
@@ -227,7 +229,7 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 	}
 
 	if err != nil {
-		return diag.Errorf("creating S3 Bucket (%s) Website Configuration: %s", bucket, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Bucket (%s) Website Configuration: %s", bucket, err)
 	}
 
 	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
@@ -237,18 +239,19 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 	})
 
 	if err != nil {
-		return diag.Errorf("waiting for S3 Bucket Website Configuration (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Website Configuration (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceBucketWebsiteConfigurationRead(ctx, d, meta)
+	return append(diags, resourceBucketWebsiteConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	output, err := findBucketWebsite(ctx, conn, bucket, expectedBucketOwner)
@@ -256,31 +259,31 @@ func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.Resou
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Bucket Website Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Bucket Website Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Website Configuration (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrBucket, bucket)
 	if err := d.Set("error_document", flattenErrorDocument(output.ErrorDocument)); err != nil {
-		return diag.Errorf("setting error_document: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting error_document: %s", err)
 	}
 	d.Set(names.AttrExpectedBucketOwner, expectedBucketOwner)
 	if err := d.Set("index_document", flattenIndexDocument(output.IndexDocument)); err != nil {
-		return diag.Errorf("setting index_document: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting index_document: %s", err)
 	}
 	if err := d.Set("redirect_all_requests_to", flattenRedirectAllRequestsTo(output.RedirectAllRequestsTo)); err != nil {
-		return diag.Errorf("setting redirect_all_requests_to: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting redirect_all_requests_to: %s", err)
 	}
 	if err := d.Set("routing_rule", flattenRoutingRules(output.RoutingRules)); err != nil {
-		return diag.Errorf("setting routing_rule: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting routing_rule: %s", err)
 	}
 	if output.RoutingRules != nil {
 		rr, err := normalizeRoutingRules(output.RoutingRules)
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 		d.Set("routing_rules", rr)
 	} else {
@@ -288,22 +291,23 @@ func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.Resou
 	}
 
 	if output, err := findBucketLocation(ctx, conn, bucket, expectedBucketOwner); err != nil {
-		return diag.Errorf("reading S3 Bucket (%s) Location: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket (%s) Location: %s", d.Id(), err)
 	} else {
 		endpoint, domain := bucketWebsiteEndpointAndDomain(bucket, string(output.LocationConstraint))
 		d.Set("website_domain", domain)
 		d.Set("website_endpoint", endpoint)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	websiteConfig := &types.WebsiteConfiguration{}
@@ -326,7 +330,7 @@ func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.Res
 		} else {
 			var unmarshalledRules []types.RoutingRule
 			if err := json.Unmarshal([]byte(d.Get("routing_rules").(string)), &unmarshalledRules); err != nil {
-				return diag.FromErr(err)
+				return sdkdiag.AppendFromErr(diags, err)
 			}
 			websiteConfig.RoutingRules = unmarshalledRules
 		}
@@ -339,7 +343,7 @@ func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.Res
 		if v, ok := d.GetOk("routing_rules"); ok {
 			var unmarshalledRules []types.RoutingRule
 			if err := json.Unmarshal([]byte(v.(string)), &unmarshalledRules); err != nil {
-				return diag.FromErr(err)
+				return sdkdiag.AppendFromErr(diags, err)
 			}
 			websiteConfig.RoutingRules = unmarshalledRules
 		}
@@ -356,18 +360,19 @@ func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.Res
 	_, err = conn.PutBucketWebsite(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating S3 Bucket Website Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating S3 Bucket Website Configuration (%s): %s", d.Id(), err)
 	}
 
-	return resourceBucketWebsiteConfigurationRead(ctx, d, meta)
+	return append(diags, resourceBucketWebsiteConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceBucketWebsiteConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &s3.DeleteBucketWebsiteInput{
@@ -380,11 +385,11 @@ func resourceBucketWebsiteConfigurationDelete(ctx context.Context, d *schema.Res
 	_, err = conn.DeleteBucketWebsite(ctx, input)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket, errCodeNoSuchWebsiteConfiguration) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting S3 Bucket Website Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Website Configuration (%s): %s", d.Id(), err)
 	}
 
 	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
@@ -392,10 +397,10 @@ func resourceBucketWebsiteConfigurationDelete(ctx context.Context, d *schema.Res
 	})
 
 	if err != nil {
-		return diag.Errorf("waiting for S3 Bucket Website Configuration (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Website Configuration (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findBucketWebsite(ctx context.Context, conn *s3.Client, bucket, expectedBucketOwner string) (*s3.GetBucketWebsiteOutput, error) {

--- a/internal/service/s3control/access_point.go
+++ b/internal/service/s3control/access_point.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -158,6 +159,7 @@ func resourceAccessPoint() *schema.Resource {
 }
 
 func resourceAccessPointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID := meta.(*conns.AWSClient).AccountID
@@ -186,17 +188,17 @@ func resourceAccessPointCreate(ctx context.Context, d *schema.ResourceData, meta
 	output, err := conn.CreateAccessPoint(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating S3 Access Point (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Access Point (%s): %s", name, err)
 	}
 
 	resourceID, err := AccessPointCreateResourceID(aws.ToString(output.AccessPointArn))
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	accountID, name, err = AccessPointParseResourceID(resourceID)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	d.SetId(resourceID)
@@ -204,7 +206,7 @@ func resourceAccessPointCreate(ctx context.Context, d *schema.ResourceData, meta
 	if v, ok := d.GetOk(names.AttrPolicy); ok && v.(string) != "" && v.(string) != "{}" {
 		policy, err := structure.NormalizeJsonString(v.(string))
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		input := &s3control.PutAccessPointPolicyInput{
@@ -216,19 +218,20 @@ func resourceAccessPointCreate(ctx context.Context, d *schema.ResourceData, meta
 		_, err = conn.PutAccessPointPolicy(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("creating S3 Access Point (%s) policy: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "creating S3 Access Point (%s) policy: %s", d.Id(), err)
 		}
 	}
 
-	return resourceAccessPointRead(ctx, d, meta)
+	return append(diags, resourceAccessPointRead(ctx, d, meta)...)
 }
 
 func resourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, name, err := AccessPointParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	output, err := findAccessPointByTwoPartKey(ctx, conn, accountID, name)
@@ -236,11 +239,11 @@ func resourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta i
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Access Point (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Access Point (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Access Point (%s): %s", d.Id(), err)
 	}
 
 	s3OnOutposts := arn.IsARN(name)
@@ -248,7 +251,7 @@ func resourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta i
 	if s3OnOutposts {
 		accessPointARN, err := arn.Parse(name)
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		// https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3onoutposts.html#amazons3onoutposts-resources-for-iam-policies.
@@ -290,14 +293,14 @@ func resourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("network_origin", output.NetworkOrigin)
 	if output.PublicAccessBlockConfiguration != nil {
 		if err := d.Set("public_access_block_configuration", []interface{}{flattenPublicAccessBlockConfiguration(output.PublicAccessBlockConfiguration)}); err != nil {
-			return diag.Errorf("setting public_access_block_configuration: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting public_access_block_configuration: %s", err)
 		}
 	} else {
 		d.Set("public_access_block_configuration", nil)
 	}
 	if output.VpcConfiguration != nil {
 		if err := d.Set(names.AttrVPCConfiguration, []interface{}{flattenVPCConfiguration(output.VpcConfiguration)}); err != nil {
-			return diag.Errorf("setting vpc_configuration: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting vpc_configuration: %s", err)
 		}
 	} else {
 		d.Set(names.AttrVPCConfiguration, nil)
@@ -314,7 +317,7 @@ func resourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta i
 
 		policyToSet, err := verify.PolicyToSet(d.Get(names.AttrPolicy).(string), policy)
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		d.Set(names.AttrPolicy, policyToSet)
@@ -322,25 +325,26 @@ func resourceAccessPointRead(ctx context.Context, d *schema.ResourceData, meta i
 		d.Set("has_public_access_policy", false)
 		d.Set(names.AttrPolicy, nil)
 	} else {
-		return diag.Errorf("reading S3 Access Point (%s) policy: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Access Point (%s) policy: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceAccessPointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, name, err := AccessPointParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	if d.HasChange(names.AttrPolicy) {
 		if v, ok := d.GetOk(names.AttrPolicy); ok && v.(string) != "" && v.(string) != "{}" {
 			policy, err := structure.NormalizeJsonString(v.(string))
 			if err != nil {
-				return diag.FromErr(err)
+				return sdkdiag.AppendFromErr(diags, err)
 			}
 
 			input := &s3control.PutAccessPointPolicyInput{
@@ -352,7 +356,7 @@ func resourceAccessPointUpdate(ctx context.Context, d *schema.ResourceData, meta
 			_, err = conn.PutAccessPointPolicy(ctx, input)
 
 			if err != nil {
-				return diag.Errorf("updating S3 Access Point (%s) policy: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "updating S3 Access Point (%s) policy: %s", d.Id(), err)
 			}
 		} else {
 			input := &s3control.DeleteAccessPointPolicyInput{
@@ -363,20 +367,21 @@ func resourceAccessPointUpdate(ctx context.Context, d *schema.ResourceData, meta
 			_, err := conn.DeleteAccessPointPolicy(ctx, input)
 
 			if err != nil {
-				return diag.Errorf("deleting S3 Access Point (%s) policy: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "deleting S3 Access Point (%s) policy: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourceAccessPointRead(ctx, d, meta)
+	return append(diags, resourceAccessPointRead(ctx, d, meta)...)
 }
 
 func resourceAccessPointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, name, err := AccessPointParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	log.Printf("[DEBUG] Deleting S3 Access Point: %s", d.Id())
@@ -386,14 +391,14 @@ func resourceAccessPointDelete(ctx context.Context, d *schema.ResourceData, meta
 	})
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchAccessPoint) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting S3 Access Point (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 Access Point (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findAccessPointByTwoPartKey(ctx context.Context, conn *s3control.Client, accountID, name string) (*s3control.GetAccessPointOutput, error) {
@@ -456,7 +461,7 @@ func AccessPointParseResourceID(id string) (string, string, error) {
 		return v.AccountID, id, nil
 	}
 
-	parts := strings.Split(id, multiRegionAccessPointResourceIDSeparator)
+	parts := strings.Split(id, accessPointResourceIDSeparator)
 
 	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
 		return parts[0], parts[1], nil

--- a/internal/service/s3control/account_public_access_block_data_source.go
+++ b/internal/service/s3control/account_public_access_block_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -45,6 +46,7 @@ func dataSourceAccountPublicAccessBlock() *schema.Resource {
 }
 
 func dataSourceAccountPublicAccessBlockRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID := meta.(*conns.AWSClient).AccountID
@@ -55,7 +57,7 @@ func dataSourceAccountPublicAccessBlockRead(ctx context.Context, d *schema.Resou
 	output, err := findPublicAccessBlockByAccountID(ctx, conn, accountID)
 
 	if err != nil {
-		return diag.Errorf("reading S3 Account Public Access Block (%s): %s", accountID, err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Account Public Access Block (%s): %s", accountID, err)
 	}
 
 	d.SetId(accountID)
@@ -64,5 +66,5 @@ func dataSourceAccountPublicAccessBlockRead(ctx context.Context, d *schema.Resou
 	d.Set("ignore_public_acls", output.IgnorePublicAcls)
 	d.Set("restrict_public_buckets", output.RestrictPublicBuckets)
 
-	return nil
+	return diags
 }

--- a/internal/service/s3control/bucket.go
+++ b/internal/service/s3control/bucket.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -84,6 +85,7 @@ func resourceBucket() *schema.Resource {
 }
 
 func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	bucket := d.Get(names.AttrBucket).(string)
@@ -95,34 +97,35 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	output, err := conn.CreateBucket(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating S3 Control Bucket (%s): %s", bucket, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Control Bucket (%s): %s", bucket, err)
 	}
 
 	d.SetId(aws.ToString(output.BucketArn))
 
 	if tags := keyValueTagsS3(ctx, getTagsInS3(ctx)); len(tags) > 0 {
 		if err := bucketUpdateTags(ctx, conn, d.Id(), nil, tags); err != nil {
-			return diag.Errorf("adding S3 Control Bucket (%s) tags: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "adding S3 Control Bucket (%s) tags: %s", d.Id(), err)
 		}
 	}
 
-	return resourceBucketRead(ctx, d, meta)
+	return append(diags, resourceBucketRead(ctx, d, meta)...)
 }
 
 func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	parsedArn, err := arn.Parse(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	// ARN resource format: outpost/<outpost-id>/bucket/<my-bucket-name>
 	arnResourceParts := strings.Split(parsedArn.Resource, "/")
 
 	if parsedArn.AccountID == "" || len(arnResourceParts) != 4 {
-		return diag.Errorf("parsing S3 Control Bucket ARN (%s): unknown format", d.Id())
+		return sdkdiag.AppendErrorf(diags, "parsing S3 Control Bucket ARN (%s): unknown format", d.Id())
 	}
 
 	output, err := findBucketByTwoPartKey(ctx, conn, parsedArn.AccountID, d.Id())
@@ -130,11 +133,11 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Control Bucket (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Control Bucket (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Control Bucket (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, d.Id())
@@ -148,35 +151,37 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	tags, err := bucketListTags(ctx, conn, d.Id())
 
 	if err != nil {
-		return diag.Errorf("listing tags for S3 Control Bucket (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for S3 Control Bucket (%s): %s", d.Id(), err)
 	}
 
 	setTagsOutS3(ctx, tagsS3(tags))
 
-	return nil
+	return diags
 }
 
 func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	if d.HasChange(names.AttrTagsAll) {
 		o, n := d.GetChange(names.AttrTagsAll)
 
 		if err := bucketUpdateTags(ctx, conn, d.Id(), o, n); err != nil {
-			return diag.Errorf("updating S3 Control Bucket (%s) tags: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating S3 Control Bucket (%s) tags: %s", d.Id(), err)
 		}
 	}
 
-	return resourceBucketRead(ctx, d, meta)
+	return append(diags, resourceBucketRead(ctx, d, meta)...)
 }
 
 func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	parsedArn, err := arn.Parse(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &s3control.DeleteBucketInput{
@@ -193,14 +198,14 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}, errCodeInvalidBucketState)
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket, errCodeNoSuchOutpost) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting S3 Control Bucket (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 Control Bucket (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findBucketByTwoPartKey(ctx context.Context, conn *s3control.Client, accountID, bucket string) (*s3control.GetBucketOutput, error) {

--- a/internal/service/s3control/multi_region_access_point_data_source.go
+++ b/internal/service/s3control/multi_region_access_point_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -102,6 +103,7 @@ func dataSourceMultiRegionAccessPoint() *schema.Resource {
 }
 
 func dataSourceMultiRegionAccessPointBlockRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID := meta.(*conns.AWSClient).AccountID
@@ -113,7 +115,7 @@ func dataSourceMultiRegionAccessPointBlockRead(ctx context.Context, d *schema.Re
 	accessPoint, err := findMultiRegionAccessPointByTwoPartKey(ctx, conn, accountID, name)
 
 	if err != nil {
-		return diag.Errorf("reading S3 Multi Region Access Point (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Multi Region Access Point (%s): %s", name, err)
 	}
 
 	d.SetId(MultiRegionAccessPointCreateResourceID(accountID, name))
@@ -136,5 +138,5 @@ func dataSourceMultiRegionAccessPointBlockRead(ctx context.Context, d *schema.Re
 	d.Set("regions", flattenRegionReports(accessPoint.Regions))
 	d.Set(names.AttrStatus, accessPoint.Status)
 
-	return nil
+	return diags
 }

--- a/internal/service/s3control/multi_region_access_point_policy.go
+++ b/internal/service/s3control/multi_region_access_point_policy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -88,6 +89,7 @@ func resourceMultiRegionAccessPointPolicy() *schema.Resource {
 }
 
 func resourceMultiRegionAccessPointPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID := meta.(*conns.AWSClient).AccountID
@@ -110,24 +112,25 @@ func resourceMultiRegionAccessPointPolicyCreate(ctx context.Context, d *schema.R
 	})
 
 	if err != nil {
-		return diag.Errorf("creating S3 Multi-Region Access Point (%s) Policy: %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Multi-Region Access Point (%s) Policy: %s", id, err)
 	}
 
 	d.SetId(id)
 
 	if _, err := waitMultiRegionAccessPointRequestSucceeded(ctx, conn, accountID, aws.ToString(output.RequestTokenARN), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return diag.Errorf("waiting for S3 Multi-Region Access Point Policy (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Multi-Region Access Point Policy (%s) create: %s", d.Id(), err)
 	}
 
-	return resourceMultiRegionAccessPointPolicyRead(ctx, d, meta)
+	return append(diags, resourceMultiRegionAccessPointPolicyRead(ctx, d, meta)...)
 }
 
 func resourceMultiRegionAccessPointPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, name, err := MultiRegionAccessPointParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	policyDocument, err := findMultiRegionAccessPointPolicyDocumentByTwoPartKey(ctx, conn, accountID, name)
@@ -135,11 +138,11 @@ func resourceMultiRegionAccessPointPolicyRead(ctx context.Context, d *schema.Res
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Multi-Region Access Point Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Multi-Region Access Point Policy (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Multi-Region Access Point Policy (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrAccountID, accountID)
@@ -150,7 +153,7 @@ func resourceMultiRegionAccessPointPolicyRead(ctx context.Context, d *schema.Res
 		}
 
 		if err := d.Set("details", []interface{}{flattenMultiRegionAccessPointPolicyDocument(name, policyDocument, oldDetails)}); err != nil {
-			return diag.Errorf("setting details: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting details: %s", err)
 		}
 	} else {
 		d.Set("details", nil)
@@ -166,15 +169,16 @@ func resourceMultiRegionAccessPointPolicyRead(ctx context.Context, d *schema.Res
 		d.Set("proposed", nil)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceMultiRegionAccessPointPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, _, err := MultiRegionAccessPointParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &s3control.PutMultiRegionAccessPointPolicyInput{
@@ -191,14 +195,14 @@ func resourceMultiRegionAccessPointPolicyUpdate(ctx context.Context, d *schema.R
 	})
 
 	if err != nil {
-		return diag.Errorf("updating S3 Multi-Region Access Point Policy (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating S3 Multi-Region Access Point Policy (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitMultiRegionAccessPointRequestSucceeded(ctx, conn, accountID, aws.ToString(output.RequestTokenARN), d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return diag.Errorf("waiting for S3 Multi-Region Access Point Policy (%s) update: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Multi-Region Access Point Policy (%s) update: %s", d.Id(), err)
 	}
 
-	return resourceMultiRegionAccessPointPolicyRead(ctx, d, meta)
+	return append(diags, resourceMultiRegionAccessPointPolicyRead(ctx, d, meta)...)
 }
 
 func findMultiRegionAccessPointPolicyDocumentByTwoPartKey(ctx context.Context, conn *s3control.Client, accountID, name string) (*types.MultiRegionAccessPointPolicyDocument, error) {

--- a/internal/service/s3control/object_lambda_access_point.go
+++ b/internal/service/s3control/object_lambda_access_point.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -133,6 +134,7 @@ func resourceObjectLambdaAccessPoint() *schema.Resource {
 }
 
 func resourceObjectLambdaAccessPointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID := meta.(*conns.AWSClient).AccountID
@@ -153,20 +155,21 @@ func resourceObjectLambdaAccessPointCreate(ctx context.Context, d *schema.Resour
 	_, err := conn.CreateAccessPointForObjectLambda(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating S3 Object Lambda Access Point (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Object Lambda Access Point (%s): %s", id, err)
 	}
 
 	d.SetId(id)
 
-	return resourceObjectLambdaAccessPointRead(ctx, d, meta)
+	return append(diags, resourceObjectLambdaAccessPointRead(ctx, d, meta)...)
 }
 
 func resourceObjectLambdaAccessPointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, name, err := ObjectLambdaAccessPointParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	outputConfiguration, err := findObjectLambdaAccessPointConfigurationByTwoPartKey(ctx, conn, accountID, name)
@@ -174,11 +177,11 @@ func resourceObjectLambdaAccessPointRead(ctx context.Context, d *schema.Resource
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Object Lambda Access Point (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Object Lambda Access Point (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Object Lambda Access Point (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrAccountID, accountID)
@@ -192,27 +195,28 @@ func resourceObjectLambdaAccessPointRead(ctx context.Context, d *schema.Resource
 	}.String()
 	d.Set(names.AttrARN, arn)
 	if err := d.Set(names.AttrConfiguration, []interface{}{flattenObjectLambdaConfiguration(outputConfiguration)}); err != nil {
-		return diag.Errorf("setting configuration: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting configuration: %s", err)
 	}
 	d.Set(names.AttrName, name)
 
 	outputAlias, err := findObjectLambdaAccessPointAliasByTwoPartKey(ctx, conn, accountID, name)
 
 	if err != nil {
-		return diag.Errorf("reading S3 Object Lambda Access Point (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Object Lambda Access Point (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrAlias, outputAlias.Value)
 
-	return nil
+	return diags
 }
 
 func resourceObjectLambdaAccessPointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, name, err := ObjectLambdaAccessPointParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &s3control.PutAccessPointConfigurationForObjectLambdaInput{
@@ -227,18 +231,19 @@ func resourceObjectLambdaAccessPointUpdate(ctx context.Context, d *schema.Resour
 	_, err = conn.PutAccessPointConfigurationForObjectLambda(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating S3 Object Lambda Access Point (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating S3 Object Lambda Access Point (%s): %s", d.Id(), err)
 	}
 
-	return resourceObjectLambdaAccessPointRead(ctx, d, meta)
+	return append(diags, resourceObjectLambdaAccessPointRead(ctx, d, meta)...)
 }
 
 func resourceObjectLambdaAccessPointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, name, err := ObjectLambdaAccessPointParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	log.Printf("[DEBUG] Deleting S3 Object Lambda Access Point: %s", d.Id())
@@ -248,14 +253,14 @@ func resourceObjectLambdaAccessPointDelete(ctx context.Context, d *schema.Resour
 	})
 
 	if tfawserr.ErrCodeEquals(err, errCodeNoSuchAccessPoint) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting S3 Object Lambda Access Point (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 Object Lambda Access Point (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findObjectLambdaAccessPointConfigurationByTwoPartKey(ctx context.Context, conn *s3control.Client, accountID, name string) (*types.ObjectLambdaConfiguration, error) {

--- a/internal/service/s3control/storage_lens_configuration.go
+++ b/internal/service/s3control/storage_lens_configuration.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -394,6 +395,7 @@ func resourceStorageLensConfiguration() *schema.Resource {
 }
 
 func resourceStorageLensConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID := meta.(*conns.AWSClient).AccountID
@@ -416,20 +418,21 @@ func resourceStorageLensConfigurationCreate(ctx context.Context, d *schema.Resou
 	_, err := conn.PutStorageLensConfiguration(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating S3 Storage Lens Configuration (%s): %s", id, err)
+		return sdkdiag.AppendErrorf(diags, "creating S3 Storage Lens Configuration (%s): %s", id, err)
 	}
 
 	d.SetId(id)
 
-	return resourceStorageLensConfigurationRead(ctx, d, meta)
+	return append(diags, resourceStorageLensConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceStorageLensConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, configID, err := StorageLensConfigurationParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	output, err := findStorageLensConfigurationByAccountIDAndConfigID(ctx, conn, accountID, configID)
@@ -437,37 +440,38 @@ func resourceStorageLensConfigurationRead(ctx context.Context, d *schema.Resourc
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Storage Lens Configuration (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading S3 Storage Lens Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Storage Lens Configuration (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrAccountID, accountID)
 	d.Set(names.AttrARN, output.StorageLensArn)
 	d.Set("config_id", configID)
 	if err := d.Set("storage_lens_configuration", []interface{}{flattenStorageLensConfiguration(output)}); err != nil {
-		return diag.Errorf("setting storage_lens_configuration: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting storage_lens_configuration: %s", err)
 	}
 
 	tags, err := storageLensConfigurationListTags(ctx, conn, accountID, configID)
 
 	if err != nil {
-		return diag.Errorf("listing tags for S3 Storage Lens Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for S3 Storage Lens Configuration (%s): %s", d.Id(), err)
 	}
 
 	setTagsOutS3(ctx, tagsS3(tags))
 
-	return nil
+	return diags
 }
 
 func resourceStorageLensConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, configID, err := StorageLensConfigurationParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
@@ -484,7 +488,7 @@ func resourceStorageLensConfigurationUpdate(ctx context.Context, d *schema.Resou
 		_, err := conn.PutStorageLensConfiguration(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating S3 Storage Lens Configuration (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating S3 Storage Lens Configuration (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -492,19 +496,20 @@ func resourceStorageLensConfigurationUpdate(ctx context.Context, d *schema.Resou
 		o, n := d.GetChange(names.AttrTagsAll)
 
 		if err := storageLensConfigurationUpdateTags(ctx, conn, accountID, configID, o, n); err != nil {
-			return diag.Errorf("updating S3 Storage Lens Configuration (%s) tags: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating S3 Storage Lens Configuration (%s) tags: %s", d.Id(), err)
 		}
 	}
 
-	return resourceStorageLensConfigurationRead(ctx, d, meta)
+	return append(diags, resourceStorageLensConfigurationRead(ctx, d, meta)...)
 }
 
 func resourceStorageLensConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
 	accountID, configID, err := StorageLensConfigurationParseResourceID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	log.Printf("[DEBUG] Deleting S3 Storage Lens Configuration: %s", d.Id())
@@ -514,14 +519,14 @@ func resourceStorageLensConfigurationDelete(ctx context.Context, d *schema.Resou
 	})
 
 	if tfawserr.ErrHTTPStatusCodeEquals(err, http.StatusNotFound) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting S3 Storage Lens Configuration (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 Storage Lens Configuration (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 const storageLensConfigurationResourceIDSeparator = ":"

--- a/internal/service/scheduler/schedule.go
+++ b/internal/service/scheduler/schedule.go
@@ -432,6 +432,7 @@ const (
 )
 
 func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SchedulerClient(ctx)
 
 	name := create.Name(d.Get(names.AttrName).(string), d.Get(names.AttrNamePrefix).(string))
@@ -484,11 +485,11 @@ func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionCreating, ResNameSchedule, name, err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionCreating, ResNameSchedule, name, err)
 	}
 
 	if out == nil || out.ScheduleArn == nil {
-		return create.DiagError(names.Scheduler, create.ErrActionCreating, ResNameSchedule, name, errors.New("empty output"))
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionCreating, ResNameSchedule, name, errors.New("empty output"))
 	}
 
 	// When the schedule is created without specifying a group, it is assigned
@@ -501,21 +502,22 @@ func resourceScheduleCreate(ctx context.Context, d *schema.ResourceData, meta in
 	id, err := ResourceScheduleIDFromARN(aws.ToString(out.ScheduleArn))
 
 	if err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionCreating, ResNameSchedule, name, fmt.Errorf("invalid resource id: %w", err))
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionCreating, ResNameSchedule, name, fmt.Errorf("invalid resource id: %w", err))
 	}
 
 	d.SetId(id)
 
-	return resourceScheduleRead(ctx, d, meta)
+	return append(diags, resourceScheduleRead(ctx, d, meta)...)
 }
 
 func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { // nosemgrep:ci.scheduler-in-func-name
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SchedulerClient(ctx)
 
 	groupName, scheduleName, err := ResourceScheduleParseID(d.Id())
 
 	if err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionReading, ResNameSchedule, d.Id(), fmt.Errorf("invalid resource id: %w", err))
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionReading, ResNameSchedule, d.Id(), fmt.Errorf("invalid resource id: %w", err))
 	}
 
 	out, err := findScheduleByTwoPartKey(ctx, conn, groupName, scheduleName)
@@ -523,11 +525,11 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] EventBridge Scheduler Schedule (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionReading, ResNameSchedule, d.Id(), err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionReading, ResNameSchedule, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
@@ -540,7 +542,7 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := d.Set("flexible_time_window", []interface{}{flattenFlexibleTimeWindow(out.FlexibleTimeWindow)}); err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionSetting, ResNameSchedule, d.Id(), err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionSetting, ResNameSchedule, d.Id(), err)
 	}
 
 	d.Set(names.AttrGroupName, out.GroupName)
@@ -559,13 +561,14 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set(names.AttrState, string(out.State))
 
 	if err := d.Set(names.AttrTarget, []interface{}{flattenTarget(ctx, out.Target)}); err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionSetting, ResNameSchedule, d.Id(), err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionSetting, ResNameSchedule, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SchedulerClient(ctx)
 
 	in := &scheduler.UpdateScheduleInput{
@@ -609,19 +612,20 @@ func resourceScheduleUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionUpdating, ResNameSchedule, d.Id(), err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionUpdating, ResNameSchedule, d.Id(), err)
 	}
 
-	return resourceScheduleRead(ctx, d, meta)
+	return append(diags, resourceScheduleRead(ctx, d, meta)...)
 }
 
 func resourceScheduleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SchedulerClient(ctx)
 
 	groupName, scheduleName, err := ResourceScheduleParseID(d.Id())
 
 	if err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionDeleting, ResNameSchedule, d.Id(), fmt.Errorf("invalid resource id: %w", err))
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionDeleting, ResNameSchedule, d.Id(), fmt.Errorf("invalid resource id: %w", err))
 	}
 
 	log.Printf("[INFO] Deleting EventBridge Scheduler Schedule %s", d.Id())
@@ -634,13 +638,13 @@ func resourceScheduleDelete(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.Scheduler, create.ErrActionDeleting, ResNameSchedule, d.Id(), err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionDeleting, ResNameSchedule, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findScheduleByTwoPartKey(ctx context.Context, conn *scheduler.Client, groupName, scheduleName string) (*scheduler.GetScheduleOutput, error) {

--- a/internal/service/scheduler/schedule_group.go
+++ b/internal/service/scheduler/schedule_group.go
@@ -95,6 +95,7 @@ const (
 )
 
 func resourceScheduleGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SchedulerClient(ctx)
 
 	name := create.Name(d.Get(names.AttrName).(string), d.Get(names.AttrNamePrefix).(string))
@@ -106,23 +107,24 @@ func resourceScheduleGroupCreate(ctx context.Context, d *schema.ResourceData, me
 
 	out, err := conn.CreateScheduleGroup(ctx, in)
 	if err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionCreating, ResNameScheduleGroup, name, err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionCreating, ResNameScheduleGroup, name, err)
 	}
 
 	if out == nil || out.ScheduleGroupArn == nil {
-		return create.DiagError(names.Scheduler, create.ErrActionCreating, ResNameScheduleGroup, name, errors.New("empty output"))
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionCreating, ResNameScheduleGroup, name, errors.New("empty output"))
 	}
 
 	d.SetId(name)
 
 	if _, err := waitScheduleGroupActive(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionWaitingForCreation, ResNameScheduleGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionWaitingForCreation, ResNameScheduleGroup, d.Id(), err)
 	}
 
-	return resourceScheduleGroupRead(ctx, d, meta)
+	return append(diags, resourceScheduleGroupRead(ctx, d, meta)...)
 }
 
 func resourceScheduleGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SchedulerClient(ctx)
 
 	out, err := findScheduleGroupByName(ctx, conn, d.Id())
@@ -130,11 +132,11 @@ func resourceScheduleGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] EventBridge Scheduler Schedule Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionReading, ResNameScheduleGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionReading, ResNameScheduleGroup, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.Arn)
@@ -144,7 +146,7 @@ func resourceScheduleGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(names.AttrNamePrefix, create.NamePrefixFromName(aws.ToString(out.Name)))
 	d.Set(names.AttrState, out.State)
 
-	return nil
+	return diags
 }
 
 func resourceScheduleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -153,6 +155,7 @@ func resourceScheduleGroupUpdate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceScheduleGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SchedulerClient(ctx)
 
 	log.Printf("[INFO] Deleting EventBridge Scheduler ScheduleGroup %s", d.Id())
@@ -164,15 +167,15 @@ func resourceScheduleGroupDelete(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.Scheduler, create.ErrActionDeleting, ResNameScheduleGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionDeleting, ResNameScheduleGroup, d.Id(), err)
 	}
 
 	if _, err := waitScheduleGroupDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.DiagError(names.Scheduler, create.ErrActionWaitingForDeletion, ResNameScheduleGroup, d.Id(), err)
+		return create.AppendDiagError(diags, names.Scheduler, create.ErrActionWaitingForDeletion, ResNameScheduleGroup, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/securityhub/insight.go
+++ b/internal/service/securityhub/insight.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -34,121 +35,124 @@ func resourceInsight() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: map[string]*schema.Schema{
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"filters": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrAWSAccountID:                        stringFilterSchema(),
-						"company_name":                                stringFilterSchema(),
-						"compliance_status":                           stringFilterSchema(),
-						"confidence":                                  numberFilterSchema(),
-						names.AttrCreatedAt:                           dateFilterSchema(),
-						"criticality":                                 numberFilterSchema(),
-						names.AttrDescription:                         stringFilterSchema(),
-						"finding_provider_fields_confidence":          numberFilterSchema(),
-						"finding_provider_fields_criticality":         numberFilterSchema(),
-						"finding_provider_fields_related_findings_id": stringFilterSchema(),
-						"finding_provider_fields_related_findings_product_arn": stringFilterSchema(),
-						"finding_provider_fields_severity_label":               stringFilterSchema(),
-						"finding_provider_fields_severity_original":            stringFilterSchema(),
-						"finding_provider_fields_types":                        stringFilterSchema(),
-						"first_observed_at":                                    dateFilterSchema(),
-						"generator_id":                                         stringFilterSchema(),
-						names.AttrID:                                           stringFilterSchema(),
-						"keyword":                                              keywordFilterSchema(),
-						"last_observed_at":                                     dateFilterSchema(),
-						"malware_name":                                         stringFilterSchema(),
-						"malware_path":                                         stringFilterSchema(),
-						"malware_state":                                        stringFilterSchema(),
-						"malware_type":                                         stringFilterSchema(),
-						"network_destination_domain":                           stringFilterSchema(),
-						"network_destination_ipv4":                             ipFilterSchema(),
-						"network_destination_ipv6":                             ipFilterSchema(),
-						"network_destination_port":                             numberFilterSchema(),
-						"network_direction":                                    stringFilterSchema(),
-						"network_protocol":                                     stringFilterSchema(),
-						"network_source_domain":                                stringFilterSchema(),
-						"network_source_ipv4":                                  ipFilterSchema(),
-						"network_source_ipv6":                                  ipFilterSchema(),
-						"network_source_mac":                                   stringFilterSchema(),
-						"network_source_port":                                  numberFilterSchema(),
-						"note_text":                                            stringFilterSchema(),
-						"note_updated_at":                                      dateFilterSchema(),
-						"note_updated_by":                                      stringFilterSchema(),
-						"process_launched_at":                                  dateFilterSchema(),
-						"process_name":                                         stringFilterSchema(),
-						"process_parent_pid":                                   numberFilterSchema(),
-						"process_path":                                         stringFilterSchema(),
-						"process_pid":                                          numberFilterSchema(),
-						"process_terminated_at":                                dateFilterSchema(),
-						"product_arn":                                          stringFilterSchema(),
-						"product_fields":                                       mapFilterSchema(),
-						"product_name":                                         stringFilterSchema(),
-						"recommendation_text":                                  stringFilterSchema(),
-						"record_state":                                         stringFilterSchema(),
-						"related_findings_id":                                  stringFilterSchema(),
-						"related_findings_product_arn":                         stringFilterSchema(),
-						"resource_aws_ec2_instance_iam_instance_profile_arn": stringFilterSchema(),
-						"resource_aws_ec2_instance_image_id":                 stringFilterSchema(),
-						"resource_aws_ec2_instance_ipv4_addresses":           ipFilterSchema(),
-						"resource_aws_ec2_instance_ipv6_addresses":           ipFilterSchema(),
-						"resource_aws_ec2_instance_key_name":                 stringFilterSchema(),
-						"resource_aws_ec2_instance_launched_at":              dateFilterSchema(),
-						"resource_aws_ec2_instance_subnet_id":                stringFilterSchema(),
-						"resource_aws_ec2_instance_type":                     stringFilterSchema(),
-						"resource_aws_ec2_instance_vpc_id":                   stringFilterSchema(),
-						"resource_aws_iam_access_key_created_at":             dateFilterSchema(),
-						"resource_aws_iam_access_key_status":                 stringFilterSchema(),
-						"resource_aws_iam_access_key_user_name":              stringFilterSchema(),
-						"resource_aws_s3_bucket_owner_id":                    stringFilterSchema(),
-						"resource_aws_s3_bucket_owner_name":                  stringFilterSchema(),
-						"resource_container_image_id":                        stringFilterSchema(),
-						"resource_container_image_name":                      stringFilterSchema(),
-						"resource_container_launched_at":                     dateFilterSchema(),
-						"resource_container_name":                            stringFilterSchema(),
-						"resource_details_other":                             mapFilterSchema(),
-						names.AttrResourceID:                                 stringFilterSchema(),
-						"resource_partition":                                 stringFilterSchema(),
-						"resource_region":                                    stringFilterSchema(),
-						names.AttrResourceTags:                               mapFilterSchema(),
-						names.AttrResourceType:                               stringFilterSchema(),
-						"severity_label":                                     stringFilterSchema(),
-						"source_url":                                         stringFilterSchema(),
-						"threat_intel_indicator_category":                    stringFilterSchema(),
-						"threat_intel_indicator_last_observed_at":            dateFilterSchema(),
-						"threat_intel_indicator_source":                      stringFilterSchema(),
-						"threat_intel_indicator_source_url":                  stringFilterSchema(),
-						"threat_intel_indicator_type":                        stringFilterSchema(),
-						"threat_intel_indicator_value":                       stringFilterSchema(),
-						"title":                                              stringFilterSchema(),
-						names.AttrType:                                       stringFilterSchema(),
-						"updated_at":                                         dateFilterSchema(),
-						"user_defined_values":                                mapFilterSchema(),
-						"verification_state":                                 stringFilterSchema(),
-						"workflow_status":                                    workflowStatusSchema(),
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				names.AttrARN: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"filters": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							names.AttrAWSAccountID:                        stringFilterSchema(),
+							"company_name":                                stringFilterSchema(),
+							"compliance_status":                           stringFilterSchema(),
+							"confidence":                                  numberFilterSchema(),
+							names.AttrCreatedAt:                           dateFilterSchema(),
+							"criticality":                                 numberFilterSchema(),
+							names.AttrDescription:                         stringFilterSchema(),
+							"finding_provider_fields_confidence":          numberFilterSchema(),
+							"finding_provider_fields_criticality":         numberFilterSchema(),
+							"finding_provider_fields_related_findings_id": stringFilterSchema(),
+							"finding_provider_fields_related_findings_product_arn": stringFilterSchema(),
+							"finding_provider_fields_severity_label":               stringFilterSchema(),
+							"finding_provider_fields_severity_original":            stringFilterSchema(),
+							"finding_provider_fields_types":                        stringFilterSchema(),
+							"first_observed_at":                                    dateFilterSchema(),
+							"generator_id":                                         stringFilterSchema(),
+							names.AttrID:                                           stringFilterSchema(),
+							"keyword":                                              keywordFilterSchema(),
+							"last_observed_at":                                     dateFilterSchema(),
+							"malware_name":                                         stringFilterSchema(),
+							"malware_path":                                         stringFilterSchema(),
+							"malware_state":                                        stringFilterSchema(),
+							"malware_type":                                         stringFilterSchema(),
+							"network_destination_domain":                           stringFilterSchema(),
+							"network_destination_ipv4":                             ipFilterSchema(),
+							"network_destination_ipv6":                             ipFilterSchema(),
+							"network_destination_port":                             numberFilterSchema(),
+							"network_direction":                                    stringFilterSchema(),
+							"network_protocol":                                     stringFilterSchema(),
+							"network_source_domain":                                stringFilterSchema(),
+							"network_source_ipv4":                                  ipFilterSchema(),
+							"network_source_ipv6":                                  ipFilterSchema(),
+							"network_source_mac":                                   stringFilterSchema(),
+							"network_source_port":                                  numberFilterSchema(),
+							"note_text":                                            stringFilterSchema(),
+							"note_updated_at":                                      dateFilterSchema(),
+							"note_updated_by":                                      stringFilterSchema(),
+							"process_launched_at":                                  dateFilterSchema(),
+							"process_name":                                         stringFilterSchema(),
+							"process_parent_pid":                                   numberFilterSchema(),
+							"process_path":                                         stringFilterSchema(),
+							"process_pid":                                          numberFilterSchema(),
+							"process_terminated_at":                                dateFilterSchema(),
+							"product_arn":                                          stringFilterSchema(),
+							"product_fields":                                       mapFilterSchema(),
+							"product_name":                                         stringFilterSchema(),
+							"recommendation_text":                                  stringFilterSchema(),
+							"record_state":                                         stringFilterSchema(),
+							"related_findings_id":                                  stringFilterSchema(),
+							"related_findings_product_arn":                         stringFilterSchema(),
+							"resource_aws_ec2_instance_iam_instance_profile_arn": stringFilterSchema(),
+							"resource_aws_ec2_instance_image_id":                 stringFilterSchema(),
+							"resource_aws_ec2_instance_ipv4_addresses":           ipFilterSchema(),
+							"resource_aws_ec2_instance_ipv6_addresses":           ipFilterSchema(),
+							"resource_aws_ec2_instance_key_name":                 stringFilterSchema(),
+							"resource_aws_ec2_instance_launched_at":              dateFilterSchema(),
+							"resource_aws_ec2_instance_subnet_id":                stringFilterSchema(),
+							"resource_aws_ec2_instance_type":                     stringFilterSchema(),
+							"resource_aws_ec2_instance_vpc_id":                   stringFilterSchema(),
+							"resource_aws_iam_access_key_created_at":             dateFilterSchema(),
+							"resource_aws_iam_access_key_status":                 stringFilterSchema(),
+							"resource_aws_iam_access_key_user_name":              stringFilterSchema(),
+							"resource_aws_s3_bucket_owner_id":                    stringFilterSchema(),
+							"resource_aws_s3_bucket_owner_name":                  stringFilterSchema(),
+							"resource_container_image_id":                        stringFilterSchema(),
+							"resource_container_image_name":                      stringFilterSchema(),
+							"resource_container_launched_at":                     dateFilterSchema(),
+							"resource_container_name":                            stringFilterSchema(),
+							"resource_details_other":                             mapFilterSchema(),
+							names.AttrResourceID:                                 stringFilterSchema(),
+							"resource_partition":                                 stringFilterSchema(),
+							"resource_region":                                    stringFilterSchema(),
+							names.AttrResourceTags:                               mapFilterSchema(),
+							names.AttrResourceType:                               stringFilterSchema(),
+							"severity_label":                                     stringFilterSchema(),
+							"source_url":                                         stringFilterSchema(),
+							"threat_intel_indicator_category":                    stringFilterSchema(),
+							"threat_intel_indicator_last_observed_at":            dateFilterSchema(),
+							"threat_intel_indicator_source":                      stringFilterSchema(),
+							"threat_intel_indicator_source_url":                  stringFilterSchema(),
+							"threat_intel_indicator_type":                        stringFilterSchema(),
+							"threat_intel_indicator_value":                       stringFilterSchema(),
+							"title":                                              stringFilterSchema(),
+							names.AttrType:                                       stringFilterSchema(),
+							"updated_at":                                         dateFilterSchema(),
+							"user_defined_values":                                mapFilterSchema(),
+							"verification_state":                                 stringFilterSchema(),
+							"workflow_status":                                    workflowStatusSchema(),
+						},
 					},
 				},
-			},
-			"group_by_attribute": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			names.AttrName: {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+				"group_by_attribute": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				names.AttrName: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			}
 		},
 	}
 }
 
 func resourceInsightCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SecurityHubClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -164,15 +168,16 @@ func resourceInsightCreate(ctx context.Context, d *schema.ResourceData, meta int
 	output, err := conn.CreateInsight(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Security Hub Insight (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Security Hub Insight (%s): %s", name, err)
 	}
 
 	d.SetId(aws.ToString(output.InsightArn))
 
-	return resourceInsightRead(ctx, d, meta)
+	return append(diags, resourceInsightRead(ctx, d, meta)...)
 }
 
 func resourceInsightRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SecurityHubClient(ctx)
 
 	insight, err := findInsightByARN(ctx, conn, d.Id())
@@ -180,24 +185,25 @@ func resourceInsightRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Security Hub Insight (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Security Hub Insight (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Security Hub Insight (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, insight.InsightArn)
 	if err := d.Set("filters", flattenSecurityFindingFilters(insight.Filters)); err != nil {
-		return diag.Errorf("setting filters: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting filters: %s", err)
 	}
 	d.Set("group_by_attribute", insight.GroupByAttribute)
 	d.Set(names.AttrName, insight.Name)
 
-	return nil
+	return diags
 }
 
 func resourceInsightUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SecurityHubClient(ctx)
 
 	input := &securityhub.UpdateInsightInput{
@@ -219,13 +225,14 @@ func resourceInsightUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	_, err := conn.UpdateInsight(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating Security Hub Insight (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Security Hub Insight (%s): %s", d.Id(), err)
 	}
 
-	return resourceInsightRead(ctx, d, meta)
+	return append(diags, resourceInsightRead(ctx, d, meta)...)
 }
 
 func resourceInsightDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SecurityHubClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Security Hub Insight: %s", d.Id())
@@ -234,14 +241,14 @@ func resourceInsightDelete(ctx context.Context, d *schema.ResourceData, meta int
 	})
 
 	if tfawserr.ErrCodeEquals(err, errCodeResourceNotFoundException) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Security Hub Insight (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Security Hub Insight (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func findInsightByARN(ctx context.Context, conn *securityhub.Client, arn string) (*types.Insight, error) {

--- a/internal/service/securityhub/invite_accepter.go
+++ b/internal/service/securityhub/invite_accepter.go
@@ -84,11 +84,11 @@ func resourceInviteAccepterRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Security Hub Master Account (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Security Hub Master Account (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Security Hub Master Account (%s): %s", d.Id(), err)
 	}
 
 	d.Set("invitation_id", master.InvitationId)

--- a/internal/service/securityhub/organization_admin_account.go
+++ b/internal/service/securityhub/organization_admin_account.go
@@ -83,7 +83,7 @@ func resourceOrganizationAdminAccountRead(ctx context.Context, d *schema.Resourc
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Security Hub Organization Admin Account (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/securityhub/product_subscription.go
+++ b/internal/service/securityhub/product_subscription.go
@@ -89,7 +89,7 @@ func resourceProductSubscriptionRead(ctx context.Context, d *schema.ResourceData
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Security Hub Product Subscription (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/securityhub/standards_control.go
+++ b/internal/service/securityhub/standards_control.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -85,6 +86,7 @@ func resourceStandardsControl() *schema.Resource {
 }
 
 func resourceStandardsControlPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SecurityHubClient(ctx)
 
 	standardsControlARN := d.Get("standards_control_arn").(string)
@@ -97,22 +99,23 @@ func resourceStandardsControlPut(ctx context.Context, d *schema.ResourceData, me
 	_, err := conn.UpdateStandardsControl(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("updating Security Hub Standards Control (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating Security Hub Standards Control (%s): %s", d.Id(), err)
 	}
 
 	if d.IsNewResource() {
 		d.SetId(standardsControlARN)
 	}
 
-	return resourceStandardsControlRead(ctx, d, meta)
+	return append(diags, resourceStandardsControlRead(ctx, d, meta)...)
 }
 
 func resourceStandardsControlRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SecurityHubClient(ctx)
 
 	standardsSubscriptionARN, err := standardsControlARNToStandardsSubscriptionARN(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	control, err := findStandardsControlByTwoPartKey(ctx, conn, standardsSubscriptionARN, d.Id())
@@ -120,11 +123,11 @@ func resourceStandardsControlRead(ctx context.Context, d *schema.ResourceData, m
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Security Hub Standards Control (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Security Hub Standards Control (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Security Hub Standards Control (%s): %s", d.Id(), err)
 	}
 
 	d.Set("control_id", control.ControlId)
@@ -138,7 +141,7 @@ func resourceStandardsControlRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("standards_control_arn", control.StandardsControlArn)
 	d.Set("title", control.Title)
 
-	return nil
+	return diags
 }
 
 // standardsControlARNToStandardsSubscriptionARN converts a security standard control ARN to a subscription ARN.

--- a/internal/service/servicecatalog/provisioning_artifacts_data_source.go
+++ b/internal/service/servicecatalog/provisioning_artifacts_data_source.go
@@ -97,7 +97,7 @@ func dataSourceProvisioningArtifactsRead(ctx context.Context, d *schema.Resource
 		return sdkdiag.AppendErrorf(diags, "setting provisioning_artifact_details: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func flattenProvisioningArtifactDetails(apiObjects []*servicecatalog.ProvisioningArtifactDetail) []interface{} {

--- a/internal/service/servicediscovery/http_namespace.go
+++ b/internal/service/servicediscovery/http_namespace.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -63,6 +64,7 @@ func ResourceHTTPNamespace() *schema.Resource {
 }
 
 func resourceHTTPNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -80,27 +82,28 @@ func resourceHTTPNamespaceCreate(ctx context.Context, d *schema.ResourceData, me
 	output, err := conn.CreateHttpNamespaceWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Service Discovery HTTP Namespace (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Service Discovery HTTP Namespace (%s): %s", name, err)
 	}
 
 	operation, err := WaitOperationSuccess(ctx, conn, aws.StringValue(output.OperationId))
 
 	if err != nil {
-		return diag.Errorf("waiting for Service Discovery HTTP Namespace (%s) create: %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Service Discovery HTTP Namespace (%s) create: %s", name, err)
 	}
 
 	namespaceID, ok := operation.Targets[servicediscovery.OperationTargetTypeNamespace]
 
 	if !ok {
-		return diag.Errorf("creating Service Discovery HTTP Namespace (%s): operation response missing Namespace ID", name)
+		return sdkdiag.AppendErrorf(diags, "creating Service Discovery HTTP Namespace (%s): operation response missing Namespace ID", name)
 	}
 
 	d.SetId(aws.StringValue(namespaceID))
 
-	return resourceHTTPNamespaceRead(ctx, d, meta)
+	return append(diags, resourceHTTPNamespaceRead(ctx, d, meta)...)
 }
 
 func resourceHTTPNamespaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	ns, err := FindNamespaceByID(ctx, conn, d.Id())
@@ -108,11 +111,11 @@ func resourceHTTPNamespaceRead(ctx context.Context, d *schema.ResourceData, meta
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Service Discovery HTTP Namespace %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Service Discovery HTTP Namespace (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Service Discovery HTTP Namespace (%s): %s", d.Id(), err)
 	}
 
 	arn := aws.StringValue(ns.Arn)
@@ -125,7 +128,7 @@ func resourceHTTPNamespaceRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 	d.Set(names.AttrName, ns.Name)
 
-	return nil
+	return diags
 }
 
 func resourceHTTPNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -134,6 +137,7 @@ func resourceHTTPNamespaceUpdate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceHTTPNamespaceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	log.Printf("[INFO] Deleting Service Discovery HTTP Namespace: %s", d.Id())
@@ -144,18 +148,18 @@ func resourceHTTPNamespaceDelete(ctx context.Context, d *schema.ResourceData, me
 	}, servicediscovery.ErrCodeResourceInUse)
 
 	if tfawserr.ErrCodeEquals(err, servicediscovery.ErrCodeNamespaceNotFound) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting Service Discovery HTTP Namespace (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Service Discovery HTTP Namespace (%s): %s", d.Id(), err)
 	}
 
 	if output := outputRaw.(*servicediscovery.DeleteNamespaceOutput); output != nil && output.OperationId != nil {
 		if _, err := WaitOperationSuccess(ctx, conn, aws.StringValue(output.OperationId)); err != nil {
-			return diag.Errorf("waiting for Service Discovery HTTP Namespace (%s) delete: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Service Discovery HTTP Namespace (%s) delete: %s", d.Id(), err)
 		}
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/servicediscovery/http_namespace_data_source.go
+++ b/internal/service/servicediscovery/http_namespace_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -44,6 +45,7 @@ func DataSourceHTTPNamespace() *schema.Resource {
 }
 
 func dataSourceHTTPNamespaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -51,7 +53,7 @@ func dataSourceHTTPNamespaceRead(ctx context.Context, d *schema.ResourceData, me
 	nsSummary, err := findNamespaceByNameAndType(ctx, conn, name, servicediscovery.NamespaceTypeHttp)
 
 	if err != nil {
-		return diag.Errorf("reading Service Discovery HTTP Namespace (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "reading Service Discovery HTTP Namespace (%s): %s", name, err)
 	}
 
 	namespaceID := aws.StringValue(nsSummary.Id)
@@ -59,7 +61,7 @@ func dataSourceHTTPNamespaceRead(ctx context.Context, d *schema.ResourceData, me
 	ns, err := FindNamespaceByID(ctx, conn, namespaceID)
 
 	if err != nil {
-		return diag.Errorf("reading Service Discovery HTTP Namespace (%s): %s", namespaceID, err)
+		return sdkdiag.AppendErrorf(diags, "reading Service Discovery HTTP Namespace (%s): %s", namespaceID, err)
 	}
 
 	d.SetId(namespaceID)
@@ -76,12 +78,12 @@ func dataSourceHTTPNamespaceRead(ctx context.Context, d *schema.ResourceData, me
 	tags, err := listTags(ctx, conn, arn)
 
 	if err != nil {
-		return diag.Errorf("listing tags for Service Discovery HTTP Namespace (%s): %s", arn, err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for Service Discovery HTTP Namespace (%s): %s", arn, err)
 	}
 
 	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/servicediscovery/instance.go
+++ b/internal/service/servicediscovery/instance.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -66,6 +67,7 @@ func ResourceInstance() *schema.Resource {
 }
 
 func resourceInstancePut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	instanceID := d.Get(names.AttrInstanceID).(string)
@@ -80,21 +82,22 @@ func resourceInstancePut(ctx context.Context, d *schema.ResourceData, meta inter
 	output, err := conn.RegisterInstanceWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("registering Service Discovery Instance (%s): %s", instanceID, err)
+		return sdkdiag.AppendErrorf(diags, "registering Service Discovery Instance (%s): %s", instanceID, err)
 	}
 
 	d.SetId(instanceID)
 
 	if output != nil && output.OperationId != nil {
 		if _, err := WaitOperationSuccess(ctx, conn, aws.StringValue(output.OperationId)); err != nil {
-			return diag.Errorf("waiting for Service Discovery Instance (%s) create: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Service Discovery Instance (%s) create: %s", d.Id(), err)
 		}
 	}
 
-	return resourceInstanceRead(ctx, d, meta)
+	return append(diags, resourceInstanceRead(ctx, d, meta)...)
 }
 
 func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	instance, err := FindInstanceByServiceIDAndInstanceID(ctx, conn, d.Get("service_id").(string), d.Get(names.AttrInstanceID).(string))
@@ -102,11 +105,11 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Service Discovery Instance (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Service Discovery Instance (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Service Discovery Instance (%s): %s", d.Id(), err)
 	}
 
 	attributes := instance.Attributes
@@ -119,19 +122,20 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set(names.AttrAttributes, aws.StringValueMap(attributes))
 	d.Set(names.AttrInstanceID, instance.Id)
 
-	return nil
+	return diags
 }
 
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	err := deregisterInstance(ctx, conn, d.Get("service_id").(string), d.Get(names.AttrInstanceID).(string))
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceInstanceImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/internal/service/servicediscovery/private_dns_namespace.go
+++ b/internal/service/servicediscovery/private_dns_namespace.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -75,6 +76,7 @@ func ResourcePrivateDNSNamespace() *schema.Resource {
 }
 
 func resourcePrivateDNSNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -92,27 +94,28 @@ func resourcePrivateDNSNamespaceCreate(ctx context.Context, d *schema.ResourceDa
 	output, err := conn.CreatePrivateDnsNamespaceWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Service Discovery Private DNS Namespace (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Service Discovery Private DNS Namespace (%s): %s", name, err)
 	}
 
 	operation, err := WaitOperationSuccess(ctx, conn, aws.StringValue(output.OperationId))
 
 	if err != nil {
-		return diag.Errorf("waiting for Service Discovery Private DNS Namespace (%s) create: %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Service Discovery Private DNS Namespace (%s) create: %s", name, err)
 	}
 
 	namespaceID, ok := operation.Targets[servicediscovery.OperationTargetTypeNamespace]
 
 	if !ok {
-		return diag.Errorf("creating Service Discovery Private DNS Namespace (%s): operation response missing Namespace ID", name)
+		return sdkdiag.AppendErrorf(diags, "creating Service Discovery Private DNS Namespace (%s): operation response missing Namespace ID", name)
 	}
 
 	d.SetId(aws.StringValue(namespaceID))
 
-	return resourcePrivateDNSNamespaceRead(ctx, d, meta)
+	return append(diags, resourcePrivateDNSNamespaceRead(ctx, d, meta)...)
 }
 
 func resourcePrivateDNSNamespaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	ns, err := FindNamespaceByID(ctx, conn, d.Id())
@@ -120,11 +123,11 @@ func resourcePrivateDNSNamespaceRead(ctx context.Context, d *schema.ResourceData
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Service Discovery Private DNS Namespace %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Service Discovery Private DNS Namespace (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Service Discovery Private DNS Namespace (%s): %s", d.Id(), err)
 	}
 
 	arn := aws.StringValue(ns.Arn)
@@ -137,10 +140,11 @@ func resourcePrivateDNSNamespaceRead(ctx context.Context, d *schema.ResourceData
 	}
 	d.Set(names.AttrName, ns.Name)
 
-	return nil
+	return diags
 }
 
 func resourcePrivateDNSNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	if d.HasChange(names.AttrDescription) {
@@ -155,20 +159,21 @@ func resourcePrivateDNSNamespaceUpdate(ctx context.Context, d *schema.ResourceDa
 		output, err := conn.UpdatePrivateDnsNamespaceWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Service Discovery Private DNS Namespace (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Service Discovery Private DNS Namespace (%s): %s", d.Id(), err)
 		}
 
 		if output != nil && output.OperationId != nil {
 			if _, err := WaitOperationSuccess(ctx, conn, aws.StringValue(output.OperationId)); err != nil {
-				return diag.Errorf("waiting for Service Discovery Private DNS Namespace (%s) update: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Service Discovery Private DNS Namespace (%s) update: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourcePrivateDNSNamespaceRead(ctx, d, meta)
+	return append(diags, resourcePrivateDNSNamespaceRead(ctx, d, meta)...)
 }
 
 func resourcePrivateDNSNamespaceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	log.Printf("[INFO] Deleting Service Discovery Private DNS Namespace: %s", d.Id())
@@ -177,14 +182,14 @@ func resourcePrivateDNSNamespaceDelete(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting Service Discovery Private DNS Namespace (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Service Discovery Private DNS Namespace (%s): %s", d.Id(), err)
 	}
 
 	if output != nil && output.OperationId != nil {
 		if _, err := WaitOperationSuccess(ctx, conn, aws.StringValue(output.OperationId)); err != nil {
-			return diag.Errorf("waiting for Service Discovery Private DNS Namespace (%s) delete: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Service Discovery Private DNS Namespace (%s) delete: %s", d.Id(), err)
 		}
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/servicediscovery/public_dns_namespace.go
+++ b/internal/service/servicediscovery/public_dns_namespace.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -60,6 +61,7 @@ func ResourcePublicDNSNamespace() *schema.Resource {
 }
 
 func resourcePublicDNSNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -76,27 +78,28 @@ func resourcePublicDNSNamespaceCreate(ctx context.Context, d *schema.ResourceDat
 	output, err := conn.CreatePublicDnsNamespaceWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Service Discovery Public DNS Namespace (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Service Discovery Public DNS Namespace (%s): %s", name, err)
 	}
 
 	operation, err := WaitOperationSuccess(ctx, conn, aws.StringValue(output.OperationId))
 
 	if err != nil {
-		return diag.Errorf("waiting for Service Discovery Public DNS Namespace (%s) create: %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Service Discovery Public DNS Namespace (%s) create: %s", name, err)
 	}
 
 	namespaceID, ok := operation.Targets[servicediscovery.OperationTargetTypeNamespace]
 
 	if !ok {
-		return diag.Errorf("creating Service Discovery Public DNS Namespace (%s): operation response missing Namespace ID", name)
+		return sdkdiag.AppendErrorf(diags, "creating Service Discovery Public DNS Namespace (%s): operation response missing Namespace ID", name)
 	}
 
 	d.SetId(aws.StringValue(namespaceID))
 
-	return resourcePublicDNSNamespaceRead(ctx, d, meta)
+	return append(diags, resourcePublicDNSNamespaceRead(ctx, d, meta)...)
 }
 
 func resourcePublicDNSNamespaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	ns, err := FindNamespaceByID(ctx, conn, d.Id())
@@ -104,11 +107,11 @@ func resourcePublicDNSNamespaceRead(ctx context.Context, d *schema.ResourceData,
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Service Discovery Public DNS Namespace %s not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Service Discovery Public DNS Namespace (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Service Discovery Public DNS Namespace (%s): %s", d.Id(), err)
 	}
 
 	arn := aws.StringValue(ns.Arn)
@@ -121,10 +124,11 @@ func resourcePublicDNSNamespaceRead(ctx context.Context, d *schema.ResourceData,
 	}
 	d.Set(names.AttrName, ns.Name)
 
-	return nil
+	return diags
 }
 
 func resourcePublicDNSNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	if d.HasChange(names.AttrDescription) {
@@ -139,20 +143,21 @@ func resourcePublicDNSNamespaceUpdate(ctx context.Context, d *schema.ResourceDat
 		output, err := conn.UpdatePublicDnsNamespaceWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Service Discovery Public DNS Namespace (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Service Discovery Public DNS Namespace (%s): %s", d.Id(), err)
 		}
 
 		if output != nil && output.OperationId != nil {
 			if _, err := WaitOperationSuccess(ctx, conn, aws.StringValue(output.OperationId)); err != nil {
-				return diag.Errorf("waiting for Service Discovery Public DNS Namespace (%s) update: %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "waiting for Service Discovery Public DNS Namespace (%s) update: %s", d.Id(), err)
 			}
 		}
 	}
 
-	return resourcePublicDNSNamespaceRead(ctx, d, meta)
+	return append(diags, resourcePublicDNSNamespaceRead(ctx, d, meta)...)
 }
 
 func resourcePublicDNSNamespaceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ServiceDiscoveryConn(ctx)
 
 	log.Printf("[INFO] Deleting Service Discovery Public DNS Namespace: %s", d.Id())
@@ -161,14 +166,14 @@ func resourcePublicDNSNamespaceDelete(ctx context.Context, d *schema.ResourceDat
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting Service Discovery Public DNS Namespace (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Service Discovery Public DNS Namespace (%s): %s", d.Id(), err)
 	}
 
 	if output != nil && output.OperationId != nil {
 		if _, err := WaitOperationSuccess(ctx, conn, aws.StringValue(output.OperationId)); err != nil {
-			return diag.Errorf("waiting for Service Discovery Public DNS Namespace (%s) delete: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Service Discovery Public DNS Namespace (%s) delete: %s", d.Id(), err)
 		}
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/sesv2/configuration_set.go
+++ b/internal/service/sesv2/configuration_set.go
@@ -184,6 +184,7 @@ const (
 )
 
 func resourceConfigurationSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SESV2Client(ctx)
 
 	in := &sesv2.CreateConfigurationSetInput{
@@ -217,19 +218,20 @@ func resourceConfigurationSetCreate(ctx context.Context, d *schema.ResourceData,
 
 	out, err := conn.CreateConfigurationSet(ctx, in)
 	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameConfigurationSet, d.Get("configuration_set_name").(string), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionCreating, ResNameConfigurationSet, d.Get("configuration_set_name").(string), err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameConfigurationSet, d.Get("configuration_set_name").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionCreating, ResNameConfigurationSet, d.Get("configuration_set_name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(d.Get("configuration_set_name").(string))
 
-	return resourceConfigurationSetRead(ctx, d, meta)
+	return append(diags, resourceConfigurationSetRead(ctx, d, meta)...)
 }
 
 func resourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SESV2Client(ctx)
 
 	out, err := FindConfigurationSetByID(ctx, conn, d.Id())
@@ -237,11 +239,11 @@ func resourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, m
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SESV2 ConfigurationSet (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameConfigurationSet, d.Id(), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionReading, ResNameConfigurationSet, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, configurationSetNameToARN(meta, aws.ToString(out.ConfigurationSetName)))
@@ -249,7 +251,7 @@ func resourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, m
 
 	if out.DeliveryOptions != nil {
 		if err := d.Set("delivery_options", []interface{}{flattenDeliveryOptions(out.DeliveryOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("delivery_options", nil)
@@ -257,7 +259,7 @@ func resourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, m
 
 	if out.ReputationOptions != nil {
 		if err := d.Set("reputation_options", []interface{}{flattenReputationOptions(out.ReputationOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("reputation_options", nil)
@@ -265,7 +267,7 @@ func resourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, m
 
 	if out.SendingOptions != nil {
 		if err := d.Set("sending_options", []interface{}{flattenSendingOptions(out.SendingOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("sending_options", nil)
@@ -273,7 +275,7 @@ func resourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, m
 
 	if out.SuppressionOptions != nil {
 		if err := d.Set("suppression_options", []interface{}{flattenSuppressionOptions(out.SuppressionOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("suppression_options", nil)
@@ -281,7 +283,7 @@ func resourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, m
 
 	if out.TrackingOptions != nil {
 		if err := d.Set("tracking_options", []interface{}{flattenTrackingOptions(out.TrackingOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("tracking_options", nil)
@@ -289,16 +291,17 @@ func resourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, m
 
 	if out.VdmOptions != nil {
 		if err := d.Set("vdm_options", []interface{}{flattenVDMOptions(out.VdmOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, ResNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("vdm_options", nil)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceConfigurationSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SESV2Client(ctx)
 
 	if d.HasChanges("delivery_options") {
@@ -321,7 +324,7 @@ func resourceConfigurationSetUpdate(ctx context.Context, d *schema.ResourceData,
 		log.Printf("[DEBUG] Updating SESV2 ConfigurationSet DeliveryOptions (%s): %#v", d.Id(), in)
 		_, err := conn.PutConfigurationSetDeliveryOptions(ctx, in)
 		if err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
 		}
 	}
 
@@ -341,7 +344,7 @@ func resourceConfigurationSetUpdate(ctx context.Context, d *schema.ResourceData,
 		log.Printf("[DEBUG] Updating SESV2 ConfigurationSet ReputationOptions (%s): %#v", d.Id(), in)
 		_, err := conn.PutConfigurationSetReputationOptions(ctx, in)
 		if err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
 		}
 	}
 
@@ -360,7 +363,7 @@ func resourceConfigurationSetUpdate(ctx context.Context, d *schema.ResourceData,
 			log.Printf("[DEBUG] Updating SESV2 ConfigurationSet SendingOptions (%s): %#v", d.Id(), in)
 			_, err := conn.PutConfigurationSetSendingOptions(ctx, in)
 			if err != nil {
-				return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
+				return create.AppendDiagError(diags, names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
 			}
 		}
 	}
@@ -381,7 +384,7 @@ func resourceConfigurationSetUpdate(ctx context.Context, d *schema.ResourceData,
 		log.Printf("[DEBUG] Updating SESV2 ConfigurationSet SuppressionOptions (%s): %#v", d.Id(), in)
 		_, err := conn.PutConfigurationSetSuppressionOptions(ctx, in)
 		if err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
 		}
 	}
 
@@ -401,7 +404,7 @@ func resourceConfigurationSetUpdate(ctx context.Context, d *schema.ResourceData,
 		log.Printf("[DEBUG] Updating SESV2 ConfigurationSet TrackingOptions (%s): %#v", d.Id(), in)
 		_, err := conn.PutConfigurationSetTrackingOptions(ctx, in)
 		if err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
 		}
 	}
 
@@ -417,14 +420,15 @@ func resourceConfigurationSetUpdate(ctx context.Context, d *schema.ResourceData,
 		log.Printf("[DEBUG] Updating SESV2 ConfigurationSet VdmOptions (%s): %#v", d.Id(), in)
 		_, err := conn.PutConfigurationSetVdmOptions(ctx, in)
 		if err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionUpdating, ResNameConfigurationSet, d.Id(), err)
 		}
 	}
 
-	return resourceConfigurationSetRead(ctx, d, meta)
+	return append(diags, resourceConfigurationSetRead(ctx, d, meta)...)
 }
 
 func resourceConfigurationSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SESV2Client(ctx)
 
 	log.Printf("[INFO] Deleting SESV2 ConfigurationSet %s", d.Id())
@@ -436,13 +440,13 @@ func resourceConfigurationSetDelete(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		var nfe *types.NotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.SESV2, create.ErrActionDeleting, ResNameConfigurationSet, d.Id(), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionDeleting, ResNameConfigurationSet, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindConfigurationSetByID(ctx context.Context, conn *sesv2.Client, id string) (*sesv2.GetConfigurationSetOutput, error) {

--- a/internal/service/sesv2/configuration_set_data_source.go
+++ b/internal/service/sesv2/configuration_set_data_source.go
@@ -144,13 +144,14 @@ const (
 )
 
 func dataSourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SESV2Client(ctx)
 
 	name := d.Get("configuration_set_name").(string)
 
 	out, err := FindConfigurationSetByID(ctx, conn, name)
 	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionReading, DSNameConfigurationSet, name, err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionReading, DSNameConfigurationSet, name, err)
 	}
 
 	d.SetId(aws.ToString(out.ConfigurationSetName))
@@ -160,7 +161,7 @@ func dataSourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData,
 
 	if out.DeliveryOptions != nil {
 		if err := d.Set("delivery_options", []interface{}{flattenDeliveryOptions(out.DeliveryOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("delivery_options", nil)
@@ -168,7 +169,7 @@ func dataSourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData,
 
 	if out.ReputationOptions != nil {
 		if err := d.Set("reputation_options", []interface{}{flattenReputationOptions(out.ReputationOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("reputation_options", nil)
@@ -176,7 +177,7 @@ func dataSourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData,
 
 	if out.SendingOptions != nil {
 		if err := d.Set("sending_options", []interface{}{flattenSendingOptions(out.SendingOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("sending_options", nil)
@@ -184,7 +185,7 @@ func dataSourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData,
 
 	if out.SuppressionOptions != nil {
 		if err := d.Set("suppression_options", []interface{}{flattenSuppressionOptions(out.SuppressionOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("suppression_options", nil)
@@ -192,7 +193,7 @@ func dataSourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData,
 
 	if out.TrackingOptions != nil {
 		if err := d.Set("tracking_options", []interface{}{flattenTrackingOptions(out.TrackingOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("tracking_options", nil)
@@ -200,7 +201,7 @@ func dataSourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData,
 
 	if out.VdmOptions != nil {
 		if err := d.Set("vdm_options", []interface{}{flattenVDMOptions(out.VdmOptions)}); err != nil {
-			return create.DiagError(names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
 		}
 	} else {
 		d.Set("vdm_options", nil)
@@ -208,14 +209,14 @@ func dataSourceConfigurationSetRead(ctx context.Context, d *schema.ResourceData,
 
 	tags, err := listTags(ctx, conn, d.Get(names.AttrARN).(string))
 	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionReading, DSNameConfigurationSet, d.Id(), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionReading, DSNameConfigurationSet, d.Id(), err)
 	}
 
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, DSNameConfigurationSet, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/sesv2/dedicated_ip_pool.go
+++ b/internal/service/sesv2/dedicated_ip_pool.go
@@ -75,6 +75,7 @@ const (
 )
 
 func resourceDedicatedIPPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SESV2Client(ctx)
 
 	in := &sesv2.CreateDedicatedIpPoolInput{
@@ -87,34 +88,35 @@ func resourceDedicatedIPPoolCreate(ctx context.Context, d *schema.ResourceData, 
 
 	out, err := conn.CreateDedicatedIpPool(ctx, in)
 	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameDedicatedIPPool, d.Get("pool_name").(string), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionCreating, ResNameDedicatedIPPool, d.Get("pool_name").(string), err)
 	}
 	if out == nil {
-		return create.DiagError(names.SESV2, create.ErrActionCreating, ResNameDedicatedIPPool, d.Get("pool_name").(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionCreating, ResNameDedicatedIPPool, d.Get("pool_name").(string), errors.New("empty output"))
 	}
 
 	d.SetId(d.Get("pool_name").(string))
-	return resourceDedicatedIPPoolRead(ctx, d, meta)
+	return append(diags, resourceDedicatedIPPoolRead(ctx, d, meta)...)
 }
 
 func resourceDedicatedIPPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SESV2Client(ctx)
 
 	out, err := FindDedicatedIPPoolByID(ctx, conn, d.Id())
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SESV2 DedicatedIPPool (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameDedicatedIPPool, d.Id(), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionReading, ResNameDedicatedIPPool, d.Id(), err)
 	}
 	poolName := aws.ToString(out.DedicatedIpPool.PoolName)
 	d.Set("pool_name", poolName)
 	d.Set("scaling_mode", string(out.DedicatedIpPool.ScalingMode))
 	d.Set(names.AttrARN, poolNameToARN(meta, poolName))
 
-	return nil
+	return diags
 }
 
 func resourceDedicatedIPPoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -123,6 +125,7 @@ func resourceDedicatedIPPoolUpdate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceDedicatedIPPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SESV2Client(ctx)
 
 	log.Printf("[INFO] Deleting SESV2 DedicatedIPPool %s", d.Id())
@@ -133,12 +136,12 @@ func resourceDedicatedIPPoolDelete(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		var nfe *types.NotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
-		return create.DiagError(names.SESV2, create.ErrActionDeleting, ResNameDedicatedIPPool, d.Id(), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionDeleting, ResNameDedicatedIPPool, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindDedicatedIPPoolByID(ctx context.Context, conn *sesv2.Client, id string) (*sesv2.GetDedicatedIpPoolOutput, error) {

--- a/internal/service/sesv2/email_identity_data_source.go
+++ b/internal/service/sesv2/email_identity_data_source.go
@@ -100,7 +100,7 @@ func dataSourceEmailIdentityRead(ctx context.Context, d *schema.ResourceData, me
 
 	out, err := FindEmailIdentityByID(ctx, conn, name)
 	if err != nil {
-		return append(diags, create.DiagError(names.SESV2, create.ErrActionReading, DSNameEmailIdentity, name, err)...)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionReading, DSNameEmailIdentity, name, err)
 	}
 
 	arn := emailIdentityNameToARN(meta, name)
@@ -116,7 +116,7 @@ func dataSourceEmailIdentityRead(ctx context.Context, d *schema.ResourceData, me
 		tfMap["domain_signing_selector"] = d.Get("dkim_signing_attributes.0.domain_signing_selector").(string)
 
 		if err := d.Set("dkim_signing_attributes", []interface{}{tfMap}); err != nil {
-			return append(diags, create.DiagError(names.SESV2, create.ErrActionSetting, ResNameEmailIdentity, name, err)...)
+			return create.AppendDiagError(diags, names.SESV2, create.ErrActionSetting, ResNameEmailIdentity, name, err)
 		}
 	} else {
 		d.Set("dkim_signing_attributes", nil)

--- a/internal/service/sesv2/email_identity_mail_from_attributes_data_source.go
+++ b/internal/service/sesv2/email_identity_mail_from_attributes_data_source.go
@@ -48,7 +48,7 @@ func dataSourceEmailIdentityMailFromAttributesRead(ctx context.Context, d *schem
 	out, err := FindEmailIdentityByID(ctx, conn, name)
 
 	if err != nil {
-		return append(diags, create.DiagError(names.SESV2, create.ErrActionReading, ResNameEmailIdentityMailFromAttributes, name, err)...)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionReading, ResNameEmailIdentityMailFromAttributes, name, err)
 	}
 
 	d.SetId(name)

--- a/internal/service/sesv2/email_identity_policy.go
+++ b/internal/service/sesv2/email_identity_policy.go
@@ -108,7 +108,7 @@ func resourceEmailIdentityPolicyRead(ctx context.Context, d *schema.ResourceData
 
 	emailIdentity, policyName, err := ParseEmailIdentityPolicyID(d.Id())
 	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameEmailIdentityPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionReading, ResNameEmailIdentityPolicy, d.Id(), err)
 	}
 
 	policy, err := FindEmailIdentityPolicyByID(ctx, conn, d.Id())
@@ -165,13 +165,14 @@ func resourceEmailIdentityPolicyUpdate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceEmailIdentityPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SESV2Client(ctx)
 
 	log.Printf("[INFO] Deleting SESV2 EmailIdentityPolicy %s", d.Id())
 
 	emailIdentity, policyName, err := ParseEmailIdentityPolicyID(d.Id())
 	if err != nil {
-		return create.DiagError(names.SESV2, create.ErrActionReading, ResNameEmailIdentityPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionReading, ResNameEmailIdentityPolicy, d.Id(), err)
 	}
 
 	_, err = conn.DeleteEmailIdentityPolicy(ctx, &sesv2.DeleteEmailIdentityPolicyInput{
@@ -182,13 +183,13 @@ func resourceEmailIdentityPolicyDelete(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		var nfe *types.NotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.SESV2, create.ErrActionDeleting, ResNameEmailIdentityPolicy, d.Id(), err)
+		return create.AppendDiagError(diags, names.SESV2, create.ErrActionDeleting, ResNameEmailIdentityPolicy, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindEmailIdentityPolicyByID(ctx context.Context, conn *sesv2.Client, id string) (string, error) {

--- a/internal/service/sfn/activity.go
+++ b/internal/service/sfn/activity.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -55,6 +56,7 @@ func ResourceActivity() *schema.Resource {
 }
 
 func resourceActivityCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -66,15 +68,16 @@ func resourceActivityCreate(ctx context.Context, d *schema.ResourceData, meta in
 	output, err := conn.CreateActivityWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("creating Step Functions Activity (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Step Functions Activity (%s): %s", name, err)
 	}
 
 	d.SetId(aws.StringValue(output.ActivityArn))
 
-	return resourceActivityRead(ctx, d, meta)
+	return append(diags, resourceActivityRead(ctx, d, meta)...)
 }
 
 func resourceActivityRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	output, err := FindActivityByARN(ctx, conn, d.Id())
@@ -82,17 +85,17 @@ func resourceActivityRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Step Functions Activity (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Step Functions Activity (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Step Functions Activity (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrCreationDate, output.CreationDate.Format(time.RFC3339))
 	d.Set(names.AttrName, output.Name)
 
-	return nil
+	return diags
 }
 
 func resourceActivityUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -101,6 +104,7 @@ func resourceActivityUpdate(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceActivityDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	log.Printf("[DEBUG] Deleting Step Functions Activity: %s", d.Id())
@@ -109,10 +113,10 @@ func resourceActivityDelete(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting Step Functions Activity (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Step Functions Activity (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindActivityByARN(ctx context.Context, conn *sfn.SFN, arn string) (*sfn.DescribeActivityOutput, error) {

--- a/internal/service/sfn/activity_data_source.go
+++ b/internal/service/sfn/activity_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -48,6 +49,7 @@ func DataSourceActivity() *schema.Resource {
 }
 
 func dataSourceActivityRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	if v, ok := d.GetOk(names.AttrName); ok {
@@ -69,13 +71,13 @@ func dataSourceActivityRead(ctx context.Context, d *schema.ResourceData, meta in
 		})
 
 		if err != nil {
-			return diag.Errorf("listing Step Functions Activities: %s", err)
+			return sdkdiag.AppendErrorf(diags, "listing Step Functions Activities: %s", err)
 		}
 
 		if n := len(activities); n == 0 {
-			return diag.Errorf("no Step Functions Activities matched")
+			return sdkdiag.AppendErrorf(diags, "no Step Functions Activities matched")
 		} else if n > 1 {
-			return diag.Errorf("%d Step Functions Activities matched; use additional constraints to reduce matches to a single Activity", n)
+			return sdkdiag.AppendErrorf(diags, "%d Step Functions Activities matched; use additional constraints to reduce matches to a single Activity", n)
 		}
 
 		activity := activities[0]
@@ -90,7 +92,7 @@ func dataSourceActivityRead(ctx context.Context, d *schema.ResourceData, meta in
 		activity, err := FindActivityByARN(ctx, conn, arn)
 
 		if err != nil {
-			return diag.Errorf("reading Step Functions Activity (%s): %s", arn, err)
+			return sdkdiag.AppendErrorf(diags, "reading Step Functions Activity (%s): %s", arn, err)
 		}
 
 		arn = aws.StringValue(activity.ActivityArn)
@@ -100,5 +102,5 @@ func dataSourceActivityRead(ctx context.Context, d *schema.ResourceData, meta in
 		d.Set(names.AttrName, activity.Name)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/sfn/alias.go
+++ b/internal/service/sfn/alias.go
@@ -82,6 +82,7 @@ const (
 )
 
 func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	in := &sfn.CreateStateMachineAliasInput{
@@ -95,19 +96,20 @@ func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	out, err := conn.CreateStateMachineAliasWithContext(ctx, in)
 	if err != nil {
-		return create.DiagError(names.SFN, create.ErrActionCreating, ResNameAlias, d.Get(names.AttrName).(string), err)
+		return create.AppendDiagError(diags, names.SFN, create.ErrActionCreating, ResNameAlias, d.Get(names.AttrName).(string), err)
 	}
 
 	if out == nil || out.StateMachineAliasArn == nil {
-		return create.DiagError(names.SFN, create.ErrActionCreating, ResNameAlias, d.Get(names.AttrName).(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.SFN, create.ErrActionCreating, ResNameAlias, d.Get(names.AttrName).(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.StringValue(out.StateMachineAliasArn))
 
-	return resourceAliasRead(ctx, d, meta)
+	return append(diags, resourceAliasRead(ctx, d, meta)...)
 }
 
 func resourceAliasRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	out, err := FindAliasByARN(ctx, conn, d.Id())
@@ -115,11 +117,11 @@ func resourceAliasRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SFN Alias (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.SFN, create.ErrActionReading, ResNameAlias, d.Id(), err)
+		return create.AppendDiagError(diags, names.SFN, create.ErrActionReading, ResNameAlias, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, out.StateMachineAliasArn)
@@ -129,12 +131,13 @@ func resourceAliasRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.SetId(aws.StringValue(out.StateMachineAliasArn))
 
 	if err := d.Set("routing_configuration", flattenAliasRoutingConfiguration(out.RoutingConfiguration)); err != nil {
-		return create.DiagError(names.SFN, create.ErrActionSetting, ResNameAlias, d.Id(), err)
+		return create.AppendDiagError(diags, names.SFN, create.ErrActionSetting, ResNameAlias, d.Id(), err)
 	}
-	return nil
+	return diags
 }
 
 func resourceAliasUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	update := false
@@ -154,31 +157,32 @@ func resourceAliasUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if !update {
-		return nil
+		return diags
 	}
 
 	log.Printf("[DEBUG] Updating SFN Alias (%s): %#v", d.Id(), in)
 	_, err := conn.UpdateStateMachineAliasWithContext(ctx, in)
 	if err != nil {
-		return create.DiagError(names.SFN, create.ErrActionUpdating, ResNameAlias, d.Id(), err)
+		return create.AppendDiagError(diags, names.SFN, create.ErrActionUpdating, ResNameAlias, d.Id(), err)
 	}
 
-	return resourceAliasRead(ctx, d, meta)
+	return append(diags, resourceAliasRead(ctx, d, meta)...)
 }
 
 func resourceAliasDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
-	log.Printf("[INFO] Deleting SFN Alias %s", d.Id())
 
+	log.Printf("[INFO] Deleting SFN Alias %s", d.Id())
 	_, err := conn.DeleteStateMachineAliasWithContext(ctx, &sfn.DeleteStateMachineAliasInput{
 		StateMachineAliasArn: aws.String(d.Id()),
 	})
 
 	if err != nil {
-		return create.DiagError(names.SFN, create.ErrActionDeleting, ResNameAlias, d.Id(), err)
+		return create.AppendDiagError(diags, names.SFN, create.ErrActionDeleting, ResNameAlias, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindAliasByARN(ctx context.Context, conn *sfn.SFN, arn string) (*sfn.DescribeStateMachineAliasOutput, error) {

--- a/internal/service/sfn/state_machine.go
+++ b/internal/service/sfn/state_machine.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -166,6 +167,7 @@ func ResourceStateMachine() *schema.Resource {
 }
 
 func resourceStateMachineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	name := create.Name(d.Get(names.AttrName).(string), d.Get(names.AttrNamePrefix).(string))
@@ -195,16 +197,17 @@ func resourceStateMachineCreate(ctx context.Context, d *schema.ResourceData, met
 	}, sfn.ErrCodeStateMachineDeleting, "AccessDeniedException")
 
 	if err != nil {
-		return diag.Errorf("creating Step Functions State Machine (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating Step Functions State Machine (%s): %s", name, err)
 	}
 
 	arn := aws.StringValue(outputRaw.(*sfn.CreateStateMachineOutput).StateMachineArn)
 	d.SetId(arn)
 
-	return resourceStateMachineRead(ctx, d, meta)
+	return append(diags, resourceStateMachineRead(ctx, d, meta)...)
 }
 
 func resourceStateMachineRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	output, err := FindStateMachineByARN(ctx, conn, d.Id())
@@ -212,11 +215,11 @@ func resourceStateMachineRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Step Functions State Machine (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading Step Functions State Machine (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading Step Functions State Machine (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, output.StateMachineArn)
@@ -229,7 +232,7 @@ func resourceStateMachineRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set(names.AttrDescription, output.Description)
 	if output.LoggingConfiguration != nil {
 		if err := d.Set(names.AttrLoggingConfiguration, []interface{}{flattenLoggingConfiguration(output.LoggingConfiguration)}); err != nil {
-			return diag.Errorf("setting logging_configuration: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting logging_configuration: %s", err)
 		}
 	} else {
 		d.Set(names.AttrLoggingConfiguration, nil)
@@ -242,7 +245,7 @@ func resourceStateMachineRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set(names.AttrStatus, output.Status)
 	if output.TracingConfiguration != nil {
 		if err := d.Set("tracing_configuration", []interface{}{flattenTracingConfiguration(output.TracingConfiguration)}); err != nil {
-			return diag.Errorf("setting tracing_configuration: %s", err)
+			return sdkdiag.AppendErrorf(diags, "setting tracing_configuration: %s", err)
 		}
 	} else {
 		d.Set("tracing_configuration", nil)
@@ -255,7 +258,7 @@ func resourceStateMachineRead(ctx context.Context, d *schema.ResourceData, meta 
 	listVersionsOutput, err := conn.ListStateMachineVersionsWithContext(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("listing Step Functions State Machine (%s) Versions: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing Step Functions State Machine (%s) Versions: %s", d.Id(), err)
 	}
 
 	// The results are sorted in descending order of the version creation time.
@@ -266,10 +269,11 @@ func resourceStateMachineRead(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("state_machine_version_arn", nil)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceStateMachineUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
@@ -300,7 +304,7 @@ func resourceStateMachineUpdate(ctx context.Context, d *schema.ResourceData, met
 		_, err := conn.UpdateStateMachineWithContext(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating Step Functions State Machine (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Step Functions State Machine (%s): %s", d.Id(), err)
 		}
 
 		// Handle eventual consistency after update.
@@ -324,14 +328,15 @@ func resourceStateMachineUpdate(ctx context.Context, d *schema.ResourceData, met
 		})
 
 		if err != nil {
-			return diag.Errorf("waiting for Step Functions State Machine (%s) update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for Step Functions State Machine (%s) update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceStateMachineRead(ctx, d, meta)
+	return append(diags, resourceStateMachineRead(ctx, d, meta)...)
 }
 
 func resourceStateMachineDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	log.Printf("[DEBUG] Deleting Step Functions State Machine: %s", d.Id())
@@ -340,14 +345,14 @@ func resourceStateMachineDelete(ctx context.Context, d *schema.ResourceData, met
 	})
 
 	if err != nil {
-		return diag.Errorf("deleting Step Functions State Machine (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Step Functions State Machine (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitStateMachineDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return diag.Errorf("waiting for Step Functions State Machine (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Step Functions State Machine (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func FindStateMachineByARN(ctx context.Context, conn *sfn.SFN, arn string) (*sfn.DescribeStateMachineOutput, error) {

--- a/internal/service/sfn/state_machine_data_source.go
+++ b/internal/service/sfn/state_machine_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -58,6 +59,7 @@ func DataSourceStateMachine() *schema.Resource {
 }
 
 func dataSourceStateMachineRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SFNConn(ctx)
 
 	name := d.Get(names.AttrName).(string)
@@ -78,20 +80,20 @@ func dataSourceStateMachineRead(ctx context.Context, d *schema.ResourceData, met
 	})
 
 	if err != nil {
-		return diag.Errorf("listing Step Functions State Machines: %s", err)
+		return sdkdiag.AppendErrorf(diags, "listing Step Functions State Machines: %s", err)
 	}
 
 	if n := len(arns); n == 0 {
-		return diag.Errorf("no Step Functions State Machines matched")
+		return sdkdiag.AppendErrorf(diags, "no Step Functions State Machines matched")
 	} else if n > 1 {
-		return diag.Errorf("%d Step Functions State Machines matched; use additional constraints to reduce matches to a single State Machine", n)
+		return sdkdiag.AppendErrorf(diags, "%d Step Functions State Machines matched; use additional constraints to reduce matches to a single State Machine", n)
 	}
 
 	arn := arns[0]
 	output, err := FindStateMachineByARN(ctx, conn, arn)
 
 	if err != nil {
-		return diag.Errorf("reading Step Functions State Machine (%s): %s", arn, err)
+		return sdkdiag.AppendErrorf(diags, "reading Step Functions State Machine (%s): %s", arn, err)
 	}
 
 	d.SetId(arn)
@@ -104,5 +106,5 @@ func dataSourceStateMachineRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("revision_id", output.RevisionId)
 	d.Set(names.AttrStatus, output.Status)
 
-	return nil
+	return diags
 }

--- a/internal/service/sns/sms_preferences.go
+++ b/internal/service/sns/sms_preferences.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/attrmap"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 func validateMonthlySpend(v interface{}, k string) (ws []string, errors []error) {
@@ -135,11 +136,12 @@ func resourceSMSPreferences() *schema.Resource {
 }
 
 func resourceSMSPreferencesSet(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
 	attributes, err := SMSPreferencesAttributeMap.ResourceDataToAPIAttributesCreate(d)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &sns.SetSMSAttributesInput{
@@ -149,27 +151,29 @@ func resourceSMSPreferencesSet(ctx context.Context, d *schema.ResourceData, meta
 	_, err = conn.SetSMSAttributes(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("setting SNS SMS Preferences: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting SNS SMS Preferences: %s", err)
 	}
 
 	d.SetId("aws_sns_sms_id")
 
-	return nil
+	return diags
 }
 
 func resourceSMSPreferencesGet(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
 	output, err := conn.GetSMSAttributes(ctx, &sns.GetSMSAttributesInput{})
 
 	if err != nil {
-		return diag.Errorf("reading SNS SMS Preferences: %s", err)
+		return sdkdiag.AppendErrorf(diags, "reading SNS SMS Preferences: %s", err)
 	}
 
-	return diag.FromErr(SMSPreferencesAttributeMap.APIAttributesToResourceData(output.Attributes, d))
+	return sdkdiag.AppendFromErr(diags, SMSPreferencesAttributeMap.APIAttributesToResourceData(output.Attributes, d))
 }
 
 func resourceSMSPreferencesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
 	// Reset the attributes to their default value.
@@ -185,8 +189,8 @@ func resourceSMSPreferencesDelete(ctx context.Context, d *schema.ResourceData, m
 	_, err := conn.SetSMSAttributes(ctx, input)
 
 	if err != nil {
-		return diag.Errorf("resetting SNS SMS Preferences: %s", err)
+		return sdkdiag.AppendErrorf(diags, "resetting SNS SMS Preferences: %s", err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -273,7 +273,7 @@ func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	attributes, err := topicAttributeMap.ResourceDataToAPIAttributesCreate(d)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	// The FifoTopic attribute must be passed in the call to CreateTopic.
@@ -337,7 +337,7 @@ func resourceTopicRead(ctx context.Context, d *schema.ResourceData, meta any) di
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SNS Topic (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading SNS Topic (%s): %s", d.Id(), err)
@@ -345,12 +345,12 @@ func resourceTopicRead(ctx context.Context, d *schema.ResourceData, meta any) di
 
 	err = topicAttributeMap.APIAttributesToResourceData(attributes, d)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	arn, err := arn.Parse(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	name := arn.Resource
@@ -361,28 +361,30 @@ func resourceTopicRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		d.Set(names.AttrNamePrefix, create.NamePrefixFromName(name))
 	}
 
-	return nil
+	return diags
 }
 
 func resourceTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
 		attributes, err := topicAttributeMap.ResourceDataToAPIAttributesUpdate(d)
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		err = putTopicAttributes(ctx, conn, d.Id(), attributes)
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
-	return resourceTopicRead(ctx, d, meta)
+	return append(diags, resourceTopicRead(ctx, d, meta)...)
 }
 
 func resourceTopicDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
 	log.Printf("[DEBUG] Deleting SNS Topic: %s", d.Id())
@@ -391,14 +393,14 @@ func resourceTopicDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if errs.IsA[*types.NotFoundException](err) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting SNS Topic (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting SNS Topic (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceTopicCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {

--- a/internal/service/sns/topic_data_source.go
+++ b/internal/service/sns/topic_data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -37,20 +38,21 @@ func dataSourceTopic() *schema.Resource {
 }
 
 func dataSourceTopicRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	topic, err := findTopicByName(ctx, conn, name)
 
 	if err != nil {
-		return diag.Errorf("reading SNS Topic (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "reading SNS Topic (%s): %s", name, err)
 	}
 
 	topicARN := aws.ToString(topic.TopicArn)
 	d.SetId(topicARN)
 	d.Set(names.AttrARN, topicARN)
 
-	return nil
+	return diags
 }
 
 func findTopicByName(ctx context.Context, conn *sns.Client, name string) (*types.Topic, error) {

--- a/internal/service/sqs/attribute_funcs.go
+++ b/internal/service/sqs/attribute_funcs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -28,11 +29,12 @@ type queueAttributeHandler struct {
 }
 
 func (h *queueAttributeHandler) Upsert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SQSClient(ctx)
 
 	attrValue, err := structure.NormalizeJsonString(d.Get(h.SchemaKey).(string))
 	if err != nil {
-		return diag.Errorf("%s (%s) is invalid JSON: %s", h.SchemaKey, d.Get(h.SchemaKey).(string), err)
+		return sdkdiag.AppendErrorf(diags, "%s (%s) is invalid JSON: %s", h.SchemaKey, d.Get(h.SchemaKey).(string), err)
 	}
 
 	attributes := map[types.QueueAttributeName]string{
@@ -49,19 +51,20 @@ func (h *queueAttributeHandler) Upsert(ctx context.Context, d *schema.ResourceDa
 	}, errCodeInvalidAttributeValue, "Invalid value for the parameter Policy")
 
 	if err != nil {
-		return diag.Errorf("setting SQS Queue (%s) attribute (%s): %s", url, h.AttributeName, err)
+		return sdkdiag.AppendErrorf(diags, "setting SQS Queue (%s) attribute (%s): %s", url, h.AttributeName, err)
 	}
 
 	d.SetId(url)
 
 	if err := waitQueueAttributesPropagated(ctx, conn, d.Id(), attributes); err != nil {
-		return diag.Errorf("waiting for SQS Queue (%s) attribute (%s) create: %s", d.Id(), h.AttributeName, err)
+		return sdkdiag.AppendErrorf(diags, "waiting for SQS Queue (%s) attribute (%s) create: %s", d.Id(), h.AttributeName, err)
 	}
 
 	return h.Read(ctx, d, meta)
 }
 
 func (h *queueAttributeHandler) Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SQSClient(ctx)
 
 	outputRaw, err := tfresource.RetryWhenNotFound(ctx, queueAttributeReadTimeout, func() (interface{}, error) {
@@ -71,32 +74,33 @@ func (h *queueAttributeHandler) Read(ctx context.Context, d *schema.ResourceData
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SQS Queue (%s) attribute (%s) not found, removing from state", d.Id(), h.AttributeName)
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading SQS Queue (%s) attribute (%s): %s", d.Id(), h.AttributeName, err)
+		return sdkdiag.AppendErrorf(diags, "reading SQS Queue (%s) attribute (%s): %s", d.Id(), h.AttributeName, err)
 	}
 
 	newValue, err := h.ToSet(d.Get(h.SchemaKey).(string), aws.ToString(outputRaw.(*string)))
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	if h.SchemaKey == names.AttrPolicy {
 		newValue, err = verify.PolicyToSet(d.Get(names.AttrPolicy).(string), newValue)
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	d.Set(h.SchemaKey, newValue)
 	d.Set("queue_url", d.Id())
 
-	return nil
+	return diags
 }
 
 func (h *queueAttributeHandler) Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SQSClient(ctx)
 
 	log.Printf("[DEBUG] Deleting SQS Queue (%s) attribute: %s", d.Id(), h.AttributeName)
@@ -109,16 +113,16 @@ func (h *queueAttributeHandler) Delete(ctx context.Context, d *schema.ResourceDa
 	})
 
 	if tfawserr.ErrCodeEquals(err, errCodeQueueDoesNotExist) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting SQS Queue (%s) attribute (%s): %s", d.Id(), h.AttributeName, err)
+		return sdkdiag.AppendErrorf(diags, "deleting SQS Queue (%s) attribute (%s): %s", d.Id(), h.AttributeName, err)
 	}
 
 	if err := waitQueueAttributesPropagated(ctx, conn, d.Id(), attributes); err != nil {
-		return diag.Errorf("waiting for SQS Queue (%s) attribute (%s) delete: %s", d.Id(), h.AttributeName, err)
+		return sdkdiag.AppendErrorf(diags, "waiting for SQS Queue (%s) attribute (%s) delete: %s", d.Id(), h.AttributeName, err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/sqs/attribute_funcs.go
+++ b/internal/service/sqs/attribute_funcs.go
@@ -60,7 +60,7 @@ func (h *queueAttributeHandler) Upsert(ctx context.Context, d *schema.ResourceDa
 		return sdkdiag.AppendErrorf(diags, "waiting for SQS Queue (%s) attribute (%s) create: %s", d.Id(), h.AttributeName, err)
 	}
 
-	return h.Read(ctx, d, meta)
+	return append(diags, h.Read(ctx, d, meta)...)
 }
 
 func (h *queueAttributeHandler) Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tfmaps "github.com/hashicorp/terraform-provider-aws/internal/maps"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
@@ -211,6 +212,7 @@ func resourceQueue() *schema.Resource {
 }
 
 func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SQSClient(ctx)
 
 	name := queueName(d)
@@ -221,7 +223,7 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	attributes, err := queueAttributeMap.ResourceDataToAPIAttributesCreate(d)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input.Attributes = flex.ExpandStringyValueMap(attributes)
@@ -240,13 +242,13 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if err != nil {
-		return diag.Errorf("creating SQS Queue (%s): %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "creating SQS Queue (%s): %s", name, err)
 	}
 
 	d.SetId(aws.ToString(outputRaw.(*sqs.CreateQueueOutput).QueueUrl))
 
 	if err := waitQueueAttributesPropagated(ctx, conn, d.Id(), attributes); err != nil {
-		return diag.Errorf("waiting for SQS Queue (%s) attributes create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for SQS Queue (%s) attributes create: %s", d.Id(), err)
 	}
 
 	// For partitions not supporting tag-on-create, attempt tag after create.
@@ -255,18 +257,19 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 		// If default tags only, continue. Otherwise, error.
 		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition, err) {
-			return resourceQueueRead(ctx, d, meta)
+			return append(diags, resourceQueueRead(ctx, d, meta)...)
 		}
 
 		if err != nil {
-			return diag.Errorf("setting SQS Queue (%s) tags: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "setting SQS Queue (%s) tags: %s", d.Id(), err)
 		}
 	}
 
-	return resourceQueueRead(ctx, d, meta)
+	return append(diags, resourceQueueRead(ctx, d, meta)...)
 }
 
 func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SQSClient(ctx)
 
 	outputRaw, err := tfresource.RetryWhenNotFound(ctx, queueReadTimeout, func() (interface{}, error) {
@@ -276,21 +279,21 @@ func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SQS Queue (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("reading SQS Queue (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading SQS Queue (%s): %s", d.Id(), err)
 	}
 
 	name, err := queueNameFromURL(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	err = queueAttributeMap.APIAttributesToResourceData(outputRaw.(map[types.QueueAttributeName]string), d)
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	// Backwards compatibility: https://github.com/hashicorp/terraform-provider-aws/issues/19786.
@@ -306,16 +309,17 @@ func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 	d.Set(names.AttrURL, d.Id())
 
-	return nil
+	return diags
 }
 
 func resourceQueueUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SQSClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
 		attributes, err := queueAttributeMap.ResourceDataToAPIAttributesUpdate(d)
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 
 		input := &sqs.SetQueueAttributesInput{
@@ -326,18 +330,19 @@ func resourceQueueUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		_, err = conn.SetQueueAttributes(ctx, input)
 
 		if err != nil {
-			return diag.Errorf("updating SQS Queue (%s) attributes: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating SQS Queue (%s) attributes: %s", d.Id(), err)
 		}
 
 		if err := waitQueueAttributesPropagated(ctx, conn, d.Id(), attributes); err != nil {
-			return diag.Errorf("waiting for SQS Queue (%s) attributes update: %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "waiting for SQS Queue (%s) attributes update: %s", d.Id(), err)
 		}
 	}
 
-	return resourceQueueRead(ctx, d, meta)
+	return append(diags, resourceQueueRead(ctx, d, meta)...)
 }
 
 func resourceQueueDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SQSClient(ctx)
 
 	log.Printf("[DEBUG] Deleting SQS Queue: %s", d.Id())
@@ -346,18 +351,18 @@ func resourceQueueDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	})
 
 	if tfawserr.ErrCodeEquals(err, errCodeQueueDoesNotExist) {
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("deleting SQS Queue (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting SQS Queue (%s): %s", d.Id(), err)
 	}
 
 	if err := waitQueueDeleted(ctx, conn, d.Id()); err != nil {
-		return diag.Errorf("waiting for SQS Queue (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for SQS Queue (%s) delete: %s", d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceQueueCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {

--- a/internal/service/sqs/queue_data_source.go
+++ b/internal/service/sqs/queue_data_source.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -45,6 +46,7 @@ func dataSourceQueue() *schema.Resource {
 }
 
 func dataSourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SQSClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
@@ -52,14 +54,14 @@ func dataSourceQueueRead(ctx context.Context, d *schema.ResourceData, meta inter
 	urlOutput, err := findQueueURLByName(ctx, conn, name)
 
 	if err != nil {
-		return diag.Errorf("reading SQS Queue (%s) URL: %s", name, err)
+		return sdkdiag.AppendErrorf(diags, "reading SQS Queue (%s) URL: %s", name, err)
 	}
 
 	queueURL := aws.ToString(urlOutput)
 	attributesOutput, err := findQueueAttributeByTwoPartKey(ctx, conn, queueURL, types.QueueAttributeNameQueueArn)
 
 	if err != nil {
-		return diag.Errorf("reading SQS Queue (%s) ARN attribute: %s", queueURL, err)
+		return sdkdiag.AppendErrorf(diags, "reading SQS Queue (%s) ARN attribute: %s", queueURL, err)
 	}
 
 	d.SetId(queueURL)
@@ -71,18 +73,18 @@ func dataSourceQueueRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition, err) {
 		// Some partitions may not support tagging, giving error
 		log.Printf("[WARN] failed listing tags for SQS Queue (%s): %s", d.Id(), err)
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return diag.Errorf("listing tags for SQS Queue (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "listing tags for SQS Queue (%s): %s", d.Id(), err)
 	}
 
 	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return diag.Errorf("setting tags: %s", err)
+		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
 	}
 
-	return nil
+	return diags
 }
 
 func findQueueURLByName(ctx context.Context, conn *sqs.Client, name string) (*string, error) {

--- a/internal/service/sqs/queues_data_source.go
+++ b/internal/service/sqs/queues_data_source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
 // @SDKDataSource("aws_sqs_queues")
@@ -33,6 +34,7 @@ func dataSourceQueues() *schema.Resource {
 }
 
 func dataSourceQueuesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SQSClient(ctx)
 
 	input := &sqs.ListQueuesInput{}
@@ -47,7 +49,7 @@ func dataSourceQueuesRead(ctx context.Context, d *schema.ResourceData, meta inte
 		page, err := pages.NextPage(ctx)
 
 		if err != nil {
-			return diag.Errorf("listing SQS Queues: %s", err)
+			return sdkdiag.AppendErrorf(diags, "listing SQS Queues: %s", err)
 		}
 
 		queueURLs = append(queueURLs, page.QueueUrls...)
@@ -56,5 +58,5 @@ func dataSourceQueuesRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.SetId(meta.(*conns.AWSClient).Region)
 	d.Set("queue_urls", queueURLs)
 
-	return nil
+	return diags
 }

--- a/internal/service/ssm/default_patch_baseline.go
+++ b/internal/service/ssm/default_patch_baseline.go
@@ -118,7 +118,7 @@ func resourceDefaultPatchBaselineRead(ctx context.Context, d *schema.ResourceDat
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SSM Default Patch Baseline (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/ssmcontacts/contact_channel.go
+++ b/internal/service/ssmcontacts/contact_channel.go
@@ -76,6 +76,7 @@ const (
 )
 
 func resourceContactChannelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	delivery_address := expandContactChannelAddress(d.Get("delivery_address").([]interface{}))
@@ -89,19 +90,20 @@ func resourceContactChannelCreate(ctx context.Context, d *schema.ResourceData, m
 
 	out, err := conn.CreateContactChannel(ctx, in)
 	if err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionCreating, ResNameContactChannel, d.Get(names.AttrName).(string), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionCreating, ResNameContactChannel, d.Get(names.AttrName).(string), err)
 	}
 
 	if out == nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionCreating, ResNameContactChannel, d.Get(names.AttrName).(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionCreating, ResNameContactChannel, d.Get(names.AttrName).(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(out.ContactChannelArn))
 
-	return resourceContactChannelRead(ctx, d, meta)
+	return append(diags, resourceContactChannelRead(ctx, d, meta)...)
 }
 
 func resourceContactChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	out, err := findContactChannelByID(ctx, conn, d.Id())
@@ -109,21 +111,22 @@ func resourceContactChannelRead(ctx context.Context, d *schema.ResourceData, met
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SSMContacts ContactChannel (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionReading, ResNameContactChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionReading, ResNameContactChannel, d.Id(), err)
 	}
 
 	if err := setContactChannelResourceData(d, out); err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionSetting, ResNameContactChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionSetting, ResNameContactChannel, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceContactChannelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	update := false
@@ -143,19 +146,20 @@ func resourceContactChannelUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if !update {
-		return nil
+		return diags
 	}
 
 	log.Printf("[DEBUG] Updating SSMContacts ContactChannel (%s): %#v", d.Id(), in)
 	_, err := conn.UpdateContactChannel(ctx, in)
 	if err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionUpdating, ResNameContactChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionUpdating, ResNameContactChannel, d.Id(), err)
 	}
 
-	return resourceContactChannelRead(ctx, d, meta)
+	return append(diags, resourceContactChannelRead(ctx, d, meta)...)
 }
 
 func resourceContactChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	log.Printf("[INFO] Deleting SSMContacts ContactChannel %s", d.Id())
@@ -167,11 +171,11 @@ func resourceContactChannelDelete(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		var nfe *types.ResourceNotFoundException
 		if errors.As(err, &nfe) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.SSMContacts, create.ErrActionDeleting, ResNameContactChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionDeleting, ResNameContactChannel, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/ssmcontacts/contact_channel_data_source.go
+++ b/internal/service/ssmcontacts/contact_channel_data_source.go
@@ -61,20 +61,21 @@ const (
 )
 
 func dataSourceContactChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	arn := d.Get(names.AttrARN).(string)
 
 	out, err := findContactChannelByID(ctx, conn, arn)
 	if err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionReading, DSNameContactChannel, arn, err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionReading, DSNameContactChannel, arn, err)
 	}
 
 	d.SetId(aws.ToString(out.ContactChannelArn))
 
 	if err := setContactChannelResourceData(d, out); err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionSetting, ResNameContactChannel, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionSetting, ResNameContactChannel, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/ssmcontacts/contact_data_source.go
+++ b/internal/service/ssmcontacts/contact_data_source.go
@@ -47,32 +47,33 @@ const (
 )
 
 func dataSourceContactRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	arn := d.Get(names.AttrARN).(string)
 
 	out, err := findContactByID(ctx, conn, arn)
 	if err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionReading, DSNameContact, arn, err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionReading, DSNameContact, arn, err)
 	}
 
 	d.SetId(aws.ToString(out.ContactArn))
 
 	if err := setContactResourceData(d, out); err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionSetting, DSNameContact, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionSetting, DSNameContact, d.Id(), err)
 	}
 
 	tags, err := listTags(ctx, conn, d.Id())
 	if err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionReading, DSNameContact, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionReading, DSNameContact, d.Id(), err)
 	}
 
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	//lintignore:AWSR002
 	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionSetting, DSNameContact, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionSetting, DSNameContact, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/ssmcontacts/plan.go
+++ b/internal/service/ssmcontacts/plan.go
@@ -99,6 +99,7 @@ const (
 )
 
 func resourcePlanCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	contactId := d.Get("contact_id").(string)
@@ -114,21 +115,20 @@ func resourcePlanCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	_, err := conn.UpdateContact(ctx, in)
 	if err != nil {
-		return create.DiagError(
-			names.SSMContacts,
+		return create.AppendDiagError(diags, names.SSMContacts,
 			create.ErrActionCreating,
 			ResNamePlan,
 			contactId,
-			err,
-		)
+			err)
 	}
 
 	d.SetId(contactId)
 
-	return resourcePlanRead(ctx, d, meta)
+	return append(diags, resourcePlanRead(ctx, d, meta)...)
 }
 
 func resourcePlanRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	out, err := findContactByID(ctx, conn, d.Id())
@@ -136,21 +136,22 @@ func resourcePlanRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SSMContacts Plan (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionReading, ResNamePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionReading, ResNamePlan, d.Id(), err)
 	}
 
 	if err := setPlanResourceData(d, out); err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionReading, ResNamePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionReading, ResNamePlan, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourcePlanUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	update := false
@@ -168,19 +169,20 @@ func resourcePlanUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if !update {
-		return nil
+		return diags
 	}
 
 	log.Printf("[DEBUG] Updating SSMContacts Plan (%s): %#v", d.Id(), in)
 	_, err := conn.UpdateContact(ctx, in)
 	if err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionUpdating, ResNamePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionUpdating, ResNamePlan, d.Id(), err)
 	}
 
-	return resourcePlanRead(ctx, d, meta)
+	return append(diags, resourcePlanRead(ctx, d, meta)...)
 }
 
 func resourcePlanDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	log.Printf("[INFO] Deleting SSMContacts Plan %s", d.Id())
@@ -193,8 +195,8 @@ func resourcePlanDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	})
 
 	if err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionDeleting, ResNamePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionDeleting, ResNamePlan, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/ssmcontacts/plan_data_source.go
+++ b/internal/service/ssmcontacts/plan_data_source.go
@@ -85,20 +85,21 @@ const (
 )
 
 func dataSourcePlanRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SSMContactsClient(ctx)
 
 	contactId := d.Get("contact_id").(string)
 
 	out, err := findContactByID(ctx, conn, contactId)
 	if err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionReading, DSNamePlan, contactId, err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionReading, DSNamePlan, contactId, err)
 	}
 
 	d.SetId(aws.ToString(out.ContactArn))
 
 	if err := setPlanResourceData(d, out); err != nil {
-		return create.DiagError(names.SSMContacts, create.ErrActionReading, DSNamePlan, contactId, err)
+		return create.AppendDiagError(diags, names.SSMContacts, create.ErrActionReading, DSNamePlan, contactId, err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/ssmincidents/replication_set_data_source.go
+++ b/internal/service/ssmincidents/replication_set_data_source.go
@@ -75,12 +75,13 @@ const (
 )
 
 func dataSourceReplicationSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	client := meta.(*conns.AWSClient).SSMIncidentsClient(ctx)
 
 	arn, err := getReplicationSetARN(ctx, client)
 
 	if err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionReading, ResNameReplicationSet, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionReading, ResNameReplicationSet, d.Id(), err)
 	}
 
 	d.SetId(arn)
@@ -88,7 +89,7 @@ func dataSourceReplicationSetRead(ctx context.Context, d *schema.ResourceData, m
 	replicationSet, err := FindReplicationSetByID(ctx, client, d.Id())
 
 	if err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionReading, ResNameReplicationSet, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionReading, ResNameReplicationSet, d.Id(), err)
 	}
 
 	d.Set(names.AttrARN, replicationSet.Arn)
@@ -98,21 +99,21 @@ func dataSourceReplicationSetRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set(names.AttrStatus, replicationSet.Status)
 
 	if err := d.Set(names.AttrRegion, flattenRegions(replicationSet.RegionMap)); err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionSetting, ResNameReplicationSet, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionSetting, ResNameReplicationSet, d.Id(), err)
 	}
 
 	tags, err := listTags(ctx, client, d.Id())
 
 	if err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionReading, DSNameReplicationSet, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionReading, DSNameReplicationSet, d.Id(), err)
 	}
 
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	//lintignore:AWSR002
 	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionSetting, DSNameReplicationSet, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionSetting, DSNameReplicationSet, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/ssmincidents/response_plan.go
+++ b/internal/service/ssmincidents/response_plan.go
@@ -194,6 +194,7 @@ func ResourceResponsePlan() *schema.Resource {
 }
 
 func resourceResponsePlanCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	client := meta.(*conns.AWSClient).SSMIncidentsClient(ctx)
 
 	input := &ssmincidents.CreateResponsePlanInput{
@@ -210,19 +211,20 @@ func resourceResponsePlanCreate(ctx context.Context, d *schema.ResourceData, met
 	output, err := client.CreateResponsePlan(ctx, input)
 
 	if err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionCreating, ResNameResponsePlan, d.Get(names.AttrName).(string), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionCreating, ResNameResponsePlan, d.Get(names.AttrName).(string), err)
 	}
 
 	if output == nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionCreating, ResNameResponsePlan, d.Get(names.AttrName).(string), errors.New("empty output"))
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionCreating, ResNameResponsePlan, d.Get(names.AttrName).(string), errors.New("empty output"))
 	}
 
 	d.SetId(aws.ToString(output.Arn))
 
-	return resourceResponsePlanRead(ctx, d, meta)
+	return append(diags, resourceResponsePlanRead(ctx, d, meta)...)
 }
 
 func resourceResponsePlanRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	client := meta.(*conns.AWSClient).SSMIncidentsClient(ctx)
 
 	responsePlan, err := FindResponsePlanByID(ctx, client, d.Id())
@@ -230,21 +232,22 @@ func resourceResponsePlanRead(ctx context.Context, d *schema.ResourceData, meta 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SSMIncidents ResponsePlan (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionReading, ResNameResponsePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionReading, ResNameResponsePlan, d.Id(), err)
 	}
 
 	if d, err := setResponsePlanResourceData(d, responsePlan); err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionSetting, ResNameResponsePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionSetting, ResNameResponsePlan, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 func resourceResponsePlanUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	client := meta.(*conns.AWSClient).SSMIncidentsClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
@@ -281,14 +284,15 @@ func resourceResponsePlanUpdate(ctx context.Context, d *schema.ResourceData, met
 		_, err := client.UpdateResponsePlan(ctx, input)
 
 		if err != nil {
-			return create.DiagError(names.SSMIncidents, create.ErrActionUpdating, ResNameResponsePlan, d.Id(), err)
+			return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionUpdating, ResNameResponsePlan, d.Id(), err)
 		}
 	}
 
-	return resourceResponsePlanRead(ctx, d, meta)
+	return append(diags, resourceResponsePlanRead(ctx, d, meta)...)
 }
 
 func resourceResponsePlanDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	client := meta.(*conns.AWSClient).SSMIncidentsClient(ctx)
 
 	log.Printf("[INFO] Deleting SSMIncidents ResponsePlan %s", d.Id())
@@ -303,13 +307,13 @@ func resourceResponsePlanDelete(ctx context.Context, d *schema.ResourceData, met
 		var notFoundError *types.ResourceNotFoundException
 
 		if errors.As(err, &notFoundError) {
-			return nil
+			return diags
 		}
 
-		return create.DiagError(names.SSMIncidents, create.ErrActionDeleting, ResNameResponsePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionDeleting, ResNameResponsePlan, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }
 
 // input validation already done in flattenIncidentTemplate function

--- a/internal/service/ssmincidents/response_plan_data_source.go
+++ b/internal/service/ssmincidents/response_plan_data_source.go
@@ -173,6 +173,7 @@ const (
 )
 
 func dataSourceResponsePlanRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
 	client := meta.(*conns.AWSClient).SSMIncidentsClient(ctx)
 
 	d.SetId(d.Get(names.AttrARN).(string))
@@ -180,24 +181,24 @@ func dataSourceResponsePlanRead(ctx context.Context, d *schema.ResourceData, met
 	responsePlan, err := FindResponsePlanByID(ctx, client, d.Id())
 
 	if err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionReading, DSNameResponsePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionReading, DSNameResponsePlan, d.Id(), err)
 	}
 
 	if d, err := setResponsePlanResourceData(d, responsePlan); err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionReading, DSNameResponsePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionReading, DSNameResponsePlan, d.Id(), err)
 	}
 
 	tags, err := listTags(ctx, client, d.Id())
 	if err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionReading, DSNameResponsePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionReading, DSNameResponsePlan, d.Id(), err)
 	}
 
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig
 
 	//lintignore:AWSR002
 	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.DiagError(names.SSMIncidents, create.ErrActionSetting, DSNameResponsePlan, d.Id(), err)
+		return create.AppendDiagError(diags, names.SSMIncidents, create.ErrActionSetting, DSNameResponsePlan, d.Id(), err)
 	}
 
-	return nil
+	return diags
 }

--- a/internal/service/swf/domain.go
+++ b/internal/service/swf/domain.go
@@ -106,7 +106,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(name)
 
-	return resourceDomainRead(ctx, d, meta)
+	return append(diags, resourceDomainRead(ctx, d, meta)...)
 }
 
 func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -118,7 +118,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] SWF Domain (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/synthetics/group.go
+++ b/internal/service/synthetics/group.go
@@ -90,7 +90,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Synthetics Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {

--- a/internal/service/synthetics/group_association.go
+++ b/internal/service/synthetics/group_association.go
@@ -89,7 +89,7 @@ func resourceGroupAssociationRead(ctx context.Context, d *schema.ResourceData, m
 	canaryArn, groupName, err := GroupAssociationParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	group, err := FindAssociatedGroup(ctx, conn, canaryArn, groupName)
@@ -97,7 +97,7 @@ func resourceGroupAssociationRead(ctx context.Context, d *schema.ResourceData, m
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] Synthetics Group Association between canary (%s) and group (%s) not found, removing from state", canaryArn, groupName)
 		d.SetId("")
-		return nil
+		return diags
 	}
 
 	if err != nil {
@@ -121,7 +121,7 @@ func resourceGroupAssociationDelete(ctx context.Context, d *schema.ResourceData,
 	canaryArn, groupName, err := GroupAssociationParseResourceID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	in := &synthetics.DisassociateResourceInput{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Enables and fixes semgrep `diags` checks for all services.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/37569.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
