### PR TITLE
[new feature] fsx lustre file system metadata

### DIFF
--- a/.changelog/37868.txt
+++ b/.changelog/37868.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fsx_lustre_file_system: Add `metadata_configuration` argument
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2
 	github.com/YakDriver/go-version v0.1.0
 	github.com/YakDriver/regexache v0.23.0
-	github.com/aws/aws-sdk-go v1.53.17
+	github.com/aws/aws-sdk-go v1.53.18
 	github.com/aws/aws-sdk-go-v2 v1.27.1
 	github.com/aws/aws-sdk-go-v2/config v1.27.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.17

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aws/aws-sdk-go v1.53.17 h1:TwtYMzVBTaqPVj/pcemHRIgk01OycWEcEUyUUX0tpCI=
-github.com/aws/aws-sdk-go v1.53.17/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/aws-sdk-go v1.53.18 h1:BeMeCK5e3bDGJj675FhnO94zRci8O35ombWXRvYomJs=
+github.com/aws/aws-sdk-go v1.53.18/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.27.1 h1:xypCL2owhog46iFxBKKpBcw+bPTX/RJzwNj8uSilENw=
 github.com/aws/aws-sdk-go-v2 v1.27.1/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 h1:x6xsQXGSmW6frevwDA+vi/wqhp1ct18mVXYN08/93to=

--- a/internal/service/fsx/lustre_file_system.go
+++ b/internal/service/fsx/lustre_file_system.go
@@ -179,6 +179,28 @@ func resourceLustreFileSystem() *schema.Resource {
 					},
 				},
 			},
+			"metadata_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mode": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(fsx.MetadataConfigurationMode_Values(), false)),
+						},
+						"iops": {
+							Type:             schema.TypeInt,
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.IntInSlice([]int{1500, 3000, 6000, 12000, 24000, 36000, 48000, 60000, 72000, 84000, 96000, 108000, 120000, 132000, 144000, 156000, 168000, 180000, 192000})),
+						},
+					},
+				},
+			},
 			"mount_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -277,18 +299,68 @@ func resourceLustreFileSystem() *schema.Resource {
 
 		CustomizeDiff: customdiff.Sequence(
 			verify.SetTagsDiff,
-			resourceLustreFileSystemSchemaCustomizeDiff,
+			resourceLustreFileSystemStorageCapacityCustomizeDiff,
+			resourceLustreFileSystemMetadataConfigCustomizeDiff,
 		),
 	}
 }
 
-func resourceLustreFileSystemSchemaCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func resourceLustreFileSystemStorageCapacityCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
 	// we want to force a new resource if the new storage capacity is less than the old one
 	if d.HasChange("storage_capacity") {
 		o, n := d.GetChange("storage_capacity")
 		if n.(int) < o.(int) || d.Get("deployment_type").(string) == fsx.LustreDeploymentTypeScratch1 {
 			if err := d.ForceNew("storage_capacity"); err != nil {
 				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceLustreFileSystemMetadataConfigCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
+	//metadata_configuration is only supported when deployment_type is persistent2
+	if v, ok := d.GetOk("metadata_configuration"); ok {
+		if len(v.([]any)) > 0 {
+			deploymentType := d.Get("deployment_type").(string)
+			if deploymentType != fsx.LustreDeploymentTypePersistent2 {
+				return fmt.Errorf("metadata_configuration can only be set when deployment type is " + fsx.LustreDeploymentTypePersistent2)
+			}
+		}
+	}
+
+	// we want to force a new resource if the new Iops is less than the old one
+	if d.HasChange("metadata_configuration") {
+		if v, ok := d.GetOk("metadata_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+
+			o, nil := d.GetChange("metadata_configuration.0.mode")
+
+			if o == fsx.MetadataConfigurationModeUserProvisioned {
+
+				o, n := d.GetChange("metadata_configuration")
+
+				oldV := o.([]interface{})
+				newV := n.([]interface{})
+				var metaOld map[string]interface{}
+				var metaNew map[string]interface{}
+
+				for _, v := range oldV {
+					metaOld = v.(map[string]interface{})
+				}
+
+				for _, v := range newV {
+					metaNew = v.(map[string]interface{})
+				}
+
+				if len(metaNew) > 0 && len(metaOld) > 0 {
+					if metaNew["iops"].(int) < metaOld["iops"].(int) {
+						log.Printf("[DEBUG] Forcing new due to metadata iops decrease. old iops: %d new iops: %d", metaOld["iops"].(int), metaNew["iops"].(int))
+						if err := d.ForceNew("metadata_configuration.0.iops"); err != nil {
+							return err
+						}
+					}
+				}
 			}
 		}
 	}
@@ -382,6 +454,11 @@ func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData,
 		inputB.LustreConfiguration.LogConfiguration = expandLustreLogCreateConfiguration(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("metadata_configuration"); ok && len(v.([]interface{})) > 0 {
+		inputC.LustreConfiguration.MetadataConfiguration = expandLustreMetadataCreateConfiguration(v.([]interface{}))
+		inputB.LustreConfiguration.MetadataConfiguration = expandLustreMetadataCreateConfiguration(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("per_unit_storage_throughput"); ok {
 		inputC.LustreConfiguration.PerUnitStorageThroughput = aws.Int64(int64(v.(int)))
 		inputB.LustreConfiguration.PerUnitStorageThroughput = aws.Int64(int64(v.(int)))
@@ -469,6 +546,9 @@ func resourceLustreFileSystemRead(ctx context.Context, d *schema.ResourceData, m
 	if err := d.Set("log_configuration", flattenLustreLogConfiguration(lustreConfig.LogConfiguration)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting log_configuration: %s", err)
 	}
+	if err := d.Set("metadata_configuration", flattenLustreMetadataConfiguration(lustreConfig.MetadataConfiguration)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting metadata_configuration: %s", err)
+	}
 	d.Set("mount_name", lustreConfig.MountName)
 	d.Set("network_interface_ids", aws.StringValueSlice(filesystem.NetworkInterfaceIds))
 	d.Set(names.AttrOwnerID, filesystem.OwnerId)
@@ -516,6 +596,10 @@ func resourceLustreFileSystemUpdate(ctx context.Context, d *schema.ResourceData,
 
 		if d.HasChange("log_configuration") {
 			input.LustreConfiguration.LogConfiguration = expandLustreLogCreateConfiguration(d.Get("log_configuration").([]interface{}))
+		}
+
+		if d.HasChange("metadata_configuration") {
+			input.LustreConfiguration.MetadataConfiguration = expandLustreMetadataUpdateConfiguration(d.Get("metadata_configuration").([]interface{}))
 		}
 
 		if d.HasChange("per_unit_storage_throughput") {
@@ -642,6 +726,56 @@ func flattenLustreLogConfiguration(adopts *fsx.LustreLogConfiguration) []map[str
 
 	if adopts.Destination != nil {
 		m[names.AttrDestination] = aws.StringValue(adopts.Destination)
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandLustreMetadataCreateConfiguration(l []interface{}) *fsx.CreateFileSystemLustreMetadataConfiguration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	data := l[0].(map[string]interface{})
+	req := &fsx.CreateFileSystemLustreMetadataConfiguration{
+		Mode: aws.String(data["mode"].(string)),
+	}
+
+	if v, ok := data["iops"].(int); ok && v != 0 {
+		req.Iops = aws.Int64(int64(v))
+	}
+
+	return req
+}
+
+func expandLustreMetadataUpdateConfiguration(l []interface{}) *fsx.UpdateFileSystemLustreMetadataConfiguration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	data := l[0].(map[string]interface{})
+	req := &fsx.UpdateFileSystemLustreMetadataConfiguration{
+		Mode: aws.String(data["mode"].(string)),
+	}
+
+	if v, ok := data["iops"].(int); ok && v != 0 {
+		req.Iops = aws.Int64(int64(v))
+	}
+
+	return req
+}
+
+func flattenLustreMetadataConfiguration(adopts *fsx.FileSystemLustreMetadataConfiguration) []map[string]interface{} {
+	if adopts == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"mode": aws.StringValue(adopts.Mode),
+	}
+
+	if adopts.Iops != nil {
+		m["iops"] = aws.Int64Value(adopts.Iops)
 	}
 
 	return []map[string]interface{}{m}

--- a/internal/service/fsx/lustre_file_system.go
+++ b/internal/service/fsx/lustre_file_system.go
@@ -333,11 +333,7 @@ func resourceLustreFileSystemMetadataConfigCustomizeDiff(_ context.Context, d *s
 	// we want to force a new resource if the new Iops is less than the old one
 	if d.HasChange("metadata_configuration") {
 		if v, ok := d.GetOk("metadata_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-
-			o, nil := d.GetChange("metadata_configuration.0.mode")
-
-			if o == fsx.MetadataConfigurationModeUserProvisioned {
-
+			if mode := d.Get("metadata_configuration.0.mode"); mode == fsx.MetadataConfigurationModeUserProvisioned {
 				o, n := d.GetChange("metadata_configuration")
 
 				oldV := o.([]interface{})

--- a/internal/service/fsx/lustre_file_system.go
+++ b/internal/service/fsx/lustre_file_system.go
@@ -186,13 +186,13 @@ func resourceLustreFileSystem() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"mode": {
+						names.AttrMode: {
 							Type:             schema.TypeString,
 							Optional:         true,
 							Computed:         true,
 							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(fsx.MetadataConfigurationMode_Values(), false)),
 						},
-						"iops": {
+						names.AttrIOPS: {
 							Type:             schema.TypeInt,
 							Optional:         true,
 							Computed:         true,
@@ -354,8 +354,8 @@ func resourceLustreFileSystemMetadataConfigCustomizeDiff(_ context.Context, d *s
 				}
 
 				if len(metaNew) > 0 && len(metaOld) > 0 {
-					if metaNew["iops"].(int) < metaOld["iops"].(int) {
-						log.Printf("[DEBUG] Forcing new due to metadata iops decrease. old iops: %d new iops: %d", metaOld["iops"].(int), metaNew["iops"].(int))
+					if metaNew[names.AttrIOPS].(int) < metaOld[names.AttrIOPS].(int) {
+						log.Printf("[DEBUG] Forcing new due to metadata iops decrease. old iops: %d new iops: %d", metaOld[names.AttrIOPS].(int), metaNew[names.AttrIOPS].(int))
 						if err := d.ForceNew("metadata_configuration.0.iops"); err != nil {
 							return err
 						}
@@ -738,10 +738,10 @@ func expandLustreMetadataCreateConfiguration(l []interface{}) *fsx.CreateFileSys
 
 	data := l[0].(map[string]interface{})
 	req := &fsx.CreateFileSystemLustreMetadataConfiguration{
-		Mode: aws.String(data["mode"].(string)),
+		Mode: aws.String(data[names.AttrMode].(string)),
 	}
 
-	if v, ok := data["iops"].(int); ok && v != 0 {
+	if v, ok := data[names.AttrIOPS].(int); ok && v != 0 {
 		req.Iops = aws.Int64(int64(v))
 	}
 
@@ -755,10 +755,10 @@ func expandLustreMetadataUpdateConfiguration(l []interface{}) *fsx.UpdateFileSys
 
 	data := l[0].(map[string]interface{})
 	req := &fsx.UpdateFileSystemLustreMetadataConfiguration{
-		Mode: aws.String(data["mode"].(string)),
+		Mode: aws.String(data[names.AttrMode].(string)),
 	}
 
-	if v, ok := data["iops"].(int); ok && v != 0 {
+	if v, ok := data[names.AttrIOPS].(int); ok && v != 0 {
 		req.Iops = aws.Int64(int64(v))
 	}
 
@@ -771,11 +771,11 @@ func flattenLustreMetadataConfiguration(adopts *fsx.FileSystemLustreMetadataConf
 	}
 
 	m := map[string]interface{}{
-		"mode": aws.StringValue(adopts.Mode),
+		names.AttrMode: aws.StringValue(adopts.Mode),
 	}
 
 	if adopts.Iops != nil {
-		m["iops"] = aws.Int64Value(adopts.Iops)
+		m[names.AttrIOPS] = aws.Int64Value(adopts.Iops)
 	}
 
 	return []map[string]interface{}{m}

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -788,6 +788,7 @@ func TestAccFSxLustreFileSystem_metadataConfig(t *testing.T) {
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "AUTOMATIC"),
+					resource.TestCheckResourceAttrSet(resourceName, "metadata_configuration.0.iops"),
 				),
 			},
 			{

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -53,6 +53,7 @@ func TestAccFSxLustreFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "imported_file_chunk_size", acctest.Ct0),
 					resource.TestCheckResourceAttr(resourceName, "log_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "log_configuration.0.level", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "mount_name"),
 					resource.TestCheckResourceAttr(resourceName, "network_interface_ids.#", acctest.Ct2),
 					acctest.CheckResourceAttrAccountID(resourceName, names.AttrOwnerID),
@@ -762,6 +763,129 @@ func TestAccFSxLustreFileSystem_logConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "log_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "log_configuration.0.level", "ERROR_ONLY"),
 					resource.TestCheckResourceAttrSet(resourceName, "log_configuration.0.destination"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFSxLustreFileSystem_metadataConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var filesystem1, filesystem2 fsx.FileSystem
+	resourceName := "aws_fsx_lustre_file_system.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, fsx.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FSxServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLustreFileSystemDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLustreFileSystemConfig_metadata(rName, "AUTOMATIC"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
+					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "AUTOMATIC"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrSecurityGroupIDs},
+			},
+			{
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem2),
+					testAccCheckLustreFileSystemNotRecreated(&filesystem1, &filesystem2),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "1500"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFSxLustreFileSystem_metadataConfig_increase(t *testing.T) {
+	ctx := acctest.Context(t)
+	var filesystem1, filesystem2 fsx.FileSystem
+	resourceName := "aws_fsx_lustre_file_system.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, fsx.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FSxServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLustreFileSystemDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "1500"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrSecurityGroupIDs},
+			},
+			{
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 3000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem2),
+					testAccCheckLustreFileSystemNotRecreated(&filesystem1, &filesystem2),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "3000"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFSxLustreFileSystem_metadataConfig_decrease(t *testing.T) {
+	ctx := acctest.Context(t)
+	var filesystem1, filesystem2 fsx.FileSystem
+	resourceName := "aws_fsx_lustre_file_system.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, fsx.EndpointsID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.FSxServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLustreFileSystemDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 3000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "3000"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrSecurityGroupIDs},
+			},
+			{
+				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem2),
+					testAccCheckLustreFileSystemRecreated(&filesystem1, &filesystem2),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "1500"),
 				),
 			},
 		},
@@ -1606,6 +1730,45 @@ resource "aws_fsx_lustre_file_system" "test" {
   }
 }
 `, rName, status))
+}
+
+func testAccLustreFileSystemConfig_metadata(rName, mode string) string {
+	return acctest.ConfigCompose(testAccLustreFileSystemConfig_base(rName), fmt.Sprintf(`
+resource "aws_fsx_lustre_file_system" "test" {
+  storage_capacity            = 1200
+  subnet_ids                  = aws_subnet.test[*].id
+  deployment_type             = "PERSISTENT_2"
+  per_unit_storage_throughput = 125
+
+  metadata_configuration {
+    mode = %[2]q
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, mode))
+}
+
+func testAccLustreFileSystemConfig_metadata_iops(rName, mode string, iops int) string {
+	return acctest.ConfigCompose(testAccLustreFileSystemConfig_base(rName), fmt.Sprintf(`
+resource "aws_fsx_lustre_file_system" "test" {
+  storage_capacity            = 1200
+  subnet_ids                  = aws_subnet.test[*].id
+  deployment_type             = "PERSISTENT_2"
+  per_unit_storage_throughput = 125
+
+  metadata_configuration {
+    mode = %[2]q
+    iops = %[3]d
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, mode, iops))
 }
 
 func testAccLustreFileSystemConfig_rootSquash(rName, uid string) string {

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -53,7 +53,7 @@ func TestAccFSxLustreFileSystem_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "imported_file_chunk_size", acctest.Ct0),
 					resource.TestCheckResourceAttr(resourceName, "log_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "log_configuration.0.level", "DISABLED"),
-					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", acctest.Ct0),
 					resource.TestCheckResourceAttrSet(resourceName, "mount_name"),
 					resource.TestCheckResourceAttr(resourceName, "network_interface_ids.#", acctest.Ct2),
 					acctest.CheckResourceAttrAccountID(resourceName, names.AttrOwnerID),
@@ -786,7 +786,7 @@ func TestAccFSxLustreFileSystem_metadataConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
-					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "AUTOMATIC"),
 					resource.TestCheckResourceAttrSet(resourceName, "metadata_configuration.0.iops"),
 				),
@@ -802,7 +802,7 @@ func TestAccFSxLustreFileSystem_metadataConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem2),
 					testAccCheckLustreFileSystemNotRecreated(&filesystem1, &filesystem2),
-					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "1500"),
 				),
@@ -827,7 +827,7 @@ func TestAccFSxLustreFileSystem_metadataConfig_increase(t *testing.T) {
 				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 1500),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
-					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "1500"),
 				),
@@ -843,7 +843,7 @@ func TestAccFSxLustreFileSystem_metadataConfig_increase(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem2),
 					testAccCheckLustreFileSystemNotRecreated(&filesystem1, &filesystem2),
-					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "3000"),
 				),
@@ -868,7 +868,7 @@ func TestAccFSxLustreFileSystem_metadataConfig_decrease(t *testing.T) {
 				Config: testAccLustreFileSystemConfig_metadata_iops(rName, "USER_PROVISIONED", 3000),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem1),
-					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "3000"),
 				),
@@ -884,7 +884,7 @@ func TestAccFSxLustreFileSystem_metadataConfig_decrease(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLustreFileSystemExists(ctx, resourceName, &filesystem2),
 					testAccCheckLustreFileSystemRecreated(&filesystem1, &filesystem2),
-					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.mode", "USER_PROVISIONED"),
 					resource.TestCheckResourceAttr(resourceName, "metadata_configuration.0.iops", "1500"),
 				),

--- a/website/docs/r/fsx_lustre_file_system.html.markdown
+++ b/website/docs/r/fsx_lustre_file_system.html.markdown
@@ -47,12 +47,20 @@ This resource supports the following arguments:
 * `data_compression_type` - (Optional) Sets the data compression configuration for the file system. Valid values are `LZ4` and `NONE`. Default value is `NONE`. Unsetting this value reverts the compression type back to `NONE`.
 * `file_system_type_version` - (Optional) Sets the Lustre version for the file system that you're creating. Valid values are 2.10 for `SCRATCH_1`, `SCRATCH_2` and `PERSISTENT_1` deployment types. Valid values for 2.12 include all deployment types.
 * `log_configuration` - (Optional) The Lustre logging configuration used when creating an Amazon FSx for Lustre file system. When logging is enabled, Lustre logs error and warning events for data repositories associated with your file system to Amazon CloudWatch Logs.
+* `metadata_configuration` - (Optional) The Lustre metadata configuration used when creating an Amazon FSx for Lustre file system. This can be used to specify a user provisioned metadata scale. This is only supported when `deployment_type` is set to `PERSISTENT_2`. See Metadata Configuration below.
 * `root_squash_configuration` - (Optional) The Lustre root squash configuration used when creating an Amazon FSx for Lustre file system. When enabled, root squash restricts root-level access from clients that try to access your file system as a root user.
 
 ### log_configuration
 
 * `destination` - (Optional) The Amazon Resource Name (ARN) that specifies the destination of the logs. The name of the Amazon CloudWatch Logs log group must begin with the `/aws/fsx` prefix. If you do not provide a destination, Amazon FSx will create and use a log stream in the CloudWatch Logs `/aws/fsx/lustre` log group.
 * `level` - (Optional) Sets which data repository events are logged by Amazon FSx. Valid values are `WARN_ONLY`, `FAILURE_ONLY`, `ERROR_ONLY`, `WARN_ERROR` and `DISABLED`. Default value is `DISABLED`.
+
+### metadata_configuration
+
+* `mode` - (Optional) Mode for the metadata configuration of the file system. Valid values are `AUTOMATIC`, and `USER_PROVISIONED`.
+* `iops` - (Optional) Amount of IOPS provisioned for metadata. This parameter should only be used when the mode is set to `USER_PROVISIONED`. Valid Values are `1500`,`3000`,`6000` and `12000` through `192000` in increments of `12000`.
+
+!> **WARNING:** Updating the value of `iops` from a higher to a lower value will force a recreation of the resource. Any data on the file system will be lost when recreating.
 
 ### root_squash_configuration
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---

--->
New Amazon FSx for Lustre Metadata Feature. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccFSxLustreFileSystem_metadataConfig' PKG_NAME=internal/service/fsx ACCTEST_PARALLELISM=3
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.21.8 test ./internal/service/fsx/... -v -count 1 -parallel 3  -run=TestAccFSxLustreFileSystem_metadataConfig -timeout 360m
=== RUN   TestAccFSxLustreFileSystem_metadataConfig
=== PAUSE TestAccFSxLustreFileSystem_metadataConfig
=== RUN   TestAccFSxLustreFileSystem_metadataConfig_increase
=== PAUSE TestAccFSxLustreFileSystem_metadataConfig_increase
=== RUN   TestAccFSxLustreFileSystem_metadataConfig_decrease
=== PAUSE TestAccFSxLustreFileSystem_metadataConfig_decrease
=== CONT  TestAccFSxLustreFileSystem_metadataConfig
=== CONT  TestAccFSxLustreFileSystem_metadataConfig_decrease
=== CONT  TestAccFSxLustreFileSystem_metadataConfig_increase
--- PASS: TestAccFSxLustreFileSystem_metadataConfig (937.82s)
--- PASS: TestAccFSxLustreFileSystem_metadataConfig_increase (1163.32s)
--- PASS: TestAccFSxLustreFileSystem_metadataConfig_decrease (1291.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fsx        1305.950s

...
```
