### PR TITLE
docs: Fix import ID desc for aws_detective_organization_configuration

### DIFF
--- a/website/docs/r/detective_organization_configuration.html.markdown
+++ b/website/docs/r/detective_organization_configuration.html.markdown
@@ -21,7 +21,7 @@ resource "aws_detective_graph" "example" {
 
 resource "aws_detective_organization_configuration" "example" {
   auto_enable = true
-  graph_arn   = aws_detective_graph.example.id
+  graph_arn   = aws_detective_graph.example.graph_arn
 }
 ```
 
@@ -40,17 +40,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `aws_detective_organization_admin_account` using the Detective Graph ID. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `aws_detective_organization_admin_account` using the behavior graph ARN. For example:
 
 ```terraform
 import {
   to = aws_detective_organization_configuration.example
-  id = "00b00fd5aecc0ab60a708659477e9617"
+  id = "arn:aws:detective:us-east-1:123456789012:graph:00b00fd5aecc0ab60a708659477e9617"
 }
 ```
 
-Using `terraform import`, import `aws_detective_organization_admin_account` using the Detective Graph ID. For example:
+Using `terraform import`, import `aws_detective_organization_admin_account` using the behavior graph ARN. For example:
 
 ```console
-% terraform import aws_detective_organization_configuration.example 00b00fd5aecc0ab60a708659477e9617
+% terraform import aws_detective_organization_configuration.example arn:aws:detective:us-east-1:123456789012:graph:00b00fd5aecc0ab60a708659477e9617
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the ID description in the import section of the `aws_detective_organization_configuration` resource doc. For good measure, I've also updated `id` to `graph_arn` for the `aws_detective_graph` reference in the example to avoid confusion.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37822

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Reviewed `organization_configuration.go` to see what `id` is set to.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
n/a
```