### PR TITLE
docs: update details on source_action_name for aws_codepipeline

### DIFF
--- a/website/docs/r/codepipeline.html.markdown
+++ b/website/docs/r/codepipeline.html.markdown
@@ -224,7 +224,7 @@ A `trigger` block supports the following arguments:
 
 A `git_configuration` block supports the following arguments:
 
-* `source_action_name` - (Required) The name of the pipeline source action where the trigger configuration.
+* `source_action_name` - (Required) The name of the pipeline source action where the trigger configuration, such as Git tags, is specified. The trigger configuration will start the pipeline upon the specified change only.
 * `pull_request` - (Optional) The field where the repository event that will start the pipeline is specified as pull requests. A `pull_request` block is documented below.
 * `push` - (Optional) The field where the repository event that will start the pipeline, such as pushing Git tags, is specified with details. A `push` block is documented below.
 


### PR DESCRIPTION
### Description

See #37906 : The current documentation for the AWS CodePipeline resource contains an incomplete sentence under 
`git_configuration`/` source_action_name`.

### Relations

Closes #37906 

### References

- [Latest AWS provider documentation for AWS CodePipeline source_action_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codepipeline#source_action_name)

- [Cloudformation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codepipeline-pipeline-gitconfiguration.html#cfn-codepipeline-pipeline-gitconfiguration-sourceactionname)

### Output from Acceptance Testing

Not required. Only documentation/ website is update.