### PR TITLE
Modify changelog generation to use a GitHub app token

### DIFF
--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -8,6 +8,11 @@ jobs:
     if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@c8f55efbd427e7465d6da1106e7979bc8aaee856 # v1.10.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PEM }}
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           fetch-depth: 0
@@ -27,5 +32,6 @@ jobs:
             git config --local user.name changelogbot
             git add CHANGELOG.md
             git commit -m "$MSG"
+            git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
             git push
           fi

--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: .ci/tools/go.mod
@@ -32,6 +33,5 @@ jobs:
             git config --local user.name changelogbot
             git add CHANGELOG.md
             git commit -m "$MSG"
-            git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
             git push
           fi


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Updates the `generate_changelog.yml` workflow to use a GitHub app to generate a token to push changelog changes back to main. This is so we can enable branch protection rulesets in a future step, but allow changelog automation to continue to work without a PR review.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

Based on:

- https://github.com/orgs/community/discussions/25305#discussioncomment-8256560