### PR TITLE
Enable codeowners for `default` and `/.github`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-# Note: Default owner is commented out in order to reduce review requested noise for maintainers.
-*       @hashicorp/terraform-aws
+* @hashicorp/terraform-aws
+/.github/ @breathingdust @justinretzolk

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Note: Default owner is commented out in order to reduce review requested noise for maintainers.
-# *       @hashicorp/terraform-aws
+*       @hashicorp/terraform-aws

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @hashicorp/terraform-aws
-/.github/ @breathingdust @justinretzolk
+*             @hashicorp/terraform-aws
+/.github/     @breathingdust @justinretzolk


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Uncomment default owner and add a more specific owner for the `/.github` directory.