### PR TITLE
Make archive tiering optional

### DIFF
--- a/internal/service/s3/bucket_intelligent_tiering_configuration.go
+++ b/internal/service/s3/bucket_intelligent_tiering_configuration.go
@@ -75,8 +75,8 @@ func resourceBucketIntelligentTieringConfiguration() *schema.Resource {
 			},
 			"tiering": {
 				Type:     schema.TypeSet,
-				Required: true,
-				MinItems: 1,
+				Optional: true,
+				MaxItems: 2,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"access_tier": {


### PR DESCRIPTION
### Description

According to the "archive" and "deep-archive" tiers are optional.  This PR makes them optional here as well.


### Relations

Closes #37077

### References

AWS S3 Intelligent Tiering Docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering-overview.html


### Output from Acceptance Testing

I did not run the acceptance test on this.  I don't have the resources to do so.