### PR TITLE
Fix ami query returning no results

### DIFF
--- a/.changelog/37958.txt
+++ b/.changelog/37958.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_ami_datasource: Fix query returning no results
+```

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -212,6 +212,10 @@ func ExpandStringValueSet(configured *schema.Set) []string {
 	return ExpandStringValueList(configured.List()) // nosemgrep:ci.helper-schema-Set-extraneous-ExpandStringList-with-List
 }
 
+func ExpandStringValueEmptySet(configured *schema.Set) []string {
+	return ExpandStringValueListEmpty(configured.List()) // nosemgrep:ci.helper-schema-Set-extraneous-ExpandStringList-with-List
+}
+
 func ExpandStringyValueSet[E ~string](configured *schema.Set) []E {
 	return ExpandStringyValueList[E](configured.List())
 }

--- a/internal/service/ec2/filters.go
+++ b/internal/service/ec2/filters.go
@@ -213,7 +213,7 @@ func newCustomFilterListV2(s *schema.Set) []awstypes.Filter {
 
 	return tfslices.ApplyToAll(s.List(), func(tfList interface{}) awstypes.Filter {
 		tfMap := tfList.(map[string]interface{})
-		return newFilterV2(tfMap[names.AttrName].(string), flex.ExpandStringValueSet(tfMap[names.AttrValues].(*schema.Set)))
+		return newFilterV2(tfMap[names.AttrName].(string), flex.ExpandStringValueEmptySet(tfMap[names.AttrValues].(*schema.Set)))
 	})
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
There was a [change/bug fix](https://github.com/aws/aws-sdk-go/blob/main/CHANGELOG.md#sdk-bugs-1) in the aws_sdk where they no longer serialize empty, non-nil lists for ec2.
This impacted the way the aws_ami datasource filter was being created. It will now call a different expand function.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37709 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTARGS="-run=TestAccEC2AMIDataSource_" PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2AMIDataSource_ -timeout 360m
=== RUN   TestAccEC2AMIDataSource_linuxInstance
=== PAUSE TestAccEC2AMIDataSource_linuxInstance
=== RUN   TestAccEC2AMIDataSource_windowsInstance
=== PAUSE TestAccEC2AMIDataSource_windowsInstance
=== RUN   TestAccEC2AMIDataSource_instanceStore
=== PAUSE TestAccEC2AMIDataSource_instanceStore
=== RUN   TestAccEC2AMIDataSource_localNameFilter
=== PAUSE TestAccEC2AMIDataSource_localNameFilter
=== RUN   TestAccEC2AMIDataSource_gp3BlockDevice
=== PAUSE TestAccEC2AMIDataSource_gp3BlockDevice
=== CONT  TestAccEC2AMIDataSource_linuxInstance
=== CONT  TestAccEC2AMIDataSource_localNameFilter
=== CONT  TestAccEC2AMIDataSource_gp3BlockDevice
=== CONT  TestAccEC2AMIDataSource_instanceStore
=== CONT  TestAccEC2AMIDataSource_windowsInstance
--- PASS: TestAccEC2AMIDataSource_linuxInstance (11.32s)
--- PASS: TestAccEC2AMIDataSource_instanceStore (11.44s)
--- PASS: TestAccEC2AMIDataSource_localNameFilter (11.48s)
--- PASS: TestAccEC2AMIDataSource_windowsInstance (12.31s)
--- PASS: TestAccEC2AMIDataSource_gp3BlockDevice (59.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        65.471s

...
```
