### PR TITLE
bugfix: Update maximum build_timeout for codebuild from 8 hours to 36 hours

### DIFF
--- a/.changelog/37970.txt
+++ b/.changelog/37970.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codebuild_project: Update build_timeout maximum from 8 hours to 36 hours.
+```

--- a/.changelog/37970.txt
+++ b/.changelog/37970.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_codebuild_project: Update build_timeout maximum from 8 hours to 36 hours.
+resource/aws_codebuild_project: Increase maximum values of `build_batch_config.timeout_in_mins` and `build_timeout` from `480` (8 hours) to `2160` (36 hours)
 ```

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -172,7 +172,7 @@ func resourceProject() *schema.Resource {
 						"timeout_in_mins": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(5, 480),
+							ValidateFunc: validation.IntBetween(5, 2160),
 						},
 					},
 				},
@@ -181,7 +181,7 @@ func resourceProject() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      60,
-				ValidateFunc: validation.IntBetween(5, 480),
+				ValidateFunc: validation.IntBetween(5, 2160),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					switch environmentType := types.EnvironmentType(d.Get("environment.0.type").(string)); environmentType {
 					case types.EnvironmentTypeArmLambdaContainer, types.EnvironmentTypeLinuxLambdaContainer:

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -1030,7 +1030,7 @@ func TestAccCodeBuildProject_buildBatchConfigDelete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "build_batch_config.0.restrictions.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "build_batch_config.0.restrictions.0.compute_types_allowed.#", acctest.Ct0),
 					resource.TestCheckResourceAttr(resourceName, "build_batch_config.0.restrictions.0.maximum_builds_allowed", acctest.Ct10),
-					resource.TestCheckResourceAttr(resourceName, "build_batch_config.0.timeout_in_mins", "480"),
+					resource.TestCheckResourceAttr(resourceName, "build_batch_config.0.timeout_in_mins", "2160"),
 				),
 			},
 			{
@@ -3918,7 +3918,7 @@ build_batch_config {
   }
 
   service_role    = aws_iam_role.test.arn
-  timeout_in_mins = 480
+  timeout_in_mins = 2160
 }
 `
 

--- a/website/docs/cdktf/python/r/codebuild_project.html.markdown
+++ b/website/docs/cdktf/python/r/codebuild_project.html.markdown
@@ -208,7 +208,7 @@ The following arguments are optional:
 
 * `badge_enabled` - (Optional) Generates a publicly-accessible URL for the projects build badge. Available as `badge_url` attribute when enabled.
 * `build_batch_config` - (Optional) Defines the batch build options for the project.
-* `build_timeout` - (Optional) Number of minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes. The `build_timeout` property is not available on the `Lambda` compute type.
+* `build_timeout` - (Optional) Number of minutes, from 5 to 2160 (36 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes. The `build_timeout` property is not available on the `Lambda` compute type.
 * `cache` - (Optional) Configuration block. Detailed below.
 * `concurrent_build_limit` - (Optional) Specify a maximum number of concurrent builds for the project. The value specified must be greater than 0 and less than the account concurrent running builds limit.
 * `description` - (Optional) Short description of the project.

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -237,7 +237,7 @@ The following arguments are optional:
 
 * `badge_enabled` - (Optional) Generates a publicly-accessible URL for the projects build badge. Available as `badge_url` attribute when enabled.
 * `build_batch_config` - (Optional) Defines the batch build options for the project.
-* `build_timeout` - (Optional) Number of minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes. The `build_timeout` property is not available on the `Lambda` compute type.
+* `build_timeout` - (Optional) Number of minutes, from 5 to 2160 (36 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes. The `build_timeout` property is not available on the `Lambda` compute type.
 * `cache` - (Optional) Configuration block. Detailed below.
 * `concurrent_build_limit` - (Optional) Specify a maximum number of concurrent builds for the project. The value specified must be greater than 0 and less than the account concurrent running builds limit.
 * `description` - (Optional) Short description of the project.


### PR DESCRIPTION
### Description
The maximum timeout for AWS CodeBuild has been updated to 36 hours (2160 minutes). Update the provider configuration to allow setting values > 480. Currently, trying to set values > 480 will result in the following provider error:
```
Error: 
expected build_timeout to be in the range (5 - 480), got 2160
```

### Relations
Fixes hashicorp/terraform-provider-aws#37823


### References
[Quotas for AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/limits.html)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccCodeBuildProject_buildBatchConfigDelete PKG=codebuild
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildProject_buildBatchConfigDelete'  -timeout 360m
=== RUN   TestAccCodeBuildProject_buildBatchConfigDelete
=== PAUSE TestAccCodeBuildProject_buildBatchConfigDelete
=== CONT  TestAccCodeBuildProject_buildBatchConfigDelete
--- PASS: TestAccCodeBuildProject_buildBatchConfigDelete (53.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codebuild	53.968s
```
