### PR TITLE
d/aws_ami: Fix `interface conversion: interface {} is types.ProductCodeValues, not string` panic

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_ami: Fix `interface conversion: interface {} is types.ProductCodeValues, not string` panic
+```

--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -4,10 +4,8 @@
 package ec2
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"sort"
 	"time"
 
@@ -20,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -50,7 +47,6 @@ func dataSourceAMI() *schema.Resource {
 			"block_device_mappings": {
 				Type:     schema.TypeSet,
 				Computed: true,
-				Set:      amiBlockDeviceMappingHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrDeviceName: {
@@ -170,7 +166,6 @@ func dataSourceAMI() *schema.Resource {
 			"product_codes": {
 				Type:     schema.TypeSet,
 				Computed: true,
-				Set:      amiProductCodesHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"product_code_id": {
@@ -349,48 +344,54 @@ func dataSourceAMIRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func flattenAMIBlockDeviceMappings(m []awstypes.BlockDeviceMapping) *schema.Set {
-	s := &schema.Set{
-		F: amiBlockDeviceMappingHash,
+func flattenAMIBlockDeviceMappings(apiObjects []awstypes.BlockDeviceMapping) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
 	}
-	for _, v := range m {
-		mapping := map[string]interface{}{
-			names.AttrDeviceName:  aws.ToString(v.DeviceName),
-			names.AttrVirtualName: aws.ToString(v.VirtualName),
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		tfMap := map[string]interface{}{
+			names.AttrDeviceName:  aws.ToString(apiObject.DeviceName),
+			names.AttrVirtualName: aws.ToString(apiObject.VirtualName),
 		}
 
-		if v.Ebs != nil {
+		if apiObject := apiObject.Ebs; apiObject != nil {
 			ebs := map[string]interface{}{
-				names.AttrDeleteOnTermination: fmt.Sprintf("%t", aws.ToBool(v.Ebs.DeleteOnTermination)),
-				names.AttrEncrypted:           fmt.Sprintf("%t", aws.ToBool(v.Ebs.Encrypted)),
-				names.AttrIOPS:                fmt.Sprintf("%d", aws.ToInt32(v.Ebs.Iops)),
-				names.AttrThroughput:          fmt.Sprintf("%d", aws.ToInt32(v.Ebs.Throughput)),
-				names.AttrVolumeSize:          fmt.Sprintf("%d", aws.ToInt32(v.Ebs.VolumeSize)),
-				names.AttrSnapshotID:          aws.ToString(v.Ebs.SnapshotId),
-				names.AttrVolumeType:          v.Ebs.VolumeType,
+				names.AttrDeleteOnTermination: flex.BoolToStringValue(apiObject.DeleteOnTermination),
+				names.AttrEncrypted:           flex.BoolToStringValue(apiObject.Encrypted),
+				names.AttrIOPS:                flex.Int32ToStringValue(apiObject.Iops),
+				names.AttrSnapshotID:          aws.ToString(apiObject.SnapshotId),
+				names.AttrThroughput:          flex.Int32ToStringValue(apiObject.Throughput),
+				names.AttrVolumeSize:          flex.Int32ToStringValue(apiObject.VolumeSize),
+				names.AttrVolumeType:          apiObject.VolumeType,
 			}
 
-			mapping["ebs"] = ebs
+			tfMap["ebs"] = ebs
 		}
 
-		log.Printf("[DEBUG] aws_ami - adding block device mapping: %v", mapping)
-		s.Add(mapping)
+		tfList = append(tfList, tfMap)
 	}
-	return s
+
+	return tfList
 }
 
-func flattenAMIProductCodes(m []awstypes.ProductCode) *schema.Set {
-	s := &schema.Set{
-		F: amiProductCodesHash,
+func flattenAMIProductCodes(apiObjects []awstypes.ProductCode) []interface{} {
+	if len(apiObjects) == 0 {
+		return nil
 	}
-	for _, v := range m {
-		code := map[string]interface{}{
-			"product_code_id":   aws.ToString(v.ProductCodeId),
-			"product_code_type": v.ProductCodeType,
-		}
-		s.Add(code)
+
+	var tfList []interface{}
+
+	for _, apiObject := range apiObjects {
+		tfList = append(tfList, map[string]interface{}{
+			"product_code_id":   aws.ToString(apiObject.ProductCodeId),
+			"product_code_type": apiObject.ProductCodeType,
+		})
 	}
-	return s
+
+	return tfList
 }
 
 func amiRootSnapshotId(image awstypes.Image) string {
@@ -419,40 +420,4 @@ func flattenAMIStateReason(m *awstypes.StateReason) map[string]interface{} {
 		s[names.AttrMessage] = "UNSET"
 	}
 	return s
-}
-
-func amiBlockDeviceMappingHash(v interface{}) int {
-	var buf bytes.Buffer
-	// All keys added in alphabetical order.
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
-	if d, ok := m["ebs"]; ok {
-		if len(d.(map[string]interface{})) > 0 {
-			e := d.(map[string]interface{})
-			buf.WriteString(fmt.Sprintf("%s-", e[names.AttrDeleteOnTermination].(string)))
-			buf.WriteString(fmt.Sprintf("%s-", e[names.AttrEncrypted].(string)))
-			buf.WriteString(fmt.Sprintf("%s-", e[names.AttrIOPS].(string)))
-			buf.WriteString(fmt.Sprintf("%s-", e[names.AttrVolumeSize].(string)))
-			buf.WriteString(fmt.Sprintf("%s-", e[names.AttrVolumeType]))
-		}
-	}
-	if d, ok := m["no_device"]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", d.(string)))
-	}
-	if d, ok := m[names.AttrVirtualName]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", d.(string)))
-	}
-	if d, ok := m[names.AttrSnapshotID]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", d.(string)))
-	}
-	return create.StringHashcode(buf.String())
-}
-
-func amiProductCodesHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	// All keys added in alphabetical order.
-	buf.WriteString(fmt.Sprintf("%s-", m["product_code_id"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["product_code_type"].(string)))
-	return create.StringHashcode(buf.String())
 }

--- a/internal/service/ec2/ec2_ami_data_source_test.go
+++ b/internal/service/ec2/ec2_ami_data_source_test.go
@@ -208,6 +208,25 @@ func TestAccEC2AMIDataSource_gp3BlockDevice(t *testing.T) {
 	})
 }
 
+func TestAccEC2AMIDataSource_productCode(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_ami.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAMIDataSourceConfig_productCode,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "product_codes.#", acctest.Ct1),
+				),
+			},
+		},
+	})
+}
+
 // testAccAMIDataSourceConfig_latestUbuntuBionicHVMInstanceStore returns the configuration for a data source that
 // describes the latest Ubuntu 18.04 AMI using HVM virtualization and an instance store root device.
 // The data source is named 'ubuntu-bionic-ami-hvm-instance-store'.
@@ -322,3 +341,16 @@ data "aws_ami" "test" {
 }
 `)
 }
+
+// Image with product code.
+const testAccAMIDataSourceConfig_productCode = `
+data "aws_ami" "test" {
+  most_recent = true
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "name"
+    values = ["AwsMarketPublished_IBM App Connect v12.0.12.0 and IBM MQ v9.3.0.16 with RapidDeploy 5.1.12 -422d2ddd-3288-4067-be37-4e2a69450606"]
+  }
+}
+`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Removes the custom set hash functions from the `aws_ami` data source -- these are not required for _Computed_ attributes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/37973.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Before fix

```console
% make testacc TESTARGS='-run=TestAccEC2AMIDataSource_productCode' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2AMIDataSource_productCode -timeout 360m
=== RUN   TestAccEC2AMIDataSource_productCode
=== PAUSE TestAccEC2AMIDataSource_productCode
=== CONT  TestAccEC2AMIDataSource_productCode
panic: interface conversion: interface {} is types.ProductCodeValues, not string

goroutine 108 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.amiProductCodesHash({0x1170c5600?, 0x14008f80210})
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/service/ec2/ec2_ami_data_source.go:456 +0x194
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).hash(0x0?, {0x1170c5600?, 0x14008f80210?})
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/set.go:221 +0x34
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).add(0x14008de56c0, {0x1170c5600, 0x14008f80210}, 0x0)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/set.go:201 +0x70
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Set).Add(...)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/set.go:79
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.flattenAMIProductCodes({0x14008de4dc0, 0x1, 0x10?})
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/service/ec2/ec2_ami_data_source.go:391 +0x74
github.com/hashicorp/terraform-provider-aws/internal/service/ec2.dataSourceAMIRead({0x11912d830, 0x14008e60030}, 0x14008c7ef00, {0x118eaa000?, 0x14004caa410})
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/service/ec2/ec2_ami_data_source.go:330 +0x978
github.com/hashicorp/terraform-provider-aws/internal/provider.New.(*wrappedDataSource).Read.interceptedHandler[...].func7(0x14008c7ef00?, {0x118eaa000?, 0x14004caa410})
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/provider/intercept.go:113 +0x1d8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x11912d830?, {0x11912d830?, 0x14008cedcb0?}, 0xd?, {0x118eaa000?, 0x14004caa410?})
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/resource.go:818 +0x64
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0x14005a28b60, {0x11912d830, 0x14008cedcb0}, 0x14008c7ee00, {0x118eaa000, 0x14004caa410})
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/resource.go:1043 +0x110
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0x14003f762e8, {0x11912d830?, 0x14008cedc20?}, 0x14008ced950)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/grpc_provider.go:1434 +0x5a4
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.(*muxServer).ReadDataSource(0x140008220e0, {0x11912d830?, 0x14008ced980?}, 0x14008ced950)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.16.0/tf5muxserver/mux_server_ReadDataSource.go:36 +0x184
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadDataSource(0x140005f2500, {0x11912d830?, 0x14008cecfc0?}, 0x14004108910)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/tf5server/server.go:688 +0x1d8
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler({0x118c8e480, 0x140005f2500}, {0x11912d830, 0x14008cecfc0}, 0x14008c7e880, 0x0)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:572 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x14000fb6000, {0x11912d830, 0x14008cecf30}, {0x11917c780, 0x14006332300}, 0x1400404fe60, 0x140049627b0, 0x1229c9d20, 0x0)
	/Users/kewbank/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1369 +0xb58
google.golang.org/grpc.(*Server).handleStream(0x14000fb6000, {0x11917c780, 0x14006332300}, 0x1400404fe60)
	/Users/kewbank/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1780 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/Users/kewbank/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1019 +0x8c
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 643
	/Users/kewbank/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1030 +0x13c
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	13.051s
FAIL
make: *** [testacc] Error 1
```

#### After fix

```console
% make testacc TESTARGS='-run=TestAccEC2AMIDataSource_' PKG=ec2         
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2AMIDataSource_ -timeout 360m
=== RUN   TestAccEC2AMIDataSource_linuxInstance
=== PAUSE TestAccEC2AMIDataSource_linuxInstance
=== RUN   TestAccEC2AMIDataSource_windowsInstance
=== PAUSE TestAccEC2AMIDataSource_windowsInstance
=== RUN   TestAccEC2AMIDataSource_instanceStore
=== PAUSE TestAccEC2AMIDataSource_instanceStore
=== RUN   TestAccEC2AMIDataSource_localNameFilter
=== PAUSE TestAccEC2AMIDataSource_localNameFilter
=== RUN   TestAccEC2AMIDataSource_gp3BlockDevice
=== PAUSE TestAccEC2AMIDataSource_gp3BlockDevice
=== RUN   TestAccEC2AMIDataSource_productCode
=== PAUSE TestAccEC2AMIDataSource_productCode
=== CONT  TestAccEC2AMIDataSource_linuxInstance
=== CONT  TestAccEC2AMIDataSource_localNameFilter
=== CONT  TestAccEC2AMIDataSource_productCode
=== CONT  TestAccEC2AMIDataSource_gp3BlockDevice
=== CONT  TestAccEC2AMIDataSource_instanceStore
=== CONT  TestAccEC2AMIDataSource_windowsInstance
--- PASS: TestAccEC2AMIDataSource_productCode (23.70s)
--- PASS: TestAccEC2AMIDataSource_linuxInstance (26.80s)
--- PASS: TestAccEC2AMIDataSource_localNameFilter (31.10s)
--- PASS: TestAccEC2AMIDataSource_instanceStore (31.12s)
--- PASS: TestAccEC2AMIDataSource_windowsInstance (31.26s)
--- PASS: TestAccEC2AMIDataSource_gp3BlockDevice (56.68s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	61.246s
```
