### PR TITLE
Ignore `NotFound` error when deleting X-Ray Group

### DIFF
--- a/internal/service/xray/group.go
+++ b/internal/service/xray/group.go
@@ -163,6 +163,10 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta inter
 		GroupARN: aws.String(d.Id()),
 	})
 
+	if errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "Group not found") {
+		return diags
+	}
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting XRay Group (%s): %s", d.Id(), err)
 	}


### PR DESCRIPTION
### Description

Ignore `NotFound` error when deleting X-Ray Group.

Acceptance test `TestAccXRayGroup_disappears` was failing

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=xray TESTS=TestAccXRayGroup_

--- PASS: TestAccXRayGroup_disappears (40.57s)
--- PASS: TestAccXRayGroup_tags_ComputedTag_OnCreate (56.25s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_emptyResourceTag (56.26s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_nullOverlappingResourceTag (56.49s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_emptyProviderOnlyTag (56.53s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_nullNonOverlappingResourceTag (56.55s)
--- PASS: TestAccXRayGroup_basic (69.97s)
--- PASS: TestAccXRayGroup_insights (70.47s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_updateToResourceOnly (76.23s)
--- PASS: TestAccXRayGroup_tags_EmptyTag_OnUpdate_Replace (76.54s)
--- PASS: TestAccXRayGroup_tags_AddOnUpdate (77.90s)
--- PASS: TestAccXRayGroup_tags_ComputedTag_OnUpdate_Replace (78.97s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_updateToProviderOnly (79.09s)
--- PASS: TestAccXRayGroup_tags_ComputedTag_OnUpdate_Add (79.63s)
--- PASS: TestAccXRayGroup_tags_EmptyTag_OnCreate (81.40s)
--- PASS: TestAccXRayGroup_tags_null (42.74s)
--- PASS: TestAccXRayGroup_tags_EmptyTag_OnUpdate_Add (89.53s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_overlapping (93.70s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_nonOverlapping (93.72s)
--- PASS: TestAccXRayGroup_tags (102.49s)
--- PASS: TestAccXRayGroup_tags_DefaultTags_providerOnly (103.60s)
```
