### PR TITLE
Bedrock Custom Models have a maximum training concurrency of 2

### DIFF
--- a/internal/service/bedrock/bedrock_test.go
+++ b/internal/service/bedrock/bedrock_test.go
@@ -13,6 +13,17 @@ func TestAccBedrock_serial(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]map[string]func(t *testing.T){
+		// Model customization has a non-adjustable maximum concurrency of 2
+		"CustomModel": {
+			acctest.CtBasic:                         testAccBedrockCustomModel_basic,
+			acctest.CtDisappears:                    testAccBedrockCustomModel_disappears,
+			"tags":                                  testAccBedrockCustomModel_tags,
+			"kmsKey":                                testAccBedrockCustomModel_kmsKey,
+			"validationDataConfig":                  testAccBedrockCustomModel_validationDataConfig,
+			"validationDataConfigWaitForCompletion": testAccBedrockCustomModel_validationDataConfigWaitForCompletion,
+			"vpcConfig":                             testAccBedrockCustomModel_vpcConfig,
+			"dataSourceBasic":                       testAccBedrockCustomModelDataSource_basic,
+		},
 		"ModelInvocationLoggingConfiguration": {
 			acctest.CtBasic:      testAccModelInvocationLoggingConfiguration_basic,
 			acctest.CtDisappears: testAccModelInvocationLoggingConfiguration_disappears,

--- a/internal/service/bedrock/custom_model_data_source_test.go
+++ b/internal/service/bedrock/custom_model_data_source_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccBedrockCustomModelDataSource_basic(t *testing.T) {
+func testAccBedrockCustomModelDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -24,7 +24,7 @@ func TestAccBedrockCustomModelDataSource_basic(t *testing.T) {
 	datasourceName := "data.aws_bedrock_custom_model.test"
 	var v bedrock.GetModelCustomizationJobOutput
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/bedrock/custom_model_test.go
+++ b/internal/service/bedrock/custom_model_test.go
@@ -21,13 +21,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccBedrockCustomModel_basic(t *testing.T) {
+func testAccBedrockCustomModel_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrock_custom_model.test"
 	var v bedrock.GetModelCustomizationJobOutput
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -72,13 +72,13 @@ func TestAccBedrockCustomModel_basic(t *testing.T) {
 	})
 }
 
-func TestAccBedrockCustomModel_disappears(t *testing.T) {
+func testAccBedrockCustomModel_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrock_custom_model.test"
 	var v bedrock.GetModelCustomizationJobOutput
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -96,13 +96,13 @@ func TestAccBedrockCustomModel_disappears(t *testing.T) {
 	})
 }
 
-func TestAccBedrockCustomModel_tags(t *testing.T) {
+func testAccBedrockCustomModel_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrock_custom_model.test"
 	var v bedrock.GetModelCustomizationJobOutput
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -143,13 +143,13 @@ func TestAccBedrockCustomModel_tags(t *testing.T) {
 	})
 }
 
-func TestAccBedrockCustomModel_kmsKey(t *testing.T) {
+func testAccBedrockCustomModel_kmsKey(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrock_custom_model.test"
 	var v bedrock.GetModelCustomizationJobOutput
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -172,13 +172,13 @@ func TestAccBedrockCustomModel_kmsKey(t *testing.T) {
 	})
 }
 
-func TestAccBedrockCustomModel_validationDataConfig(t *testing.T) {
+func testAccBedrockCustomModel_validationDataConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrock_custom_model.test"
 	var v bedrock.GetModelCustomizationJobOutput
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -203,7 +203,7 @@ func TestAccBedrockCustomModel_validationDataConfig(t *testing.T) {
 	})
 }
 
-func TestAccBedrockCustomModel_validationDataConfigWaitForCompletion(t *testing.T) {
+func testAccBedrockCustomModel_validationDataConfigWaitForCompletion(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -213,7 +213,7 @@ func TestAccBedrockCustomModel_validationDataConfigWaitForCompletion(t *testing.
 	resourceName := "aws_bedrock_custom_model.test"
 	var v bedrock.GetModelCustomizationJobOutput
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -251,13 +251,13 @@ func TestAccBedrockCustomModel_validationDataConfigWaitForCompletion(t *testing.
 	})
 }
 
-func TestAccBedrockCustomModel_vpcConfig(t *testing.T) {
+func testAccBedrockCustomModel_vpcConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrock_custom_model.test"
 	var v bedrock.GetModelCustomizationJobOutput
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,


### PR DESCRIPTION
### Description

Bedrock Custom Models have a maximum training concurrency of 2, and this limit cannot adjusted. Serializes the acceptance tests.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrock TESTS='TestAccBedrock_serial/CustomModel'

--- PASS: TestAccBedrock_serial (14500.35s)
    --- PASS: TestAccBedrock_serial/CustomModel (14500.35s)
        --- PASS: TestAccBedrock_serial/CustomModel/vpcConfig (78.05s)
        --- PASS: TestAccBedrock_serial/CustomModel/dataSourceBasic (7069.65s)
        --- PASS: TestAccBedrock_serial/CustomModel/basic (67.86s)
        --- PASS: TestAccBedrock_serial/CustomModel/disappears (68.86s)
        --- PASS: TestAccBedrock_serial/CustomModel/tags (54.00s)
        --- PASS: TestAccBedrock_serial/CustomModel/kmsKey (58.00s)
        --- PASS: TestAccBedrock_serial/CustomModel/validationDataConfig (63.64s)
        --- PASS: TestAccBedrock_serial/CustomModel/validationDataConfigWaitForCompletion (7040.27s)
```
