### PR TITLE
resource/aws_dynamodb_table: Fixes perpetual diff when `ttl.attribute_name` is set when not enabled

### DIFF
--- a/.changelog/37991.txt
+++ b/.changelog/37991.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fixes perpetual diff when `ttl.attribute_name` is set when `ttl.enabled` is not set.
+```
+
+```release-note:enhancement
+resource/aws_dynamodb_table: Adds validation for `ttl` values.
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -2403,23 +2403,18 @@ func validateTTLCustomDiff(ctx context.Context, d *schema.ResourceDiff, meta any
 	ttlPath := cty.GetAttrPath("ttl")
 	ttl := configRaw.GetAttr("ttl")
 	if ttl.IsKnown() && !ttl.IsNull() {
-		listenerActionsPlantimeValidate(ttlPath, ttl, &diags)
+		if ttl.LengthInt() == 1 {
+			idx := cty.NumberIntVal(0)
+			ttl := ttl.Index(idx)
+			ttlPath := ttlPath.Index(idx)
+			ttlPlantimeValidate(ttlPath, ttl, &diags)
+		}
 	}
 
 	return sdkdiag.DiagnosticsError(diags)
 }
 
-func listenerActionsPlantimeValidate(ttlPath cty.Path, ttl cty.Value, diags *diag.Diagnostics) {
-	it := ttl.ElementIterator()
-	for it.Next() {
-		i, action := it.Element()
-		ttlPath := ttlPath.Index(i)
-
-		listenerActionPlantimeValidate(ttlPath, action, diags)
-	}
-}
-
-func listenerActionPlantimeValidate(ttlPath cty.Path, ttl cty.Value, diags *diag.Diagnostics) {
+func ttlPlantimeValidate(ttlPath cty.Path, ttl cty.Value, diags *diag.Diagnostics) {
 	attribute := ttl.GetAttr("attribute_name")
 	if !attribute.IsKnown() {
 		return

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -3648,7 +3648,7 @@ resource "aws_dynamodb_table" "test" {
 
   ttl {
     attribute_name = ""
-    enabled = %[2]t
+    enabled        = %[2]t
   }
 }
 `, rName, ttlEnabled)

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -19,7 +19,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -372,10 +375,16 @@ func TestAccDynamoDBTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "table_class", "STANDARD"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct0),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsAllPercent, acctest.Ct0),
-					resource.TestCheckResourceAttr(resourceName, "ttl.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "ttl.0.enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "write_capacity", acctest.Ct1),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ttl"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"attribute_name":  knownvalue.StringExact(""),
+							names.AttrEnabled: knownvalue.Bool(false),
+						}),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1365,10 +1374,15 @@ func TestAccDynamoDBTable_TTL_enabled(t *testing.T) {
 				Config: testAccTableConfig_timeToLive(rName, rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, resourceName, &table),
-					resource.TestCheckResourceAttr(resourceName, "ttl.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "ttl.0.attribute_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "ttl.0.enabled", acctest.CtTrue),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ttl"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"attribute_name":  knownvalue.StringExact(rName),
+							names.AttrEnabled: knownvalue.Bool(true),
+						}),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1402,10 +1416,15 @@ func TestAccDynamoDBTable_TTL_disabled(t *testing.T) {
 				Config: testAccTableConfig_timeToLive(rName, "", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, resourceName, &table),
-					resource.TestCheckResourceAttr(resourceName, "ttl.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "ttl.0.attribute_name", ""),
-					resource.TestCheckResourceAttr(resourceName, "ttl.0.enabled", acctest.CtFalse),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ttl"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"attribute_name":  knownvalue.StringExact(""),
+							names.AttrEnabled: knownvalue.Bool(false),
+						}),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1439,10 +1458,15 @@ func TestAccDynamoDBTable_TTL_update(t *testing.T) {
 				Config: testAccTableConfig_timeToLive(rName, "", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, resourceName, &table),
-					resource.TestCheckResourceAttr(resourceName, "ttl.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "ttl.0.attribute_name", ""),
-					resource.TestCheckResourceAttr(resourceName, "ttl.0.enabled", acctest.CtFalse),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ttl"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"attribute_name":  knownvalue.StringExact(""),
+							names.AttrEnabled: knownvalue.Bool(false),
+						}),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -1453,10 +1477,15 @@ func TestAccDynamoDBTable_TTL_update(t *testing.T) {
 				Config: testAccTableConfig_timeToLive(rName, rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, resourceName, &table),
-					resource.TestCheckResourceAttr(resourceName, "ttl.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "ttl.0.attribute_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "ttl.0.enabled", acctest.CtTrue),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("ttl"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"attribute_name":  knownvalue.StringExact(rName),
+							names.AttrEnabled: knownvalue.Bool(true),
+						}),
+					})),
+				},
 			},
 		},
 	})

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -55,7 +55,7 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
 
   ttl {
     attribute_name = "TimeToExist"
-    enabled        = false
+    enabled        = true
   }
 
   global_secondary_index {
@@ -261,8 +261,10 @@ Optional arguments:
 
 ### `ttl`
 
-* `enabled` - (Required) Whether TTL is enabled.
-* `attribute_name` - (Required) Name of the table attribute to store the TTL timestamp in.
+* `attribute_name` - (Optional) Name of the table attribute to store the TTL timestamp in.
+  Required if `enabled` is `true`, must not be set otherwise.
+* `enabled` - (Optional) Whether TTL is enabled.
+  Default value is `false`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

If `ttl.attribute_name` is set when not enabled, it would cause a perpetual diff. Adds validation to require `attribute_name` when enabled, and not allow it when not enabled.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #10304

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dynamodb TESTS=TestAccDynamoDBTable

--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (9.82s)
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (18.27s)
--- PASS: TestAccDynamoDBTableItem_disappears (26.63s)
--- PASS: TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey (37.70s)
--- PASS: TestAccDynamoDBTableItem_mapOutOfBandUpdate (42.48s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (44.35s)
--- PASS: TestAccDynamoDBTable_TTL_validate (6.02s)
--- PASS: TestAccDynamoDBTableDataSource_basic (57.47s)
--- PASS: TestAccDynamoDBTableItem_updateWithRangeKey (39.22s)
--- PASS: TestAccDynamoDBTable_tags (62.24s)
--- PASS: TestAccDynamoDBTableItem_wonkyItems (26.04s)
--- PASS: TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey (24.68s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (67.79s)
--- PASS: TestAccDynamoDBTableItem_update (35.36s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (73.77s)
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (77.08s)
--- PASS: TestAccDynamoDBTableItemDataSource_projectionExpression (25.43s)
--- PASS: TestAccDynamoDBTable_streamSpecification (84.81s)
--- PASS: TestAccDynamoDBTableItem_withMultipleItems (27.15s)
--- PASS: TestAccDynamoDBTableItem_basic (24.13s)
--- PASS: TestAccDynamoDBTableItem_rangeKey (25.96s)
--- PASS: TestAccDynamoDBTable_TTL_update (40.58s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (36.58s)
--- PASS: TestAccDynamoDBTableItemDataSource_basic (25.67s)
--- PASS: TestAccDynamoDBTable_encryption (129.36s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (45.03s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (45.00s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (65.59s)
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (158.05s)
--- PASS: TestAccDynamoDBTable_enablePITR (61.31s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (85.54s)
--- PASS: TestAccDynamoDBTable_disappears (17.87s)
--- PASS: TestAccDynamoDBTable_deletion_protection (28.42s)
--- PASS: TestAccDynamoDBTable_tableClass_migrate (37.20s)
--- PASS: TestAccDynamoDBTableReplica_pitr (206.87s)
--- PASS: TestAccDynamoDBTable_basic (20.75s)
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (25.11s)
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (36.07s)
--- PASS: TestAccDynamoDBTable_importTable (89.64s)
--- PASS: TestAccDynamoDBTableReplica_basic (248.35s)
--- PASS: TestAccDynamoDBTableReplica_disappears (271.34s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (39.89s)
--- PASS: TestAccDynamoDBTable_Replica_single (467.17s)
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (430.13s)
--- PASS: TestAccDynamoDBTable_Replica_pitr (313.67s)
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (424.39s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (587.80s)
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (349.42s)
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (324.01s)
--- PASS: TestAccDynamoDBTableReplica_tableClass (370.98s)
--- PASS: TestAccDynamoDBTableReplica_keys (372.84s)
--- PASS: TestAccDynamoDBTableReplica_tags (251.05s)
--- PASS: TestAccDynamoDBTableItemDataSource_expressionAttributeNames (36.73s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (32.72s)
--- PASS: TestAccDynamoDBTableReplica_pitrKMS (254.06s)
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (252.88s)
--- PASS: TestAccDynamoDBTableReplica_pitrDefault (259.57s)
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (225.80s)
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (273.74s)
--- PASS: TestAccDynamoDBTable_backupEncryption (712.74s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (843.08s)
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (333.48s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (862.75s)
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (379.43s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (918.33s)
--- PASS: TestAccDynamoDBTable_extended (915.90s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (1020.69s)
--- PASS: TestAccDynamoDBTableExport_basic (1001.47s)
--- PASS: TestAccDynamoDBTableExport_kms (1111.90s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (1312.04s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (1372.22s)
--- PASS: TestAccDynamoDBTable_Replica_doubleAddCMK (851.39s)
--- PASS: TestAccDynamoDBTableExport_s3Prefix (1393.89s)
```
