### PR TITLE
s3: add `refresh_content` attribute to `aws_s3_object` to diff drift on human readable objects

### DIFF
--- a/.changelog/37993.txt
+++ b/.changelog/37993.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_object: Add `refresh_content` attribute
+```

--- a/internal/acctest/plancheck/attribute_change.go
+++ b/internal/acctest/plancheck/attribute_change.go
@@ -1,0 +1,70 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package plancheck
+
+import (
+	"context"
+	"fmt"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+type expectKnownChange struct {
+	resourceAddress string
+	attributePath   tfjsonpath.Path
+	knownvalueFrom  knownvalue.Check
+	knownvalueTo    knownvalue.Check
+}
+
+func (e expectKnownChange) CheckPlan(ctx context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	var rc *tfjson.ResourceChange
+
+	for _, resourceChange := range req.Plan.ResourceChanges {
+		if resourceChange.Address == e.resourceAddress {
+			rc = resourceChange
+			break
+		}
+	}
+
+	if rc == nil {
+		resp.Error = fmt.Errorf("%s - Resource not found in plan", e.resourceAddress)
+		return
+	}
+
+	before, err := tfjsonpath.Traverse(rc.Change.Before, e.attributePath)
+
+	if err != nil {
+		resp.Error = err
+		return
+	}
+
+	if err := e.knownvalueFrom.CheckValue(before); err != nil {
+		resp.Error = err
+		return
+	}
+
+	after, err := tfjsonpath.Traverse(rc.Change.After, e.attributePath)
+
+	if err != nil {
+		resp.Error = err
+		return
+	}
+
+	if err := e.knownvalueTo.CheckValue(after); err != nil {
+		resp.Error = err
+		return
+	}
+}
+
+func ExpectKnownChange(resourceAddress string, attributePath tfjsonpath.Path, knownvalueFrom, knownvalueTo knownvalue.Check) plancheck.PlanCheck {
+	return expectKnownChange{
+		resourceAddress: resourceAddress,
+		attributePath:   attributePath,
+		knownvalueFrom:  knownvalueFrom,
+		knownvalueTo:    knownvalueTo,
+	}
+}

--- a/internal/service/s3/object_tags_gen_test.go
+++ b/internal/service/s3/object_tags_gen_test.go
@@ -70,7 +70,7 @@ func TestAccS3Object_tags(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -119,7 +119,7 @@ func TestAccS3Object_tags(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -163,7 +163,7 @@ func TestAccS3Object_tags(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -197,7 +197,7 @@ func TestAccS3Object_tags(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -252,7 +252,7 @@ func TestAccS3Object_tags_null(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -342,7 +342,7 @@ func TestAccS3Object_tags_AddOnUpdate(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -401,7 +401,7 @@ func TestAccS3Object_tags_EmptyTag_OnCreate(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -435,7 +435,7 @@ func TestAccS3Object_tags_EmptyTag_OnCreate(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -526,7 +526,7 @@ func TestAccS3Object_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -570,7 +570,7 @@ func TestAccS3Object_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -657,7 +657,7 @@ func TestAccS3Object_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -719,7 +719,7 @@ func TestAccS3Object_tags_DefaultTags_providerOnly(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -770,7 +770,7 @@ func TestAccS3Object_tags_DefaultTags_providerOnly(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -817,7 +817,7 @@ func TestAccS3Object_tags_DefaultTags_providerOnly(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -854,7 +854,7 @@ func TestAccS3Object_tags_DefaultTags_providerOnly(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -926,7 +926,7 @@ func TestAccS3Object_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -989,7 +989,7 @@ func TestAccS3Object_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -1026,7 +1026,7 @@ func TestAccS3Object_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -1096,7 +1096,7 @@ func TestAccS3Object_tags_DefaultTags_overlapping(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -1159,7 +1159,7 @@ func TestAccS3Object_tags_DefaultTags_overlapping(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 			{
@@ -1214,7 +1214,7 @@ func TestAccS3Object_tags_DefaultTags_overlapping(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -1308,7 +1308,7 @@ func TestAccS3Object_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -1401,7 +1401,7 @@ func TestAccS3Object_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -1470,7 +1470,7 @@ func TestAccS3Object_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -1531,7 +1531,7 @@ func TestAccS3Object_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -1597,7 +1597,7 @@ func TestAccS3Object_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -1663,7 +1663,7 @@ func TestAccS3Object_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -1721,7 +1721,7 @@ func TestAccS3Object_tags_ComputedTag_OnCreate(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -1815,7 +1815,7 @@ func TestAccS3Object_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},
@@ -1902,7 +1902,7 @@ func TestAccS3Object_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ImportStateIdFunc: testAccObjectImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					names.AttrForceDestroy,
+					names.AttrForceDestroy, "refresh_content",
 				},
 			},
 		},

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,8 +24,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	sdkplancheck "github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest/plancheck"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfs3 "github.com/hashicorp/terraform-provider-aws/internal/service/s3"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -161,7 +166,7 @@ func TestAccS3Object_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -274,7 +279,7 @@ func TestAccS3Object_source(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource, "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -304,7 +309,7 @@ func TestAccS3Object_content(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrContent, "content_base64", names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrContent, "content_base64", names.AttrForceDestroy, "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -337,7 +342,7 @@ func TestAccS3Object_etagEncryption(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource, "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -415,7 +420,7 @@ func TestAccS3Object_sourceHashTrigger(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrContent, "content_base64", names.AttrForceDestroy, names.AttrSource, "source_hash"},
+				ImportStateVerifyIgnore: []string{names.AttrContent, "content_base64", names.AttrForceDestroy, names.AttrSource, "source_hash", "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -476,7 +481,7 @@ func TestAccS3Object_nonVersioned(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource, "refresh_content"},
 				ImportStateId:           fmt.Sprintf("s3://%s/updateable-key", rName),
 			},
 		},
@@ -526,7 +531,7 @@ func TestAccS3Object_updates(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource, "refresh_content"},
 				ImportStateId:           fmt.Sprintf("s3://%s/updateable-key", rName),
 			},
 		},
@@ -619,7 +624,7 @@ func TestAccS3Object_updatesWithVersioning(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource, "refresh_content"},
 				ImportStateId:           fmt.Sprintf("s3://%s/updateable-key", rName),
 			},
 		},
@@ -667,6 +672,88 @@ func TestAccS3Object_updatesWithVersioningViaAccessPoint(t *testing.T) {
 	})
 }
 
+func TestAccS3Object_updatesWithContentRefresh(t *testing.T) {
+	ctx := acctest.Context(t)
+	var originalObj s3.GetObjectOutput
+	resourceName := "aws_s3_object.object"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	contentInitial := "managed by terraform"
+	contentUpdated := "not managed by terraform"
+
+	updateObjectBody := func(ctx context.Context, n, newBody string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			rs := s.RootModule().Resources[n]
+
+			conn := acctest.Provider.Meta().(*conns.AWSClient).S3Client(ctx)
+			if tfs3.IsDirectoryBucket(rs.Primary.Attributes[names.AttrBucket]) {
+				conn = acctest.Provider.Meta().(*conns.AWSClient).S3ExpressClient(ctx)
+			}
+
+			var optFns []func(*s3.Options)
+			if arn.IsARN(rs.Primary.Attributes[names.AttrBucket]) && conn.Options().Region == names.GlobalRegionID {
+				optFns = append(optFns, func(o *s3.Options) { o.UseARNRegion = true })
+			}
+
+			input := &s3.PutObjectInput{
+				Bucket: aws.String(rs.Primary.Attributes[names.AttrBucket]),
+				Key:    aws.String(tfs3.SDKv1CompatibleCleanKey(rs.Primary.Attributes[names.AttrKey])),
+				Body:   strings.NewReader(newBody),
+			}
+
+			_, err := conn.PutObject(ctx, input, optFns...)
+
+			return err
+		}
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckObjectDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObjectConfig_contentRefresh(rName, contentInitial),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckObjectExists(ctx, resourceName, &originalObj),
+					testAccCheckObjectBody(&originalObj, contentInitial),
+					updateObjectBody(ctx, resourceName, contentUpdated),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPreRefresh: []sdkplancheck.PlanCheck{
+						sdkplancheck.ExpectEmptyPlan(),
+					},
+					PostApplyPostRefresh: []sdkplancheck.PlanCheck{
+						sdkplancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectKnownChange(
+							resourceName,
+							tfjsonpath.New(names.AttrContent),
+							knownvalue.StringExact(contentUpdated),
+							knownvalue.StringExact(contentInitial),
+						),
+					},
+				},
+			},
+			{
+				Config: testAccObjectConfig_contentRefresh(rName, contentInitial),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckObjectExists(ctx, resourceName, &originalObj),
+					testAccCheckObjectBody(&originalObj, contentInitial),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrContent, "refresh_content", "etag"},
+				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccS3Object_kms(t *testing.T) {
 	ctx := acctest.Context(t)
 	var obj s3.GetObjectOutput
@@ -694,7 +781,7 @@ func TestAccS3Object_kms(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource, "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -728,7 +815,7 @@ func TestAccS3Object_sse(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, names.AttrSource, "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -780,7 +867,7 @@ func TestAccS3Object_acl(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"acl", names.AttrContent, names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{"acl", names.AttrContent, names.AttrForceDestroy, "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -828,7 +915,7 @@ func TestAccS3Object_metadata(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -891,7 +978,7 @@ func TestAccS3Object_storageClass(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrContent, names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrContent, names.AttrForceDestroy, "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -960,7 +1047,7 @@ func TestAccS3Object_tagsLeadingSingleSlash(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrContent, names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrContent, names.AttrForceDestroy, "refresh_content"},
 				ImportStateId:           fmt.Sprintf("s3://%s/%s", rName, key),
 			},
 		},
@@ -1600,7 +1687,7 @@ func TestAccS3Object_checksumAlgorithm(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"checksum_algorithm", "checksum_crc32", names.AttrContent, names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{"checksum_algorithm", "checksum_crc32", names.AttrContent, names.AttrForceDestroy, "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 			{
@@ -1712,7 +1799,7 @@ func TestAccS3Object_directoryBucket(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "override_provider"},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "override_provider", "refresh_content"},
 				ImportStateIdFunc:       testAccObjectImportStateIdFunc(resourceName),
 			},
 		},
@@ -1795,7 +1882,7 @@ func TestAccS3Object_prefix(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrForceDestroy},
+				ImportStateVerifyIgnore: []string{names.AttrForceDestroy, "refresh_content"},
 				ImportStateId:           fmt.Sprintf("s3://%s/pfx/", rName),
 			},
 		},
@@ -2262,6 +2349,21 @@ resource "aws_s3_object" "object" {
   bucket  = aws_s3_bucket.test.bucket
   key     = "test-key"
   content = %[2]q
+}
+`, rName, content)
+}
+
+func testAccObjectConfig_contentRefresh(rName string, content string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_object" "object" {
+  bucket          = aws_s3_bucket.test.bucket
+  key             = "test-key"
+  content         = %[2]q
+  refresh_content = true
 }
 `, rName, content)
 }

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -187,6 +187,7 @@ The following arguments are optional:
 * `object_lock_mode` - (Optional) Object lock [retention mode](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-modes) that you want to apply to this object. Valid values are `GOVERNANCE` and `COMPLIANCE`.
 * `object_lock_retain_until_date` - (Optional) Date and time, in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8), when this object's object lock will [expire](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html#object-lock-retention-periods).
 * `override_provider` - (Optional) Override provider-level configuration options. See [Override Provider](#override-provider) below for more details.
+* `refresh_content` - (Optional, conflicts with `content_base64` and `source`) Whether to include object content when refreshing the state of the resource. Default value is `false`. This value should be set to `true` only if the expected content is a human-readable string.
 * `server_side_encryption` - (Optional) Server-side encryption of the object in S3. Valid values are "`AES256`" and "`aws:kms`".
 * `source_hash` - (Optional) Triggers updates like `etag` but useful to address `etag` encryption limitations. Set using `filemd5("path/to/source")` (Terraform 0.11.12 or later). (The value is only stored in state and not saved by AWS.)
 * `source` - (Optional, conflicts with `content` and `content_base64`) Path to a file that will be read and uploaded as raw bytes for the object content.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds an attribute to `aws_s3_object` that will refresh `content` (and only `content`) during a state refresh when enabled. The use case for this is human-readable configuration files being stored in S3 that have been manually managed and moving to a process that automates management via Terraform.

The provider's current behaviour is to test against a number of fields in the `HeadObject` response and if any of those are different to what's been set it assumes that the content has changed but doesn't refresh it. This makes total sense! The content could be binary, base64 encoded or just plain enormous - pulling the body of the object back would be a waste of time and bandwidth and produce a really messy plan.

However, in the case of human-readable configuration files it would save a lot of heartache and make the process of detecting drift a lot more straightforward, so it seems like it'd be desirable to let someone opt-in. The scenario that I'm trying to protect against is this:

```mermaid
sequenceDiagram
    actor M as Mahivir
    actor J as Julianne
    participant T as Terraform
    participant O as Config Object
    J->>T: Create config object
    activate J
    activate T
    T->>O: Create object
    activate O
    O-->>T: Create OK
    deactivate O
    T-->>J: Apply OK
    deactivate T
    deactivate J
    M->>O: Makes change
    activate M
    activate O
    O-->>M: Change OK
    deactivate O
    deactivate M
    J->>T: Modify config object
    activate J
    activate T
    T-->>J: Plan showing just Julianne's changes
    deactivate T
    J->>T: Apply plan
    activate T
    T->>O: Update clobbers Mahivir's change
    activate O
    O-->>T: Change OK
    deactivate O
    T-->>J: Apply OK
    deactivate T
    deactivate J
```

Given the following Terraform:

```terraform
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 5.0"
    }
  }
}

locals {
  object_content = <<-EOT
  apple
  banana
  pear
  EOT
}

provider "aws" {}

resource "aws_s3_bucket" "this" {
  bucket_prefix = "provider-test-"
}

resource "aws_s3_object" "this" {
  bucket  = aws_s3_bucket.this.id
  key     = "provider-test"
  content = local.object_content
}
```

Suppose someone updates the object to replace `banana` with `broccoli`. If a plan is run with no changes to the `content` attribute, Terraform detects no changes and produces an empty plan. If `durian` is added to the bottom of the list, the plan shows only that addition and a subsequent apply will overwrite the `broccoli` change.

Adding `etag` _does_ help solve the issue of detecting that drift has occurred:

```terraform
resource "aws_s3_object" "this" {
  bucket  = aws_s3_bucket.this.id
  key     = "provider-test"
  content = local.object_content
  etag    = md5(local.object_content)
}
```

But it only shows the change in `etag`:

```console
aws_s3_bucket.this: Refreshing state... [id=provider-test-20240615094005775400000001]
aws_s3_object.this: Refreshing state... [id=provider-test]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_s3_object.this will be updated in-place
  ~ resource "aws_s3_object" "this" {
      ~ etag                          = "377f30e3f9b82696cf2b9a9aa4ff6970" -> "572dbdcb7c04b9e3d53bbb77bf202176"
        id                            = "provider-test"
        tags                          = {}
      + version_id                    = (known after apply)
        # (23 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The problem with this is that you then have to pull down the object from S3 and parse it for what the drift that has occurred actually is. If it's constructed from the attributes of other resources and data sources (which is the main reason this workflow is so desirable!) then diff-ing expected and reality may not be so simple.

With the change I'm proposing, users can opt into refreshing the `content` of an object (which should be a human-readable string of a reasonable size - otherwise they'd probably be using `content_base64` or `source`) and the same scenario would result in drift being detected and visualised:

```terraform
resource "aws_s3_object" "this" {
  bucket          = aws_s3_bucket.this.id
  key             = "provider-test"
  content         = local.object_content
  refresh_content = true
}
```

```console
│ Warning: Provider development overrides are in effect

aws_s3_bucket.this: Refreshing state... [id=provider-test-20240615095357884600000001]
aws_s3_object.this: Refreshing state... [id=provider-test]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_s3_object.this will be updated in-place
  ~ resource "aws_s3_object" "this" {
      ~ content                       = <<-EOT
            apple
          - broccoli
          + banana
            pear
        EOT
        id                            = "provider-test"
        tags                          = {}
      + version_id                    = (known after apply)
        # (24 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Object_'  -timeout 360m
=== RUN   TestAccS3Object_tags
=== PAUSE TestAccS3Object_tags
=== RUN   TestAccS3Object_tags_null
=== PAUSE TestAccS3Object_tags_null
=== RUN   TestAccS3Object_tags_AddOnUpdate
=== PAUSE TestAccS3Object_tags_AddOnUpdate
=== RUN   TestAccS3Object_tags_EmptyTag_OnCreate
=== PAUSE TestAccS3Object_tags_EmptyTag_OnCreate
=== RUN   TestAccS3Object_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccS3Object_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccS3Object_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccS3Object_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccS3Object_tags_DefaultTags_providerOnly
=== PAUSE TestAccS3Object_tags_DefaultTags_providerOnly
=== RUN   TestAccS3Object_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccS3Object_tags_DefaultTags_nonOverlapping
=== RUN   TestAccS3Object_tags_DefaultTags_overlapping
=== PAUSE TestAccS3Object_tags_DefaultTags_overlapping
=== RUN   TestAccS3Object_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccS3Object_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccS3Object_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccS3Object_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccS3Object_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccS3Object_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccS3Object_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccS3Object_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccS3Object_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccS3Object_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccS3Object_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccS3Object_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccS3Object_tags_ComputedTag_OnCreate
=== PAUSE TestAccS3Object_tags_ComputedTag_OnCreate
=== RUN   TestAccS3Object_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccS3Object_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccS3Object_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccS3Object_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== RUN   TestAccS3Object_disappears
=== PAUSE TestAccS3Object_disappears
=== RUN   TestAccS3Object_Disappears_bucket
=== PAUSE TestAccS3Object_Disappears_bucket
=== RUN   TestAccS3Object_upgradeFromV4
=== PAUSE TestAccS3Object_upgradeFromV4
=== RUN   TestAccS3Object_source
=== PAUSE TestAccS3Object_source
=== RUN   TestAccS3Object_content
=== PAUSE TestAccS3Object_content
=== RUN   TestAccS3Object_etagEncryption
=== PAUSE TestAccS3Object_etagEncryption
=== RUN   TestAccS3Object_contentBase64
=== PAUSE TestAccS3Object_contentBase64
=== RUN   TestAccS3Object_sourceHashTrigger
=== PAUSE TestAccS3Object_sourceHashTrigger
=== RUN   TestAccS3Object_withContentCharacteristics
=== PAUSE TestAccS3Object_withContentCharacteristics
=== RUN   TestAccS3Object_nonVersioned
=== PAUSE TestAccS3Object_nonVersioned
=== RUN   TestAccS3Object_updates
=== PAUSE TestAccS3Object_updates
=== RUN   TestAccS3Object_updateSameFile
=== PAUSE TestAccS3Object_updateSameFile
=== RUN   TestAccS3Object_updatesWithVersioning
=== PAUSE TestAccS3Object_updatesWithVersioning
=== RUN   TestAccS3Object_updatesWithVersioningViaAccessPoint
=== PAUSE TestAccS3Object_updatesWithVersioningViaAccessPoint
=== RUN   TestAccS3Object_updatesWithContentRefresh
=== PAUSE TestAccS3Object_updatesWithContentRefresh
=== RUN   TestAccS3Object_kms
=== PAUSE TestAccS3Object_kms
=== RUN   TestAccS3Object_sse
=== PAUSE TestAccS3Object_sse
=== RUN   TestAccS3Object_acl
=== PAUSE TestAccS3Object_acl
=== RUN   TestAccS3Object_metadata
=== PAUSE TestAccS3Object_metadata
=== RUN   TestAccS3Object_storageClass
=== PAUSE TestAccS3Object_storageClass
=== RUN   TestAccS3Object_tagsLeadingSingleSlash
=== PAUSE TestAccS3Object_tagsLeadingSingleSlash
=== RUN   TestAccS3Object_tagsLeadingMultipleSlashes
=== PAUSE TestAccS3Object_tagsLeadingMultipleSlashes
=== RUN   TestAccS3Object_tagsMultipleSlashes
=== PAUSE TestAccS3Object_tagsMultipleSlashes
=== RUN   TestAccS3Object_tagsViaAccessPointARN
=== PAUSE TestAccS3Object_tagsViaAccessPointARN
=== RUN   TestAccS3Object_tagsViaAccessPointAlias
=== PAUSE TestAccS3Object_tagsViaAccessPointAlias
=== RUN   TestAccS3Object_tagsViaMultiRegionAccessPoint
=== PAUSE TestAccS3Object_tagsViaMultiRegionAccessPoint
=== RUN   TestAccS3Object_tagsViaObjectLambdaAccessPointARN
    object_test.go:1306: Accessing Objects via Lambda Access Points is not yet supported
--- SKIP: TestAccS3Object_tagsViaObjectLambdaAccessPointARN (0.00s)
=== RUN   TestAccS3Object_objectLockLegalHoldStartWithNone
=== PAUSE TestAccS3Object_objectLockLegalHoldStartWithNone
=== RUN   TestAccS3Object_objectLockLegalHoldStartWithOn
=== PAUSE TestAccS3Object_objectLockLegalHoldStartWithOn
=== RUN   TestAccS3Object_objectLockRetentionStartWithNone
=== PAUSE TestAccS3Object_objectLockRetentionStartWithNone
=== RUN   TestAccS3Object_objectLockRetentionStartWithSet
=== PAUSE TestAccS3Object_objectLockRetentionStartWithSet
=== RUN   TestAccS3Object_objectBucketKeyEnabled
=== PAUSE TestAccS3Object_objectBucketKeyEnabled
=== RUN   TestAccS3Object_bucketBucketKeyEnabled
=== PAUSE TestAccS3Object_bucketBucketKeyEnabled
=== RUN   TestAccS3Object_defaultBucketSSE
=== PAUSE TestAccS3Object_defaultBucketSSE
=== RUN   TestAccS3Object_ignoreTags
=== PAUSE TestAccS3Object_ignoreTags
=== RUN   TestAccS3Object_checksumAlgorithm
=== PAUSE TestAccS3Object_checksumAlgorithm
=== RUN   TestAccS3Object_keyWithSlashesMigrated
=== PAUSE TestAccS3Object_keyWithSlashesMigrated
=== RUN   TestAccS3Object_directoryBucket
=== PAUSE TestAccS3Object_directoryBucket
=== RUN   TestAccS3Object_DirectoryBucket_disappears
=== PAUSE TestAccS3Object_DirectoryBucket_disappears
=== RUN   TestAccS3Object_DirectoryBucket_DefaultTags_providerOnly
=== PAUSE TestAccS3Object_DirectoryBucket_DefaultTags_providerOnly
=== RUN   TestAccS3Object_prefix
=== PAUSE TestAccS3Object_prefix
=== RUN   TestAccS3Object_crossRegion
=== PAUSE TestAccS3Object_crossRegion
=== RUN   TestAccS3Object_optInRegion
=== PAUSE TestAccS3Object_optInRegion
=== CONT  TestAccS3Object_tags
=== CONT  TestAccS3Object_updatesWithVersioning
=== CONT  TestAccS3Object_objectLockLegalHoldStartWithOn
=== CONT  TestAccS3Object_tags_ComputedTag_OnUpdate_Replace
=== CONT  TestAccS3Object_tags_ComputedTag_OnUpdate_Add
=== CONT  TestAccS3Object_updateSameFile
=== CONT  TestAccS3Object_updates
=== CONT  TestAccS3Object_nonVersioned
=== CONT  TestAccS3Object_withContentCharacteristics
=== CONT  TestAccS3Object_sourceHashTrigger
=== CONT  TestAccS3Object_contentBase64
=== CONT  TestAccS3Object_etagEncryption
=== CONT  TestAccS3Object_content
=== CONT  TestAccS3Object_source
=== CONT  TestAccS3Object_upgradeFromV4
=== CONT  TestAccS3Object_Disappears_bucket
=== CONT  TestAccS3Object_disappears
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3Object_tagsLeadingSingleSlash
=== CONT  TestAccS3Object_optInRegion
=== NAME  TestAccS3Object_nonVersioned
    object_test.go:467: skipping test; environment variable TF_ACC_ASSUME_ROLE_ARN must be set. Usage: Amazon Resource Name (ARN) of existing IAM Role to assume for testing restricted permissions
--- SKIP: TestAccS3Object_nonVersioned (0.78s)
=== CONT  TestAccS3Object_objectLockLegalHoldStartWithNone
=== NAME  TestAccS3Object_optInRegion
    object_test.go:1929: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccS3Object_optInRegion (2.14s)
=== CONT  TestAccS3Object_tagsViaMultiRegionAccessPoint
--- PASS: TestAccS3Object_withContentCharacteristics (38.59s)
=== CONT  TestAccS3Object_tagsViaAccessPointAlias
--- PASS: TestAccS3Object_contentBase64 (41.17s)
=== CONT  TestAccS3Object_crossRegion
--- PASS: TestAccS3Object_Disappears_bucket (44.93s)
=== CONT  TestAccS3Object_tagsViaAccessPointARN
--- PASS: TestAccS3Object_disappears (45.88s)
=== CONT  TestAccS3Object_prefix
--- PASS: TestAccS3Object_basic (47.01s)
=== CONT  TestAccS3Object_tagsMultipleSlashes
--- PASS: TestAccS3Object_source (48.83s)
=== CONT  TestAccS3Object_DirectoryBucket_DefaultTags_providerOnly
--- PASS: TestAccS3Object_etagEncryption (50.21s)
=== CONT  TestAccS3Object_tagsLeadingMultipleSlashes
--- PASS: TestAccS3Object_content (51.61s)
=== CONT  TestAccS3Object_DirectoryBucket_disappears
--- PASS: TestAccS3Object_upgradeFromV4 (64.55s)
=== CONT  TestAccS3Object_directoryBucket
--- PASS: TestAccS3Object_crossRegion (30.92s)
=== CONT  TestAccS3Object_tags_DefaultTags_overlapping
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithOn (82.43s)
=== CONT  TestAccS3Object_keyWithSlashesMigrated
--- PASS: TestAccS3Object_DirectoryBucket_DefaultTags_providerOnly (33.66s)
=== CONT  TestAccS3Object_tags_ComputedTag_OnCreate
--- PASS: TestAccS3Object_sourceHashTrigger (83.88s)
=== CONT  TestAccS3Object_checksumAlgorithm
--- PASS: TestAccS3Object_updateSameFile (83.90s)
=== CONT  TestAccS3Object_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccS3Object_updates (84.85s)
=== CONT  TestAccS3Object_ignoreTags
--- PASS: TestAccS3Object_updatesWithVersioning (85.20s)
=== CONT  TestAccS3Object_defaultBucketSSE
--- PASS: TestAccS3Object_prefix (42.88s)
=== CONT  TestAccS3Object_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccS3Object_DirectoryBucket_disappears (39.42s)
=== CONT  TestAccS3Object_bucketBucketKeyEnabled
--- PASS: TestAccS3Object_tags_ComputedTag_OnUpdate_Replace (98.87s)
=== CONT  TestAccS3Object_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccS3Object_tags_ComputedTag_OnUpdate_Add (99.65s)
=== CONT  TestAccS3Object_objectBucketKeyEnabled
--- PASS: TestAccS3Object_directoryBucket (45.84s)
=== CONT  TestAccS3Object_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccS3Object_objectLockLegalHoldStartWithNone (114.04s)
=== CONT  TestAccS3Object_objectLockRetentionStartWithSet
--- PASS: TestAccS3Object_tagsViaAccessPointAlias (80.44s)
=== CONT  TestAccS3Object_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccS3Object_tagsViaAccessPointARN (78.37s)
=== CONT  TestAccS3Object_objectLockRetentionStartWithNone
--- PASS: TestAccS3Object_defaultBucketSSE (39.97s)
=== CONT  TestAccS3Object_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccS3Object_bucketBucketKeyEnabled (38.46s)
=== CONT  TestAccS3Object_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccS3Object_objectBucketKeyEnabled (35.72s)
=== CONT  TestAccS3Object_tags_AddOnUpdate
--- PASS: TestAccS3Object_tags_ComputedTag_OnCreate (57.18s)
=== CONT  TestAccS3Object_tags_DefaultTags_nonOverlapping
--- PASS: TestAccS3Object_tags_DefaultTags_nullNonOverlappingResourceTag (56.09s)
=== CONT  TestAccS3Object_tags_EmptyTag_OnCreate
--- PASS: TestAccS3Object_tags_DefaultTags_nullOverlappingResourceTag (55.98s)
=== CONT  TestAccS3Object_tags_DefaultTags_providerOnly
--- PASS: TestAccS3Object_keyWithSlashesMigrated (63.46s)
=== CONT  TestAccS3Object_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccS3Object_tags_DefaultTags_emptyProviderOnlyTag (52.18s)
=== CONT  TestAccS3Object_kms
--- PASS: TestAccS3Object_tagsLeadingSingleSlash (156.04s)
=== CONT  TestAccS3Object_metadata
--- PASS: TestAccS3Object_checksumAlgorithm (72.88s)
=== CONT  TestAccS3Object_acl
--- PASS: TestAccS3Object_ignoreTags (76.36s)
=== CONT  TestAccS3Object_sse
--- PASS: TestAccS3Object_tags_DefaultTags_emptyResourceTag (55.62s)
=== CONT  TestAccS3Object_storageClass
--- PASS: TestAccS3Object_tagsMultipleSlashes (137.60s)
=== CONT  TestAccS3Object_tags_null
--- PASS: TestAccS3Object_tagsLeadingMultipleSlashes (138.34s)
=== CONT  TestAccS3Object_updatesWithContentRefresh
--- PASS: TestAccS3Object_tags (190.44s)
=== CONT  TestAccS3Object_updatesWithVersioningViaAccessPoint
--- PASS: TestAccS3Object_kms (45.66s)
--- PASS: TestAccS3Object_sse (46.05s)
--- PASS: TestAccS3Object_tags_DefaultTags_updateToResourceOnly (93.46s)
--- PASS: TestAccS3Object_tags_DefaultTags_updateToProviderOnly (91.58s)
--- PASS: TestAccS3Object_tags_AddOnUpdate (87.01s)
--- PASS: TestAccS3Object_tags_DefaultTags_overlapping (151.64s)
--- PASS: TestAccS3Object_objectLockRetentionStartWithNone (103.00s)
--- PASS: TestAccS3Object_tags_EmptyTag_OnUpdate_Replace (84.63s)
--- PASS: TestAccS3Object_tags_EmptyTag_OnCreate (92.95s)
--- PASS: TestAccS3Object_tags_null (62.61s)
--- PASS: TestAccS3Object_objectLockRetentionStartWithSet (133.15s)
--- PASS: TestAccS3Object_metadata (93.72s)
--- PASS: TestAccS3Object_updatesWithContentRefresh (64.23s)
--- PASS: TestAccS3Object_tags_EmptyTag_OnUpdate_Add (123.40s)
--- PASS: TestAccS3Object_updatesWithVersioningViaAccessPoint (69.15s)
--- PASS: TestAccS3Object_acl (104.43s)
--- PASS: TestAccS3Object_tags_DefaultTags_nonOverlapping (130.21s)
--- PASS: TestAccS3Object_storageClass (124.07s)
--- PASS: TestAccS3Object_tags_DefaultTags_providerOnly (158.60s)
--- PASS: TestAccS3Object_tagsViaMultiRegionAccessPoint (315.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 317.614s
```
I had a bit of difficulty writing acceptance tests that I thought adequately covered the change and intended functionality. As a result, I've ended up adding a custom `plancheck` for checking that an attribute changes from one known value to another (instead of just changing to a known value). I've also added `refresh_content` to the list of ignored attributes for imports because it isn't actually a property of the object so much as a way of telling the provider what the desired behaviour is (similar to `force_destroy`). If anything I've done is no good, please let me know and I'll try my best to fix it.