### PR TITLE
doc: add fields to attribute reference of route53 zone data

### DIFF
--- a/website/docs/d/route53_zone.html.markdown
+++ b/website/docs/d/route53_zone.html.markdown
@@ -35,10 +35,9 @@ resource "aws_route53_record" "www" {
 
 The arguments of this data source act as filters for querying the available
 Hosted Zone. You have to use `zone_id` or `name`, not both of them. The given filter must match exactly one
-Hosted Zone. If you use `name` field for private Hosted Zone, you need to add `private_zone` field to `true`
+Hosted Zone. If you use `name` field for private Hosted Zone, you need to add `private_zone` field to `true`.
 
 * `zone_id` - (Optional) Hosted Zone id of the desired Hosted Zone.
-
 * `name` - (Optional) Hosted Zone name of the desired Hosted Zone.
 * `private_zone` - (Optional) Used with `name` field to get a private Hosted Zone.
 * `vpc_id` - (Optional) Used with `name` field to get a private Hosted Zone associated with the vpc_id (in this case, private_zone is not mandatory).
@@ -56,8 +55,12 @@ The following attribute is additionally exported:
 * `arn` - ARN of the Hosted Zone.
 * `caller_reference` - Caller Reference of the Hosted Zone.
 * `comment` - Comment field of the Hosted Zone.
-* `name_servers` - List of DNS name servers for the Hosted Zone.
-* `primary_name_server` - The Route 53 name server that created the SOA record.
-* `resource_record_set_count` - The number of Record Set in the Hosted Zone.
 * `linked_service_principal` - The service that created the Hosted Zone (e.g., `servicediscovery.amazonaws.com`).
 * `linked_service_description` - The description provided by the service that created the Hosted Zone (e.g., `arn:aws:servicediscovery:us-east-1:1234567890:namespace/ns-xxxxxxxxxxxxxxxx`).
+* `name` - The Hosted Zone name.
+* `name_servers` - List of DNS name servers for the Hosted Zone.
+* `primary_name_server` - The Route 53 name server that created the SOA record.
+* `private_zone` - Indicates whether this is a private hosted zone.
+* `resource_record_set_count` - The number of Record Set in the Hosted Zone.
+* `tags` - A map of tags assigned to the Hosted Zone.
+* `zone_id` - The Hosted Zone identifier.


### PR DESCRIPTION
### Description

- Add missing fields `name`, `private_zone`, `tags`, `zone_id`
- Re-ordered attributes alphabetically

Additional cleanup:
- Removed blank link from Argument Reference section
- Add missing `.` to a sentence in Argument Reference section

### Relations

Closes #37908 .
In the title of the related issue "missing id" is mentioned. In the description and code example `zone_id` is mentioned, e.g.

```hcl
output "zone_id" {
  value = data.aws_route53_zone.id
}
```
I opted for adding `zone_id`, and leaving `id` out. 
Please let me know if I should add `id` also. Contentwise `id` and `zone_id` are identical.

### References

None.

### Output from Acceptance Testing

- Not applicable. Only documentation was updated.