### PR TITLE
Increase limit for Amazon API Gateway integration timeout beyond 29 s…

### DIFF
--- a/.changelog/38010.txt
+++ b/.changelog/38010.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_api_gateway_integration: Increase limit for Amazon API Gateway integration `timeout` beyond 29 seconds to 300 seconds
+resource/aws_api_gateway_integration: Increase maximum value of `timeout_milliseconds` from `29000` (29 seconds) to `300000` (5 minutes)
 ```

--- a/.changelog/38010.txt
+++ b/.changelog/38010.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_api_gateway_integration: Increase limit for Amazon API Gateway integration `timeout` beyond 29 seconds to 300 seconds
+```

--- a/internal/service/apigateway/integration.go
+++ b/internal/service/apigateway/integration.go
@@ -128,7 +128,7 @@ func resourceIntegration() *schema.Resource {
 			"timeout_milliseconds": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: validation.IntBetween(50, 29000),
+				ValidateFunc: validation.IntBetween(50, 300000),
 				Default:      29000,
 			},
 			"tls_config": {

--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -223,7 +223,7 @@ This resource supports the following arguments:
 * `cache_key_parameters` - (Optional) List of cache key parameters for the integration.
 * `cache_namespace` - (Optional) Integration's cache namespace.
 * `content_handling` - (Optional) How to handle request payload content type conversions. Supported values are `CONVERT_TO_BINARY` and `CONVERT_TO_TEXT`. If this property is not defined, the request payload will be passed through from the method request to integration request without modification, provided that the passthroughBehaviors is configured to support payload pass-through.
-* `timeout_milliseconds` - (Optional) Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds.
+* `timeout_milliseconds` - (Optional) Custom timeout between 50 and 3,00,000 milliseconds. The default value is 29,000 milliseconds. You need to raise a [Service Quota Ticket](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) to increase time beyond 29,000 milliseconds.
 * `tls_config` - (Optional) TLS configuration. See below.
 
 ### tls_config Configuration Block

--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -223,7 +223,7 @@ This resource supports the following arguments:
 * `cache_key_parameters` - (Optional) List of cache key parameters for the integration.
 * `cache_namespace` - (Optional) Integration's cache namespace.
 * `content_handling` - (Optional) How to handle request payload content type conversions. Supported values are `CONVERT_TO_BINARY` and `CONVERT_TO_TEXT`. If this property is not defined, the request payload will be passed through from the method request to integration request without modification, provided that the passthroughBehaviors is configured to support payload pass-through.
-* `timeout_milliseconds` - (Optional) Custom timeout between 50 and 3,00,000 milliseconds. The default value is 29,000 milliseconds. You need to raise a [Service Quota Ticket](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) to increase time beyond 29,000 milliseconds.
+* `timeout_milliseconds` - (Optional) Custom timeout between 50 and 300,000 milliseconds. The default value is 29,000 milliseconds. You need to raise a [Service Quota Ticket](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) to increase time beyond 29,000 milliseconds.
 * `tls_config` - (Optional) TLS configuration. See below.
 
 ### tls_config Configuration Block


### PR DESCRIPTION

### Description
AWS recently [announced](https://aws.amazon.com/about-aws/whats-new/2024/06/amazon-api-gateway-integration-timeout-limit-29-seconds/) that the REST API Gateways had an increased timeout limit and this bumps that max timeout validation check from 29 seconds to 300 seconds.

User need to raise a [Service Quota Ticket](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html) to increase time beyond 29 seconds

Currently in Terraform we have update the range and documentation of api_gateway from lower limit as 50 milliseconds and upper limit can be 3,00,000 milliseconds


### Relations

Closes #23417.
Closes #37859.
Closes https://github.com/hashicorp/terraform-provider-aws/pull/37905.

### References
https://aws.amazon.com/about-aws/whats-new/2024/06/amazon-api-gateway-integration-timeout-limit-29-seconds
https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html
https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#api-gateway-execution-service-limits-table

### Output from Acceptance Testing


```console
% make testacc TESTS=TestAccAPIGatewayIntegration_basic PKG=apigateway      
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayIntegration_basic'  -timeout 600m
=== RUN   TestAccAPIGatewayIntegration_basic
=== PAUSE TestAccAPIGatewayIntegration_basic
=== CONT  TestAccAPIGatewayIntegration_basic
--- PASS: TestAccAPIGatewayIntegration_basic (92.87s)
PASS
ok      [github.com/hashicorp/terraform-provider-aws/internal/service/apigateway](http://github.com/hashicorp/terraform-provider-aws/internal/service/apigateway) 212.006s

...
```
