### PR TITLE
r/sagemaker_endpoint_configuration - add support for `inference_ami_version`

### DIFF
--- a/.changelog/38085.txt
+++ b/.changelog/38085.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configuration: Add `production_variants.inference_ami_version` and `shadow_production_variants.inference_ami_version` arguments
+```

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -295,6 +295,12 @@ func ResourceEndpointConfiguration() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"inference_ami_version": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(sagemaker.ProductionVariantInferenceAmiVersion_Values(), false),
+						},
 						"initial_instance_count": {
 							Type:         schema.TypeInt,
 							Optional:     true,
@@ -432,6 +438,12 @@ func ResourceEndpointConfiguration() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
+						},
+						"inference_ami_version": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice(sagemaker.ProductionVariantInferenceAmiVersion_Values(), false),
 						},
 						"initial_instance_count": {
 							Type:         schema.TypeInt,
@@ -697,6 +709,10 @@ func expandProductionVariants(configured []interface{}) []*sagemaker.ProductionV
 			l.EnableSSMAccess = aws.Bool(v)
 		}
 
+		if v, ok := data["inference_ami_version"].(string); ok && v != "" {
+			l.InferenceAmiVersion = aws.String(v)
+		}
+
 		containers = append(containers, l)
 	}
 
@@ -748,6 +764,10 @@ func flattenProductionVariants(list []*sagemaker.ProductionVariant) []map[string
 
 		if i.EnableSSMAccess != nil {
 			l["enable_ssm_access"] = aws.BoolValue(i.EnableSSMAccess)
+		}
+
+		if i.InferenceAmiVersion != nil {
+			l["inference_ami_version"] = aws.StringValue(i.InferenceAmiVersion)
 		}
 
 		result = append(result, l)

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -230,7 +230,7 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_ami(t *testing.T) 
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "production_variants.0.inference_ami_version", "al2-ami-sagemaker-inference-gpu-2"),
+					resource.TestCheckResourceAttr(resourceName, "production_variants.0.inference_ami_version", "al2-ami-sagemaker-inference-gpu-2"), //lintignore:AWSAT002
 				),
 			},
 			{
@@ -1293,6 +1293,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 }
 
 func testAccEndpointConfigurationConfig_ami(rName string) string {
+	//lintignore:AWSAT002
 	return acctest.ConfigCompose(testAccEndpointConfigurationConfig_base(rName), fmt.Sprintf(`
 resource "aws_sagemaker_endpoint_configuration" "test" {
   name = %[1]q

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -50,6 +50,7 @@ This resource supports the following arguments:
 * `container_startup_health_check_timeout_in_seconds` - (Optional) The timeout value, in seconds, for your inference container to pass health check by SageMaker Hosting. For more information about health check, see [How Your Container Should Respond to Health Check (Ping) Requests](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html#your-algorithms-inference-algo-ping-requests). Valid values between `60` and `3600`.
 * `core_dump_config` - (Optional) Specifies configuration for a core dump from the model container when the process crashes. Fields are documented below.
 * `enable_ssm_access` - (Optional) You can use this parameter to turn on native Amazon Web Services Systems Manager (SSM) access for a production variant behind an endpoint. By default, SSM access is disabled for all production variants behind an endpoints.
+* `inference_ami_version` - (Optional) Specifies an option from a collection of preconfigured Amazon Machine Image (AMI) images. Each image is configured by Amazon Web Services with a set of software and driver versions. Amazon Web Services optimizes these configurations for different machine learning workloads.
 * `initial_instance_count` - (Optional) Initial number of instances used for auto-scaling.
 * `instance_type` - (Optional)  The type of instance to start.
 * `initial_variant_weight` - (Optional) Determines initial traffic distribution among all of the models that you specify in the endpoint configuration. If unspecified, it defaults to `1.0`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccSageMakerEndpointConfiguration_ProductionVariants_ami  PKG=sagemaker

--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_ami (24.29s)
```
