### PR TITLE
r/sagemaker_workteam - add support for `worker_access_configuration`

### DIFF
--- a/.changelog/38087.txt
+++ b/.changelog/38087.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_workteam: Add `worker_access_configuration` attribute
+```

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -111,11 +111,12 @@ func TestAccSageMaker_serial(t *testing.T) {
 			"VPC":                testAccWorkforce_vpc,
 		},
 		"Workteam": {
-			acctest.CtDisappears: testAccWorkteam_disappears,
-			"tags":               testAccWorkteam_tags,
-			"CognitoConfig":      testAccWorkteam_cognitoConfig,
-			"NotificationConfig": testAccWorkteam_notificationConfig,
-			"OidcConfig":         testAccWorkteam_oidcConfig,
+			acctest.CtDisappears:        testAccWorkteam_disappears,
+			"tags":                      testAccWorkteam_tags,
+			"CognitoConfig":             testAccWorkteam_cognitoConfig,
+			"NotificationConfig":        testAccWorkteam_notificationConfig,
+			"WorkerAccessConfiguration": testAccWorkteam_workerAccessConfiguration,
+			"OidcConfig":                testAccWorkteam_oidcConfig,
 		},
 		"Servicecatalog": {
 			acctest.CtBasic: testAccServicecatalogPortfolioStatus_basic,

--- a/internal/service/sagemaker/workteam.go
+++ b/internal/service/sagemaker/workteam.go
@@ -111,6 +111,45 @@ func ResourceWorkteam() *schema.Resource {
 				},
 				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
 			},
+			"worker_access_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"s3_presign": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"iam_policy_constraints": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"source_ip": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.EnabledOrDisabled_Values(), false),
+													ExactlyOneOf: []string{"worker_access_configuration.0.s3_presign.0.iam_policy_constraints.0.source_ip", "worker_access_configuration.0.s3_presign.0.iam_policy_constraints.0.vpc_source_ip"},
+												},
+												"vpc_source_ip": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(sagemaker.EnabledOrDisabled_Values(), false),
+													ExactlyOneOf: []string{"worker_access_configuration.0.s3_presign.0.iam_policy_constraints.0.source_ip", "worker_access_configuration.0.s3_presign.0.iam_policy_constraints.0.vpc_source_ip"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"subdomain": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -152,6 +191,10 @@ func resourceWorkteamCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	if v, ok := d.GetOk("notification_configuration"); ok {
 		input.NotificationConfiguration = expandWorkteamNotificationConfiguration(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("worker_access_configuration"); ok {
+		input.WorkerAccessConfiguration = expandWorkerAccessConfiguration(v.([]interface{}))
 	}
 
 	log.Printf("[DEBUG] Updating SageMaker Workteam: %s", input)
@@ -198,6 +241,10 @@ func resourceWorkteamRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "setting notification_configuration: %s", err)
 	}
 
+	if err := d.Set("worker_access_configuration", flattenWorkerAccessConfiguration(workteam.WorkerAccessConfiguration)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting worker_access_configuration: %s", err)
+	}
+
 	return diags
 }
 
@@ -217,6 +264,10 @@ func resourceWorkteamUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 		if d.HasChange("notification_configuration") {
 			input.NotificationConfiguration = expandWorkteamNotificationConfiguration(d.Get("notification_configuration").([]interface{}))
+		}
+
+		if d.HasChange("worker_access_configuration") {
+			input.WorkerAccessConfiguration = expandWorkerAccessConfiguration(d.Get("worker_access_configuration").([]interface{}))
 		}
 
 		log.Printf("[DEBUG] Updating SageMaker Workteam: %s", input)
@@ -376,6 +427,99 @@ func flattenWorkteamNotificationConfiguration(config *sagemaker.NotificationConf
 
 	m := map[string]interface{}{
 		"notification_topic_arn": aws.StringValue(config.NotificationTopicArn),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandWorkerAccessConfiguration(l []interface{}) *sagemaker.WorkerAccessConfiguration {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.WorkerAccessConfiguration{}
+
+	if v, ok := m["s3_presign"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		config.S3Presign = expandS3Presign(v)
+	} else {
+		return nil
+	}
+
+	return config
+}
+
+func flattenWorkerAccessConfiguration(config *sagemaker.WorkerAccessConfiguration) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"s3_presign": flattenS3Presign(config.S3Presign),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandS3Presign(l []interface{}) *sagemaker.S3Presign {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.S3Presign{}
+
+	if v, ok := m["iam_policy_constraints"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		config.IamPolicyConstraints = expandIamPolicyConstraints(v)
+	} else {
+		return nil
+	}
+
+	return config
+}
+
+func flattenS3Presign(config *sagemaker.S3Presign) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"iam_policy_constraints": flattenIamPolicyConstraints(config.IamPolicyConstraints),
+	}
+
+	return []map[string]interface{}{m}
+}
+
+func expandIamPolicyConstraints(l []interface{}) *sagemaker.IamPolicyConstraints {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	m := l[0].(map[string]interface{})
+
+	config := &sagemaker.IamPolicyConstraints{}
+
+	if v, ok := m["source_ip"].(string); ok && v != "" {
+		config.SourceIp = aws.String(v)
+	}
+
+	if v, ok := m["vpc_source_ip"].(string); ok && v != "" {
+		config.VpcSourceIp = aws.String(v)
+	}
+
+	return config
+}
+
+func flattenIamPolicyConstraints(config *sagemaker.IamPolicyConstraints) []map[string]interface{} {
+	if config == nil {
+		return []map[string]interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"source_ip":     aws.StringValue(config.SourceIp),
+		"vpc_source_ip": aws.StringValue(config.VpcSourceIp),
 	}
 
 	return []map[string]interface{}{m}

--- a/internal/service/sagemaker/workteam.go
+++ b/internal/service/sagemaker/workteam.go
@@ -114,30 +114,35 @@ func ResourceWorkteam() *schema.Resource {
 			"worker_access_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"s3_presign": {
 							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"iam_policy_constraints": {
 										Type:     schema.TypeList,
 										Optional: true,
+										Computed: true,
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"source_ip": {
 													Type:         schema.TypeString,
 													Optional:     true,
+													Computed:     true,
 													ValidateFunc: validation.StringInSlice(sagemaker.EnabledOrDisabled_Values(), false),
 													ExactlyOneOf: []string{"worker_access_configuration.0.s3_presign.0.iam_policy_constraints.0.source_ip", "worker_access_configuration.0.s3_presign.0.iam_policy_constraints.0.vpc_source_ip"},
 												},
 												"vpc_source_ip": {
 													Type:         schema.TypeString,
 													Optional:     true,
+													Computed:     true,
 													ValidateFunc: validation.StringInSlice(sagemaker.EnabledOrDisabled_Values(), false),
 													ExactlyOneOf: []string{"worker_access_configuration.0.s3_presign.0.iam_policy_constraints.0.source_ip", "worker_access_configuration.0.s3_presign.0.iam_policy_constraints.0.vpc_source_ip"},
 												},

--- a/internal/service/sagemaker/workteam.go
+++ b/internal/service/sagemaker/workteam.go
@@ -472,7 +472,7 @@ func expandS3Presign(l []interface{}) *sagemaker.S3Presign {
 	config := &sagemaker.S3Presign{}
 
 	if v, ok := m["iam_policy_constraints"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		config.IamPolicyConstraints = expandIamPolicyConstraints(v)
+		config.IamPolicyConstraints = expandIAMPolicyConstraints(v)
 	} else {
 		return nil
 	}
@@ -486,13 +486,13 @@ func flattenS3Presign(config *sagemaker.S3Presign) []map[string]interface{} {
 	}
 
 	m := map[string]interface{}{
-		"iam_policy_constraints": flattenIamPolicyConstraints(config.IamPolicyConstraints),
+		"iam_policy_constraints": flattenIAMPolicyConstraints(config.IamPolicyConstraints),
 	}
 
 	return []map[string]interface{}{m}
 }
 
-func expandIamPolicyConstraints(l []interface{}) *sagemaker.IamPolicyConstraints {
+func expandIAMPolicyConstraints(l []interface{}) *sagemaker.IamPolicyConstraints {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -512,7 +512,7 @@ func expandIamPolicyConstraints(l []interface{}) *sagemaker.IamPolicyConstraints
 	return config
 }
 
-func flattenIamPolicyConstraints(config *sagemaker.IamPolicyConstraints) []map[string]interface{} {
+func flattenIAMPolicyConstraints(config *sagemaker.IamPolicyConstraints) []map[string]interface{} {
 	if config == nil {
 		return []map[string]interface{}{}
 	}

--- a/website/docs/r/sagemaker_workteam.html.markdown
+++ b/website/docs/r/sagemaker_workteam.html.markdown
@@ -55,6 +55,7 @@ This resource supports the following arguments:
 * `workteam_name` - (Required) The name of the workforce.
 * `member_definition` - (Required) A list of Member Definitions that contains objects that identify the workers that make up the work team. Workforces can be created using Amazon Cognito or your own OIDC Identity Provider (IdP). For private workforces created using Amazon Cognito use `cognito_member_definition`. For workforces created using your own OIDC identity provider (IdP) use `oidc_member_definition`. Do not provide input for both of these parameters in a single request. see [Member Definition](#member-definition) details below.
 * `notification_configuration` - (Optional) Configures notification of workers regarding available or expiring work items. see [Notification Configuration](#notification-configuration) details below.
+* `worker_access_configuration` - (Optional) Use this optional parameter to constrain access to an Amazon S3 resource based on the IP address using supported IAM global condition keys. The Amazon S3 resource is accessed in the worker portal using a Amazon S3 presigned URL. see [Worker Access Configuration](#worker-access-configuration) details below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Member Definition
@@ -75,6 +76,19 @@ This resource supports the following arguments:
 ### Notification Configuration
 
 * `notification_topic_arn` - (Required) The ARN for the SNS topic to which notifications should be published.
+
+### Worker Access Configuration
+
+* `s3_presign` - (Required) Defines any Amazon S3 resource constraints. see [S3 Presign](#s3-presign) details below.
+
+#### S3 Presign
+
+* `iam_policy_constraints` - (Required) Use this parameter to specify the allowed request source. Possible sources are either SourceIp or VpcSourceIp. see [IAM Policy Constraints](#iam-policy-constraints) details below.
+
+##### IAM Policy Constraints
+
+* `source_ip` - (Optional) When SourceIp is Enabled the worker's IP address when a task is rendered in the worker portal is added to the IAM policy as a Condition used to generate the Amazon S3 presigned URL. This IP address is checked by Amazon S3 and must match in order for the Amazon S3 resource to be rendered in the worker portal. Valid values are `Enabled` or `Disabled`
+* `vpc_source_ip` - (Optional) When VpcSourceIp is Enabled the worker's IP address when a task is rendered in private worker portal inside the VPC is added to the IAM policy as a Condition used to generate the Amazon S3 presigned URL. To render the task successfully Amazon S3 checks that the presigned URL is being accessed over an Amazon S3 VPC Endpoint, and that the worker's IP address matches the IP address in the IAM policy. To learn more about configuring private worker portal, see [Use Amazon VPC mode from a private worker portal](https://docs.aws.amazon.com/sagemaker/latest/dg/samurai-vpc-worker-portal.html). Valid values are `Enabled` or `Disabled`
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccSageMaker_serial/Workteam/WorkerAccessConfiguration  PKG=sagemaker

--- PASS: TestAccSageMaker_serial (23.02s)
    --- PASS: TestAccSageMaker_serial/Workteam (23.02s)
        --- PASS: TestAccSageMaker_serial/Workteam/WorkerAccessConfiguration (23.02s)
```
