### PR TITLE
Bug fix update of aws_route53recoverycontrolconfig_safety_rule resource

### DIFF
--- a/internal/service/route53recoverycontrolconfig/route53recoverycontrolconfig_test.go
+++ b/internal/service/route53recoverycontrolconfig/route53recoverycontrolconfig_test.go
@@ -25,13 +25,15 @@ func TestAccRoute53RecoveryControlConfig_serial(t *testing.T) {
 		},
 		"RoutingControl": {
 			acctest.CtBasic:         testAccRoutingControl_basic,
+			acctest.CtValue1Updated: testAccRoutingControl_updated,
 			acctest.CtDisappears:    testAccRoutingControl_disappears,
 			"nonDefaultControlPane": testAccRoutingControl_nonDefaultControlPanel,
 		},
 		"SafetyRule": {
-			"assertionRule":      testAccSafetyRule_assertionRule,
-			"gatingRule":         testAccSafetyRule_gatingRule,
-			acctest.CtDisappears: testAccSafetyRule_disappears,
+			"assertionRule":         testAccSafetyRule_assertionRule,
+			"gatingRule":            testAccSafetyRule_gatingRule,
+			acctest.CtValue1Updated: testAccSafetyRule_updated,
+			acctest.CtDisappears:    testAccSafetyRule_disappears,
 		},
 	}
 

--- a/internal/service/route53recoverycontrolconfig/safety_rule.go
+++ b/internal/service/route53recoverycontrolconfig/safety_rule.go
@@ -325,13 +325,8 @@ func updateAssertionRule(ctx context.Context, d *schema.ResourceData, meta inter
 		SafetyRuleArn: aws.String(d.Get(names.AttrARN).(string)),
 	}
 
-	if d.HasChange(names.AttrName) {
-		assertionRuleUpdate.Name = aws.String(d.Get(names.AttrName).(string))
-	}
-
-	if d.HasChange("wait_period_ms") {
-		assertionRuleUpdate.WaitPeriodMs = aws.Int64(int64(d.Get("wait_period_ms").(int)))
-	}
+	assertionRuleUpdate.Name = aws.String(d.Get(names.AttrName).(string))
+	assertionRuleUpdate.WaitPeriodMs = aws.Int64(int64(d.Get("wait_period_ms").(int)))
 
 	input := &r53rcc.UpdateSafetyRuleInput{
 		AssertionRuleUpdate: assertionRuleUpdate,
@@ -343,7 +338,7 @@ func updateAssertionRule(ctx context.Context, d *schema.ResourceData, meta inter
 		return sdkdiag.AppendErrorf(diags, "updating Route53 Recovery Control Config Assertion Rule: %s", err)
 	}
 
-	return append(diags, sdkdiag.WrapDiagsf(resourceControlPanelRead(ctx, d, meta), "updating Route53 Recovery Control Config Assertion Rule")...)
+	return append(diags, sdkdiag.WrapDiagsf(resourceSafetyRuleRead(ctx, d, meta), "updating Route53 Recovery Control Config Assertion Rule")...)
 }
 
 func updateGatingRule(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -354,13 +349,8 @@ func updateGatingRule(ctx context.Context, d *schema.ResourceData, meta interfac
 		SafetyRuleArn: aws.String(d.Get(names.AttrARN).(string)),
 	}
 
-	if d.HasChange(names.AttrName) {
-		gatingRuleUpdate.Name = aws.String(d.Get(names.AttrName).(string))
-	}
-
-	if d.HasChange("wait_period_ms") {
-		gatingRuleUpdate.WaitPeriodMs = aws.Int64(int64(d.Get("wait_period_ms").(int)))
-	}
+	gatingRuleUpdate.Name = aws.String(d.Get(names.AttrName).(string))
+	gatingRuleUpdate.WaitPeriodMs = aws.Int64(int64(d.Get("wait_period_ms").(int)))
 
 	input := &r53rcc.UpdateSafetyRuleInput{
 		GatingRuleUpdate: gatingRuleUpdate,
@@ -372,7 +362,7 @@ func updateGatingRule(ctx context.Context, d *schema.ResourceData, meta interfac
 		return sdkdiag.AppendErrorf(diags, "updating Route53 Recovery Control Config Gating Rule: %s", err)
 	}
 
-	return append(diags, sdkdiag.WrapDiagsf(resourceControlPanelRead(ctx, d, meta), "updating Route53 Recovery Control Config Gating Rule")...)
+	return append(diags, sdkdiag.WrapDiagsf(resourceSafetyRuleRead(ctx, d, meta), "updating Route53 Recovery Control Config Gating Rule")...)
 }
 
 func testAccSafetyRuleConfig_expandRule(tfMap map[string]interface{}) *r53rcc.RuleConfig {


### PR DESCRIPTION
    Always set name and wait_period_ms on request, fix wrong resource read on return
    Fixed acceptance test to test UpdateRoutingControl API

### Description
This resolves an issue with renaming a resource with aws_route53recoverycontrolconfig_safety_rule and aws_route53recoverycontrolconfig_routing_control resources when WaitForMs parameter is not included and "Malformed control panel arn" on control panels.

### Relations
Closes #37763

### References
Per https://docs.aws.amazon.com/recovery-cluster/latest/api/safetyrule.html, WaitPeriodMs is always required on update.

### Output from Acceptance Testing
```
% make testacc TESTS=TestAccRoute53RecoveryControlConfig_serial/RoutingControl PKG=route53recoverycontrolconfig
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/route53recoverycontrolconfig/... -v -count 1 -parallel 20 -run='TestAccRoute53RecoveryControlConfig_serial/RoutingControl'  -timeout 360m
=== RUN   TestAccRoute53RecoveryControlConfig_serial
=== PAUSE TestAccRoute53RecoveryControlConfig_serial
=== CONT  TestAccRoute53RecoveryControlConfig_serial
=== RUN   TestAccRoute53RecoveryControlConfig_serial/RoutingControl
=== RUN   TestAccRoute53RecoveryControlConfig_serial/RoutingControl/basic
=== RUN   TestAccRoute53RecoveryControlConfig_serial/RoutingControl/value1updated
=== RUN   TestAccRoute53RecoveryControlConfig_serial/RoutingControl/disappears
=== RUN   TestAccRoute53RecoveryControlConfig_serial/RoutingControl/nonDefaultControlPane
--- PASS: TestAccRoute53RecoveryControlConfig_serial (343.83s)
    --- PASS: TestAccRoute53RecoveryControlConfig_serial/RoutingControl (343.83s)
        --- PASS: TestAccRoute53RecoveryControlConfig_serial/RoutingControl/basic (80.49s)
        --- PASS: TestAccRoute53RecoveryControlConfig_serial/RoutingControl/value1updated (89.56s)
        --- PASS: TestAccRoute53RecoveryControlConfig_serial/RoutingControl/disappears (74.90s)
        --- PASS: TestAccRoute53RecoveryControlConfig_serial/RoutingControl/nonDefaultControlPane (98.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig	348.206s

 % make testacc TESTS=TestAccRoute53RecoveryControlConfig_serial/SafetyRule/value1updated PKG=route53recoverycontrolconfig
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.2 test ./internal/service/route53recoverycontrolconfig/... -v -count 1 -parallel 20 -run='TestAccRoute53RecoveryControlConfig_serial/SafetyRule/value1updated'  -timeout 360m
=== RUN   TestAccRoute53RecoveryControlConfig_serial
=== PAUSE TestAccRoute53RecoveryControlConfig_serial
=== CONT  TestAccRoute53RecoveryControlConfig_serial
=== RUN   TestAccRoute53RecoveryControlConfig_serial/SafetyRule
=== RUN   TestAccRoute53RecoveryControlConfig_serial/SafetyRule/value1updated
--- PASS: TestAccRoute53RecoveryControlConfig_serial (178.49s)
    --- PASS: TestAccRoute53RecoveryControlConfig_serial/SafetyRule (178.49s)
        --- PASS: TestAccRoute53RecoveryControlConfig_serial/SafetyRule/value1updated (178.49s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53recoverycontrolconfig	182.670s
...
```
