### PR TITLE
Updates for GoReleaser v2 / ghaction-terraform-provider-release

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,7 +22,8 @@ jobs:
       - name: goreleaser release
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
-          args: release --rm-dist --skip-sign --snapshot --timeout 2h
+          args: release --clean --skip=sign --snapshot --timeout 2h
+          version: "~> v2"
       - name: artifact naming
         id: naming
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 archives:
   - files:
       # Ensure only built binary and license file are archived


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

#38062 updates the [ghaction-terraform-provider-release](https://github.com/hashicorp/ghaction-terraform-provider-release) action to a new major version which begins to use [GoReleaser v2](https://goreleaser.com/blog/goreleaser-v2/) under the hood.  GoReleaser v2 includes a number of [deprecations](https://goreleaser.com/deprecations/#removed-in-v2). Currently the snapshot.yml action is [failing](https://github.com/hashicorp/terraform-provider-aws/actions/runs/9640011043/job/26583087087#step:5:15) due to use of a deprecated flag (`--rm-dist`) as we have already updated https://github.com/goreleaser/goreleaser-action to the latest version including those deprecations.

This PR updates usage of any deprecated flags as well as update the goreleaser.yml file to use v2. This should resolve the failing snapshot actions and use v2 for release. The previously mentioned #38062 will also need to be merged.

### Relations

Relates #38062

### References

- https://goreleaser.com/blog/goreleaser-v2/
- https://github.com/hashicorp/ghaction-terraform-provider-release/releases/tag/v5.0.0
