### PR TITLE
Update dynamodb_table.html.markdown

### DIFF
--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -169,7 +169,7 @@ resource "aws_dynamodb_tag" "example" {
 
 Required arguments:
 
-* `attribute` - (Required) Set of nested attribute definitions. Only required for `hash_key` and `range_key` attributes. See below.
+* `attribute` - (Required) Attributes as Blocks definitions. Only required for `hash_key` and `range_key` attributes. See below.
 * `hash_key` - (Required, Forces new resource) Attribute to use as the hash (partition) key. Must also be defined as an `attribute`. See below.
 * `name` - (Required) Unique within a region name of the table.
 


### PR DESCRIPTION
As part of documentation attribute has been mentioned as "List of nested attribute" but based on https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table and https://developer.hashicorp.com/terraform/language/attr-as-blocks it should be "Attributes as Blocks"

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
As part of documentation attribute has been mentioned as "List of nested attribute" but it should be "Attributes as Blocks"



### Relations
This Pull Request will be resolving https://github.com/hashicorp/terraform-provider-aws/issues/25655

Related issue : https://github.com/hashicorp/terraform-provider-aws/issues/8861
https://github.com/hashicorp/terraform-provider-aws/pull/8878

### References
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table https://developer.hashicorp.com/terraform/language/attr-as-blocks


### Output from Acceptance Testing
Not Applicable
...
```
