### PR TITLE
r/aws_opensearch_domain: handle domain update propagation delays

### DIFF
--- a/.changelog/38136.txt
+++ b/.changelog/38136.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_opensearch_domain: Handle delayed domain status propagation, preventing a `ValidationException`.
+```

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -1468,7 +1468,8 @@ func domainErrorRetryable(err error) (bool, error) {
 		tfawserr.ErrMessageContains(err, "ValidationException", "The passed role has not propagated yet"),
 		tfawserr.ErrMessageContains(err, "ValidationException", "Authentication error"),
 		tfawserr.ErrMessageContains(err, "ValidationException", "Unauthorized Operation: OpenSearch Service must be authorised to describe"),
-		tfawserr.ErrMessageContains(err, "ValidationException", "The passed role must authorize Amazon OpenSearch Service to describe"):
+		tfawserr.ErrMessageContains(err, "ValidationException", "The passed role must authorize Amazon OpenSearch Service to describe"),
+		tfawserr.ErrMessageContains(err, "ValidationException", "A change/update is in progress"):
 		return true, err
 
 	default:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Addresses an issue which is very similar to https://github.com/hashicorp/terraform-provider-aws/issues/35811, but it happens when updating the domain settings and external resource (security group) at the same time, causing ValidationException.

The current workaround is to retry the `terraform apply` command, until it succeeds which usually works, because the race condition no longer exist and the domain is already in Active state (accepting new changes).

### Relations

Closes #38136

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
