### PR TITLE
docs: Fix improper use of "argument" as ref to resources, data sources, and config blocks

### DIFF
--- a/website/docs/d/apigatewayv2_api.html.markdown
+++ b/website/docs/d/apigatewayv2_api.html.markdown
@@ -23,7 +23,7 @@ data "aws_apigatewayv2_api" "example" {
 The arguments of this data source act as filters for querying the available APIs in the current region.
 The given filters must match exactly one API whose data will be exported as attributes.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `api_id` - (Required) API identifier.
 

--- a/website/docs/d/connect_contact_flow.html.markdown
+++ b/website/docs/d/connect_contact_flow.html.markdown
@@ -34,7 +34,7 @@ data "aws_connect_contact_flow" "test" {
 
 ~> **NOTE:** `instance_id` and one of either `name` or `contact_flow_id` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `contact_flow_id` - (Optional) Returns information on a specific Contact Flow by contact flow id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance

--- a/website/docs/d/connect_contact_flow_module.html.markdown
+++ b/website/docs/d/connect_contact_flow_module.html.markdown
@@ -34,7 +34,7 @@ data "aws_connect_contact_flow_module" "example" {
 
 ~> **NOTE:** `instance_id` and one of either `name` or `contact_flow_module_id` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `contact_flow_module_id` - (Optional) Returns information on a specific Contact Flow Module by contact flow module id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance

--- a/website/docs/d/connect_hours_of_operation.html.markdown
+++ b/website/docs/d/connect_hours_of_operation.html.markdown
@@ -34,7 +34,7 @@ data "aws_connect_hours_of_operation" "test" {
 
 ~> **NOTE:** `instance_id` and one of either `name` or `hours_of_operation_id` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `hours_of_operation_id` - (Optional) Returns information on a specific Hours of Operation by hours of operation id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance

--- a/website/docs/d/connect_instance.html.markdown
+++ b/website/docs/d/connect_instance.html.markdown
@@ -32,7 +32,7 @@ data "aws_connect_instance" "foo" {
 
 ~> **NOTE:** One of either `instance_id` or `instance_alias` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `instance_id` - (Optional) Returns information on a specific connect instance by id
 

--- a/website/docs/d/connect_queue.html.markdown
+++ b/website/docs/d/connect_queue.html.markdown
@@ -34,7 +34,7 @@ data "aws_connect_queue" "example" {
 
 ~> **NOTE:** `instance_id` and one of either `name` or `queue_id` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `queue_id` - (Optional) Returns information on a specific Queue by Queue id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance

--- a/website/docs/d/connect_quick_connect.html.markdown
+++ b/website/docs/d/connect_quick_connect.html.markdown
@@ -34,7 +34,7 @@ data "aws_connect_quick_connect" "example" {
 
 ~> **NOTE:** `instance_id` and one of either `name` or `quick_connect_id` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `quick_connect_id` - (Optional) Returns information on a specific Quick Connect by Quick Connect id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance

--- a/website/docs/d/connect_routing_profile.html.markdown
+++ b/website/docs/d/connect_routing_profile.html.markdown
@@ -34,7 +34,7 @@ data "aws_connect_routing_profile" "example" {
 
 ~> **NOTE:** `instance_id` and one of either `name` or `routing_profile_id` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `instance_id` - Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific Routing Profile by name

--- a/website/docs/d/connect_security_profile.html.markdown
+++ b/website/docs/d/connect_security_profile.html.markdown
@@ -34,7 +34,7 @@ data "aws_connect_security_profile" "example" {
 
 ~> **NOTE:** `instance_id` and one of either `name` or `security_profile_id` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `security_profile_id` - (Optional) Returns information on a specific Security Profile by Security Profile id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance

--- a/website/docs/d/connect_user.html.markdown
+++ b/website/docs/d/connect_user.html.markdown
@@ -34,7 +34,7 @@ data "aws_connect_user" "example" {
 
 ~> **NOTE:** `instance_id` and one of either `name` or `user_id` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific User by name

--- a/website/docs/d/connect_user_hierarchy_group.html.markdown
+++ b/website/docs/d/connect_user_hierarchy_group.html.markdown
@@ -34,7 +34,7 @@ data "aws_connect_user_hierarchy_group" "example" {
 
 ~> **NOTE:** `instance_id` and one of either `name` or `hierarchy_group_id` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `hierarchy_group_id` - (Optional) Returns information on a specific hierarchy group by hierarchy group id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance

--- a/website/docs/d/connect_vocabulary.html.markdown
+++ b/website/docs/d/connect_vocabulary.html.markdown
@@ -34,7 +34,7 @@ data "aws_connect_vocabulary" "example" {
 
 ~> **NOTE:** `instance_id` and one of either `name` or `vocabulary_id` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific Vocabulary by name

--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -49,7 +49,7 @@ resource "aws_db_instance" "dev" {
 
 ~> **NOTE:** One of either `db_instance_identifier` or `db_snapshot_identifier` is required.
 
-This argument supports the following arguments:
+This data source supports the following arguments:
 
 * `most_recent` - (Optional) If more than one result is returned, use the most
 recent Snapshot.

--- a/website/docs/d/service_discovery_service.html.markdown
+++ b/website/docs/d/service_discovery_service.html.markdown
@@ -33,37 +33,37 @@ This data source exports the following attributes in addition to the arguments a
 * `id` - ID of the service.
 * `arn` - ARN of the service.
 * `description` - Description of the service.
-* `dns_config` - Complex type that contains information about the resource record sets that you want Amazon Route 53 to create when you register an instance.
-* `health_check_config` - Complex type that contains settings for an optional health check. Only for Public DNS namespaces.
-* `health_check_custom_config` -  A complex type that contains settings for ECS managed health checks.
+* `dns_config` - Complex type that contains information about the resource record sets that you want Amazon Route 53 to create when you register an instance. See [`dns_config` Block](#dns_config-block) for details.
+* `health_check_config` - Complex type that contains settings for an optional health check. Only for Public DNS namespaces. See [`health_check_config` Block](#health_check_config-block) for details.
+* `health_check_custom_config` -  A complex type that contains settings for ECS managed health checks. See [`health_check_custom_config` Block](#health_check_custom_config-block) for details.
 * `tags` - Map of tags to assign to the service. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `tags_all` - (**Deprecated**) Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
-### dns_config
+### `dns_config` Block
 
-This argument supports the following arguments:
+The `dns_config` configuration block supports the following arguments:
 
 * `namespace_id` - ID of the namespace to use for DNS configuration.
-* `dns_records` - An array that contains one DnsRecord object for each resource record set.
+* `dns_records` - An array that contains one DnsRecord object for each resource record set. See [`dns_records` Block](#dns_records-block) for details.
 * `routing_policy` - Routing policy that you want to apply to all records that Route 53 creates when you register an instance and specify the service. Valid Values: MULTIVALUE, WEIGHTED
 
-#### dns_records
+#### `dns_records` Block
 
-This argument supports the following arguments:
+The `dns_records` configuration block supports the following arguments:
 
 * `ttl` - Amount of time, in seconds, that you want DNS resolvers to cache the settings for this resource record set.
 * `type` - Type of the resource, which indicates the value that Amazon Route 53 returns in response to DNS queries. Valid Values: A, AAAA, SRV, CNAME
 
-### health_check_config
+### `health_check_config` Block
 
-This argument supports the following arguments:
+The `health_check_config` configuration block supports the following arguments:
 
 * `failure_threshold` - Number of consecutive health checks. Maximum value of 10.
 * `resource_path` - Path that you want Route 53 to request when performing health checks. Route 53 automatically adds the DNS name for the service. If you don't specify a value, the default value is /.
 * `type` -  The type of health check that you want to create, which indicates how Route 53 determines whether an endpoint is healthy. Valid Values: HTTP, HTTPS, TCP
 
-### health_check_custom_config
+### `health_check_custom_config` Block
 
-This argument supports the following arguments:
+The `health_check_custom_config` configuration block supports the following arguments:
 
 * `failure_threshold` -  The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance.  Maximum value of 10.

--- a/website/docs/r/appsync_datasource.html.markdown
+++ b/website/docs/r/appsync_datasource.html.markdown
@@ -81,88 +81,90 @@ This resource supports the following arguments:
 * `name` - (Required) User-supplied name for the data source.
 * `type` - (Required) Type of the Data Source. Valid values: `AWS_LAMBDA`, `AMAZON_DYNAMODB`, `AMAZON_ELASTICSEARCH`, `HTTP`, `NONE`, `RELATIONAL_DATABASE`, `AMAZON_EVENTBRIDGE`, `AMAZON_OPENSEARCH_SERVICE`.
 * `description` - (Optional) Description of the data source.
-* `dynamodb_config` - (Optional) DynamoDB settings. See [DynamoDB Config](#dynamodb-config)
-* `elasticsearch_config` - (Optional) Amazon Elasticsearch settings. See [ElasticSearch Config](#elasticsearch-config)
-* `event_bridge_config` - (Optional) AWS EventBridge settings. See [Event Bridge Config](#event-bridge-config)
-* `http_config` - (Optional) HTTP settings. See [HTTP Config](#http-config)
-* `lambda_config` - (Optional) AWS Lambda settings. See [Lambda Config](#lambda-config)
-* `opensearchservice_config` - (Optional) Amazon OpenSearch Service settings. See [OpenSearch Service Config](#opensearch-service-config)
-* `relational_database_config` (Optional) AWS RDS settings. See [Relational Database Config](#relational-database-config)
+* `dynamodb_config` - (Optional) DynamoDB settings. See [`dynamodb_config` Block](#dynamodb_config-block) for details.
+* `elasticsearch_config` - (Optional) Amazon Elasticsearch settings. See [`elasticsearch_config` Block](#elasticsearch_config-block) for details.
+* `event_bridge_config` - (Optional) AWS EventBridge settings. See [`event_bridge_config` Block](#event_bridge_config-block) for details.
+* `http_config` - (Optional) HTTP settings. See [`http_config` Block](#http_config-block) for details.
+* `lambda_config` - (Optional) AWS Lambda settings. See [`lambda_config` Block](#lambda_config-block) for details.
+* `opensearchservice_config` - (Optional) Amazon OpenSearch Service settings. See [`opensearchservice_config` Block](#opensearchservice_config-block) for details.
+* `relational_database_config` (Optional) AWS RDS settings. See [`relational_database_config` Block](#relational_database_config-block) for details.
 * `service_role_arn` - (Optional) IAM service role ARN for the data source. Required if `type` is specified as `AWS_LAMBDA`, `AMAZON_DYNAMODB`, `AMAZON_ELASTICSEARCH`, `AMAZON_EVENTBRIDGE`, or `AMAZON_OPENSEARCH_SERVICE`.
 
-### DynamoDB Config
+### `dynamodb_config` Block
 
-This argument supports the following arguments:
+The `dynamodb_config` configuration block supports the following arguments:
 
 * `table_name` - (Required) Name of the DynamoDB table.
 * `region` - (Optional) AWS region of the DynamoDB table. Defaults to current region.
 * `use_caller_credentials` - (Optional) Set to `true` to use Amazon Cognito credentials with this data source.
-* `delta_sync_config` - (Optional) The DeltaSyncConfig for a versioned data source. See [Delta Sync Config](#delta-sync-config)
+* `delta_sync_config` - (Optional) The DeltaSyncConfig for a versioned data source. See [`delta_sync_config` Block](#delta_sync_config-block) for details.
 * `versioned` - (Optional) Detects Conflict Detection and Resolution with this data source.
 
-### Delta Sync Config
+### `delta_sync_config` Block
+
+The `delta_sync_config` configuration block supports the following arguments:
 
 * `base_table_ttl` - (Optional) The number of minutes that an Item is stored in the data source.
 * `delta_sync_table_name` - (Required) The table name.
 * `delta_sync_table_ttl` - (Optional) The number of minutes that a Delta Sync log entry is stored in the Delta Sync table.
 
-### ElasticSearch Config
+### `elasticsearch_config` Block
 
-This argument supports the following arguments:
+The `elasticsearch_config` configuration block supports the following arguments:
 
 * `endpoint` - (Required) HTTP endpoint of the Elasticsearch domain.
 * `region` - (Optional) AWS region of Elasticsearch domain. Defaults to current region.
 
-### Event Bridge Config
+### `event_bridge_config` Block
 
-This argument supports the following arguments:
+The `event_bridge_config` configuration block supports the following arguments:
 
 * `event_bus_arn` - (Required) ARN for the EventBridge bus.
 
-### HTTP Config
+### `http_config` Block
 
-This argument supports the following arguments:
+The `http_config` configuration block supports the following arguments:
 
 * `endpoint` - (Required) HTTP URL.
-* `authorization_config` - (Optional) Authorization configuration in case the HTTP endpoint requires authorization. See [Authorization Config](#authorization-config).
+* `authorization_config` - (Optional) Authorization configuration in case the HTTP endpoint requires authorization. See [`authorization_config` Block](#authorization_config-block) for details.
 
-#### Authorization Config
+### `authorization_config` Block
 
-This argument supports the following arguments:
+The `authorization_config` configuration block supports the following arguments:
 
 * `authorization_type` - (Optional) Authorization type that the HTTP endpoint requires. Default values is `AWS_IAM`.
-* `aws_iam_config` - (Optional) Identity and Access Management (IAM) settings. See [AWS IAM Config](#aws-iam-config).
+* `aws_iam_config` - (Optional) Identity and Access Management (IAM) settings. See [`aws_iam_config` Block](#aws_iam_config-block) for details.
 
-##### AWS IAM Config
+### `aws_iam_config` Block
 
-This argument supports the following arguments:
+The `aws_iam_config` configuration block supports the following arguments:
 
 * `signing_region` - (Optional) Signing Amazon Web Services Region for IAM authorization.
 * `signing_service_name`- (Optional) Signing service name for IAM authorization.
 
-### Lambda Config
+### `lambda_config` Block
 
-This argument supports the following arguments:
+The `lambda_config` configuration block supports the following arguments:
 
 * `function_arn` - (Required) ARN for the Lambda function.
 
-### OpenSearch Service Config
+### `opensearchservice_config` Block
 
-This argument supports the following arguments:
+The `opensearchservice_config` configuration block supports the following arguments:
 
 * `endpoint` - (Required) HTTP endpoint of the OpenSearch domain.
 * `region` - (Optional) AWS region of the OpenSearch domain. Defaults to current region.
 
-### Relational Database Config
+### `relational_database_config` Block
 
-This argument supports the following arguments:
+The `relational_database_config` configuration block supports the following arguments:
 
-* `http_endpoint_config` - (Required) Amazon RDS HTTP endpoint configuration. See [HTTP Endpoint Config](#http-endpoint-config).
+* `http_endpoint_config` - (Required) Amazon RDS HTTP endpoint configuration. See [`http_endpoint_config` Block](#http_endpoint_config-block) for details.
 * `source_type` - (Optional) Source type for the relational database. Valid values: `RDS_HTTP_ENDPOINT`.
 
-#### HTTP Endpoint Config
+### `http_endpoint_config` Block
 
-This argument supports the following arguments:
+The `http_endpoint_config` configuration block supports the following arguments:
 
 * `db_cluster_identifier` - (Required) Amazon RDS cluster identifier.
 * `aws_secret_store_arn` - (Required) AWS secret store ARN for database credentials.

--- a/website/docs/r/appsync_function.html.markdown
+++ b/website/docs/r/appsync_function.html.markdown
@@ -100,28 +100,28 @@ This resource supports the following arguments:
 * `request_mapping_template` - (Optional) Function request mapping template. Functions support only the 2018-05-29 version of the request mapping template.
 * `response_mapping_template` - (Optional) Function response mapping template.
 * `description` - (Optional) Function description.
-* `runtime` - (Optional) Describes a runtime used by an AWS AppSync pipeline resolver or AWS AppSync function. Specifies the name and version of the runtime to use. Note that if a runtime is specified, code must also be specified. See [Runtime](#runtime).
-* `sync_config` - (Optional) Describes a Sync configuration for a resolver. See [Sync Config](#sync-config).
+* `runtime` - (Optional) Describes a runtime used by an AWS AppSync pipeline resolver or AWS AppSync function. Specifies the name and version of the runtime to use. Note that if a runtime is specified, code must also be specified. See [`runtime` Block](#runtime-block) for details.
+* `sync_config` - (Optional) Describes a Sync configuration for a resolver. See [`sync_config` Block](#sync_config-block) for details.
 * `function_version` - (Optional) Version of the request mapping template. Currently the supported value is `2018-05-29`. Does not apply when specifying `code`.
 
-### Runtime
+### `runtime` Block
 
-This argument supports the following arguments:
+The `runtime` configuration block supports the following arguments:
 
 * `name` - (Optional) The name of the runtime to use. Currently, the only allowed value is `APPSYNC_JS`.
 * `runtime_version` - (Optional) The version of the runtime to use. Currently, the only allowed version is `1.0.0`.
 
-### Sync Config
+### `sync_config` Block
 
-This argument supports the following arguments:
+The `sync_config` configuration block supports the following arguments:
 
 * `conflict_detection` - (Optional) Conflict Detection strategy to use. Valid values are `NONE` and `VERSION`.
 * `conflict_handler` - (Optional) Conflict Resolution strategy to perform in the event of a conflict. Valid values are `NONE`, `OPTIMISTIC_CONCURRENCY`, `AUTOMERGE`, and `LAMBDA`.
-* `lambda_conflict_handler_config` - (Optional) Lambda Conflict Handler Config when configuring `LAMBDA` as the Conflict Handler. See [Lambda Conflict Handler Config](#lambda-conflict-handler-config).
+* `lambda_conflict_handler_config` - (Optional) Lambda Conflict Handler Config when configuring `LAMBDA` as the Conflict Handler. See [`lambda_conflict_handler_config` Block](#lambda_conflict_handler_config-block) for details.
 
-#### Lambda Conflict Handler Config
+#### `lambda_conflict_handler_config` Block
 
-This argument supports the following arguments:
+The `lambda_conflict_handler_config` configuration block supports the following arguments:
 
 * `lambda_conflict_handler_arn` - (Optional) ARN for the Lambda function to use as the Conflict Handler.
 

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -215,13 +215,13 @@ resource "aws_appsync_graphql_api" "example" {
 This resource supports the following arguments:
 
 * `authentication_type` - (Required) Authentication type. Valid values: `API_KEY`, `AWS_IAM`, `AMAZON_COGNITO_USER_POOLS`, `OPENID_CONNECT`, `AWS_LAMBDA`
-* `name` - (Required) User-supplied name for the GraphqlApi.
-* `log_config` - (Optional) Nested argument containing logging configuration. Defined below.
-* `openid_connect_config` - (Optional) Nested argument containing OpenID Connect configuration. Defined below.
-* `user_pool_config` - (Optional) Amazon Cognito User Pool configuration. Defined below.
-* `lambda_authorizer_config` - (Optional) Nested argument containing Lambda authorizer configuration. Defined below.
+* `name` - (Required) User-supplied name for the GraphSQL API.
+* `log_config` - (Optional) Nested argument containing logging configuration. See [`log_config` Block](#log_config-block) for details.
+* `openid_connect_config` - (Optional) Nested argument containing OpenID Connect configuration. See [`openid_connect_config` Block](#openid_connect_config-block) for details.
+* `user_pool_config` - (Optional) Amazon Cognito User Pool configuration. See [`user_pool_config` Block](#user_pool_config-block) for details.
+* `lambda_authorizer_config` - (Optional) Nested argument containing Lambda authorizer configuration. See [`lambda_authorizer_config` Block](#lambda_authorizer_config-block) for details.
 * `schema` - (Optional) Schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration.
-* `additional_authentication_provider` - (Optional) One or more additional authentication providers for the GraphqlApi. Defined below.
+* `additional_authentication_provider` - (Optional) One or more additional authentication providers for the GraphSQL API. See [`additional_authentication_provider` Block](#additional_authentication_provider-block) for details.
 * `introspection_config` - (Optional) Sets the value of the GraphQL API to enable (`ENABLED`) or disable (`DISABLED`) introspection. If no value is provided, the introspection configuration will be set to ENABLED by default. This field will produce an error if the operation attempts to use the introspection feature while this field is disabled. For more information about introspection, see [GraphQL introspection](https://graphql.org/learn/introspection/).
 * `query_depth_limit` - (Optional) The maximum depth a query can have in a single request. Depth refers to the amount of nested levels allowed in the body of query. The default value is `0` (or unspecified), which indicates there's no depth limit. If you set a limit, it can be between `1` and `75` nested levels. This field will produce a limit error if the operation falls out of bounds.
 
@@ -231,43 +231,43 @@ This resource supports the following arguments:
 * `xray_enabled` - (Optional) Whether tracing with X-ray is enabled. Defaults to false.
 * `visibility` - (Optional) Sets the value of the GraphQL API to public (`GLOBAL`) or private (`PRIVATE`). If no value is provided, the visibility will be set to `GLOBAL` by default. This value cannot be changed once the API has been created.
 
-### log_config
+### `log_config` Block
 
-This argument supports the following arguments:
+The `log_config` configuration block supports the following arguments:
 
 * `cloudwatch_logs_role_arn` - (Required) Amazon Resource Name of the service role that AWS AppSync will assume to publish to Amazon CloudWatch logs in your account.
 * `field_log_level` - (Required) Field logging level. Valid values: `ALL`, `ERROR`, `NONE`.
 * `exclude_verbose_content` - (Optional) Set to TRUE to exclude sections that contain information such as headers, context, and evaluated mapping templates, regardless of logging  level. Valid values: `true`, `false`. Default value: `false`
 
-### additional_authentication_provider
+### `additional_authentication_provider` Block
 
-This argument supports the following arguments:
+The `additional_authentication_provider` configuration block supports the following arguments:
 
 * `authentication_type` - (Required) Authentication type. Valid values: `API_KEY`, `AWS_IAM`, `AMAZON_COGNITO_USER_POOLS`, `OPENID_CONNECT`, `AWS_LAMBDA`
-* `openid_connect_config` - (Optional) Nested argument containing OpenID Connect configuration. Defined below.
-* `user_pool_config` - (Optional) Amazon Cognito User Pool configuration. Defined below.
+* `openid_connect_config` - (Optional) Nested argument containing OpenID Connect configuration. See [`openid_connect_config` Block](#openid_connect_config-block) for details.
+* `user_pool_config` - (Optional) Amazon Cognito User Pool configuration. See [`user_pool_config` Block](#user_pool_config-block) for details.
 
-### openid_connect_config
+### `openid_connect_config` Block
 
-This argument supports the following arguments:
+The `openid_connect_config` configuration block supports the following arguments:
 
 * `issuer` - (Required) Issuer for the OpenID Connect configuration. The issuer returned by discovery MUST exactly match the value of iss in the ID Token.
 * `auth_ttl` - (Optional) Number of milliseconds a token is valid after being authenticated.
 * `client_id` - (Optional) Client identifier of the Relying party at the OpenID identity provider. This identifier is typically obtained when the Relying party is registered with the OpenID identity provider. You can specify a regular expression so the AWS AppSync can validate against multiple client identifiers at a time.
 * `iat_ttl` - (Optional) Number of milliseconds a token is valid after being issued to a user.
 
-### user_pool_config
+### `user_pool_config` Block
 
-This argument supports the following arguments:
+The `user_pool_config` configuration block supports the following arguments:
 
 * `default_action` - (Required only if Cognito is used as the default auth provider) Action that you want your GraphQL API to take when a request that uses Amazon Cognito User Pool authentication doesn't match the Amazon Cognito User Pool configuration. Valid: `ALLOW` and `DENY`
 * `user_pool_id` - (Required) User pool ID.
 * `app_id_client_regex` - (Optional) Regular expression for validating the incoming Amazon Cognito User Pool app client ID.
 * `aws_region` - (Optional) AWS region in which the user pool was created.
 
-### lambda_authorizer_config
+### `lambda_authorizer_config` Block
 
-This argument supports the following arguments:
+The `lambda_authorizer_config` configuration block supports the following arguments:
 
 * `authorizer_uri` - (Required) ARN of the Lambda function to be called for authorization. Note: This Lambda function must have a resource-based policy assigned to it, to allow `lambda:InvokeFunction` from service principal `appsync.amazonaws.com`.
 * `authorizer_result_ttl_in_seconds` - (Optional) Number of seconds a response should be cached for. The default is 5 minutes (300 seconds). The Lambda function can override this by returning a `ttlOverride` key in its response. A value of 0 disables caching of responses. Minimum value of 0. Maximum value of 3600.

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -257,14 +257,14 @@ The following fields are available in target tracking configuration:
 
 ### predefined_metric_specification
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `predefined_metric_type` - (Required) Metric type.
 * `resource_label` - (Optional) Identifies the resource associated with the metric type.
 
 ### customized_metric_specification
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `metric_dimension` - (Optional) Dimensions of the metric.
 * `metric_name` - (Optional) Name of the metric.
@@ -275,14 +275,14 @@ This argument supports the following arguments:
 
 #### metric_dimension
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `name` - (Required) Name of the dimension.
 * `value` - (Required) Value of the dimension.
 
 #### metrics
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `expression` - (Optional) Math expression used on the returned metric. You must specify either `expression` or `metric_stat`, but not both.
 * `id` - (Required) Short name for the metric used in target tracking scaling policy.
@@ -292,7 +292,7 @@ This argument supports the following arguments:
 
 ##### metric_stat
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `metric` - (Required) Structure that defines the CloudWatch metric to return, including the metric name, namespace, and dimensions.
 * `stat` - (Required) Statistic of the metrics to return.
@@ -300,7 +300,7 @@ This argument supports the following arguments:
 
 ##### metric
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `dimensions` - (Optional) Dimensions of the metric.
 * `metric_name` - (Required) Name of the metric.
@@ -308,14 +308,14 @@ This argument supports the following arguments:
 
 ###### dimensions
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `name` - (Required) Name of the dimension.
 * `value` - (Required) Value of the dimension.
 
 ### predictive_scaling_configuration
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `max_capacity_breach_behavior` - (Optional) Defines the behavior that should be applied if the forecast capacity approaches or exceeds the maximum capacity of the Auto Scaling group. Valid values are `HonorMaxCapacity` or `IncreaseMaxCapacity`. Default is `HonorMaxCapacity`.
 * `max_capacity_buffer` - (Optional) Size of the capacity buffer to use when the forecast capacity is close to or exceeds the maximum capacity. Valid range is `0` to `100`. If set to `0`, Amazon EC2 Auto Scaling may scale capacity higher than the maximum capacity to equal but not exceed forecast capacity.
@@ -325,7 +325,7 @@ This argument supports the following arguments:
 
 #### metric_specification
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `customized_capacity_metric_specification` - (Optional) Customized capacity metric specification. The field is only valid when you use `customized_load_metric_specification`
 * `customized_load_metric_specification` - (Optional) Customized load metric specification.
@@ -336,46 +336,46 @@ This argument supports the following arguments:
 
 ##### predefined_load_metric_specification
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `predefined_metric_type` - (Required) Metric type. Valid values are `ASGTotalCPUUtilization`, `ASGTotalNetworkIn`, `ASGTotalNetworkOut`, or `ALBTargetGroupRequestCount`.
 * `resource_label` - (Required) Label that uniquely identifies a specific Application Load Balancer target group from which to determine the request count served by your Auto Scaling group. You create the resource label by appending the final portion of the load balancer ARN and the final portion of the target group ARN into a single value, separated by a forward slash (/). Refer to [PredefinedMetricSpecification](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_PredefinedMetricSpecification.html) for more information.
 
 ##### predefined_metric_pair_specification
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `predefined_metric_type` - (Required) Which metrics to use. There are two different types of metrics for each metric type: one is a load metric and one is a scaling metric. For example, if the metric type is `ASGCPUUtilization`, the Auto Scaling group's total CPU metric is used as the load metric, and the average CPU metric is used for the scaling metric. Valid values are `ASGCPUUtilization`, `ASGNetworkIn`, `ASGNetworkOut`, or `ALBRequestCount`.
 * `resource_label` - (Required) Label that uniquely identifies a specific Application Load Balancer target group from which to determine the request count served by your Auto Scaling group. You create the resource label by appending the final portion of the load balancer ARN and the final portion of the target group ARN into a single value, separated by a forward slash (/). Refer to [PredefinedMetricSpecification](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_PredefinedMetricSpecification.html) for more information.
 
 ##### predefined_scaling_metric_specification
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `predefined_metric_type` - (Required) Describes a scaling metric for a predictive scaling policy. Valid values are `ASGAverageCPUUtilization`, `ASGAverageNetworkIn`, `ASGAverageNetworkOut`, or `ALBRequestCountPerTarget`.
 * `resource_label` - (Required) Label that uniquely identifies a specific Application Load Balancer target group from which to determine the request count served by your Auto Scaling group. You create the resource label by appending the final portion of the load balancer ARN and the final portion of the target group ARN into a single value, separated by a forward slash (/). Refer to [PredefinedMetricSpecification](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_PredefinedMetricSpecification.html) for more information.
 
 ##### customized_scaling_metric_specification
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `metric_data_queries` - (Required) List of up to 10 structures that defines custom scaling metric in predictive scaling policy
 
 ##### customized_load_metric_specification
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `metric_data_queries` - (Required) List of up to 10 structures that defines custom load metric in predictive scaling policy
 
 ##### customized_capacity_metric_specification
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `metric_data_queries` - (Required) List of up to 10 structures that defines custom capacity metric in predictive scaling policy
 
 ##### metric_data_queries
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `expression` - (Optional) Math expression used on the returned metric. You must specify either `expression` or `metric_stat`, but not both.
 * `id` - (Required) Short name for the metric used in predictive scaling policy.
@@ -385,7 +385,7 @@ This argument supports the following arguments:
 
 ##### metric_stat
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `metric` - (Required) Structure that defines the CloudWatch metric to return, including the metric name, namespace, and dimensions.
 * `stat` - (Required) Statistic of the metrics to return.
@@ -393,7 +393,7 @@ This argument supports the following arguments:
 
 ##### metric
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `dimensions` - (Optional) Dimensions of the metric.
 * `metric_name` - (Required) Name of the metric.
@@ -401,7 +401,7 @@ This argument supports the following arguments:
 
 ##### dimensions
 
-This argument supports the following arguments:
+This configuration block supports the following arguments:
 
 * `name` - (Required) Name of the dimension.
 * `value` - (Required) Value of the dimension.

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -174,7 +174,7 @@ You must choose one or the other
 See [related part of AWS Docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html)
 for details about valid values.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `alarm_name` - (Required) The descriptive name for the alarm. This name must be unique within the user's AWS account
 * `comparison_operator` - (Required) The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: `GreaterThanOrEqualToThreshold`, `GreaterThanThreshold`, `LessThanThreshold`, `LessThanOrEqualToThreshold`. Additionally, the values  `LessThanLowerOrGreaterThanUpperThreshold`, `LessThanLowerThreshold`, and `GreaterThanUpperThreshold` are used only for alarms based on anomaly detection models.

--- a/website/docs/r/config_conformance_pack.html.markdown
+++ b/website/docs/r/config_conformance_pack.html.markdown
@@ -82,7 +82,7 @@ EOT
 
 ~> **Note:** If both `template_body` and `template_s3_uri` are specified, AWS Config uses the `template_s3_uri` and ignores the `template_body`.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `name` - (Required, Forces new resource) The name of the conformance pack. Must begin with a letter and contain from 1 to 256 alphanumeric characters and hyphens.
 * `delivery_s3_bucket` - (Optional) Amazon S3 bucket where AWS Config stores conformance pack templates. Maximum length of 63.

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -277,7 +277,7 @@ resource "aws_db_instance" "default" {
 For more detailed documentation about each argument, refer to the [AWS official
 documentation](http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `allocated_storage` - (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) The allocated storage in gibibytes. If `max_allocated_storage` is configured, this argument represents the initial storage allocation and differences from the configuration will be ignored automatically when Storage Autoscaling occurs. If `replicate_source_db` is set, the value is ignored during the creation of the instance.
 * `allow_major_version_upgrade` - (Optional) Indicates that major version

--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -40,7 +40,7 @@ resource "aws_docdb_cluster" "docdb" {
 For more detailed documentation about each argument, refer to
 the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/docdb/create-db-cluster.html).
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `allow_major_version_upgrade` - (Optional) A value that indicates whether major version upgrades are allowed. Constraints: You must allow major version upgrades when specifying a value for the EngineVersion parameter that is a different major version than the DB cluster's current version.
 * `apply_immediately` - (Optional) Specifies whether any cluster modifications

--- a/website/docs/r/docdb_cluster_instance.html.markdown
+++ b/website/docs/r/docdb_cluster_instance.html.markdown
@@ -40,7 +40,7 @@ resource "aws_docdb_cluster" "default" {
 For more detailed documentation about each argument, refer to
 the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/docdb/create-db-instance.html).
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `apply_immediately` - (Optional) Specifies whether any database modifications
      are applied immediately, or during the next maintenance window. Default is`false`.

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -95,7 +95,7 @@ A full example of how to create a VPN Gateway in one AWS account, create a Direc
 
 ~> **NOTE:** If the `associated_gateway_id` is in another region, an [alias](https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations) in a new provider block for that region should be specified.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `dx_gateway_id` - (Required) The ID of the Direct Connect gateway.
 * `associated_gateway_id` - (Optional) The ID of the VGW or transit gateway with which to associate the Direct Connect gateway.

--- a/website/docs/r/dynamodb_table_item.html.markdown
+++ b/website/docs/r/dynamodb_table_item.html.markdown
@@ -48,7 +48,7 @@ resource "aws_dynamodb_table" "example" {
 
 ~> **Note:** Names included in `item` are represented internally with everything but letters removed. There is the possibility of collisions if two names, once filtered, are the same. For example, the names `your-name-here` and `yournamehere` will overlap and cause an error.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `hash_key` - (Required) Hash key to use for lookups and identification of the item
 * `item` - (Required) JSON representation of a map of attribute name/value pairs, one for each attribute. Only the primary key attributes are required; you can optionally provide other attribute name-value pairs for the item.

--- a/website/docs/r/elastictranscoder_pipeline.html.markdown
+++ b/website/docs/r/elastictranscoder_pipeline.html.markdown
@@ -34,7 +34,7 @@ resource "aws_elastictranscoder_pipeline" "bar" {
 
 See ["Create Pipeline"](http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/create-pipeline.html) in the AWS docs for reference.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `aws_kms_key_arn` - (Optional) The AWS Key Management Service (AWS KMS) key that you want to use with this pipeline.
 * `content_config` - (Optional) The ContentConfig object specifies information about the Amazon S3 bucket in which you want Elastic Transcoder to save transcoded files and playlists. (documented below)

--- a/website/docs/r/elastictranscoder_preset.html.markdown
+++ b/website/docs/r/elastictranscoder_preset.html.markdown
@@ -80,7 +80,7 @@ resource "aws_elastictranscoder_preset" "bar" {
 
 See ["Create Preset"](http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/create-preset.html) in the AWS docs for reference.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `audio` - (Optional, Forces new resource) Audio parameters object (documented below).
 * `audio_codec_options` - (Optional, Forces new resource) Codec options for the audio parameters (documented below)

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -178,7 +178,7 @@ resource "aws_s3_bucket" "example" {
 
 ~> **NOTE:** One of `eni_id`, `subnet_id`, `transit_gateway_id`, `transit_gateway_attachment_id`, or `vpc_id` must be specified.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `traffic_type` - (Required) The type of traffic to capture. Valid values: `ACCEPT`,`REJECT`, `ALL`.
 * `deliver_cross_account_role` - (Optional) ARN of the IAM role that allows Amazon EC2 to publish flow logs across accounts.

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -130,7 +130,7 @@ resource "aws_glue_crawler" "events_crawler" {
 
 ~> **NOTE:** Must specify at least one of `dynamodb_target`, `jdbc_target`, `s3_target`, `mongodb_target` or `catalog_target`.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `database_name` (Required) Glue database where results are written.
 * `name` (Required) Name of the crawler.

--- a/website/docs/r/guardduty_organization_configuration.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration.html.markdown
@@ -48,7 +48,7 @@ resource "aws_guardduty_organization_configuration" "example" {
 
 ~> **NOTE:** One of `auto_enable` or `auto_enable_organization_members` must be specified.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `auto_enable` - (Optional) *Deprecated:* Use `auto_enable_organization_members` instead. When this setting is enabled, all new accounts that are created in, or added to, the organization are added as a member accounts of the organization’s GuardDuty delegated administrator and GuardDuty is enabled in that AWS Region.
 * `auto_enable_organization_members` - (Optional) Indicates the auto-enablement configuration of GuardDuty for the member accounts in the organization. Valid values are `ALL`, `NEW`, `NONE`.

--- a/website/docs/r/lightsail_container_service.html.markdown
+++ b/website/docs/r/lightsail_container_service.html.markdown
@@ -96,7 +96,7 @@ resource "aws_ecr_repository_policy" "default" {
 container service. For more information, see
 [Enabling and managing custom domains for your Amazon Lightsail container services](https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-creating-container-services-certificates).
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `name` - (Required) The name for the container service. Names must be of length 1 to 63, and be
   unique within each AWS Region in your Lightsail account.

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -197,7 +197,7 @@ the AWS official documentation :
 * [create-db-cluster](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html)
 * [modify-db-cluster](https://docs.aws.amazon.com/cli/latest/reference/rds/modify-db-cluster.html)
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `allocated_storage` - (Optional, Required for Multi-AZ DB cluster) The amount of storage in gibibytes (GiB) to allocate to each DB instance in the Multi-AZ DB cluster.
 * `allow_major_version_upgrade` - (Optional) Enable to allow major engine version upgrades when changing engine versions. Defaults to `false`.

--- a/website/docs/r/rds_cluster_activity_stream.html.markdown
+++ b/website/docs/r/rds_cluster_activity_stream.html.markdown
@@ -56,7 +56,7 @@ resource "aws_rds_cluster_activity_stream" "default" {
 For more detailed documentation about each argument, refer to
 the [AWS official documentation][3].
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `resource_arn` - (Required, Forces new resources) The Amazon Resource Name (ARN) of the DB cluster.
 * `mode` - (Required, Forces new resources) Specifies the mode of the database activity stream. Database events such as a change or access generate an activity stream event. The database session can handle these events either synchronously or asynchronously. One of: `sync`, `async`.

--- a/website/docs/r/rds_cluster_endpoint.html.markdown
+++ b/website/docs/r/rds_cluster_endpoint.html.markdown
@@ -79,7 +79,7 @@ resource "aws_rds_cluster_endpoint" "static" {
 For more detailed documentation about each argument, refer to
 the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster-endpoint.html).
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `cluster_identifier` - (Required, Forces new resources) The cluster identifier.
 * `cluster_endpoint_identifier` - (Required, Forces new resources) The identifier to use for the new endpoint. This parameter is stored as a lowercase string.

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -51,7 +51,7 @@ resource "aws_rds_cluster" "default" {
 For more detailed documentation about each argument, refer to
 the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html).
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `apply_immediately` - (Optional) Specifies whether any database modifications are applied immediately, or during the next maintenance window. Default is`false`.
 * `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default `true`.

--- a/website/docs/r/route53domains_delegation_signer_record.html.markdown
+++ b/website/docs/r/route53domains_delegation_signer_record.html.markdown
@@ -106,7 +106,7 @@ resource "aws_route53domains_delegation_signer_record" "example" {
 
 ## Argument Reference
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `domain_name` - (Required) The name of the domain that will have its parent DNS zone updated with the Delegation Signer record.
 * `signing_attributes` - (Required) The information about a key, including the algorithm, public key-value, and flags.

--- a/website/docs/r/route53domains_registered_domain.html.markdown
+++ b/website/docs/r/route53domains_registered_domain.html.markdown
@@ -38,7 +38,7 @@ resource "aws_route53domains_registered_domain" "example" {
 
 ~> **NOTE:** You must specify the same privacy setting for `admin_privacy`, `registrant_privacy` and `tech_privacy`.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `admin_contact` - (Optional) Details about the domain administrative contact. See [Contact Blocks](#contact-blocks) for more details.
 * `admin_privacy` - (Optional) Whether domain administrative contact information is concealed from WHOIS queries. Default: `true`.

--- a/website/docs/r/route_table_association.html.markdown
+++ b/website/docs/r/route_table_association.html.markdown
@@ -31,7 +31,7 @@ resource "aws_route_table_association" "b" {
 
 ~> **NOTE:** Please note that one of either `subnet_id` or `gateway_id` is required.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `subnet_id` - (Optional) The subnet ID to create an association. Conflicts with `gateway_id`.
 * `gateway_id` - (Optional) The gateway ID to create an association. Conflicts with `subnet_id`.

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -75,44 +75,44 @@ resource "aws_service_discovery_service" "example" {
 
 This resource supports the following arguments:
 
-* `name` - (Required, ForceNew) The name of the service.
+* `name` - (Required, Forces new resource) The name of the service.
 * `description` - (Optional) The description of the service.
-* `dns_config` - (Optional) A complex type that contains information about the resource record sets that you want Amazon Route 53 to create when you register an instance.
-* `health_check_config` - (Optional) A complex type that contains settings for an optional health check. Only for Public DNS namespaces.
-* `force_destroy` - (Optional, Default:false ) A boolean that indicates all instances should be deleted from the service so that the service can be destroyed without error. These instances are not recoverable.
-* `health_check_custom_config` - (Optional, ForceNew) A complex type that contains settings for ECS managed health checks.
+* `dns_config` - (Optional) A complex type that contains information about the resource record sets that you want Amazon Route 53 to create when you register an instance. See [`dns_config` Block](#dns_config-block) for details.
+* `health_check_config` - (Optional) A complex type that contains settings for an optional health check. Only for Public DNS namespaces. See [`health_check_config` Block](#health_check_config-block) for details.
+* `force_destroy` - (Optional) A boolean that indicates all instances should be deleted from the service so that the service can be destroyed without error. These instances are not recoverable. Defaults to `false`.
+* `health_check_custom_config` - (Optional, Forces new resource) A complex type that contains settings for ECS managed health checks. See [`health_check_custom_config` Block](#health_check_custom_config-block) for details.
 * `namespace_id` - (Optional) The ID of the namespace that you want to use to create the service.
 * `type` - (Optional) If present, specifies that the service instances are only discoverable using the `DiscoverInstances` API operation. No DNS records is registered for the service instances. The only valid value is `HTTP`.
 * `tags` - (Optional) A map of tags to assign to the service. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### dns_config
+### `dns_config` Block
 
-This argument supports the following arguments:
+The `dns_config` configuration block supports the following arguments:
 
-* `namespace_id` - (Required, ForceNew) The ID of the namespace to use for DNS configuration.
-* `dns_records` - (Required) An array that contains one DnsRecord object for each resource record set.
+* `namespace_id` - (Required, Forces new resource) The ID of the namespace to use for DNS configuration.
+* `dns_records` - (Required) An array that contains one DnsRecord object for each resource record set. See [`dns_records` Block](#dns_records-block) for details.
 * `routing_policy` - (Optional) The routing policy that you want to apply to all records that Route 53 creates when you register an instance and specify the service. Valid Values: MULTIVALUE, WEIGHTED
 
-#### dns_records
+#### `dns_records` Block
 
-This argument supports the following arguments:
+The `dns_records` configuration block supports the following arguments:
 
 * `ttl` - (Required) The amount of time, in seconds, that you want DNS resolvers to cache the settings for this resource record set.
-* `type` - (Required, ForceNew) The type of the resource, which indicates the value that Amazon Route 53 returns in response to DNS queries. Valid Values: A, AAAA, SRV, CNAME
+* `type` - (Required, Forces new resource) The type of the resource, which indicates the value that Amazon Route 53 returns in response to DNS queries. Valid Values: A, AAAA, SRV, CNAME
 
-### health_check_config
+### `health_check_config` Block
 
-This argument supports the following arguments:
+The `health_check_config` configuration block supports the following arguments:
 
 * `failure_threshold` - (Optional) The number of consecutive health checks. Maximum value of 10.
 * `resource_path` - (Optional) The path that you want Route 53 to request when performing health checks. Route 53 automatically adds the DNS name for the service. If you don't specify a value, the default value is /.
-* `type` - (Optional, ForceNew) The type of health check that you want to create, which indicates how Route 53 determines whether an endpoint is healthy. Valid Values: HTTP, HTTPS, TCP
+* `type` - (Optional, Forces new resource) The type of health check that you want to create, which indicates how Route 53 determines whether an endpoint is healthy. Valid Values: HTTP, HTTPS, TCP
 
-### health_check_custom_config
+### `health_check_custom_config` Block
 
-This argument supports the following arguments:
+The `health_check_custom_config` configuration block supports the following arguments:
 
-* `failure_threshold` - (Optional, ForceNew) The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance.  Maximum value of 10.
+* `failure_threshold` - (Optional, Forces new resource) The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance.  Maximum value of 10.
 
 ## Attribute Reference
 

--- a/website/docs/r/servicecatalog_product.html.markdown
+++ b/website/docs/r/servicecatalog_product.html.markdown
@@ -40,7 +40,7 @@ The following arguments are required:
 
 * `name` - (Required) Name of the product.
 * `owner` - (Required) Owner of the product.
-* `provisioning_artifact_parameters` - (Required) Configuration block for provisioning artifact (i.e., version) parameters. Detailed below.
+* `provisioning_artifact_parameters` - (Required) Configuration block for provisioning artifact (i.e., version) parameters. See [`provisioning_artifact_parameters` Block](#provisioning_artifact_parameters-block) for details.
 * `type` - (Required) Type of product. See [AWS Docs](https://docs.aws.amazon.com/servicecatalog/latest/dg/API_CreateProduct.html#API_CreateProduct_RequestSyntax) for valid list of values.
 
 The following arguments are optional:
@@ -53,9 +53,9 @@ The following arguments are optional:
 * `support_url` - (Optional) Contact URL for product support.
 * `tags` - (Optional) Tags to apply to the product. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### provisioning_artifact_parameters
+### `provisioning_artifact_parameters` Block
 
-This argument supports the following arguments:
+The `provisioning_artifact_parameters` configuration block supports the following arguments:
 
 * `description` - (Optional) Description of the provisioning artifact (i.e., version), including how it differs from the previous provisioning artifact.
 * `disable_template_validation` - (Optional) Whether AWS Service Catalog stops validating the specified provisioning artifact template even if it is invalid.

--- a/website/docs/r/servicecatalog_provisioned_product.html.markdown
+++ b/website/docs/r/servicecatalog_provisioned_product.html.markdown
@@ -56,24 +56,24 @@ The following arguments are optional:
 * `product_name` - (Optional) Name of the product. You must provide `product_id` or `product_name`, but not both.
 * `provisioning_artifact_id` - (Optional) Identifier of the provisioning artifact. For example, `pa-4abcdjnxjj6ne`. You must provide the `provisioning_artifact_id` or `provisioning_artifact_name`, but not both.
 * `provisioning_artifact_name` - (Optional) Name of the provisioning artifact. You must provide the `provisioning_artifact_id` or `provisioning_artifact_name`, but not both.
-* `provisioning_parameters` - (Optional) Configuration block with parameters specified by the administrator that are required for provisioning the product. See details below.
+* `provisioning_parameters` - (Optional) Configuration block with parameters specified by the administrator that are required for provisioning the product. See [`provisioning_parameters` Block](#provisioning_parameters-block) for details.
 * `retain_physical_resources` - (Optional) _Only applies to deleting._ Whether to delete the Service Catalog provisioned product but leave the CloudFormation stack, stack set, or the underlying resources of the deleted provisioned product. The default value is `false`.
-* `stack_set_provisioning_preferences` - (Optional) Configuration block with information about the provisioning preferences for a stack set. See details below.
+* `stack_set_provisioning_preferences` - (Optional) Configuration block with information about the provisioning preferences for a stack set. See [`stack_set_provisioning_preferences` Block](#stack_set_provisioning_preferences-block) for details.
 * `tags` - (Optional) Tags to apply to the provisioned product. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### provisioning_parameters
+### `provisioning_parameters` Block
 
-This argument supports the following arguments:
+The `provisioning_parameters` configuration block supports the following arguments:
 
 * `key` - (Required) Parameter key.
 * `use_previous_value` - (Optional) Whether to ignore `value` and keep the previous parameter value. Ignored when initially provisioning a product.
 * `value` - (Optional) Parameter value.
 
-### stack_set_provisioning_preferences
+### `stack_set_provisioning_preferences` Block
 
 All of the `stack_set_provisioning_preferences` are only applicable to a `CFN_STACKSET` provisioned product type.
 
-This argument supports the following arguments:
+The `stack_set_provisioning_preferences` configuration block supports the following arguments:
 
 * `accounts` - (Optional) One or more AWS accounts that will have access to the provisioned product. The AWS accounts specified should be within the list of accounts in the STACKSET constraint. To get the list of accounts in the STACKSET constraint, use the `aws_servicecatalog_provisioning_parameters` data source. If no values are specified, the default value is all accounts from the STACKSET constraint.
 * `failure_tolerance_count` - (Optional) Number of accounts, per region, for which this operation can fail before AWS Service Catalog stops the operation in that region. If the operation is stopped in a region, AWS Service Catalog doesn't attempt the operation in any subsequent regions. You must specify either `failure_tolerance_count` or `failure_tolerance_percentage`, but not both. The default value is 0 if no value is specified.

--- a/website/docs/r/sesv2_configuration_set.html.markdown
+++ b/website/docs/r/sesv2_configuration_set.html.markdown
@@ -45,51 +45,61 @@ resource "aws_sesv2_configuration_set" "example" {
 This resource supports the following arguments:
 
 * `configuration_set_name` - (Required) The name of the configuration set.
-* `delivery_options` - (Optional) An object that defines the dedicated IP pool that is used to send emails that you send using the configuration set.
-* `reputation_options` - (Optional) An object that defines whether or not Amazon SES collects reputation metrics for the emails that you send that use the configuration set.
-* `sending_options` - (Optional) An object that defines whether or not Amazon SES can send email that you send using the configuration set.
-* `suppression_options` - (Optional) An object that contains information about the suppression list preferences for your account.
+* `delivery_options` - (Optional) An object that defines the dedicated IP pool that is used to send emails that you send using the configuration set. See [`delivery_options` Block](#delivery_options-block) for details.
+* `reputation_options` - (Optional) An object that defines whether or not Amazon SES collects reputation metrics for the emails that you send that use the configuration set. See [`reputation_options` Block](#reputation_options-block) for details.
+* `sending_options` - (Optional) An object that defines whether or not Amazon SES can send email that you send using the configuration set. See [`sending_options` Block](#sending_options-block) for details.
+* `suppression_options` - (Optional) An object that contains information about the suppression list preferences for your account. See [`suppression_options` Block](#suppression_options-block) for details.
 * `tags` - (Optional) A map of tags to assign to the service. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `tracking_options` - (Optional) An object that defines the open and click tracking options for emails that you send using the configuration set.
-* `vdm_options` - (Optional) An object that defines the VDM settings that apply to emails that you send using the configuration set.
+* `tracking_options` - (Optional) An object that defines the open and click tracking options for emails that you send using the configuration set. See [`tracking_options` Block](#tracking_options-block) for details.
+* `vdm_options` - (Optional) An object that defines the VDM settings that apply to emails that you send using the configuration set. See [`vdm_options` Block](#vdm_options-block) for details.
 
-### delivery_options
+### `delivery_options` Block
 
-This argument supports the following arguments:
+The `delivery_options` configuration block supports the following arguments:
 
 * `sending_pool_name` - (Optional) The name of the dedicated IP pool to associate with the configuration set.
 * `tls_policy` - (Optional) Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). Valid values: `REQUIRE`, `OPTIONAL`.
 
-### reputation_options
+### `reputation_options` Block
 
-This argument supports the following arguments:
+The `reputation_options` configuration block supports the following arguments:
 
 * `reputation_metrics_enabled` - (Optional) If `true`, tracking of reputation metrics is enabled for the configuration set. If `false`, tracking of reputation metrics is disabled for the configuration set.
 
-### sending_options
+### `sending_options` Block
 
-This argument supports the following arguments:
+The `sending_options` configuration block supports the following arguments:
 
 * `sending_enabled` - (Optional) If `true`, email sending is enabled for the configuration set. If `false`, email sending is disabled for the configuration set.
 
-### suppression_options
+### `suppression_options` Block
+
+The `suppression_options` configuration block supports the following arguments:
 
 * `suppressed_reasons` - (Optional) A list that contains the reasons that email addresses are automatically added to the suppression list for your account. Valid values: `BOUNCE`, `COMPLAINT`.
 
-### tracking_options
+### `tracking_options` Block
+
+The `tracking_options` configuration block supports the following arguments:
 
 * `custom_redirect_domain` - (Required) The domain to use for tracking open and click events.
 
-### vdm_options
+### `vdm_options` Block
 
-* `dashboard_options` - (Optional) Specifies additional settings for your VDM configuration as applicable to the Dashboard.
-* `guardian_options` - (Optional) Specifies additional settings for your VDM configuration as applicable to the Guardian.
+The `vdm_options` configuration block supports the following arguments:
 
-### dashboard_options
+* `dashboard_options` - (Optional) Specifies additional settings for your VDM configuration as applicable to the Dashboard. See [`dashboard_options` Block](#dashboard_options-block) for details.
+* `guardian_options` - (Optional) Specifies additional settings for your VDM configuration as applicable to the Guardian. See [`guardian_options` Block](#guardian_options-block) for details.
+
+### `dashboard_options` Block
+
+The `dashboard_options` configuration block supports the following arguments:
 
 * `engagement_metrics` - (Optional) Specifies the status of your VDM engagement metrics collection. Valid values: `ENABLED`, `DISABLED`.
 
-### guardian_options
+### `guardian_options` Block
+
+The `guardian_options` configuration block supports the following arguments:
 
 * `optimized_shared_delivery` - (Optional) Specifies the status of your VDM optimized shared delivery. Valid values: `ENABLED`, `DISABLED`.
 

--- a/website/docs/r/storagegateway_gateway.html.markdown
+++ b/website/docs/r/storagegateway_gateway.html.markdown
@@ -100,7 +100,7 @@ resource "aws_storagegateway_gateway" "example" {
 
 ~> **NOTE:** One of `activation_key` or `gateway_ip_address` must be provided for resource creation (gateway activation). Neither is required for resource import. If using `gateway_ip_address`, Terraform must be able to make an HTTP (port 80) GET request to the specified IP address from where it is running.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `gateway_name` - (Required) Name of the gateway.
 * `gateway_timezone` - (Required) Time zone for the gateway. The time zone is of the format "GMT", "GMT-hr:mm", or "GMT+hr:mm". For example, `GMT-4:00` indicates the time is 4 hours behind GMT. The time zone is used, for example, for scheduling snapshots and your gateway's maintenance schedule.

--- a/website/docs/r/vpc_peering_connection.html.markdown
+++ b/website/docs/r/vpc_peering_connection.html.markdown
@@ -103,7 +103,7 @@ can be done using the [`auto_accept`](vpc_peering_connection.html#auto_accept) a
 Connection has to be made active manually using other means. See [notes](vpc_peering_connection.html#notes) below for
 more information.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `peer_owner_id` - (Optional) The AWS account ID of the target peer VPC.
    Defaults to the account ID the [AWS provider][1] is currently connected to, so must be managed if connecting cross-account.

--- a/website/docs/r/vpc_security_group_egress_rule.html.markdown
+++ b/website/docs/r/vpc_security_group_egress_rule.html.markdown
@@ -34,7 +34,7 @@ resource "aws_vpc_security_group_egress_rule" "example" {
 
 ~> **Note** Although `cidr_ipv4`, `cidr_ipv6`, `prefix_list_id`, and `referenced_security_group_id` are all marked as optional, you *must* provide one of them in order to configure the destination of the traffic. The `from_port` and `to_port` arguments are required unless `ip_protocol` is set to `-1` or `icmpv6`.
 
-This argument supports the following arguments:
+This resource supports the following arguments:
 
 * `cidr_ipv4` - (Optional) The destination IPv4 CIDR range.
 * `cidr_ipv6` - (Optional) The destination IPv6 CIDR range.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the improper use of the word "argument" to refer to resources, data sources, and configuration blocks in the first sentence of various resource and data source documentation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38072

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a