### PR TITLE
ci: Sets the parallelism for AMP acceptance tests to 10

### DIFF
--- a/.teamcity/components/generated/services_all.kt
+++ b/.teamcity/components/generated/services_all.kt
@@ -5,7 +5,7 @@ val services = mapOf(
     "account" to ServiceSpec("Account Management"),
     "acm" to ServiceSpec("ACM (Certificate Manager)"),
     "acmpca" to ServiceSpec("ACM PCA (Certificate Manager Private Certificate Authority)"),
-    "amp" to ServiceSpec("AMP (Managed Prometheus)"),
+    "amp" to ServiceSpec("AMP (Managed Prometheus)", parallelismOverride = 10),
     "amplify" to ServiceSpec("Amplify"),
     "apigateway" to ServiceSpec("API Gateway", vpcLock = true),
     "apigatewayv2" to ServiceSpec("API Gateway V2", vpcLock = true),

--- a/internal/generate/teamcity/acctest_services.hcl
+++ b/internal/generate/teamcity/acctest_services.hcl
@@ -1,6 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+service "amp" {
+  # The maximum scrapers per region quota is fixed at 10
+  parallelism = 10
+}
+
 service "appautoscaling" {
   vpc_lock = true
 }


### PR DESCRIPTION
### Description

AMP has a maximum of 10 scrapers per region, and this quota cannot be adjusted.
