### PR TITLE
Add resource_set_ids attribute to fms policy

### DIFF
--- a/.changelog/38161.txt
+++ b/.changelog/38161.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fms_policy: Add `resource_set_ids` attribute
+```

--- a/internal/service/fms/fms_test.go
+++ b/internal/service/fms/fms_test.go
@@ -28,6 +28,7 @@ func TestAccFMS_serial(t *testing.T) {
 			"securityGroup":          testAccPolicy_securityGroup,
 			"tags":                   testAccPolicy_tags,
 			"update":                 testAccPolicy_update,
+			"rsc_set":                testAccPolicy_rsc_set,
 		},
 		"ResourceSet": {
 			acctest.CtBasic:      testAccFMSResourceSet_basic,

--- a/internal/service/fms/fms_test.go
+++ b/internal/service/fms/fms_test.go
@@ -28,7 +28,7 @@ func TestAccFMS_serial(t *testing.T) {
 			"securityGroup":          testAccPolicy_securityGroup,
 			"tags":                   testAccPolicy_tags,
 			"update":                 testAccPolicy_update,
-			"rsc_set":                testAccPolicy_rsc_set,
+			"rscSet":                 testAccPolicy_rscSet,
 		},
 		"ResourceSet": {
 			acctest.CtBasic:      testAccFMSResourceSet_basic,

--- a/internal/service/fms/policy.go
+++ b/internal/service/fms/policy.go
@@ -134,6 +134,14 @@ func resourcePolicy() *schema.Resource {
 				ValidateFunc:  validation.StringMatch(regexache.MustCompile(`^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$`), "must match a supported resource type, such as AWS::EC2::VPC, see also: https://docs.aws.amazon.com/fms/2018-01-01/APIReference/API_Policy.html"),
 				ConflictsWith: []string{"resource_type_list"},
 			},
+			"resource_set_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"resource_type_list": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -275,6 +283,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	d.Set(names.AttrResourceType, policy.ResourceType)
 	d.Set("resource_type_list", policy.ResourceTypeList)
+	d.Set("resource_set_ids", policy.ResourceSetIds)
 	securityServicePolicy := []map[string]interface{}{{
 		names.AttrType:         string(policy.SecurityServicePolicyData.Type),
 		"managed_service_data": aws.ToString(policy.SecurityServicePolicyData.ManagedServiceData),
@@ -376,6 +385,7 @@ func expandPolicy(d *schema.ResourceData) *awstypes.Policy {
 		RemediationEnabled:             d.Get("remediation_enabled").(bool),
 		ResourceType:                   resourceType,
 		ResourceTypeList:               flex.ExpandStringValueSet(d.Get("resource_type_list").(*schema.Set)),
+		ResourceSetIds:                 flex.ExpandStringValueSet(d.Get("resource_set_ids").(*schema.Set)),
 	}
 
 	if d.Id() != "" {

--- a/internal/service/fms/policy_test.go
+++ b/internal/service/fms/policy_test.go
@@ -44,6 +44,7 @@ func testAccPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "security_service_policy_data.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct0),
+					resource.TestCheckResourceAttr(resourceName, "resource_set_ids.#", acctest.Ct1),
 				),
 			},
 			{
@@ -413,6 +414,7 @@ resource "aws_fms_policy" "test" {
   name                  = %[1]q
   description           = "test description"
   remediation_enabled   = false
+  resource_set_ids      = [aws_fms_resource_set.test.id]
   resource_type_list    = ["AWS::ElasticLoadBalancingV2::LoadBalancer"]
 
   exclude_map {
@@ -430,6 +432,14 @@ resource "aws_fms_policy" "test" {
 resource "aws_wafregional_rule_group" "test" {
   metric_name = "MyTest"
   name        = %[2]q
+}
+
+resource "aws_fms_resource_set" "test" {
+  depends_on = [aws_fms_admin_account.test]
+  resource_set {
+    name               = %[1]q
+    resource_type_list = ["AWS::NetworkFirewall::Firewall"]
+  }
 }
 `, policyName, ruleGroupName))
 }

--- a/internal/service/fms/policy_test.go
+++ b/internal/service/fms/policy_test.go
@@ -44,7 +44,6 @@ func testAccPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "security_service_policy_data.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct0),
-					resource.TestCheckResourceAttr(resourceName, "resource_set_ids.#", acctest.Ct1),
 				),
 			},
 			{
@@ -360,6 +359,34 @@ func testAccPolicy_securityGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "security_service_policy_data.0.type", "SECURITY_GROUPS_CONTENT_AUDIT"),
 					acctest.CheckResourceAttrJMES(resourceName, "security_service_policy_data.0.managed_service_data", names.AttrType, "SECURITY_GROUPS_CONTENT_AUDIT"),
 					acctest.CheckResourceAttrJMES(resourceName, "security_service_policy_data.0.managed_service_data", "securityGroupAction.type", "ALLOW"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPolicy_rsc_set(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_fms_policy.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckRegion(t, names.USEast1RegionID)
+			acctest.PreCheckOrganizationsEnabled(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyConfig_basic(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "resource_set_ids.#", acctest.Ct1),
 				),
 			},
 		},
@@ -854,4 +881,41 @@ resource "aws_fms_policy" "test" {
   depends_on = [aws_fms_admin_account.test]
 }
 `, rName))
+}
+
+func testAccPolicyConfig_rsc_set(policyName, ruleGroupName string) string {
+	return acctest.ConfigCompose(testAccAdminAccountConfig_basic, fmt.Sprintf(`
+resource "aws_fms_policy" "test" {
+  exclude_resource_tags = false
+  name                  = %[1]q
+  description           = "test description"
+  remediation_enabled   = false
+  resource_set_ids      = [aws_fms_resource_set.test.id]
+  resource_type_list    = ["AWS::ElasticLoadBalancingV2::LoadBalancer"]
+
+  exclude_map {
+    account = [data.aws_caller_identity.current.account_id]
+  }
+
+  security_service_policy_data {
+    type                 = "WAF"
+    managed_service_data = "{\"type\": \"WAF\", \"ruleGroups\": [{\"id\":\"${aws_wafregional_rule_group.test.id}\", \"overrideAction\" : {\"type\": \"COUNT\"}}],\"defaultAction\": {\"type\": \"BLOCK\"}, \"overrideCustomerWebACLAssociation\": false}"
+  }
+
+  depends_on = [aws_fms_admin_account.test]
+}
+
+resource "aws_wafregional_rule_group" "test" {
+  metric_name = "MyTest"
+  name        = %[2]q
+}
+
+resource "aws_fms_resource_set" "test" {
+  depends_on = [aws_fms_admin_account.test]
+  resource_set {
+    name               = %[1]q
+    resource_type_list = ["AWS::NetworkFirewall::Firewall"]
+  }
+}
+`, policyName, ruleGroupName))
 }

--- a/internal/service/fms/policy_test.go
+++ b/internal/service/fms/policy_test.go
@@ -365,7 +365,7 @@ func testAccPolicy_securityGroup(t *testing.T) {
 	})
 }
 
-func testAccPolicy_rsc_set(t *testing.T) {
+func testAccPolicy_rscSet(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_fms_policy.test"
@@ -382,7 +382,7 @@ func testAccPolicy_rsc_set(t *testing.T) {
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPolicyConfig_basic(rName, rName),
+				Config: testAccPolicyConfig_rscSet(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPolicyExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -883,7 +883,7 @@ resource "aws_fms_policy" "test" {
 `, rName))
 }
 
-func testAccPolicyConfig_rsc_set(policyName, ruleGroupName string) string {
+func testAccPolicyConfig_rscSet(policyName, ruleGroupName string) string {
 	return acctest.ConfigCompose(testAccAdminAccountConfig_basic, fmt.Sprintf(`
 resource "aws_fms_policy" "test" {
   exclude_resource_tags = false


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add resource_set_ids attribute to fms policy

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33372

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTARGS="-run=TestAccFMS_serial/Policy/rscSet" PKG=fms
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.4 test ./internal/service/fms/... -v -count 1 -parallel 20  -run=TestAccFMS_serial/Policy/rscSet -timeout 360m
=== RUN   TestAccFMS_serial
=== PAUSE TestAccFMS_serial
=== CONT  TestAccFMS_serial
=== RUN   TestAccFMS_serial/Policy
=== RUN   TestAccFMS_serial/Policy/rscSet
--- PASS: TestAccFMS_serial (1110.98s)
    --- PASS: TestAccFMS_serial/Policy (1110.98s)
        --- PASS: TestAccFMS_serial/Policy/rscSet (1110.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fms        1116.454s

...
```
