### PR TITLE
BugFix: Fixes 400 error in dataSourceUserPoolClientRead

### DIFF
--- a/.changelog/38168.txt
+++ b/.changelog/38168.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data-source/aws_cognito_user_pool_client: Fix error reading Cognito User Pool Client
+data-source/aws_cognito_user_pool_client: Fix `InvalidParameterException: 2 validation errors detected`  errors on Read
 ```

--- a/.changelog/38168.txt
+++ b/.changelog/38168.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_cognito_user_pool_client: Fix error reading Cognito User Pool Client
+```

--- a/internal/service/cognitoidp/user_pool_client_data_source.go
+++ b/internal/service/cognitoidp/user_pool_client_data_source.go
@@ -187,7 +187,7 @@ func dataSourceUserPoolClientRead(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
 	clientID := d.Get(names.AttrClientID).(string)
-	userPoolClient, err := findUserPoolClientByTwoPartKey(ctx, conn, d.Get(names.AttrUserPoolID).(string), d.Id())
+	userPoolClient, err := findUserPoolClientByTwoPartKey(ctx, conn, d.Get(names.AttrUserPoolID).(string), clientID)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading Cognito User Pool Client (%s): %s", clientID, err)

--- a/internal/service/cognitoidp/user_pool_client_data_source_test.go
+++ b/internal/service/cognitoidp/user_pool_client_data_source_test.go
@@ -6,6 +6,7 @@ package cognitoidp_test
 import (
 	"testing"
 
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -14,6 +15,7 @@ import (
 
 func TestAccCognitoIDPUserPoolClientDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
+	var client awstypes.UserPoolClientType
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "data.aws_cognito_user_pool_client.test"
 
@@ -25,6 +27,7 @@ func TestAccCognitoIDPUserPoolClientDataSource_basic(t *testing.T) {
 			{
 				Config: testAccUserPoolClientDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", acctest.Ct1),
 					resource.TestCheckTypeSetElemAttr(resourceName, "explicit_auth_flows.*", "ADMIN_NO_SRP_AUTH"),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes the bug in dataSourceUserPoolClientRead and adds additional acceptance test.
The bug seems to be introduced in the PR below.
https://github.com/hashicorp/terraform-provider-aws/pull/37024/files#diff-7756a038996f7336f61d258833fecdc9c15d8a139179e33686cbbde60b920d5eR190

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #4974 
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/38167

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

before

```console
-> % make testacc TESTARGS='-run=TestAccCognitoIDPUserPoolClientDataSource_' PKG=cognitoidp ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.4 test ./internal/service/cognitoidp/... -v -count 1 -parallel 3  -run=TestAccCognitoIDPUserPoolClientDataSource_ -timeout 360m
=== RUN   TestAccCognitoIDPUserPoolClientDataSource_basic
=== PAUSE TestAccCognitoIDPUserPoolClientDataSource_basic
=== CONT  TestAccCognitoIDPUserPoolClientDataSource_basic
    user_pool_client_data_source_test.go:22: Step 1/1 error: Error running apply: exit status 1

        Error: reading Cognito User Pool Client (1vhdb3971704qgf16a7be9dinj): operation error Cognito Identity Provider: DescribeUserPoolClient, https response error StatusCode: 400, RequestID: 945a7c16-7813-4e3c-97c0-eb367b712c01, InvalidParameterException: 2 validation errors detected: Value '' at 'clientId' failed to satisfy constraint: Member must have length greater than or equal to 1; Value '' at 'clientId' failed to satisfy constraint: Member must satisfy regular expression pattern: [\w+]+

          with data.aws_cognito_user_pool_client.test,
          on terraform_plugin_test.tf line 22, in data "aws_cognito_user_pool_client" "test":
          22: data "aws_cognito_user_pool_client" "test" {

--- FAIL: TestAccCognitoIDPUserPoolClientDataSource_basic (9.87s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	13.447s
FAIL
make: *** [testacc] Error 1

...
```

after 

```console
-> % make testacc TESTARGS='-run=TestAccCognitoIDPUserPoolClientDataSource_' PKG=cognitoidp ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.4 test ./internal/service/cognitoidp/... -v -count 1 -parallel 3  -run=TestAccCognitoIDPUserPoolClientDataSource_ -timeout 360m
=== RUN   TestAccCognitoIDPUserPoolClientDataSource_basic
=== PAUSE TestAccCognitoIDPUserPoolClientDataSource_basic
=== CONT  TestAccCognitoIDPUserPoolClientDataSource_basic
--- PASS: TestAccCognitoIDPUserPoolClientDataSource_basic (12.17s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	15.749s
```