### PR TITLE
Update documentation of ssm_patch_baseline operating_system argument …

### DIFF
--- a/website/docs/d/ssm_patch_baseline.html.markdown
+++ b/website/docs/d/ssm_patch_baseline.html.markdown
@@ -38,12 +38,12 @@ data "aws_ssm_patch_baseline" "default_custom" {
 The following arguments are required:
 
 * `owner` - (Required) Owner of the baseline. Valid values: `All`, `AWS`, `Self` (the current account).
+* `operating_system` - (Required) Specified OS for the baseline. Valid values: `AMAZON_LINUX`, `AMAZON_LINUX_2`, `UBUNTU`, `REDHAT_ENTERPRISE_LINUX`, `SUSE`, `CENTOS`, `ORACLE_LINUX`, `DEBIAN`, `MACOS`, `RASPBIAN` and `ROCKY_LINUX`.
 
 The following arguments are optional:
 
 * `default_baseline` - (Optional) Filters the results against the baselines default_baseline field.
 * `name_prefix` - (Optional) Filter results by the baseline name prefix.
-* `operating_system` - (Optional) Specified OS for the baseline. Valid values: `AMAZON_LINUX`, `AMAZON_LINUX_2`, `UBUNTU`, `REDHAT_ENTERPRISE_LINUX`, `SUSE`, `CENTOS`, `ORACLE_LINUX`, `DEBIAN`, `MACOS`, `RASPBIAN` and `ROCKY_LINUX`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
When using the data source "aws_ssm_patch_baseline" the terraform plan will fail with the follow error if you don't include the `operating_system` argument:
```
Error: Your query returned no results. Please change your search criteria and try again.
│
│   with data.aws_ssm_patch_baseline.test,
│   on main.tf line 15, in data "aws_ssm_patch_baseline" "test":
│   15: data "aws_ssm_patch_baseline" "test"{
│
```

The documentation for this data source says `operating_system` is optional, however, the code will not work without that argument so I feel that the documentation should be amended to make it required.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_patch_baseline

Non-Working code block:
```
data "aws_ssm_patch_baseline" "test"{
    owner = "AWS"
    name_prefix = "AWS"
}
```
Working code block:
```
data "aws_ssm_patch_baseline" "test"{
    owner = "AWS"
    name_prefix = "AWS"
    operating_system = "CENTOS"
}
```

### Relations
Relates https://github.com/hashicorp/terraform-provider-aws/issues/27239
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27267