### PR TITLE
aws_globalaccelerator_cross_account_attachment

### DIFF
--- a/.changelog/38196.txt
+++ b/.changelog/38196.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_globalaccelerator_cross_account_attachment: Add `cidr_block` argument to `resource` configuration block
+```

--- a/internal/service/globalaccelerator/cross_account_attachment.go
+++ b/internal/service/globalaccelerator/cross_account_attachment.go
@@ -85,6 +85,9 @@ func (r *crossAccountAttachmentResource) Schema(ctx context.Context, request res
 						names.AttrRegion: schema.StringAttribute{
 							Optional: true,
 						},
+						names.AttrCIDRBlock: schema.StringAttribute{
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -213,17 +216,19 @@ func (r *crossAccountAttachmentResource) Update(ctx context.Context, request res
 			}
 
 			add, remove, _ := flex.DiffSlices(oldResources, newResources, func(v1, v2 *resourceModel) bool {
-				return v1.EndpointID.Equal(v2.EndpointID) && v1.Region.Equal(v2.Region)
+				return v1.Cidr.Equal(v2.Cidr) && v1.EndpointID.Equal(v2.EndpointID) && v1.Region.Equal(v2.Region)
 			})
 
 			input.AddResources = tfslices.ApplyToAll(add, func(v *resourceModel) awstypes.Resource {
 				return awstypes.Resource{
+					Cidr:       fwflex.StringFromFramework(ctx, v.Cidr),
 					EndpointId: fwflex.StringFromFramework(ctx, v.EndpointID),
 					Region:     fwflex.StringFromFramework(ctx, v.Region),
 				}
 			})
 			input.RemoveResources = tfslices.ApplyToAll(remove, func(v *resourceModel) awstypes.Resource {
 				return awstypes.Resource{
+					Cidr:       fwflex.StringFromFramework(ctx, v.Cidr),
 					EndpointId: fwflex.StringFromFramework(ctx, v.EndpointID),
 					Region:     fwflex.StringFromFramework(ctx, v.Region),
 				}
@@ -322,6 +327,7 @@ func (m *crossAccountAttachmentResourceModel) setID() {
 }
 
 type resourceModel struct {
+	Cidr       types.String `tfsdk:"cidr_block"`
 	EndpointID types.String `tfsdk:"endpoint_id"`
 	Region     types.String `tfsdk:"region"`
 }

--- a/internal/service/globalaccelerator/cross_account_attachment_test.go
+++ b/internal/service/globalaccelerator/cross_account_attachment_test.go
@@ -114,6 +114,7 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_resources(t *testing.T) {
 				Config: testAccCrossAccountAttachmentConfig_resources(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "resource.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "resource.0.cidr_block", "192.168.0.0/22"),
 				),
 			},
 			{
@@ -125,6 +126,7 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_resources(t *testing.T) {
 				Config: testAccCrossAccountAttachmentConfig_resourcesUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "resource.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "resource.0.cidr_block", "192.168.0.0/24"),
 				),
 			},
 		},
@@ -278,6 +280,7 @@ resource "aws_globalaccelerator_cross_account_attachment" "test" {
   name = %[1]q
 
   resource {
+    cidr_block  = "192.168.0.0/22"
     endpoint_id = aws_lb.test.id
   }
 }
@@ -296,6 +299,7 @@ resource "aws_globalaccelerator_cross_account_attachment" "test" {
   name = %[1]q
 
   resource {
+    cidr_block  = "192.168.0.0/24"
     endpoint_id = aws_eip.test.arn
   }
 }

--- a/internal/service/globalaccelerator/cross_account_attachment_test.go
+++ b/internal/service/globalaccelerator/cross_account_attachment_test.go
@@ -114,7 +114,6 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_resources(t *testing.T) {
 				Config: testAccCrossAccountAttachmentConfig_resources(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "resource.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "resource.0.cidr_block", "192.168.0.0/22"),
 				),
 			},
 			{
@@ -126,41 +125,6 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_resources(t *testing.T) {
 				Config: testAccCrossAccountAttachmentConfig_resourcesUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "resource.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "resource.0.cidr_block", "192.168.0.0/24"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccGlobalAcceleratorCrossAccountAttachment_resources_cidrBlock(t *testing.T) {
-	ctx := acctest.Context(t)
-	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.GlobalAcceleratorServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckCrossAccountAttachmentDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCrossAccountAttachmentConfig_resources_cidrBlock(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "resource.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "resource.0.cidr_block", "192.168.1.0/24"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccCrossAccountAttachmentConfig_resources_cidrBlockUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "resource.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "resource.0.cidr_block", "192.168.0.0/24"),
 				),
 			},
 		},
@@ -336,42 +300,6 @@ resource "aws_globalaccelerator_cross_account_attachment" "test" {
   }
 }
 `, rName))
-}
-
-func testAccCrossAccountAttachmentConfig_resources_cidrBlock(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_eip" "test" {
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_globalaccelerator_cross_account_attachment" "test" {
-  name = %[1]q
-
-  resource {
-    cidr_block  = "192.168.1.0/24"
-  }
-}
-`, rName)
-}
-
-func testAccCrossAccountAttachmentConfig_resources_cidrBlockUpdated(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_eip" "test" {
-  tags = {
-    Name = %[1]q
-  }
-}
-
-resource "aws_globalaccelerator_cross_account_attachment" "test" {
-  name = %[1]q
-
-  resource {
-    cidr_block  = "192.168.0.0/24"
-  }
-}
-`, rName)
 }
 
 func testAccCrossAccountAttachmentConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/internal/service/globalaccelerator/cross_account_attachment_test.go
+++ b/internal/service/globalaccelerator/cross_account_attachment_test.go
@@ -133,6 +133,40 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_resources(t *testing.T) {
 	})
 }
 
+func TestAccGlobalAcceleratorCrossAccountAttachment_resources_cidrBlock(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlobalAcceleratorServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCrossAccountAttachmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCrossAccountAttachmentConfig_resources_cidrBlock(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "resource.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "resource.0.cidr_block", "192.168.1.0/24"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCrossAccountAttachmentConfig_resources_cidrBlockUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "resource.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "resource.0.cidr_block", "192.168.0.0/24"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGlobalAcceleratorCrossAccountAttachment_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
@@ -280,7 +314,6 @@ resource "aws_globalaccelerator_cross_account_attachment" "test" {
   name = %[1]q
 
   resource {
-    cidr_block  = "192.168.0.0/22"
     endpoint_id = aws_lb.test.id
   }
 }
@@ -299,11 +332,46 @@ resource "aws_globalaccelerator_cross_account_attachment" "test" {
   name = %[1]q
 
   resource {
-    cidr_block  = "192.168.0.0/24"
     endpoint_id = aws_eip.test.arn
   }
 }
 `, rName))
+}
+
+func testAccCrossAccountAttachmentConfig_resources_cidrBlock(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_eip" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_globalaccelerator_cross_account_attachment" "test" {
+  name = %[1]q
+
+  resource {
+    cidr_block  = "192.168.1.0/24"
+  }
+}
+`, rName)
+}
+
+func testAccCrossAccountAttachmentConfig_resources_cidrBlockUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_eip" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_globalaccelerator_cross_account_attachment" "test" {
+  name = %[1]q
+
+  resource {
+    cidr_block  = "192.168.0.0/24"
+  }
+}
+`, rName)
 }
 
 func testAccCrossAccountAttachmentConfig_tags1(rName, tagKey1, tagValue1 string) string {

--- a/website/docs/r/globalaccelerator_cross_account_attachment.html.markdown
+++ b/website/docs/r/globalaccelerator_cross_account_attachment.html.markdown
@@ -44,7 +44,7 @@ The following arguments are optional:
 
 * `principals` - (Optional) List of AWS account IDs that are allowed to associate resources with the accelerator.
 * `resource` - (Optional) List of resources to be associated with the accelerator.
-      * `cidr_block` - (Optional) IP address range, in CIDR format, that is specified as resource. 
+      * `cidr_block` - (Optional) IP address range, in CIDR format, that is specified as resource.
       * `endpoint_id` - (Optional) The endpoint ID for the endpoint that is specified as a AWS resource.
       * `region` - (Optional) The AWS Region where a shared endpoint resource is located.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.

--- a/website/docs/r/globalaccelerator_cross_account_attachment.html.markdown
+++ b/website/docs/r/globalaccelerator_cross_account_attachment.html.markdown
@@ -44,8 +44,9 @@ The following arguments are optional:
 
 * `principals` - (Optional) List of AWS account IDs that are allowed to associate resources with the accelerator.
 * `resource` - (Optional) List of resources to be associated with the accelerator.
-    * `endpoint_id` - (Optional) The endpoint ID for the endpoint that is specified as a AWS resource.
-    * `region` - (Optional) The AWS Region where a shared endpoint resource is located.
+      * `cidr_block` - (Optional) IP address range, in CIDR format, that is specified as resource. 
+      * `endpoint_id` - (Optional) The endpoint ID for the endpoint that is specified as a AWS resource.
+      * `region` - (Optional) The AWS Region where a shared endpoint resource is located.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference

--- a/website/docs/r/globalaccelerator_cross_account_attachment.html.markdown
+++ b/website/docs/r/globalaccelerator_cross_account_attachment.html.markdown
@@ -44,9 +44,9 @@ The following arguments are optional:
 
 * `principals` - (Optional) List of AWS account IDs that are allowed to associate resources with the accelerator.
 * `resource` - (Optional) List of resources to be associated with the accelerator.
-      * `cidr_block` - (Optional) IP address range, in CIDR format, that is specified as resource.
-      * `endpoint_id` - (Optional) The endpoint ID for the endpoint that is specified as a AWS resource.
-      * `region` - (Optional) The AWS Region where a shared endpoint resource is located.
+    * `cidr_block` - (Optional) IP address range, in CIDR format, that is specified as resource.
+    * `endpoint_id` - (Optional) The endpoint ID for the endpoint that is specified as a AWS resource.
+    * `region` - (Optional) The AWS Region where a shared endpoint resource is located.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38117

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccGlobalAcceleratorCrossAccountAttachment_ PKG=globalaccelerator
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.4 test ./internal/service/globalaccelerator/... -v -count 1 -parallel 20 -run='TestAccGlobalAcceleratorCrossAccountAttachment_'  -timeout 360m
=== RUN   TestAccGlobalAcceleratorCrossAccountAttachment_basic
=== PAUSE TestAccGlobalAcceleratorCrossAccountAttachment_basic
=== RUN   TestAccGlobalAcceleratorCrossAccountAttachment_principals
=== PAUSE TestAccGlobalAcceleratorCrossAccountAttachment_principals
=== RUN   TestAccGlobalAcceleratorCrossAccountAttachment_resources
=== PAUSE TestAccGlobalAcceleratorCrossAccountAttachment_resources
=== RUN   TestAccGlobalAcceleratorCrossAccountAttachment_disappears
=== PAUSE TestAccGlobalAcceleratorCrossAccountAttachment_disappears
=== RUN   TestAccGlobalAcceleratorCrossAccountAttachment_tags
=== PAUSE TestAccGlobalAcceleratorCrossAccountAttachment_tags
=== CONT  TestAccGlobalAcceleratorCrossAccountAttachment_basic
=== CONT  TestAccGlobalAcceleratorCrossAccountAttachment_disappears
=== CONT  TestAccGlobalAcceleratorCrossAccountAttachment_resources
=== CONT  TestAccGlobalAcceleratorCrossAccountAttachment_principals
=== CONT  TestAccGlobalAcceleratorCrossAccountAttachment_tags
--- PASS: TestAccGlobalAcceleratorCrossAccountAttachment_disappears (61.30s)
--- PASS: TestAccGlobalAcceleratorCrossAccountAttachment_principals (100.72s)
--- PASS: TestAccGlobalAcceleratorCrossAccountAttachment_basic (100.74s)
--- PASS: TestAccGlobalAcceleratorCrossAccountAttachment_tags (122.06s)
--- PASS: TestAccGlobalAcceleratorCrossAccountAttachment_resources (286.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator	307.188s

...
```
