### PR TITLE
New Data source for Eventbridge Event Rule

### DIFF
--- a/.changelog/38201.txt
+++ b/.changelog/38201.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_cloudwatch_event_rule
+```

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .terraform/
 .vagrant/
 .vscode
+.tool-versions
 *.backup
 *.bak
 *.dll

--- a/internal/service/events/rule_data_source.go
+++ b/internal/service/events/rule_data_source.go
@@ -1,0 +1,81 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package events
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_cloudwatch_event_rule", name="Rule")
+func dataSourceRule() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceRuleRead,
+
+		Schema: map[string]*schema.Schema{
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"event_bus_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  DefaultEventBusName,
+			},
+			"event_pattern": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrScheduleExpression: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrState: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).EventsClient(ctx)
+
+	name := d.Get(names.AttrName).(string)
+	eventBusName := d.Get("event_bus_name").(string)
+
+	output, err := findRuleByTwoPartKey(ctx, conn, eventBusName, name)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading EventBridge Rule (%s): %s", name, err)
+	}
+
+	arn := aws.ToString(output.Arn)
+	d.SetId(name)
+	d.Set(names.AttrARN, arn)
+	d.Set("event_bus_name", output.EventBusName)
+	if output.EventPattern != nil {
+		pattern, err := ruleEventPatternJSONDecoder(aws.ToString(output.EventPattern))
+		if err != nil {
+			return sdkdiag.AppendFromErr(diags, err)
+		}
+		d.Set("event_pattern", pattern)
+	}
+
+	d.Set(names.AttrScheduleExpression, output.ScheduleExpression)
+	d.Set(names.AttrState, output.State)
+
+	return diags
+}

--- a/internal/service/events/rule_data_source_test.go
+++ b/internal/service/events/rule_data_source_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package events_test
+
+import (
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRuleDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	dataSourceName := "data.aws_cloudwatch_event_rule.test"
+	resourceName := "aws_cloudwatch_event_rule.test"
+
+	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleDataSourceConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "event_bus_name", resourceName, "event_bus_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrScheduleExpression, resourceName, names.AttrScheduleExpression),
+					resource.TestCheckResourceAttrPair(dataSourceName, "event_pattern", resourceName, "event_pattern"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRuleDataSource_eventBus(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	dataSourceName := "data.aws_cloudwatch_event_rule.test"
+	resourceName := "aws_cloudwatch_event_rule.test"
+
+	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	eventBusName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleDataSourceConfig_eventBus(name, eventBusName, "test"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "event_bus_name", resourceName, "event_bus_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrScheduleExpression, resourceName, names.AttrScheduleExpression),
+					resource.TestCheckResourceAttrPair(dataSourceName, "event_pattern", resourceName, "event_pattern"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRuleDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccRuleConfig_basic(rName),
+		`
+data "aws_cloudwatch_event_rule" "test" {
+  name = aws_cloudwatch_event_rule.test.name
+}
+`,
+	)
+}
+
+func testAccRuleDataSourceConfig_eventBus(rName, eventBusName, description string) string {
+	return acctest.ConfigCompose(
+		testAccRuleConfig_busName(rName, eventBusName, description),
+		`
+data "aws_cloudwatch_event_rule" "test" {
+  name = aws_cloudwatch_event_rule.test.name
+  event_bus_name = aws_cloudwatch_event_bus.test.name
+}
+`,
+	)
+}

--- a/internal/service/events/service_package_gen.go
+++ b/internal/service/events/service_package_gen.go
@@ -35,6 +35,11 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Name:     "Connection",
 		},
 		{
+			Factory:  dataSourceRule,
+			TypeName: "aws_cloudwatch_event_rule",
+			Name:     "Rule",
+		},
+		{
 			Factory:  dataSourceSource,
 			TypeName: "aws_cloudwatch_event_source",
 			Name:     "Source",

--- a/website/docs/d/cloudwatch_event_rule.markdown
+++ b/website/docs/d/cloudwatch_event_rule.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "EventBridge"
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_event_bus"
+description: |-
+    Get information about an EventBridge (Cloudwatch) event rule
+---
+
+# Data Source: aws_events_rule
+
+  A data source to get information about an EventBridge event rule.
+
+~> **Note:** EventBridge was formerly known as CloudWatch Events. The functionality is identical.
+
+## Example Usage
+
+```terraform
+data "aws_cloudwatch_event_rule" "example" {
+    name = "example-rule"
+    event_bus_name = "example-bus" # omitting uses the "default" bus
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the EventBridge rule.
+
+* `event_bus_name` - (Optional) Name of the EventBridge event bus associated with the rule. The "default" bus is used if omitted.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Rule.
+
+* `event_pattern` - Rule pattern
+
+* `schedule_expression` - schedule expression
+
+* `state` - State of the event rule. One of `DISABLED`, `ENABLED`, and `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS`


### PR DESCRIPTION
### Description

Adds the `aws_cloudwatch_event_rule` data source

### Relations

Closes #38157

### Output from Acceptance Testing

```console
➜ make testacc TESTS=TestAccRuleDataSource PKG=events 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.4 test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccRuleDataSource'  -timeout 360m
=== RUN   TestAccRuleDataSource_basic
=== PAUSE TestAccRuleDataSource_basic
=== RUN   TestAccRuleDataSource_eventBus
=== PAUSE TestAccRuleDataSource_eventBus
=== CONT  TestAccRuleDataSource_basic
=== CONT  TestAccRuleDataSource_eventBus
--- PASS: TestAccRuleDataSource_basic (16.00s)
--- PASS: TestAccRuleDataSource_eventBus (16.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     16.516s
...
