### PR TITLE
aws_kinesis_firehose_delivery_stream

### DIFF
--- a/.changelog/38245.txt
+++ b/.changelog/38245.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kinesis_firehose_delivery_stream: Add `secret_manager_configuration` attribute in `http_endpoint_configuration`
+```

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -781,6 +781,7 @@ The `http_endpoint_configuration` configuration block supports the following arg
 * `role_arn` - (Required) Kinesis Data Firehose uses this IAM role for all the permissions that the delivery stream needs. The pattern needs to be `arn:.*`.
 * `s3_configuration` - (Required) The S3 Configuration. See [`s3_configuration` block](#s3_configuration-block) below for details.
 * `s3_backup_mode` - (Optional) Defines how documents should be delivered to Amazon S3.  Valid values are `FailedDataOnly` and `AllData`.  Default value is `FailedDataOnly`.
+* `secret_manager_configuration` - (Optional) The Secret Manager Configuration. See [`secret_manager_configuration` block](#secret_manager_configuration-block) below for details.
 * `buffering_size` - (Optional) Buffer incoming data to the specified size, in MBs, before delivering it to the destination. The default value is 5.
 * `buffering_interval` - (Optional) Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300 (5 minutes).
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. See [`cloudwatch_logging_options` block](#cloudwatch_logging_options-block) below for details.
@@ -926,6 +927,14 @@ The `s3_configuration` configuration block supports the following arguments:
 * `kms_key_arn` - (Optional) Specifies the KMS key ARN the stream will use to encrypt data. If not set, no encryption will
   be used.
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. See [`cloudwatch_logging_options` block](#cloudwatch_logging_options-block) below for details.
+
+### `secret_manager_configuration` block
+
+The `secret_manager_configuration` configuration block supports the following arguments:
+
+* `enabled` - (Required) Enables or disables secrets manager feature.
+* `role_arn` - (Optional) The role that Firehose assumes when calling the Secrets Manager API operation.
+* `secret_arn` - (Optional) The ARN of the secret that stores your credentials.
 
 ### `input_format_configuration` block
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38210

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccFirehoseDeliveryStream_HTTPEndpoint_ PKG=firehose
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.4 test ./internal/service/firehose/... -v -count 1 -parallel 20 -run='TestAccFirehoseDeliveryStream_HTTPEndpoint_'  -timeout 360m
=== RUN   TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix
=== PAUSE TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix
=== RUN   TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration
=== PAUSE TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration
=== RUN   TestAccFirehoseDeliveryStream_HTTPEndpoint_SecretsManagerConfiguration
=== PAUSE TestAccFirehoseDeliveryStream_HTTPEndpoint_SecretsManagerConfiguration
=== CONT  TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix
=== CONT  TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration
=== CONT  TestAccFirehoseDeliveryStream_HTTPEndpoint_SecretsManagerConfiguration
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_SecretsManagerConfiguration (139.87s)
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration (187.83s)
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix (235.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/firehose	256.440s

...
```
