### PR TITLE
Adds validation of Diagnostics and logging to AutoFlEx tests

### DIFF
--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -25,8 +25,6 @@ import (
 func TestExpand(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
 	testString := "test"
 	testStringResult := "a"
 
@@ -276,8 +274,8 @@ func TestExpand(t *testing.T) {
 			},
 		},
 		{
-			Context:  context.WithValue(ctx, ResourcePrefix, "Intent"),
-			TestName: "resource name prefix",
+			ContextFn: func(ctx context.Context) context.Context { return context.WithValue(ctx, ResourcePrefix, "Intent") },
+			TestName:  "resource name prefix",
 			Source: &TestFlexTF16{
 				Name: types.StringValue("Ovodoghen"),
 			},
@@ -332,7 +330,7 @@ func TestExpand(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandGeneric(t *testing.T) {
@@ -684,7 +682,7 @@ func TestExpandGeneric(t *testing.T) {
 		},
 	}
 
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandSimpleSingleNestedBlock(t *testing.T) {
@@ -730,7 +728,7 @@ func TestExpandSimpleSingleNestedBlock(t *testing.T) {
 			WantTarget: &aws03{Field1: aws01{Field1: aws.String("a"), Field2: 1}},
 		},
 	}
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandComplexSingleNestedBlock(t *testing.T) {
@@ -781,7 +779,7 @@ func TestExpandComplexSingleNestedBlock(t *testing.T) {
 			WantTarget: &aws03{Field1: &aws02{Field1: &aws01{Field1: true, Field2: []string{"a", "b"}}}},
 		},
 	}
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandStringEnum(t *testing.T) {
@@ -790,7 +788,6 @@ func TestExpandStringEnum(t *testing.T) {
 	var testEnum TestEnum
 	testEnumList := TestEnumList
 
-	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
 			TestName:   "valid value",
@@ -805,13 +802,12 @@ func TestExpandStringEnum(t *testing.T) {
 			WantTarget: &testEnum,
 		},
 	}
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandListOfInt64(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
 			TestName: "valid value []int64",
@@ -898,13 +894,12 @@ func TestExpandListOfInt64(t *testing.T) {
 			WantTarget: &[]*int32{},
 		},
 	}
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandSetOfInt64(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
 			TestName: "valid value []int64",
@@ -991,7 +986,7 @@ func TestExpandSetOfInt64(t *testing.T) {
 			WantTarget: &[]*int32{},
 		},
 	}
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandListOfStringEnum(t *testing.T) {
@@ -1001,7 +996,6 @@ func TestExpandListOfStringEnum(t *testing.T) {
 	var testEnumFoo testEnum = "foo"
 	var testEnumBar testEnum = "bar"
 
-	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
 			TestName: "valid value",
@@ -1025,7 +1019,7 @@ func TestExpandListOfStringEnum(t *testing.T) {
 			WantTarget: &[]testEnum{},
 		},
 	}
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandSetOfStringEnum(t *testing.T) {
@@ -1035,7 +1029,6 @@ func TestExpandSetOfStringEnum(t *testing.T) {
 	var testEnumFoo testEnum = "foo"
 	var testEnumBar testEnum = "bar"
 
-	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
 			TestName: "valid value",
@@ -1059,7 +1052,7 @@ func TestExpandSetOfStringEnum(t *testing.T) {
 			WantTarget: &[]testEnum{},
 		},
 	}
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandSimpleNestedBlockWithStringEnum(t *testing.T) {
@@ -1074,7 +1067,6 @@ func TestExpandSimpleNestedBlockWithStringEnum(t *testing.T) {
 		Field2 TestEnum
 	}
 
-	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
 			TestName:   "single nested valid value",
@@ -1089,7 +1081,7 @@ func TestExpandSimpleNestedBlockWithStringEnum(t *testing.T) {
 			WantTarget: &aws01{Field1: 1, Field2: ""},
 		},
 	}
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandComplexNestedBlockWithStringEnum(t *testing.T) {
@@ -1125,7 +1117,7 @@ func TestExpandComplexNestedBlockWithStringEnum(t *testing.T) {
 			WantTarget: &aws01{Field1: 1, Field2: &aws02{Field2: ""}},
 		},
 	}
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 func TestExpandOptions(t *testing.T) {
@@ -1206,11 +1198,11 @@ func TestExpandOptions(t *testing.T) {
 			},
 		},
 	}
-	runAutoExpandTestCases(ctx, t, testCases)
+	runAutoExpandTestCases(t, testCases)
 }
 
 type autoFlexTestCase struct {
-	Context          context.Context //nolint:containedctx // testing context use
+	ContextFn        func(context.Context) context.Context
 	Options          []AutoFlexOptionsFunc
 	TestName         string
 	Source           any
@@ -1223,7 +1215,7 @@ type autoFlexTestCase struct {
 
 type autoFlexTestCases []autoFlexTestCase
 
-func runAutoExpandTestCases(ctx context.Context, t *testing.T, testCases autoFlexTestCases) {
+func runAutoExpandTestCases(t *testing.T, testCases autoFlexTestCases) {
 	t.Helper()
 
 	for _, testCase := range testCases {
@@ -1231,15 +1223,15 @@ func runAutoExpandTestCases(ctx context.Context, t *testing.T, testCases autoFle
 		t.Run(testCase.TestName, func(t *testing.T) {
 			t.Parallel()
 
-			testCtx := ctx //nolint:contextcheck // simplify use of testing context
-			if testCase.Context != nil {
-				testCtx = testCase.Context
+			ctx := context.Background()
+			if testCase.ContextFn != nil {
+				ctx = testCase.ContextFn(ctx)
 			}
 
 			var buf bytes.Buffer
-			testCtx = tflogtest.RootLogger(testCtx, &buf)
+			ctx = tflogtest.RootLogger(ctx, &buf)
 
-			diags := Expand(testCtx, testCase.Source, testCase.Target, testCase.Options...)
+			diags := Expand(ctx, testCase.Source, testCase.Target, testCase.Options...)
 
 			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
 				t.Errorf("unexpected diagnostics difference: %s", diff)

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -404,8 +404,8 @@ func TestFlatten(t *testing.T) {
 			},
 		},
 		{
-			Context:  context.WithValue(ctx, ResourcePrefix, "Intent"),
-			TestName: "resource name prefix",
+			ContextFn: func(ctx context.Context) context.Context { return context.WithValue(ctx, ResourcePrefix, "Intent") },
+			TestName:  "resource name prefix",
 			Source: &TestFlexAWS18{
 				IntentName: aws.String("Ovodoghen"),
 			},
@@ -470,7 +470,7 @@ func TestFlatten(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
 func TestFlattenGeneric(t *testing.T) {
@@ -795,7 +795,7 @@ func TestFlattenGeneric(t *testing.T) {
 		},
 	}
 
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
 func TestFlattenSimpleNestedBlockWithStringEnum(t *testing.T) {
@@ -810,7 +810,6 @@ func TestFlattenSimpleNestedBlockWithStringEnum(t *testing.T) {
 		Field2 TestEnum
 	}
 
-	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
 			TestName:   "single nested valid value",
@@ -825,7 +824,7 @@ func TestFlattenSimpleNestedBlockWithStringEnum(t *testing.T) {
 			WantTarget: &tf01{Field1: types.Int64Value(1), Field2: fwtypes.StringEnumNull[TestEnum]()},
 		},
 	}
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
 func TestFlattenComplexNestedBlockWithStringEnum(t *testing.T) {
@@ -868,7 +867,7 @@ func TestFlattenComplexNestedBlockWithStringEnum(t *testing.T) {
 			WantTarget: &tf02{Field1: types.Int64Value(1), Field2: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &tf01{Field2: zero})},
 		},
 	}
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
 func TestFlattenSimpleSingleNestedBlock(t *testing.T) {
@@ -914,7 +913,7 @@ func TestFlattenSimpleSingleNestedBlock(t *testing.T) {
 			WantTarget: &tf02{Field1: fwtypes.NewObjectValueOfMust[tf01](ctx, &tf01{Field1: types.StringValue("a"), Field2: types.Int64Value(1)})},
 		},
 	}
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
 func TestFlattenComplexSingleNestedBlock(t *testing.T) {
@@ -966,7 +965,7 @@ func TestFlattenComplexSingleNestedBlock(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
 func TestFlattenSimpleNestedBlockWithFloat32(t *testing.T) {
@@ -981,7 +980,6 @@ func TestFlattenSimpleNestedBlockWithFloat32(t *testing.T) {
 		Field2 *float32
 	}
 
-	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
 			TestName:   "single nested valid value",
@@ -990,7 +988,7 @@ func TestFlattenSimpleNestedBlockWithFloat32(t *testing.T) {
 			WantTarget: &tf01{Field1: types.Int64Value(1), Field2: types.Float64Value(0.01)},
 		},
 	}
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
 func TestFlattenComplexNestedBlockWithFloat32(t *testing.T) {
@@ -1022,7 +1020,7 @@ func TestFlattenComplexNestedBlockWithFloat32(t *testing.T) {
 			WantTarget: &tf02{Field1: types.Int64Value(1), Field2: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &tf01{Field1: types.Float64Value(1.11), Field2: types.Float64Value(-2.22)})},
 		},
 	}
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
 func TestFlattenSimpleNestedBlockWithFloat64(t *testing.T) {
@@ -1037,7 +1035,6 @@ func TestFlattenSimpleNestedBlockWithFloat64(t *testing.T) {
 		Field2 *float64
 	}
 
-	ctx := context.Background()
 	testCases := autoFlexTestCases{
 		{
 			TestName:   "single nested valid value",
@@ -1046,7 +1043,7 @@ func TestFlattenSimpleNestedBlockWithFloat64(t *testing.T) {
 			WantTarget: &tf01{Field1: types.Int64Value(1), Field2: types.Float64Value(0.01)},
 		},
 	}
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
 func TestFlattenComplexNestedBlockWithFloat64(t *testing.T) {
@@ -1078,7 +1075,7 @@ func TestFlattenComplexNestedBlockWithFloat64(t *testing.T) {
 			WantTarget: &tf02{Field1: types.Int64Value(1), Field2: fwtypes.NewListNestedObjectValueOfPtrMust(ctx, &tf01{Field1: types.Float64Value(1.11), Field2: types.Float64Value(-2.22)})},
 		},
 	}
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
 func TestFlattenOptions(t *testing.T) {
@@ -1179,10 +1176,10 @@ func TestFlattenOptions(t *testing.T) {
 			},
 		},
 	}
-	runAutoFlattenTestCases(ctx, t, testCases)
+	runAutoFlattenTestCases(t, testCases)
 }
 
-func runAutoFlattenTestCases(ctx context.Context, t *testing.T, testCases autoFlexTestCases) {
+func runAutoFlattenTestCases(t *testing.T, testCases autoFlexTestCases) {
 	t.Helper()
 
 	for _, testCase := range testCases {
@@ -1190,15 +1187,15 @@ func runAutoFlattenTestCases(ctx context.Context, t *testing.T, testCases autoFl
 		t.Run(testCase.TestName, func(t *testing.T) {
 			t.Parallel()
 
-			testCtx := ctx //nolint:contextcheck // simplify use of testing context
-			if testCase.Context != nil {
-				testCtx = testCase.Context
+			ctx := context.Background()
+			if testCase.ContextFn != nil {
+				ctx = testCase.ContextFn(ctx)
 			}
 
 			var buf bytes.Buffer
-			testCtx = tflogtest.RootLogger(testCtx, &buf)
+			ctx = tflogtest.RootLogger(ctx, &buf)
 
-			diags := Flatten(testCtx, testCase.Source, testCase.Target, testCase.Options...)
+			diags := Flatten(ctx, testCase.Source, testCase.Target, testCase.Options...)
 
 			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
 				t.Errorf("unexpected diagnostics difference: %s", diff)


### PR DESCRIPTION
### Description

Currently the tests for AutoFlEx check simply for the presence of an error, not the contents. Tests do not capture logs.

This PR replaces the boolean `WantErr` field with the `diag.Diagnostics` `expectedDiags` field to validate the error messages. It also adds the field `expectedLogLines` to capture logs.

In addition to explicitly expecting error messages and log entries, this sets the baseline for what is currently output so that we can update them as we define the expected behaviour.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #38192
