### PR TITLE
add support to use predefined stage names to import secret version

### DIFF
--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -41,7 +41,7 @@ func resourceSecretVersion() *schema.Resource {
 		DeleteWithoutTimeout: resourceSecretVersionDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceIntegrationImport,
+			StateContext: resourceSecretVersionImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -304,7 +304,7 @@ func resourceSecretVersionDelete(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceIntegrationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceSecretVersionImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	secretID, versionID, err := secretVersionParseResourceID(d.Id())
 	if err != nil {
 		return []*schema.ResourceData{}, err

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -40,7 +41,7 @@ func resourceSecretVersion() *schema.Resource {
 		DeleteWithoutTimeout: resourceSecretVersionDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceIntegrationImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -301,6 +302,42 @@ func resourceSecretVersionDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	return diags
+}
+
+func resourceIntegrationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	secretID, versionID, err := secretVersionParseResourceID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	conn := meta.(*conns.AWSClient).SecretsManagerClient(ctx)
+
+	input := &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(secretID),
+	}
+
+	var predefinedVersionStages = []string{secretVersionStageCurrent, secretVersionStagePrevious}
+	if slices.Contains(predefinedVersionStages, versionID) {
+		input.VersionStage = aws.String(versionID)
+	} else {
+		input.VersionId = aws.String(versionID)
+	}
+
+	output, err := findSecretVersion(ctx, conn, input)
+
+	if err != nil {
+		return []*schema.ResourceData{}, fmt.Errorf("reading Secrets Manager Secret Versions (%s): %s", secretID, err)
+	}
+
+	id := secretVersionCreateResourceID(secretID, aws.ToString(output.VersionId))
+	d.SetId(id)
+	d.Set(names.AttrARN, output.ARN)
+	d.Set("secret_binary", itypes.Base64EncodeOnce(output.SecretBinary))
+	d.Set("secret_id", secretID)
+	d.Set("secret_string", output.SecretString)
+	d.Set("version_id", output.VersionId)
+	d.Set("version_stages", output.VersionStages)
+	return []*schema.ResourceData{d}, nil
 }
 
 const secretVersionIDSeparator = "|"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/35827

### References


### Output from Acceptance Testing
```
% make testacc TESTS=TestAccSecretsManagerSecretVersion_ PKG=secretsmanager
TF_ACC=1 go1.22.2 test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecretVersion_'  -timeout 360m
=== RUN   TestAccSecretsManagerSecretVersion_basicString
=== PAUSE TestAccSecretsManagerSecretVersion_basicString
=== RUN   TestAccSecretsManagerSecretVersion_base64Binary
=== PAUSE TestAccSecretsManagerSecretVersion_base64Binary
=== RUN   TestAccSecretsManagerSecretVersion_versionStages
=== PAUSE TestAccSecretsManagerSecretVersion_versionStages
=== RUN   TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate
=== PAUSE TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate
=== RUN   TestAccSecretsManagerSecretVersion_disappears
=== PAUSE TestAccSecretsManagerSecretVersion_disappears
=== RUN   TestAccSecretsManagerSecretVersion_Disappears_secret
=== PAUSE TestAccSecretsManagerSecretVersion_Disappears_secret
=== RUN   TestAccSecretsManagerSecretVersion_multipleVersions
=== PAUSE TestAccSecretsManagerSecretVersion_multipleVersions
=== CONT  TestAccSecretsManagerSecretVersion_basicString
=== CONT  TestAccSecretsManagerSecretVersion_disappears
=== CONT  TestAccSecretsManagerSecretVersion_multipleVersions
=== CONT  TestAccSecretsManagerSecretVersion_versionStages
=== CONT  TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate
=== CONT  TestAccSecretsManagerSecretVersion_base64Binary
=== CONT  TestAccSecretsManagerSecretVersion_Disappears_secret
--- PASS: TestAccSecretsManagerSecretVersion_disappears (51.42s)
--- PASS: TestAccSecretsManagerSecretVersion_Disappears_secret (52.65s)
--- PASS: TestAccSecretsManagerSecretVersion_multipleVersions (58.06s)
--- PASS: TestAccSecretsManagerSecretVersion_base64Binary (63.53s)
--- PASS: TestAccSecretsManagerSecretVersion_basicString (63.57s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStagesExternalUpdate (81.22s)
--- PASS: TestAccSecretsManagerSecretVersion_versionStages (111.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	116.002s

...
```