### PR TITLE
[Tech Debt] - Migrate `iot` sweepers to use paginators

### DIFF
--- a/internal/service/iot/sweep.go
+++ b/internal/service/iot/sweep.go
@@ -110,24 +110,27 @@ func sweepCertificates(region string) error {
 	input := &iot.ListCertificatesInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListCertificates(ctx, input)
+	pages := iot.NewListCertificatesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.Certificates {
-		r := resourceCertificate()
-		d := r.Data(nil)
-		d.SetId(aws.ToString(v.CertificateId))
-		d.Set("active", true)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IoT Certificate sweep for %s: %s", region, err)
+			return nil
+		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
+		if err != nil {
+			return fmt.Errorf("error listing IoT Certificates (%s): %w", region, err)
+		}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Certificate sweep for %s: %s", region, err)
-		return nil
-	}
+		for _, v := range page.Certificates {
+			r := resourceCertificate()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.CertificateId))
+			d.Set("active", true)
 
-	if err != nil {
-		return fmt.Errorf("error listing IoT Certificates (%s): %w", region, err)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -150,42 +153,48 @@ func sweepPolicyAttachments(region string) error {
 	sweepResources := make([]sweep.Sweepable, 0)
 	var sweeperErrs *multierror.Error
 
-	out, err := conn.ListPolicies(ctx, input)
-
-	for _, v := range out.Policies {
-		policyName := v.PolicyName
-		input := &iot.ListTargetsForPolicyInput{
-			PolicyName: policyName,
-		}
-
-		output, err := conn.ListTargetsForPolicy(ctx, input)
-
-		for _, v := range output.Targets {
-			r := resourcePolicyAttachment()
-			d := r.Data(nil)
-			d.SetId(fmt.Sprintf("%s|%s", aws.ToString(policyName), v))
-			d.Set(names.AttrPolicy, policyName)
-			d.Set(names.AttrTarget, v)
-
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-		}
+	pages := iot.NewListPoliciesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
 		if awsv2.SkipSweepError(err) {
-			continue
+			log.Printf("[WARN] Skipping IoT Policy Attachment sweep for %s: %s", region, err)
+			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
 		}
 
 		if err != nil {
-			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IoT Targets For Policy (%s): %w", region, err))
+			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IoT Policies (%s): %w", region, err))
 		}
-	}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Policy Attachment sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
-	}
+		for _, v := range page.Policies {
+			policyName := v.PolicyName
+			input := &iot.ListTargetsForPolicyInput{
+				PolicyName: policyName,
+			}
 
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IoT Policies (%s): %w", region, err))
+			pages := iot.NewListTargetsForPolicyPaginator(conn, input)
+			for pages.HasMorePages() {
+				page, err := pages.NextPage(ctx)
+
+				for _, v := range page.Targets {
+					r := resourcePolicyAttachment()
+					d := r.Data(nil)
+					d.SetId(fmt.Sprintf("%s|%s", aws.ToString(policyName), v))
+					d.Set(names.AttrPolicy, policyName)
+					d.Set(names.AttrTarget, v)
+
+					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+				}
+
+				if awsv2.SkipSweepError(err) {
+					continue
+				}
+
+				if err != nil {
+					sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IoT Targets For Policy (%s): %w", region, err))
+				}
+			}
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -207,23 +216,26 @@ func sweepPolicies(region string) error {
 	input := &iot.ListPoliciesInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListPolicies(ctx, input)
+	pages := iot.NewListPoliciesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.Policies {
-		r := resourcePolicy()
-		d := r.Data(nil)
-		d.SetId(aws.ToString(v.PolicyName))
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IoT Policy sweep for %s: %s", region, err)
+			return nil
+		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
+		if err != nil {
+			return fmt.Errorf("error listing IoT Policies (%s): %w", region, err)
+		}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Policy sweep for %s: %s", region, err)
-		return nil
-	}
+		for _, v := range page.Policies {
+			r := resourcePolicy()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.PolicyName))
 
-	if err != nil {
-		return fmt.Errorf("error listing IoT Policies (%s): %w", region, err)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -245,23 +257,26 @@ func sweepRoleAliases(region string) error {
 	input := &iot.ListRoleAliasesInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListRoleAliases(ctx, input)
+	pages := iot.NewListRoleAliasesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.RoleAliases {
-		r := ResourceRoleAlias()
-		d := r.Data(nil)
-		d.SetId(v)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Role Alias sweep for %s: %s", region, err)
+			return nil
+		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
+		if err != nil {
+			return fmt.Errorf("error listing Role Aliases (%s): %w", region, err)
+		}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping Role Alias sweep for %s: %s", region, err)
-		return nil
-	}
+		for _, v := range page.RoleAliases {
+			r := ResourceRoleAlias()
+			d := r.Data(nil)
+			d.SetId(v)
 
-	if err != nil {
-		return fmt.Errorf("error listing Role Aliases (%s): %w", region, err)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -284,42 +299,48 @@ func sweepThingPrincipalAttachments(region string) error {
 	sweepResources := make([]sweep.Sweepable, 0)
 	var sweeperErrs *multierror.Error
 
-	out, err := conn.ListThings(ctx, input)
-
-	for _, v := range out.Things {
-		thingName := aws.ToString(v.ThingName)
-		input := &iot.ListThingPrincipalsInput{
-			ThingName: aws.String(thingName),
-		}
-
-		output, err := conn.ListThingPrincipals(ctx, input)
-
-		for _, v := range output.Principals {
-			r := resourceThingPrincipalAttachment()
-			d := r.Data(nil)
-			d.SetId(fmt.Sprintf("%s|%s", thingName, v))
-			d.Set(names.AttrPrincipal, v)
-			d.Set("thing", thingName)
-
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-		}
+	pages := iot.NewListThingsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
 		if awsv2.SkipSweepError(err) {
-			continue
+			log.Printf("[WARN] Skipping IoT Thing Principal Attachment sweep for %s: %s", region, err)
+			return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
 		}
 
 		if err != nil {
-			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IoT Thing Principals (%s): %w", region, err))
+			sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IoT Things (%s): %w", region, err))
 		}
-	}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Thing Principal Attachment sweep for %s: %s", region, err)
-		return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
-	}
+		for _, v := range page.Things {
+			thingName := aws.ToString(v.ThingName)
+			input := &iot.ListThingPrincipalsInput{
+				ThingName: aws.String(thingName),
+			}
 
-	if err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IoT Things (%s): %w", region, err))
+			pages := iot.NewListThingPrincipalsPaginator(conn, input)
+			for pages.HasMorePages() {
+				page, err := pages.NextPage(ctx)
+
+				if awsv2.SkipSweepError(err) {
+					continue
+				}
+
+				if err != nil {
+					sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error listing IoT Thing Principals (%s): %w", region, err))
+				}
+
+				for _, v := range page.Principals {
+					r := resourceThingPrincipalAttachment()
+					d := r.Data(nil)
+					d.SetId(fmt.Sprintf("%s|%s", thingName, v))
+					d.Set(names.AttrPrincipal, v)
+					d.Set("thing", thingName)
+
+					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+				}
+			}
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -341,23 +362,26 @@ func sweepThings(region string) error {
 	input := &iot.ListThingsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListThings(ctx, input)
+	pages := iot.NewListThingsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.Things {
-		r := resourceThing()
-		d := r.Data(nil)
-		d.SetId(aws.ToString(v.ThingName))
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IoT Thing sweep for %s: %s", region, err)
+			return nil
+		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
+		if err != nil {
+			return fmt.Errorf("error listing IoT Things (%s): %w", region, err)
+		}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Thing sweep for %s: %s", region, err)
-		return nil
-	}
+		for _, v := range page.Things {
+			r := resourceThing()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.ThingName))
 
-	if err != nil {
-		return fmt.Errorf("error listing IoT Things (%s): %w", region, err)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -379,23 +403,26 @@ func sweepThingTypes(region string) error {
 	input := &iot.ListThingTypesInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListThingTypes(ctx, input)
+	pages := iot.NewListThingTypesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.ThingTypes {
-		r := resourceThingType()
-		d := r.Data(nil)
-		d.SetId(aws.ToString(v.ThingTypeName))
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IoT Thing Type sweep for %s: %s", region, err)
+			return nil
+		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
+		if err != nil {
+			return fmt.Errorf("error listing IoT Thing Types (%s): %w", region, err)
+		}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Thing Type sweep for %s: %s", region, err)
-		return nil
-	}
+		for _, v := range page.ThingTypes {
+			r := resourceThingType()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.ThingTypeName))
 
-	if err != nil {
-		return fmt.Errorf("error listing IoT Thing Types (%s): %w", region, err)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -417,23 +444,26 @@ func sweepTopicRules(region string) error {
 	input := &iot.ListTopicRulesInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListTopicRules(ctx, input)
+	pages := iot.NewListTopicRulesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.Rules {
-		r := resourceTopicRule()
-		d := r.Data(nil)
-		d.SetId(aws.ToString(v.RuleName))
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IoT Topic Rule sweep for %s: %s", region, err)
+			return nil
+		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
+		if err != nil {
+			return fmt.Errorf("error listing IoT Topic Rules (%s): %w", region, err)
+		}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Topic Rule sweep for %s: %s", region, err)
-		return nil
-	}
+		for _, v := range page.Rules {
+			r := resourceTopicRule()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.RuleName))
 
-	if err != nil {
-		return fmt.Errorf("error listing IoT Topic Rules (%s): %w", region, err)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -455,23 +485,26 @@ func sweepThingGroups(region string) error {
 	input := &iot.ListThingGroupsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListThingGroups(ctx, input)
+	pages := iot.NewListThingGroupsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.ThingGroups {
-		r := resourceThingGroup()
-		d := r.Data(nil)
-		d.SetId(aws.ToString(v.GroupName))
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IoT Thing Group sweep for %s: %s", region, err)
+			return nil
+		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
+		if err != nil {
+			return fmt.Errorf("error listing IoT Thing Groups (%s): %w", region, err)
+		}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Thing Group sweep for %s: %s", region, err)
-		return nil
-	}
+		for _, v := range page.ThingGroups {
+			r := resourceThingGroup()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.GroupName))
 
-	if err != nil {
-		return fmt.Errorf("error listing IoT Thing Groups (%s): %w", region, err)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -493,23 +526,26 @@ func sweepTopicRuleDestinations(region string) error {
 	input := &iot.ListTopicRuleDestinationsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListTopicRuleDestinations(ctx, input)
+	pages := iot.NewListTopicRuleDestinationsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.DestinationSummaries {
-		r := resourceTopicRuleDestination()
-		d := r.Data(nil)
-		d.SetId(aws.ToString(v.Arn))
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IoT Topic Rule Destination sweep for %s: %s", region, err)
+			return nil
+		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
+		if err != nil {
+			return fmt.Errorf("error listing IoT Topic Rule Destinations (%s): %w", region, err)
+		}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Topic Rule Destination sweep for %s: %s", region, err)
-		return nil
-	}
+		for _, v := range page.DestinationSummaries {
+			r := resourceTopicRuleDestination()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.Arn))
 
-	if err != nil {
-		return fmt.Errorf("error listing IoT Topic Rule Destinations (%s): %w", region, err)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -531,24 +567,27 @@ func sweepAuthorizers(region string) error {
 	input := &iot.ListAuthorizersInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListAuthorizers(ctx, input)
+	pages := iot.NewListAuthorizersPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.Authorizers {
-		r := resourceAuthorizer()
-		d := r.Data(nil)
-		d.SetId(aws.ToString(v.AuthorizerName))
-		d.Set(names.AttrStatus, awstypes.AuthorizerStatusActive)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IoT Authorizer sweep for %s: %s", region, err)
+			return nil
+		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
+		if err != nil {
+			return fmt.Errorf("error listing IoT Authorizers (%s): %w", region, err)
+		}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Authorizer sweep for %s: %s", region, err)
-		return nil
-	}
+		for _, v := range page.Authorizers {
+			r := resourceAuthorizer()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.AuthorizerName))
+			d.Set(names.AttrStatus, awstypes.AuthorizerStatusActive)
 
-	if err != nil {
-		return fmt.Errorf("error listing IoT Authorizers (%s): %w", region, err)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -570,46 +609,49 @@ func sweepDomainConfigurations(region string) error {
 	input := &iot.ListDomainConfigurationsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListDomainConfigurations(ctx, input)
+	pages := iot.NewListDomainConfigurationsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.DomainConfigurations {
-		name := aws.ToString(v.DomainConfigurationName)
-
-		if strings.HasPrefix(name, "iot:") {
-			log.Printf("[INFO] Skipping IoT Domain Configuration %s", name)
-			continue
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IoT Domain Configuration sweep for %s: %s", region, err)
+			return nil
 		}
-
-		output, err := findDomainConfigurationByName(ctx, conn, name)
 
 		if err != nil {
-			log.Printf("[WARN] IoT Domain Configuration (%s): %s", name, err)
-			continue
+			return fmt.Errorf("error listing IoT Domain Configurations (%s): %w", region, err)
 		}
 
-		if output.DomainType == awstypes.DomainTypeAwsManaged && output.DomainConfigurationStatus == awstypes.DomainConfigurationStatusDisabled {
-			// AWS Managed Domain Configuration must be disabled for at least 7 days before it can be deleted.
-			if output.LastStatusChangeDate.After(time.Now().AddDate(0, 0, -7)) {
+		for _, v := range page.DomainConfigurations {
+			name := aws.ToString(v.DomainConfigurationName)
+
+			if strings.HasPrefix(name, "iot:") {
 				log.Printf("[INFO] Skipping IoT Domain Configuration %s", name)
 				continue
 			}
+
+			output, err := findDomainConfigurationByName(ctx, conn, name)
+
+			if err != nil {
+				log.Printf("[WARN] IoT Domain Configuration (%s): %s", name, err)
+				continue
+			}
+
+			if output.DomainType == awstypes.DomainTypeAwsManaged && output.DomainConfigurationStatus == awstypes.DomainConfigurationStatusDisabled {
+				// AWS Managed Domain Configuration must be disabled for at least 7 days before it can be deleted.
+				if output.LastStatusChangeDate.After(time.Now().AddDate(0, 0, -7)) {
+					log.Printf("[INFO] Skipping IoT Domain Configuration %s", name)
+					continue
+				}
+			}
+
+			r := resourceDomainConfiguration()
+			d := r.Data(nil)
+			d.SetId(name)
+			d.Set(names.AttrStatus, output.DomainConfigurationStatus)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
-
-		r := resourceDomainConfiguration()
-		d := r.Data(nil)
-		d.SetId(name)
-		d.Set(names.AttrStatus, output.DomainConfigurationStatus)
-
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
-
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT Domain Configuration sweep for %s: %s", region, err)
-		return nil
-	}
-
-	if err != nil {
-		return fmt.Errorf("error listing IoT Domain Configurations (%s): %w", region, err)
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
@@ -631,24 +673,27 @@ func sweepCACertificates(region string) error {
 	input := &iot.ListCACertificatesInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	out, err := conn.ListCACertificates(ctx, input)
+	pages := iot.NewListCACertificatesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-	for _, v := range out.Certificates {
-		r := resourceCACertificate()
-		d := r.Data(nil)
-		d.SetId(aws.ToString(v.CertificateId))
-		d.Set("active", true)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping IoT CA Certificate sweep for %s: %s", region, err)
+			return nil
+		}
 
-		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
-	}
+		if err != nil {
+			return fmt.Errorf("error listing IoT CA Certificates (%s): %w", region, err)
+		}
 
-	if awsv2.SkipSweepError(err) {
-		log.Printf("[WARN] Skipping IoT CA Certificate sweep for %s: %s", region, err)
-		return nil
-	}
+		for _, v := range page.Certificates {
+			r := resourceCACertificate()
+			d := r.Data(nil)
+			d.SetId(aws.ToString(v.CertificateId))
+			d.Set("active", true)
 
-	if err != nil {
-		return fmt.Errorf("error listing IoT CA Certificates (%s): %w", region, err)
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	err = sweep.SweepOrchestrator(ctx, sweepResources)

--- a/internal/service/iot/sweep.go
+++ b/internal/service/iot/sweep.go
@@ -53,26 +53,32 @@ func RegisterSweepers() {
 	})
 
 	resource.AddTestSweepers("aws_iot_thing", &resource.Sweeper{
-		Name:         "aws_iot_thing",
-		F:            sweepThings,
-		Dependencies: []string{"aws_iot_thing_principal_attachment"},
+		Name: "aws_iot_thing",
+		F:    sweepThings,
+		Dependencies: []string{
+			"aws_iot_thing_principal_attachment",
+		},
 	})
 
 	resource.AddTestSweepers("aws_iot_thing_group", &resource.Sweeper{
-		Name: "aws_iot_policy_attachment",
+		Name: "aws_iot_thing_group",
 		F:    sweepThingGroups,
 	})
 
 	resource.AddTestSweepers("aws_iot_thing_type", &resource.Sweeper{
-		Name:         "aws_iot_thing_type",
-		F:            sweepThingTypes,
-		Dependencies: []string{"aws_iot_thing"},
+		Name: "aws_iot_thing_type",
+		F:    sweepThingTypes,
+		Dependencies: []string{
+			"aws_iot_thing",
+		},
 	})
 
 	resource.AddTestSweepers("aws_iot_topic_rule", &resource.Sweeper{
-		Name:         "aws_iot_topic_rule",
-		F:            sweepTopicRules,
-		Dependencies: []string{"aws_iot_topic_rule_destination"},
+		Name: "aws_iot_topic_rule",
+		F:    sweepTopicRules,
+		Dependencies: []string{
+			"aws_iot_topic_rule_destination",
+		},
 	})
 
 	resource.AddTestSweepers("aws_iot_topic_rule_destination", &resource.Sweeper{
@@ -81,9 +87,11 @@ func RegisterSweepers() {
 	})
 
 	resource.AddTestSweepers("aws_iot_authorizer", &resource.Sweeper{
-		Name:         "aws_iot_authorizer",
-		F:            sweepAuthorizers,
-		Dependencies: []string{"aws_iot_domain_configuration"},
+		Name: "aws_iot_authorizer",
+		F:    sweepAuthorizers,
+		Dependencies: []string{
+			"aws_iot_domain_configuration",
+		},
 	})
 
 	resource.AddTestSweepers("aws_iot_domain_configuration", &resource.Sweeper{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR addresses technical debt in the `iot` sweepers, it migrates the sweepers to use paginators.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/38230

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
