### PR TITLE
aws_cloudwatch_event_target

### DIFF
--- a/.changelog/38267.txt
+++ b/.changelog/38267.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_target: Fix default `maximum_event_age_in_seconds`
+```

--- a/internal/service/events/target.go
+++ b/internal/service/events/target.go
@@ -398,7 +398,8 @@ func resourceTarget() *schema.Resource {
 						"maximum_event_age_in_seconds": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(0, 86400),
+							Default:      86400,
+							ValidateFunc: validation.IntBetween(60, 86400),
 						},
 						"maximum_retry_attempts": {
 							Type:         schema.TypeInt,

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -562,7 +562,7 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 ### retry_policy
 
-* `maximum_event_age_in_seconds` - (Optional) The age in seconds to continue to make retry attempts.
+* `maximum_event_age_in_seconds` - (Optional) The age in seconds to continue to make retry attempts. Default value is `86400`
 * `maximum_retry_attempts` - (Optional) maximum number of retry attempts to make before the request fails
 
 ### run_command_targets


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38265

### References

Default value is 24 hours 
https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html#eb-create-scheduled-rule-target



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccEventsTarget_RetryPolicy_update PKG=events
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.4 test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsTarget_RetryPolicy_update'  -timeout 360m
=== RUN   TestAccEventsTarget_RetryPolicy_update
=== PAUSE TestAccEventsTarget_RetryPolicy_update
=== CONT  TestAccEventsTarget_RetryPolicy_update
--- PASS: TestAccEventsTarget_RetryPolicy_update (34.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	50.765s

...
```
