### PR TITLE
aws_cloudtrail_event_data_store

### DIFF
--- a/.changelog/38273.txt
+++ b/.changelog/38273.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudtrail_event_data_store: Add `billing_mode` argument
+```

--- a/internal/service/cloudtrail/event_data_store.go
+++ b/internal/service/cloudtrail/event_data_store.go
@@ -142,6 +142,12 @@ func resourceEventDataStore() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"billing_mode": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          types.BillingModeExtendableRetentionPricing,
+				ValidateDiagFunc: enum.Validate[types.BillingMode](),
+			},
 			names.AttrKMSKeyID: {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -188,6 +194,7 @@ func resourceEventDataStoreCreate(ctx context.Context, d *schema.ResourceData, m
 
 	name := d.Get(names.AttrName).(string)
 	input := &cloudtrail.CreateEventDataStoreInput{
+		BillingMode:                  types.BillingMode(d.Get("billing_mode").(string)),
 		MultiRegionEnabled:           aws.Bool(d.Get("multi_region_enabled").(bool)),
 		Name:                         aws.String(name),
 		OrganizationEnabled:          aws.Bool(d.Get("organization_enabled").(bool)),
@@ -240,6 +247,7 @@ func resourceEventDataStoreRead(ctx context.Context, d *schema.ResourceData, met
 	}
 	d.Set(names.AttrARN, output.EventDataStoreArn)
 	d.Set(names.AttrKMSKeyID, output.KmsKeyId)
+	d.Set("billing_mode", output.BillingMode)
 	d.Set("multi_region_enabled", output.MultiRegionEnabled)
 	d.Set(names.AttrName, output.Name)
 	d.Set("organization_enabled", output.OrganizationEnabled)
@@ -260,6 +268,10 @@ func resourceEventDataStoreUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		if d.HasChange("advanced_event_selector") {
 			input.AdvancedEventSelectors = expandAdvancedEventSelector(d.Get("advanced_event_selector").([]interface{}))
+		}
+
+		if d.HasChange("billing_mode") {
+			input.BillingMode = types.BillingMode(d.Get("billing_mode").(string))
 		}
 
 		if d.HasChange("multi_region_enabled") {

--- a/internal/service/cloudtrail/event_data_store_test.go
+++ b/internal/service/cloudtrail/event_data_store_test.go
@@ -76,7 +76,7 @@ func TestAccCloudTrailEventDataStore_billingMode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventDataStoreExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "billing_mode", "EXTENDABLE_RETENTION_PRICING"),
-					resource.TestCheckResourceAttr(resourceName, "termination_protection_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection_enabled", acctest.CtFalse),
 				),
 			},
 			{

--- a/internal/service/cloudtrail/event_data_store_test.go
+++ b/internal/service/cloudtrail/event_data_store_test.go
@@ -66,7 +66,7 @@ func TestAccCloudTrailEventDataStore_billingMode(t *testing.T) {
 	resourceName := "aws_cloudtrail_event_data_store.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOrganizationManagementAccount(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudTrailServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckEventDataStoreDestroy(ctx),

--- a/internal/service/cloudtrail/event_data_store_test.go
+++ b/internal/service/cloudtrail/event_data_store_test.go
@@ -60,6 +60,42 @@ func TestAccCloudTrailEventDataStore_basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudTrailEventDataStore_billingMode(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudtrail_event_data_store.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOrganizationManagementAccount(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudTrailServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEventDataStoreDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventDataStoreConfig_billingMode(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventDataStoreExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "billing_mode", "EXTENDABLE_RETENTION_PRICING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection_enabled", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEventDataStoreConfig_billingModeUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEventDataStoreExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "billing_mode", "FIXED_RETENTION_PRICING"),
+					resource.TestCheckResourceAttr(resourceName, "termination_protection_enabled", acctest.CtFalse),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudTrailEventDataStore_kmsKeyId(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -175,7 +211,6 @@ func TestAccCloudTrailEventDataStore_options(t *testing.T) {
 				Config: testAccEventDataStoreConfig_options(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventDataStoreExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "billing_mode", "EXTENDABLE_RETENTION_PRICING"),
 					resource.TestCheckResourceAttr(resourceName, "multi_region_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "organization_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrRetentionPeriod, "365"),
@@ -191,7 +226,6 @@ func TestAccCloudTrailEventDataStore_options(t *testing.T) {
 				Config: testAccEventDataStoreConfig_optionsUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventDataStoreExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "billing_mode", "FIXED_RETENTION_PRICING"),
 					resource.TestCheckResourceAttr(resourceName, "multi_region_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "organization_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrRetentionPeriod, "90"),
@@ -348,6 +382,27 @@ resource "aws_cloudtrail_event_data_store" "test" {
 `, rName)
 }
 
+func testAccEventDataStoreConfig_billingMode(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudtrail_event_data_store" "test" {
+  name = %[1]q
+
+  termination_protection_enabled = false # For ease of deletion.
+}
+`, rName)
+}
+
+func testAccEventDataStoreConfig_billingModeUpdated(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudtrail_event_data_store" "test" {
+  name = %[1]q
+
+  billing_mode                   = "FIXED_RETENTION_PRICING"
+  termination_protection_enabled = false # For ease of deletion.
+}
+`, rName)
+}
+
 func testAccEventDataStoreConfig_kmsKeyId(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
@@ -421,7 +476,6 @@ func testAccEventDataStoreConfig_optionsUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudtrail_event_data_store" "test" {
   name                 = %[1]q
-  billing_mode         = "FIXED_RETENTION_PRICING"
   multi_region_enabled = true
   organization_enabled = false
   retention_period     = 90

--- a/internal/service/cloudtrail/event_data_store_test.go
+++ b/internal/service/cloudtrail/event_data_store_test.go
@@ -43,6 +43,7 @@ func TestAccCloudTrailEventDataStore_basic(t *testing.T) {
 					}),
 					resource.TestCheckResourceAttr(resourceName, "advanced_event_selector.0.name", "Default management events"),
 					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "cloudtrail", regexache.MustCompile(`eventdatastore/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "billing_mode", "EXTENDABLE_RETENTION_PRICING"),
 					resource.TestCheckResourceAttr(resourceName, "multi_region_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "organization_enabled", acctest.CtFalse),
@@ -75,7 +76,7 @@ func TestAccCloudTrailEventDataStore_billingMode(t *testing.T) {
 				Config: testAccEventDataStoreConfig_billingMode(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventDataStoreExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "billing_mode", "EXTENDABLE_RETENTION_PRICING"),
+					resource.TestCheckResourceAttr(resourceName, "billing_mode", "FIXED_RETENTION_PRICING"),
 					resource.TestCheckResourceAttr(resourceName, "termination_protection_enabled", acctest.CtFalse),
 				),
 			},
@@ -88,7 +89,7 @@ func TestAccCloudTrailEventDataStore_billingMode(t *testing.T) {
 				Config: testAccEventDataStoreConfig_billingModeUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventDataStoreExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "billing_mode", "FIXED_RETENTION_PRICING"),
+					resource.TestCheckResourceAttr(resourceName, "billing_mode", "EXTENDABLE_RETENTION_PRICING"),
 					resource.TestCheckResourceAttr(resourceName, "termination_protection_enabled", acctest.CtFalse),
 				),
 			},
@@ -387,6 +388,7 @@ func testAccEventDataStoreConfig_billingMode(rName string) string {
 resource "aws_cloudtrail_event_data_store" "test" {
   name = %[1]q
 
+  billing_mode                   = "FIXED_RETENTION_PRICING"
   termination_protection_enabled = false # For ease of deletion.
 }
 `, rName)
@@ -397,7 +399,7 @@ func testAccEventDataStoreConfig_billingModeUpdated(rName string) string {
 resource "aws_cloudtrail_event_data_store" "test" {
   name = %[1]q
 
-  billing_mode                   = "FIXED_RETENTION_PRICING"
+  billing_mode                   = "EXTENDABLE_RETENTION_PRICING"
   termination_protection_enabled = false # For ease of deletion.
 }
 `, rName)

--- a/internal/service/cloudtrail/event_data_store_test.go
+++ b/internal/service/cloudtrail/event_data_store_test.go
@@ -175,6 +175,7 @@ func TestAccCloudTrailEventDataStore_options(t *testing.T) {
 				Config: testAccEventDataStoreConfig_options(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventDataStoreExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "billing_mode", "EXTENDABLE_RETENTION_PRICING"),
 					resource.TestCheckResourceAttr(resourceName, "multi_region_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "organization_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrRetentionPeriod, "365"),
@@ -190,6 +191,7 @@ func TestAccCloudTrailEventDataStore_options(t *testing.T) {
 				Config: testAccEventDataStoreConfig_optionsUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventDataStoreExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "billing_mode", "FIXED_RETENTION_PRICING"),
 					resource.TestCheckResourceAttr(resourceName, "multi_region_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "organization_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrRetentionPeriod, "90"),
@@ -419,6 +421,7 @@ func testAccEventDataStoreConfig_optionsUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudtrail_event_data_store" "test" {
   name                 = %[1]q
+  billing_mode         = "FIXED_RETENTION_PRICING"
   multi_region_enabled = true
   organization_enabled = false
   retention_period     = 90

--- a/website/docs/r/cloudtrail_event_data_store.html.markdown
+++ b/website/docs/r/cloudtrail_event_data_store.html.markdown
@@ -79,6 +79,7 @@ resource "aws_cloudtrail_event_data_store" "example" {
 This resource supports the following arguments:
 
 - `name` - (Required) The name of the event data store.
+- `billing_mode` - (Optional) The billing mode for the event data store. The valid values are `EXTENDABLE_RETENTION_PRICING` and `FIXED_RETENTION_PRICING`. Defaults to `EXTENDABLE_RETENTION_PRICING`.
 - `advanced_event_selector` - (Optional) The advanced event selectors to use to select the events for the data store. For more information about how to use advanced event selectors, see [Log events by using advanced event selectors](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html#creating-data-event-selectors-advanced) in the CloudTrail User Guide.
 - `multi_region_enabled` - (Optional) Specifies whether the event data store includes events from all regions, or only from the region in which the event data store is created. Default: `true`.
 - `organization_enabled` - (Optional) Specifies whether an event data store collects events logged for an organization in AWS Organizations. Default: `false`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34494

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccCloudTrailEventDataStore_ PKG=cloudtrail 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.4 test ./internal/service/cloudtrail/... -v -count 1 -parallel 20 -run='TestAccCloudTrailEventDataStore_'  -timeout 360m
=== RUN   TestAccCloudTrailEventDataStore_basic
=== PAUSE TestAccCloudTrailEventDataStore_basic
=== RUN   TestAccCloudTrailEventDataStore_kmsKeyId
=== PAUSE TestAccCloudTrailEventDataStore_kmsKeyId
=== RUN   TestAccCloudTrailEventDataStore_disappears
=== PAUSE TestAccCloudTrailEventDataStore_disappears
=== RUN   TestAccCloudTrailEventDataStore_tags
=== PAUSE TestAccCloudTrailEventDataStore_tags
=== RUN   TestAccCloudTrailEventDataStore_options
=== PAUSE TestAccCloudTrailEventDataStore_options
=== RUN   TestAccCloudTrailEventDataStore_advancedEventSelector
=== PAUSE TestAccCloudTrailEventDataStore_advancedEventSelector
=== CONT  TestAccCloudTrailEventDataStore_basic
=== CONT  TestAccCloudTrailEventDataStore_tags
=== CONT  TestAccCloudTrailEventDataStore_advancedEventSelector
=== CONT  TestAccCloudTrailEventDataStore_options
=== CONT  TestAccCloudTrailEventDataStore_disappears
=== CONT  TestAccCloudTrailEventDataStore_kmsKeyId
=== NAME  TestAccCloudTrailEventDataStore_options
    event_data_store_test.go:169: this AWS account must be an existing member of an AWS Organization
--- SKIP: TestAccCloudTrailEventDataStore_options (1.39s)
--- PASS: TestAccCloudTrailEventDataStore_disappears (99.63s)
--- PASS: TestAccCloudTrailEventDataStore_basic (121.26s)
--- PASS: TestAccCloudTrailEventDataStore_advancedEventSelector (121.35s)
--- PASS: TestAccCloudTrailEventDataStore_kmsKeyId (122.10s)
--- PASS: TestAccCloudTrailEventDataStore_tags (190.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail	237.895s

...
```
