### PR TITLE
Add associate_public_ip_address param to vpc_network_interface

### DIFF
--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -200,6 +200,10 @@ func resourceNetworkInterface() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"associate_public_ip_address": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			names.AttrSubnetID: {
 				Type:     schema.TypeString,
 				Required: true,
@@ -476,6 +480,18 @@ func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
+	if v, ok := d.GetOkExists("associate_public_ip_address"); ok {
+		input := &ec2.ModifyNetworkInterfaceAttributeInput{
+			NetworkInterfaceId:       aws.String(d.Id()),
+			AssociatePublicIpAddress: aws.Bool(v.(bool)),
+		}
+		_, err := conn.ModifyNetworkInterfaceAttribute(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "modifying EC2 Network Interface (%s) AssociatePublicIpAddress: %s", d.Id(), err)
+		}
+	}
+
 	if v, ok := d.GetOk("attachment"); ok && v.(*schema.Set).Len() > 0 {
 		attachment := v.(*schema.Set).List()[0].(map[string]interface{})
 
@@ -558,6 +574,14 @@ func resourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "setting security_groups: %s", err)
 	}
 	d.Set("source_dest_check", eni.SourceDestCheck)
+	attribute, err := conn.DescribeNetworkInterfaceAttribute(ctx, &ec2.DescribeNetworkInterfaceAttributeInput{
+		NetworkInterfaceId: aws.String(d.Id()),
+		Attribute:          types.NetworkInterfaceAttributeAssociatePublicIpAddress,
+	})
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading EC2 Network Interface (%s) AssociatePublicIpAddress: %s", d.Id(), err)
+	}
+	d.Set("associate_public_ip_address", aws.ToBool(attribute.AssociatePublicIpAddress))
 	d.Set(names.AttrSubnetID, eni.SubnetId)
 
 	setTagsOutV2(ctx, eni.TagSet)
@@ -1004,6 +1028,19 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "modifying EC2 Network Interface (%s) SourceDestCheck: %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("associate_public_ip_address") {
+		input := &ec2.ModifyNetworkInterfaceAttributeInput{
+			NetworkInterfaceId:       aws.String(d.Id()),
+			AssociatePublicIpAddress: aws.Bool(d.Get("associate_public_ip_address").(bool)),
+		}
+
+		_, err := conn.ModifyNetworkInterfaceAttribute(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "modifying EC2 Network Interface (%s) AssociatePublicIpAddress: %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/ec2/vpc_network_interface_test.go
+++ b/internal/service/ec2/vpc_network_interface_test.go
@@ -422,6 +422,49 @@ func TestAccVPCNetworkInterface_sourceDestCheck(t *testing.T) {
 	})
 }
 
+func TestAccVPCNetworkInterface_associatePublicIpAddress(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf types.NetworkInterface
+	resourceName := "aws_network_interface.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckENIDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCNetworkInterfaceConfig_associatePublicIpAddress(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckENIExistsV2(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"private_ip_list_enabled", "ipv6_address_list_enabled"},
+			},
+			{
+				Config: testAccVPCNetworkInterfaceConfig_associatePublicIpAddress(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckENIExistsV2(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", acctest.CtTrue),
+				),
+			},
+			{
+				Config: testAccVPCNetworkInterfaceConfig_associatePublicIpAddress(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckENIExistsV2(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "associate_public_ip_address", acctest.CtFalse),
+				),
+			},
+		},
+	})
+}
+
 func TestAccVPCNetworkInterface_privateIPsCount(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf types.NetworkInterface
@@ -1291,6 +1334,20 @@ resource "aws_network_interface" "test" {
   }
 }
 `, rName, sourceDestCheck))
+}
+
+func testAccVPCNetworkInterfaceConfig_associatePublicIpAddress(rName string, associatePublicIpAddress bool) string {
+	return acctest.ConfigCompose(testAccVPCNetworkInterfaceConfig_baseIPV6(rName), fmt.Sprintf(`
+resource "aws_network_interface" "test" {
+  subnet_id                   = aws_subnet.test.id
+  associate_public_ip_address = %[2]t
+  private_ips                 = ["172.16.10.100"]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, associatePublicIpAddress))
 }
 
 func testAccVPCNetworkInterfaceConfig_attachment(rName string) string {

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -67,6 +67,7 @@ The following arguments are optional:
 * `private_ips_count` - (Optional) Number of secondary private IPs to assign to the ENI. The total number of private IPs will be 1 + `private_ips_count`, as a primary private IP will be assiged to an ENI by default.
 * `security_groups` - (Optional) List of security group IDs to assign to the ENI.
 * `source_dest_check` - (Optional) Whether to enable source destination checking for the ENI. Default true.
+* `associate_public_ip_address` - (Optional) Whether to enable auto association of public IP address for the ENI.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Attachment


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds the `associate_public_ip_address` parameter to the `network_interface` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/38275

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccVPCNetworkInterface_associatePubli
cIpAddress PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.4 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkInterface_associatePublicIpAddress'  -timeout 360m
=== RUN   TestAccVPCNetworkInterface_associatePublicIpAddress
=== PAUSE TestAccVPCNetworkInterface_associatePublicIpAddress
=== CONT  TestAccVPCNetworkInterface_associatePublicIpAddress
--- PASS: TestAccVPCNetworkInterface_associatePublicIpAddress (102.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        102.773s

...
```
