### PR TITLE
Ensure that all errors are checked during read, not just `tfresource.NotFound`

### DIFF
--- a/.changelog/38292.txt
+++ b/.changelog/38292.txt
@@ -1,0 +1,39 @@
+```release-note:bug
+aws_dx_lag: Checks for errors other than NotFound when reading.
+```
+
+```release-note:bug
+aws_dynamodb_kinesis_streaming_destination: Checks for errors other than NotFound when reading.
+```
+
+```release-note:bug
+aws_ec2_capacity_block_reservation: Checks for errors other than NotFound when reading.
+```
+
+```release-note:bug
+aws_route_table: Checks for errors other than NotFound when reading.
+```
+
+```release-note:bug
+aws_opensearchserverless_access_policy: Checks for errors other than NotFound when reading.
+```
+
+```release-note:bug
+aws_opensearchserverless_collection: Checks for errors other than NotFound when reading.
+```
+
+```release-note:bug
+aws_opensearchserverless_security_config: Checks for errors other than NotFound when reading.
+```
+
+```release-note:bug
+aws_opensearchserverless_security_policy: Checks for errors other than NotFound when reading.
+```
+
+```release-note:bug
+aws_opensearchserverless_vpc_endpoint: Checks for errors other than NotFound when reading.
+```
+
+```release-note:bug
+aws_ram_principal_association: Checks for errors other than NotFound when reading.
+```

--- a/.ci/semgrep/errors/error-checks.go
+++ b/.ci/semgrep/errors/error-checks.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func test1() {
+	_, err := call()
+
+	// ruleid: notfound-without-err-checks
+	if tfresource.NotFound(err) {
+		return
+	}
+
+	return
+}
+
+func test2() {
+	_, err := call()
+
+	// ok: notfound-without-err-checks
+	if tfresource.NotFound(err) {
+		return
+	}
+
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func test3() {
+	_, err := call()
+
+	if err != nil {
+		// ok: notfound-without-err-checks
+		if tfresource.NotFound(err) {
+			return
+		}
+		return
+	}
+
+	return
+}
+
+func test4() {
+	_, err := call()
+
+	if err == nil {
+		return
+		// ok: notfound-without-err-checks
+	} else if tfresource.NotFound(err) {
+		return
+	} else {
+		return
+	}
+}
+
+func test5() {
+	_, err := call()
+
+	// ok: notfound-without-err-checks
+	if tfresource.NotFound(err) {
+		return
+	} else if err != nil {
+		return
+	} else {
+		return
+	}
+}
+
+func test6() error {
+	_, err := call()
+
+	// ok: notfound-without-err-checks
+	if tfresource.NotFound(err) {
+		return
+	}
+
+	return err
+}
+
+func test7() {
+	for {
+		_, err := call()
+
+		// ok: notfound-without-err-checks
+		if tfresource.NotFound(err) {
+			continue
+		}
+	}
+
+	return err
+}
+
+func test8() {
+	_, err := call()
+
+	// ok: notfound-without-err-checks
+	if tfresource.NotFound(err) {
+		return
+	}
+
+	if tfawserr.ErrCodeEquals(err, "SomeError") {
+		return
+	}
+
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func test9() {
+	_, err := call()
+
+	if err != nil {
+		// ok: notfound-without-err-checks
+		if tfresource.NotFound(err) {
+			return
+		} else {
+			return
+		}
+	}
+
+	return
+}
+
+func test10() {
+	_, err := call()
+
+	// ok: notfound-without-err-checks
+	if tfresource.NotFound(err) {
+		return
+	} else if err != nil {
+		return
+	}
+
+	return
+}
+
+func test11() {
+	ctx := context.Background()
+
+	tfresource.RetryWhen(ctx, 1*time.Second, nil, func(err error) (bool error) {
+		// ok: notfound-without-err-checks
+		if tfresource.NotFound(err) {
+			return true, err
+		}
+
+		return false, err
+	})
+}
+
+func test12() {
+	_, err := call()
+
+	// ok: notfound-without-err-checks
+	if tfresource.NotFound(err) {
+		return
+	}
+
+	if PreCheckSkipError(err) {
+		return
+	}
+
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func call() (any, error) {
+	return nil, errors.New("error")
+}

--- a/.ci/semgrep/errors/error-checks.yml
+++ b/.ci/semgrep/errors/error-checks.yml
@@ -1,0 +1,59 @@
+rules:
+  - id: notfound-without-err-checks
+    languages: [go]
+    message: When checking for tfresource.NotFound() errors, typically other error conditions should be checked.
+    patterns:
+      - pattern: |
+          if tfresource.NotFound($ERR) { ... }
+      - pattern-not-inside: |
+          if tfresource.NotFound($ERR) { ... }
+          if $ERR != nil { ... }
+      - pattern-not-inside: |
+          if tfresource.NotFound($ERR) { ... }
+          if $FUNC($ERR, ...) { ... }
+          if $ERR != nil { ... }
+      - pattern-not-inside: |
+          if err != nil {
+            if tfresource.NotFound($ERR) { ... }
+            return ...
+          }
+      - pattern-not-inside: |
+          if err != nil {
+            if tfresource.NotFound($ERR) {
+              ...
+            } else {
+              ...
+            }
+          }
+      - pattern-not-inside: |
+          if err == nil {
+            ...
+          } else if tfresource.NotFound($ERR) {
+            ...
+          } else { ... }
+      - pattern-not-inside: |
+          if tfresource.NotFound($ERR) {
+            ...
+          } else if err != nil {
+            ...
+          } else {
+            ...
+          }
+      - pattern-not-inside: |
+          if tfresource.NotFound($ERR) {
+            ...
+          }
+          return $ERR
+      - pattern-not-inside: |
+          if tfresource.NotFound($ERR) {
+            continue
+          }
+      - pattern-not-inside: |
+          if tfresource.NotFound($ERR) {
+            ...
+          } else if err != nil {
+            ...
+          }
+      - pattern-not-inside: |
+          tfresource.RetryWhen(...)
+    severity: ERROR

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - run: |
           semgrep $SEMGREP_ARGS \
+          --exclude .ci/semgrep/**/*.go \
           --config .ci/.semgrep.yml \
           --config .ci/.semgrep-constants.yml \
           --config .ci/.semgrep-test-constants.yml \

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -24,8 +24,34 @@ env:
   SEMGREP_ARGS: --error --quiet
 
 jobs:
+  semgrep-validate:
+    name: Validate Code Quality Rules
+    runs-on: ubuntu-latest
+    container:
+      image: "returntocorp/semgrep:1.52.0"
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - run: |
+          semgrep --validate \
+          --config .ci/.semgrep.yml \
+          --config .ci/.semgrep-constants.yml \
+          --config .ci/.semgrep-test-constants.yml \
+          --config .ci/semgrep/
+
+  semgrep-test:
+    name: Semgrep Rule Tests
+    needs: [semgrep-validate]
+    runs-on: ubuntu-latest
+    container:
+      image: "returntocorp/semgrep:1.52.0"
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - run: |
+          semgrep --quiet --test .ci/semgrep/
+
   semgrep:
     name: Code Quality Scan
+    needs: [semgrep-test]
     runs-on: ubuntu-latest
     container:
       image: "returntocorp/semgrep:1.52.0"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -462,6 +462,7 @@ semgrep-all: semgrep-validate ## Run semgrep on all files
 	@echo "make: Running Semgrep checks locally (must have semgrep installed)..."
 	@semgrep $(SEMGREP_ARGS) \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
+        --exclude .ci/semgrep/**/*.go \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-constants.yml \
 		--config .ci/.semgrep-test-constants.yml \
@@ -484,6 +485,7 @@ semgrep-code-quality: semgrep-validate ## [CI] Semgrep Checks / Code Quality Sca
 	@echo "make: Running Semgrep checks locally (must have semgrep installed)"
 	semgrep $(SEMGREP_ARGS) \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
+        --exclude .ci/semgrep/**/*.go \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-constants.yml \
 		--config .ci/.semgrep-test-constants.yml \
@@ -512,6 +514,7 @@ semgrep-fix: semgrep-validate ## Fix Semgrep issues that have fixes
 	@echo "make: WARNING: This will not fix rules that don't have autofixes"
 	@semgrep $(SEMGREP_ARGS) --autofix \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
+        --exclude .ci/semgrep/**/*.go \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-constants.yml \
 		--config .ci/.semgrep-test-constants.yml \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -458,11 +458,11 @@ sanity: prereq-go ## Run sanity check (failures allowed)
 
 semgrep: semgrep-code-quality semgrep-naming semgrep-naming-cae semgrep-service-naming ## [CI] Run all CI Semgrep checks
 
-semgrep-all: semgrep-validate ## Run semgrep on all files
+semgrep-all: semgrep-test semgrep-validate ## Run semgrep on all files
 	@echo "make: Running Semgrep checks locally (must have semgrep installed)..."
 	@semgrep $(SEMGREP_ARGS) \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
-        --exclude .ci/semgrep/**/*.go \
+		--exclude .ci/semgrep/**/*.go \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-constants.yml \
 		--config .ci/.semgrep-test-constants.yml \
@@ -480,12 +480,12 @@ semgrep-all: semgrep-validate ## Run semgrep on all files
 		--config 'r/dgryski.semgrep-go.oddifsequence' \
 		--config 'r/dgryski.semgrep-go.oserrors'
 
-semgrep-code-quality: semgrep-validate ## [CI] Semgrep Checks / Code Quality Scan
+semgrep-code-quality: semgrep-test semgrep-validate ## [CI] Semgrep Checks / Code Quality Scan
 	@echo "make: Semgrep Checks / Code Quality Scan..."
 	@echo "make: Running Semgrep checks locally (must have semgrep installed)"
-	semgrep $(SEMGREP_ARGS) \
+	@semgrep $(SEMGREP_ARGS) \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
-        --exclude .ci/semgrep/**/*.go \
+		--exclude .ci/semgrep/**/*.go \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-constants.yml \
 		--config .ci/.semgrep-test-constants.yml \
@@ -514,7 +514,7 @@ semgrep-fix: semgrep-validate ## Fix Semgrep issues that have fixes
 	@echo "make: WARNING: This will not fix rules that don't have autofixes"
 	@semgrep $(SEMGREP_ARGS) --autofix \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
-        --exclude .ci/semgrep/**/*.go \
+		--exclude .ci/semgrep/**/*.go \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-constants.yml \
 		--config .ci/.semgrep-test-constants.yml \
@@ -545,6 +545,11 @@ semgrep-naming-cae: semgrep-validate ## [CI] Semgrep Checks / Naming Scan Caps/A
 	@semgrep $(SEMGREP_ARGS) \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
 		--config .ci/.semgrep-caps-aws-ec2.yml
+
+semgrep-test: semgrep-validate ## Test Semgrep configuration files
+	@echo "make: Running Semgrep rule tests..."
+	@semgrep --quiet \
+		--test .ci/semgrep/
 
 semgrep-service-naming: semgrep-validate ## [CI] Semgrep Checks / Service Name Scan A-Z
 	@echo "make: Semgrep Checks / Service Name Scan A-Z..."
@@ -607,7 +612,7 @@ sweeper-unlinked: go-build ## [CI] Provider Checks / Sweeper Functions Not Linke
 		grep --count --extended-regexp 'internal/service/[a-zA-Z0-9]+\.sweep[a-zA-Z0-9]+$$'` ; \
 	echo "make: sweeper-unlinked: found $$count, expected 0" ; \
 	[ $$count -eq 0 ] || \
-        (echo "Expected `strings` to detect no sweeper function names in provider binary."; exit 1)
+		(echo "Expected `strings` to detect no sweeper function names in provider binary."; exit 1)
 
 t: prereq-go fmt-check ## Run acceptance tests (similar to testacc)
 	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
@@ -640,8 +645,8 @@ testacc: prereq-go fmt-check ## Run acceptance tests
 testacc-lint: ## [CI] Acceptance Test Linting / terrafmt
 	@echo "make: Acceptance Test Linting / terrafmt..."
 	@find $(SVC_DIR) -type f -name '*_test.go' \
-    	| sort -u \
-    	| xargs -I {} terrafmt diff --check --fmtcompat {}
+		| sort -u \
+		| xargs -I {} terrafmt diff --check --fmtcompat {}
 
 testacc-lint-fix: ## Fix acceptance test linter findings
 	@echo "make: Fixing Acceptance Test Linting / terrafmt..."

--- a/internal/retry/wrappers.go
+++ b/internal/retry/wrappers.go
@@ -82,7 +82,7 @@ func (o operation[T]) UntilFoundN(continuousTargetOccurence int) operation[T] {
 			return true, nil
 		}
 
-		if tfresource.NotFound(err) {
+		if tfresource.NotFound(err) { // nosemgrep:ci.semgrep.errors.notfound-without-err-checks
 			targetOccurence = 0
 
 			return true, err
@@ -100,7 +100,7 @@ func (o operation[T]) UntilNotFound() operation[T] {
 			return true, nil
 		}
 
-		if tfresource.NotFound(err) {
+		if tfresource.NotFound(err) { // nosemgrep:ci.semgrep.errors.notfound-without-err-checks
 			return false, nil
 		}
 

--- a/internal/service/directconnect/lag.go
+++ b/internal/service/directconnect/lag.go
@@ -201,6 +201,10 @@ func resourceLagDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 			return diags
 		}
 
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "deleting Direct Connect LAG (%s): listing connections: %s", d.Id(), err)
+		}
+
 		for _, connection := range lag.Connections {
 			if err := deleteConnection(ctx, conn, aws.StringValue(connection.ConnectionId), waitConnectionDeleted); err != nil {
 				return sdkdiag.AppendFromErr(diags, err)

--- a/internal/service/dynamodb/kinesis_streaming_destination.go
+++ b/internal/service/dynamodb/kinesis_streaming_destination.go
@@ -128,6 +128,10 @@ func resourceKinesisStreamingDestinationDelete(ctx context.Context, d *schema.Re
 		return diags
 	}
 
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "disabling DynamoDB Kinesis Streaming Destination (%s): %s", d.Id(), err)
+	}
+
 	log.Printf("[DEBUG] Deleting DynamoDB Kinesis Streaming Destination: %s", d.Id())
 	_, err = conn.DisableKinesisStreamingDestination(ctx, &dynamodb.DisableKinesisStreamingDestinationInput{
 		TableName: aws.String(tableName),

--- a/internal/service/ec2/ec2_capacity_block_reservation.go
+++ b/internal/service/ec2/ec2_capacity_block_reservation.go
@@ -194,7 +194,7 @@ func (r *resourceCapacityBlockReservation) Create(ctx context.Context, request r
 	output, err := conn.PurchaseCapacityBlock(ctx, input)
 	if err != nil {
 		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameCapacityBlockReservation, plan.CapacityBlockOfferingID.String(), err),
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameCapacityBlockReservation, plan.CapacityBlockOfferingID.ValueString(), err),
 			err.Error(),
 		)
 		return
@@ -202,7 +202,7 @@ func (r *resourceCapacityBlockReservation) Create(ctx context.Context, request r
 
 	if output == nil || output.CapacityReservation == nil {
 		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameCapacityBlockReservation, plan.CapacityBlockOfferingID.String(), nil),
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameCapacityBlockReservation, plan.CapacityBlockOfferingID.ValueString(), nil),
 			errors.New("empty output").Error(),
 		)
 		return
@@ -217,7 +217,7 @@ func (r *resourceCapacityBlockReservation) Create(ctx context.Context, request r
 
 	if err != nil {
 		response.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionWaitingForCreation, ResNameCapacityBlockReservation, state.ID.String(), err),
+			create.ProblemStandardMessage(names.EC2, create.ErrActionWaitingForCreation, ResNameCapacityBlockReservation, state.ID.ValueString(), err),
 			err.Error(),
 		)
 		return
@@ -247,6 +247,13 @@ func (r *resourceCapacityBlockReservation) Read(ctx context.Context, request res
 	if tfresource.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		response.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		response.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionReading, ResNameCapacityBlockReservation, data.ID.ValueString(), err),
+			err.Error(),
+		)
 		return
 	}
 

--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -506,6 +506,10 @@ func routeTableAddRoute(ctx context.Context, conn *ec2.Client, routeTableID stri
 			return fmt.Errorf("local route cannot be created but must exist to be adopted, %s %s does not exist", target, destination)
 		}
 
+		if err != nil {
+			return fmt.Errorf("finding local route %s %s: %w", target, destination, err)
+		}
+
 		return nil
 	}
 

--- a/internal/service/opensearchserverless/access_policy.go
+++ b/internal/service/opensearchserverless/access_policy.go
@@ -157,6 +157,14 @@ func (r *resourceAccessPolicy) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, ResNameAccessPolicy, state.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
 	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/service/opensearchserverless/collection.go
+++ b/internal/service/opensearchserverless/collection.go
@@ -214,6 +214,14 @@ func (r *resourceCollection) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, ResNameCollection, state.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
 	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/service/opensearchserverless/security_config.go
+++ b/internal/service/opensearchserverless/security_config.go
@@ -178,6 +178,14 @@ func (r *resourceSecurityConfig) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, ResNameSecurityConfig, state.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
 	state.refreshFromOutput(ctx, out)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/service/opensearchserverless/security_config.go
+++ b/internal/service/opensearchserverless/security_config.go
@@ -152,7 +152,7 @@ func (r *resourceSecurityConfig) Create(ctx context.Context, req resource.Create
 	if out == nil || out.SecurityConfigDetail == nil {
 		resp.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionCreating, ResNameSecurityConfig, plan.Name.String(), nil),
-			err.Error(),
+			"Empty response.",
 		)
 		return
 	}

--- a/internal/service/opensearchserverless/security_policy.go
+++ b/internal/service/opensearchserverless/security_policy.go
@@ -149,6 +149,14 @@ func (r *resourceSecurityPolicy) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, ResNameSecurityPolicy, state.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
 	resp.Diagnostics.Append(state.refreshFromOutput(ctx, out)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/service/opensearchserverless/vpc_endpoint.go
+++ b/internal/service/opensearchserverless/vpc_endpoint.go
@@ -184,6 +184,14 @@ func (r *resourceVpcEndpoint) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.OpenSearchServerless, create.ErrActionReading, ResNameVPCEndpoint, state.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
 	state.refreshFromOutput(ctx, out)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -329,7 +329,7 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	stack, err := FindStackByID(ctx, conn, d.Id())
 
-	if tfresource.NotFound(err) {
+	if tfresource.NotFound(err) { // nosemgrep:ci.semgrep.errors.notfound-without-err-checks
 		// If it's not found in the default region we're in, we check us-east-1
 		// in the event this stack was created with Terraform before version 0.9.
 		// See https://github.com/hashicorp/terraform/issues/12842.

--- a/internal/service/ram/principal_association_test.go
+++ b/internal/service/ram/principal_association_test.go
@@ -138,6 +138,10 @@ func testAccPreCheckSharingWithOrganizationEnabled(ctx context.Context, t *testi
 	if tfresource.NotFound(err) {
 		t.Skipf("Sharing with AWS Organization not found, skipping acceptance test: %s", err)
 	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
 }
 
 func testAccCheckPrincipalAssociationExists(ctx context.Context, n string, v *awstypes.ResourceShareAssociation) resource.TestCheckFunc {

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -1819,9 +1819,10 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 		v, err = findDBInstanceByIDSDKv1(ctx, conn, d.Id())
 	} else {
 		v, err = findDBInstanceByIDSDKv1(ctx, conn, d.Id())
-		if tfresource.NotFound(err) {
+		if tfresource.NotFound(err) { // nosemgrep:ci.semgrep.errors.notfound-without-err-checks
+			// Retry with `identifier`
 			v, err = findDBInstanceByIDSDKv1(ctx, conn, d.Get(names.AttrIdentifier).(string))
-			if tfresource.NotFound(err) {
+			if tfresource.NotFound(err) { // nosemgrep:ci.semgrep.errors.notfound-without-err-checks
 				log.Printf("[WARN] RDS DB Instance (%s) not found, removing from state", d.Get(names.AttrIdentifier).(string))
 				d.SetId("")
 				return diags

--- a/internal/service/ssmincidents/replication_set_test.go
+++ b/internal/service/ssmincidents/replication_set_test.go
@@ -436,8 +436,6 @@ func testAccCheckReplicationSetDestroy(ctx context.Context) resource.TestCheckFu
 				continue
 			}
 
-			log.Printf("Replication Set Resource has incorrect Error\n")
-
 			if err != nil {
 				return create.Error(names.SSMIncidents, create.ErrActionCheckingDestroyed, tfssmincidents.ResNameReplicationSet, resource.Primary.ID,
 					errors.New("expected resource not found error, received an unexpected error"))


### PR DESCRIPTION
### Description

In a number of cases, only `tfresource.NotFound` is checked, but other errors are not checked.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38138
