### PR TITLE
Update s3_bucket_object_lock_configuration.html.markdown

### DIFF
--- a/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_object_lock_configuration.html.markdown
@@ -51,8 +51,8 @@ This resource supports the following arguments:
 * `expected_bucket_owner` - (Optional, Forces new resource) Account ID of the expected bucket owner.
 * `object_lock_enabled` - (Optional, Forces new resource) Indicates whether this bucket has an Object Lock configuration enabled. Defaults to `Enabled`. Valid values: `Enabled`.
 * `rule` - (Optional) Configuration block for specifying the Object Lock rule for the specified object. [See below](#rule).
-* `token` - (Optional) Token to allow Object Lock to be enabled for an existing bucket. You must contact AWS support for the bucket's "Object Lock token".
-The token is generated in the back-end when [versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html) is enabled on a bucket. For more details on versioning, see the [`aws_s3_bucket_versioning` resource](s3_bucket_versioning.html.markdown).
+* `token` - (Optional,Deprecated) This argument is deprecated and no longer needed to enable Object Lock. 
+To enable Object Lock for an existing bucket, you must first enable versioning on the bucket and then enable Object Lock. For more details on versioning, see the [`aws_s3_bucket_versioning` resource](s3_bucket_versioning.html.markdown).
 
 ### rule
 


### PR DESCRIPTION
Referred Doc:  https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-configure.html https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-s3-enabling-object-lock-buckets/

and Tested it for existing S3 bucket , no token is getting generated we just need to enable version and then lock


### Description
As per above document no token is needed to enable S3 Object Lock for existing buckets. We can enable versioning and then enable the lock.


### Relations
This will be closing the below issue 
Closes :  https://github.com/hashicorp/terraform-provider-aws/issues/36938




### Output from Acceptance Testing
Go to the AWS Console --> Go to the S3 Bucket --> Go to Properties --> Enable versioning first --> Enable to Lock 
![Step1](https://github.com/hashicorp/terraform-provider-aws/assets/62237566/3dbf86f0-2a39-40ac-b7b9-dd6fca7eaa44)
![Step2](https://github.com/hashicorp/terraform-provider-aws/assets/62237566/57a45a64-594b-4128-840f-ec8471fc5efe)
![Step3](https://github.com/hashicorp/terraform-provider-aws/assets/62237566/03bae277-3373-4d52-907e-580a56057541)
![Step4](https://github.com/hashicorp/terraform-provider-aws/assets/62237566/b50b9d80-fc5f-49ea-8d3a-f4ff8e45e215)
