### PR TITLE
resource/aws_pinpoint_app: Fix panic when nested objects are empty

### DIFF
--- a/internal/service/pinpoint/app.go
+++ b/internal/service/pinpoint/app.go
@@ -313,7 +313,7 @@ func findAppSettingsByID(ctx context.Context, conn *pinpoint.Pinpoint, id string
 }
 
 func expandCampaignHook(configs []interface{}) *pinpoint.CampaignHook {
-	if len(configs) == 0 {
+	if len(configs) == 0 || configs[0] == nil {
 		return nil
 	}
 
@@ -351,7 +351,7 @@ func flattenCampaignHook(ch *pinpoint.CampaignHook) []interface{} {
 }
 
 func expandCampaignLimits(configs []interface{}) *pinpoint.CampaignLimits {
-	if len(configs) == 0 {
+	if len(configs) == 0 || configs[0] == nil {
 		return nil
 	}
 
@@ -394,7 +394,7 @@ func flattenCampaignLimits(cl *pinpoint.CampaignLimits) []interface{} {
 }
 
 func expandQuietTime(configs []interface{}) *pinpoint.QuietTime {
-	if len(configs) == 0 {
+	if len(configs) == 0 || configs[0] == nil {
 		return nil
 	}
 

--- a/internal/service/pinpoint/app_test.go
+++ b/internal/service/pinpoint/app_test.go
@@ -232,6 +232,42 @@ func TestAccPinpointApp_campaignHookLambda(t *testing.T) {
 	})
 }
 
+func TestAccPinpointApp_campaignHookEmpty(t *testing.T) {
+	ctx := acctest.Context(t)
+	var application pinpoint.ApplicationResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_pinpoint_app.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckApp(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.PinpointServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppConfig_campaignHookEmpty(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppExists(ctx, resourceName, &application),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("campaign_hook"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"lambda_function_name": knownvalue.StringExact(""),
+							names.AttrMode:         knownvalue.StringExact(""),
+							"web_url":              knownvalue.StringExact(""),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccPinpointApp_limits(t *testing.T) {
 	ctx := acctest.Context(t)
 	var application pinpoint.ApplicationResponse
@@ -269,6 +305,43 @@ func TestAccPinpointApp_limits(t *testing.T) {
 	})
 }
 
+func TestAccPinpointApp_limitsEmpty(t *testing.T) {
+	ctx := acctest.Context(t)
+	var application pinpoint.ApplicationResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_pinpoint_app.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckApp(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.PinpointServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppConfig_limitsEmpty(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppExists(ctx, resourceName, &application),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("limits"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"daily":               knownvalue.Int64Exact(0),
+							"maximum_duration":    knownvalue.Int64Exact(0),
+							"messages_per_second": knownvalue.Int64Exact(0),
+							"total":               knownvalue.Int64Exact(0),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccPinpointApp_quietTime(t *testing.T) {
 	ctx := acctest.Context(t)
 	var application pinpoint.ApplicationResponse
@@ -291,6 +364,41 @@ func TestAccPinpointApp_quietTime(t *testing.T) {
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"end":   knownvalue.StringExact("03:00"),
 							"start": knownvalue.StringExact("00:00"),
+						}),
+					})),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPinpointApp_quietTimeEmpty(t *testing.T) {
+	ctx := acctest.Context(t)
+	var application pinpoint.ApplicationResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_pinpoint_app.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckApp(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.PinpointServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAppDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppConfig_quietTimeEmpty(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppExists(ctx, resourceName, &application),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quiet_time"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"end":   knownvalue.StringExact(""),
+							"start": knownvalue.StringExact(""),
 						}),
 					})),
 				},
@@ -461,6 +569,16 @@ resource "aws_lambda_permission" "test" {
 `, rName)
 }
 
+func testAccAppConfig_campaignHookEmpty(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_pinpoint_app" "test" {
+  name = %[1]q
+
+  campaign_hook {}
+}
+`, rName)
+}
+
 func testAccAppConfig_limits(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test" {
@@ -476,6 +594,16 @@ resource "aws_pinpoint_app" "test" {
 `, rName)
 }
 
+func testAccAppConfig_limitsEmpty(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_pinpoint_app" "test" {
+  name = %[1]q
+
+  limits {}
+}
+`, rName)
+}
+
 func testAccAppConfig_quietTime(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_pinpoint_app" "test" {
@@ -485,6 +613,16 @@ resource "aws_pinpoint_app" "test" {
     start = "00:00"
     end   = "03:00"
   }
+}
+`, rName)
+}
+
+func testAccAppConfig_quietTimeEmpty(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_pinpoint_app" "test" {
+  name = %[1]q
+
+  quiet_time {}
 }
 `, rName)
 }

--- a/internal/service/pinpoint/app_test.go
+++ b/internal/service/pinpoint/app_test.go
@@ -43,7 +43,6 @@ func TestAccPinpointApp_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
-					resource.TestCheckResourceAttr(resourceName, "quiet_time.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct0),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -60,6 +59,12 @@ func TestAccPinpointApp_basic(t *testing.T) {
 							"maximum_duration":    knownvalue.Int64Exact(0),
 							"messages_per_second": knownvalue.Int64Exact(0),
 							"total":               knownvalue.Int64Exact(0),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quiet_time"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"end":   knownvalue.StringExact(""),
+							"start": knownvalue.StringExact(""),
 						}),
 					})),
 				},
@@ -279,9 +284,15 @@ func TestAccPinpointApp_quietTime(t *testing.T) {
 				Config: testAccAppConfig_quietTime(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAppExists(ctx, resourceName, &application),
-					resource.TestCheckResourceAttr(resourceName, "quiet_time.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "quiet_time.0.start", "00:00"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("quiet_time"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"end":   knownvalue.StringExact("03:00"),
+							"start": knownvalue.StringExact("00:00"),
+						}),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,

--- a/internal/service/pinpoint/app_test.go
+++ b/internal/service/pinpoint/app_test.go
@@ -43,7 +43,6 @@ func TestAccPinpointApp_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct0),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("campaign_hook"), knownvalue.ListExact([]knownvalue.Check{
@@ -67,6 +66,8 @@ func TestAccPinpointApp_basic(t *testing.T) {
 							"start": knownvalue.StringExact(""),
 						}),
 					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{})),
 				},
 			},
 			{


### PR DESCRIPTION
### Description

Fixes panic when nested objects, e.g. `campaign_hook`, `limits`, or `quiet_time`, are empty

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #25861

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=pinpoint TESTS=TestAccPinpointApp_

--- PASS: TestAccPinpointApp_nameGenerated (18.97s)
--- PASS: TestAccPinpointApp_namePrefix (20.51s)
--- PASS: TestAccPinpointApp_disappears (21.36s)
--- PASS: TestAccPinpointApp_basic (24.33s)
--- PASS: TestAccPinpointApp_campaignHookEmpty (25.11s)
--- PASS: TestAccPinpointApp_quietTimeEmpty (25.25s)
--- PASS: TestAccPinpointApp_limitsEmpty (25.26s)
--- PASS: TestAccPinpointApp_limits (25.30s)
--- PASS: TestAccPinpointApp_quietTime (25.34s)
--- PASS: TestAccPinpointApp_campaignHookLambda (34.25s)
--- PASS: TestAccPinpointApp_tags (37.32s)
```
