### PR TITLE
Rmove network_interface from spot instance request

### DIFF
--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -2531,9 +2531,11 @@ func buildNetworkInterfaceOpts(d *schema.ResourceData, groups []string, nInterfa
 			ini := v.(map[string]interface{})
 			ni := awstypes.InstanceNetworkInterfaceSpecification{
 				DeviceIndex:         aws.Int32(int32(ini["device_index"].(int))),
-				NetworkCardIndex:    aws.Int32(int32(ini["network_card_index"].(int))),
 				NetworkInterfaceId:  aws.String(ini[names.AttrNetworkInterfaceID].(string)),
 				DeleteOnTermination: aws.Bool(ini[names.AttrDeleteOnTermination].(bool)),
+			}
+			if nci, ok := ini["network_card_index"]; ok {
+				ni.NetworkCardIndex = aws.Int32(int32(nci.(int)))
 			}
 			networkInterfaces = append(networkInterfaces, ni)
 		}

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -141,6 +141,8 @@ func resourceSpotInstanceRequest() *schema.Resource {
 				Default:  false,
 			}
 
+			delete(s["network_interface"].Elem.(*schema.Resource).Schema, "network_card_index")
+
 			return s
 		}(),
 


### PR DESCRIPTION
### Description

The apply command fails with response 400 from AWS, and error text mentions that `network_card_index` is not acceptable for a spot instance request.

Removing the `network_card_index` from the spot instance request schema seems as a reasonable fix for this issue. 

### Relations

Closes #38335

### References

Please read the issue description for references.