### PR TITLE
docs: mark attributes as required in  wafv2 web acl  and wafv2 web acl logging configuration

### DIFF
--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -946,7 +946,7 @@ Inspect a single header. Provide the name of the header to inspect, for example,
 
 The `single_header` block supports the following arguments:
 
-* `name` - (Optional) Name of the query header to inspect. This setting must be provided as lower case characters.
+* `name` - (Required) Name of the query header to inspect. This setting must be provided as lower case characters.
 
 ### `single_query_argument` Block
 
@@ -954,7 +954,7 @@ Inspect a single query argument. Provide the name of the query argument to inspe
 
 The `single_query_argument` block supports the following arguments:
 
-* `name` - (Optional) Name of the query header to inspect. This setting must be provided as lower case characters.
+* `name` - (Required) Name of the query header to inspect. This setting must be provided as lower case characters.
 
 ### `body` Block
 

--- a/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
+++ b/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
@@ -178,7 +178,7 @@ To redact a single header, provide the name of the header to be redacted. For ex
 
 The `single_header` block supports the following arguments:
 
-* `name` - (Optional) Name of the query header to redact. This setting must be provided in lowercase characters.
+* `name` - (Required) Name of the query header to redact. This setting must be provided in lowercase characters.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
 
This PR is to update the documentation to reflect 
- that the `name` in the `single_header` block  of  resource `aws_wafv2_web_acl_logging_configuration`  is not optional, but required.  See [this section](https://github.com/hashicorp/terraform-provider-aws/blob/cd31961d3f059ad85e67474c1484065d899b607b/internal/service/wafv2/web_acl_logging_configuration.go#L141) in the provider code base and also the [CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-loggingconfiguration-singleheader.html).

- a similar change in the resource `aws_wafv2_web_acl` for the `single_header` blocker. Here `name` is also marked as optional, but should be marked as required.  [Here](https://github.com/hashicorp/terraform-provider-aws/blob/cd31961d3f059ad85e67474c1484065d899b607b/internal/service/wafv2/schemas.go#L358) to the Terraform provide code base and [CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-singleheader.html).

- a similar change in the resource `aws_wafv2_web_acl` for the `single_query_argument_block`. The `name` is here also marked as optional, but is required. See [here](https://github.com/hashicorp/terraform-provider-aws/blob/cd31961d3f059ad85e67474c1484065d899b607b/internal/service/wafv2/schemas.go#L385).  The CloudFormation docs are available [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-singlequeryargument.html).

### Relations

Closes #38333 

### References

Provided as part of the description.

### Output from Acceptance Testing

not applicable , only changes to website documentation were made.