### PR TITLE
add explicit reference to the type of the expected value

### DIFF
--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -53,7 +53,7 @@ This resource supports the following arguments:
 * `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
 * `db_subnet_group_name` - (Optional) A DB subnet group to associate with this DB instance.
 * `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
-* `deletion_protection` - (Optional) A value that indicates whether the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled. By default, deletion protection is disabled.
+* `deletion_protection` - (Optional) A boolean value that indicates whether the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled. Defaults to `false`.
 * `enabled_cloudwatch_logs_exports` - (Optional) List of log types to export to cloudwatch. If omitted, no logs will be exported.
    The following log types are supported: `audit`, `profiler`.
 * `engine_version` - (Optional) The database engine version. Updating this argument results in an outage.


### PR DESCRIPTION
### Description
I was confused as to whether this should be a string (eg, `enabled`) or a boolean. It was easy enough to find out, but it would have been nicer if the docs had been more explicit.

This commit makes the boolean type of the value explicit.

### References
current docs
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster#deletion_protection