### PR TITLE
r/aws_kinesisanalyticsv2_application: Document support for FLINK-1_19

### DIFF
--- a/.changelog/38350.txt
+++ b/.changelog/38350.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_kinesisanalyticsv2_application: Add support for `FLINK-1_19` `runtime_environment` value
+resource/aws_kinesisanalyticsv2_application: Support `FLINK-1_19` as a valid value for `runtime_environment`
 ```

--- a/.changelog/38350.txt
+++ b/.changelog/38350.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_kinesisanalyticsv2_application: Add support for `FLINK-1_19` `runtime_environment` value
+```

--- a/website/docs/r/kinesisanalyticsv2_application.html.markdown
+++ b/website/docs/r/kinesisanalyticsv2_application.html.markdown
@@ -256,7 +256,7 @@ resource "aws_kinesisanalyticsv2_application" "example" {
 This resource supports the following arguments:
 
 * `name` - (Required) The name of the application.
-* `runtime_environment` - (Required) The runtime environment for the application. Valid values: `SQL-1_0`, `FLINK-1_6`, `FLINK-1_8`, `FLINK-1_11`, `FLINK-1_13`, `FLINK-1_15`, `FLINK-1_18`.
+* `runtime_environment` - (Required) The runtime environment for the application. Valid values: `SQL-1_0`, `FLINK-1_6`, `FLINK-1_8`, `FLINK-1_11`, `FLINK-1_13`, `FLINK-1_15`, `FLINK-1_18`, `FLINK-1_19`.
 * `service_execution_role` - (Required) The ARN of the [IAM role](/docs/providers/aws/r/iam_role.html) used by the application to access Kinesis data streams, Kinesis Data Firehose delivery streams, Amazon S3 objects, and other external resources.
 * `application_configuration` - (Optional) The application's configuration
 * `application_mode` - (Optional) The application's mode. Valid values are `STREAMING`, `INTERACTIVE`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Add documentation for supported Flink runtime 1.19
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38348

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The option was added in release [v1.54.11](https://github.com/aws/aws-sdk-go/commit/9607ced1cc4b6b39263b9017eea3185ec15636ee#diff-034b3d8a3c745211948e31a862fa399c4c2a131e7facc0eede08307be9481d18)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
