### PR TITLE
docs: add svm_admin_password to fsx_ontap_storage_virtual_machine args

### DIFF
--- a/website/docs/r/fsx_ontap_storage_virtual_machine.html.markdown
+++ b/website/docs/r/fsx_ontap_storage_virtual_machine.html.markdown
@@ -51,6 +51,7 @@ This resource supports the following arguments:
 * `file_system_id` - (Required) The ID of the Amazon FSx ONTAP File System that this SVM will be created on.
 * `name` - (Required) The name of the SVM. You can use a maximum of 47 alphanumeric characters, plus the underscore (_) special character.
 * `root_volume_security_style` - (Optional) Specifies the root volume security style, Valid values are `UNIX`, `NTFS`, and `MIXED`. All volumes created under this SVM will inherit the root security style unless the security style is specified on the volume. Default value is `UNIX`.
+* `svm_admin_password` - (Optional) Specifies the password to use when logging on to the SVM using a secure shell (SSH) connection to the SVM's management endpoint. Doing so enables you to manage the SVM using the NetApp ONTAP CLI or REST API. If you do not specify a password, you can still use the file system's fsxadmin user to manage the SVM.
 * `tags` - (Optional) A map of tags to assign to the storage virtual machine. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### active_directory_configuration


### PR DESCRIPTION

### Description

The documenation is missing the argument `svm_admin_password` for the resource `aws_fsx_ontap_storage_virtual_machine`.

### Relations

Closes #38154

### References

- [AWS Cloudformation Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-fsx-storagevirtualmachine.html#cfn-fsx-storagevirtualmachine-svmadminpassword)
- [Terraform Provider Code](https://github.com/hashicorp/terraform-provider-aws/blob/26d1b59bef1a1462f08c637b0c1cf297ba763292/internal/service/fsx/ontap_storage_virtual_machine.go#L222)

### Output from Acceptance Testing

Not required as only documentation is updated.