### PR TITLE
td/serverless application repository: migrate to AWS go SDKv2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,6 +177,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.32.3
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.51.3
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.16.3
+	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.22.3
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.28.3
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.3
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.23.3

--- a/go.sum
+++ b/go.sum
@@ -384,6 +384,8 @@ github.com/aws/aws-sdk-go-v2/service/securityhub v1.51.3 h1:tFzkGJZKDWgwGDSQXwxZ
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.51.3/go.mod h1:MfWlz2hEZ2O0XdyBBJNtF6qUZwpHtvc892BU7gludBw=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.16.3 h1:7isk2tSNmVbm2f8epPfokkHjjWfwS46IpNNmI+rarUo=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.16.3/go.mod h1:X5rHkguK4jCvFOM74tkme3oLUOaR++APKgwhNcIdOW0=
+github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.22.3 h1:E4NzUkgPrKmlbC9OxVUEQnTdPRg3MTTiDwmq5dJfH9U=
+github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.22.3/go.mod h1:/nzQOH+tOGrQVv5QbVN+88HoNYc15s8aKsJmOT9MPJI=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.28.3 h1:l19QC3al5lqQydnJRz1cpduAoL0YoEeSxI5Wb5NUEis=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.28.3/go.mod h1:0Em81iN4ZnER1M0XDirgcbsZK3jNghA0YlY2Xw2BDOQ=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.3 h1:EthA93BNgTnk36FoI9DCKtv4S0m63WzdGDYlBp/CvHQ=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -169,6 +169,7 @@ import (
 	secretsmanager_sdkv2 "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	securityhub_sdkv2 "github.com/aws/aws-sdk-go-v2/service/securityhub"
 	securitylake_sdkv2 "github.com/aws/aws-sdk-go-v2/service/securitylake"
+	serverlessapplicationrepository_sdkv2 "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository"
 	servicecatalogappregistry_sdkv2 "github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry"
 	servicediscovery_sdkv2 "github.com/aws/aws-sdk-go-v2/service/servicediscovery"
 	servicequotas_sdkv2 "github.com/aws/aws-sdk-go-v2/service/servicequotas"
@@ -1149,6 +1150,10 @@ func (c *AWSClient) SecurityLakeClient(ctx context.Context) *securitylake_sdkv2.
 
 func (c *AWSClient) ServerlessRepoConn(ctx context.Context) *serverlessapplicationrepository_sdkv1.ServerlessApplicationRepository {
 	return errs.Must(conn[*serverlessapplicationrepository_sdkv1.ServerlessApplicationRepository](ctx, c, names.ServerlessRepo, make(map[string]any)))
+}
+
+func (c *AWSClient) ServerlessRepoClient(ctx context.Context) *serverlessapplicationrepository_sdkv2.Client {
+	return errs.Must(client[*serverlessapplicationrepository_sdkv2.Client](ctx, c, names.ServerlessRepo, make(map[string]any)))
 }
 
 func (c *AWSClient) ServiceCatalogConn(ctx context.Context) *servicecatalog_sdkv1.ServiceCatalog {

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -246,7 +246,6 @@ import (
 	route53resolver_sdkv1 "github.com/aws/aws-sdk-go/service/route53resolver"
 	s3outposts_sdkv1 "github.com/aws/aws-sdk-go/service/s3outposts"
 	sagemaker_sdkv1 "github.com/aws/aws-sdk-go/service/sagemaker"
-	serverlessapplicationrepository_sdkv1 "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
 	servicecatalog_sdkv1 "github.com/aws/aws-sdk-go/service/servicecatalog"
 	ses_sdkv1 "github.com/aws/aws-sdk-go/service/ses"
 	simpledb_sdkv1 "github.com/aws/aws-sdk-go/service/simpledb"
@@ -1146,10 +1145,6 @@ func (c *AWSClient) SecurityHubClient(ctx context.Context) *securityhub_sdkv2.Cl
 
 func (c *AWSClient) SecurityLakeClient(ctx context.Context) *securitylake_sdkv2.Client {
 	return errs.Must(client[*securitylake_sdkv2.Client](ctx, c, names.SecurityLake, make(map[string]any)))
-}
-
-func (c *AWSClient) ServerlessRepoConn(ctx context.Context) *serverlessapplicationrepository_sdkv1.ServerlessApplicationRepository {
-	return errs.Must(conn[*serverlessapplicationrepository_sdkv1.ServerlessApplicationRepository](ctx, c, names.ServerlessRepo, make(map[string]any)))
 }
 
 func (c *AWSClient) ServerlessRepoClient(ctx context.Context) *serverlessapplicationrepository_sdkv2.Client {

--- a/internal/service/serverlessrepo/application_data_source.go
+++ b/internal/service/serverlessrepo/application_data_source.go
@@ -56,7 +56,7 @@ func DataSourceApplication() *schema.Resource {
 
 func dataSourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).ServerlessRepoConn(ctx)
+	conn := meta.(*conns.AWSClient).ServerlessRepoClient(ctx)
 
 	applicationID := d.Get(names.AttrApplicationID).(string)
 	semanticVersion := d.Get("semantic_version").(string)
@@ -75,7 +75,7 @@ func dataSourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("semantic_version", output.Version.SemanticVersion)
 	d.Set("source_code_url", output.Version.SourceCodeUrl)
 	d.Set("template_url", output.Version.TemplateUrl)
-	if err = d.Set("required_capabilities", flex.FlattenStringValueSet(output.Version.RequiredCapabilities)); err != nil {
+	if err = d.Set("required_capabilities", flex.FlattenStringyValueSet(output.Version.RequiredCapabilities)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "to set required_capabilities: %s", err)
 	}
 

--- a/internal/service/serverlessrepo/application_data_source.go
+++ b/internal/service/serverlessrepo/application_data_source.go
@@ -75,7 +75,7 @@ func dataSourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("semantic_version", output.Version.SemanticVersion)
 	d.Set("source_code_url", output.Version.SourceCodeUrl)
 	d.Set("template_url", output.Version.TemplateUrl)
-	if err = d.Set("required_capabilities", flex.FlattenStringSet(output.Version.RequiredCapabilities)); err != nil {
+	if err = d.Set("required_capabilities", flex.FlattenStringValueSet(output.Version.RequiredCapabilities)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "to set required_capabilities: %s", err)
 	}
 

--- a/internal/service/serverlessrepo/cloudformation_stack.go
+++ b/internal/service/serverlessrepo/cloudformation_stack.go
@@ -315,7 +315,6 @@ func createCloudFormationChangeSet(ctx context.Context, d *schema.ResourceData, 
 		changeSetRequest.ParameterOverrides = expandCloudFormationChangeSetParameters(v.(map[string]interface{}))
 	}
 
-	log.Printf("[DEBUG] Creating Serverless Application Repository CloudFormation change set: %s", changeSetRequest)
 	changeSetResponse, err := serverlessConn.CreateCloudFormationChangeSet(ctx, &changeSetRequest)
 	if err != nil {
 		return nil, err
@@ -341,7 +340,7 @@ func flattenStackCapabilities(stackCapabilities []cloudformationtypes.Capability
 	capabilities := flex.FlattenStringyValueSet(stackCapabilities)
 	for _, capability := range applicationRequiredCapabilities {
 		if capability == awstypes.CapabilityCapabilityResourcePolicy {
-			capabilities.Add(awstypes.CapabilityCapabilityResourcePolicy)
+			capabilities.Add(string(awstypes.CapabilityCapabilityResourcePolicy))
 			break
 		}
 	}

--- a/internal/service/serverlessrepo/cloudformation_stack_test.go
+++ b/internal/service/serverlessrepo/cloudformation_stack_test.go
@@ -9,14 +9,13 @@ import (
 	"log"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	cloudformationtypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	serverlessrepo "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -336,7 +335,7 @@ func testAccCloudFormationApplicationID() string {
 
 	return arn.ARN{
 		Partition: acctest.Partition(),
-		Service:   serverlessrepo.ServiceName,
+		Service:   names.ServerlessRepo,
 		Region:    arnRegion,
 		AccountID: arnAccountID,
 		Resource:  "applications/SecretsManagerRDSPostgreSQLRotationSingleUser",
@@ -574,8 +573,8 @@ func testAccCheckAMIDestroy(ctx context.Context) resource.TestCheckFunc {
 
 			if len(resp.Images) > 0 {
 				state := resp.Images[0].State
-				return fmt.Errorf("AMI %s still exists in the state: %s.", aws.StringValue(resp.Images[0].ImageId),
-					aws.StringValue(state))
+				return fmt.Errorf("AMI %s still exists in the state: %s.", aws.ToString(resp.Images[0].ImageId),
+					aws.ToString(state))
 			}
 		}
 		return nil
@@ -602,7 +601,7 @@ func testAccCheckCloudFormationDestroy(ctx context.Context) resource.TestCheckFu
 			}
 
 			for _, s := range resp.Stacks {
-				if aws.StringValue(s.StackId) == rs.Primary.ID && s.StackStatus != cloudformationtypes.StackStatusDeleteComplete {
+				if aws.ToString(s.StackId) == rs.Primary.ID && s.StackStatus != cloudformationtypes.StackStatusDeleteComplete {
 					return fmt.Errorf("CloudFormation stack still exists: %q", rs.Primary.ID)
 				}
 			}
@@ -614,7 +613,7 @@ func testAccCheckCloudFormationDestroy(ctx context.Context) resource.TestCheckFu
 
 func testAccCheckCloudFormationStackNotRecreated(i, j *cloudformationtypes.Stack) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if aws.StringValue(i.StackId) != aws.StringValue(j.StackId) {
+		if aws.ToString(i.StackId) != aws.ToString(j.StackId) {
 			return fmt.Errorf("CloudFormation stack recreated")
 		}
 

--- a/internal/service/serverlessrepo/cloudformation_stack_test.go
+++ b/internal/service/serverlessrepo/cloudformation_stack_test.go
@@ -114,7 +114,7 @@ func TestAccServerlessRepoCloudFormationStack_versioned(t *testing.T) {
 	resourceName := "aws_serverlessapplicationrepository_cloudformation_stack.postgres-rotator"
 
 	const (
-		version1 = "1.1.36"
+		version1 = "1.1.465"
 		version2 = "1.1.88"
 	)
 
@@ -173,7 +173,7 @@ func TestAccServerlessRepoCloudFormationStack_paired(t *testing.T) {
 	appARN := testAccCloudFormationApplicationID()
 	resourceName := "aws_serverlessapplicationrepository_cloudformation_stack.postgres-rotator"
 
-	const version = "1.1.36"
+	const version = "1.1.465"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },

--- a/internal/service/serverlessrepo/find.go
+++ b/internal/service/serverlessrepo/find.go
@@ -5,12 +5,12 @@ package serverlessrepo
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	serverlessrepo "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository"
-	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 )
 
 func findApplication(ctx context.Context, conn *serverlessrepo.Client, applicationID, version string) (*serverlessrepo.GetApplicationOutput, error) {
@@ -21,9 +21,8 @@ func findApplication(ctx context.Context, conn *serverlessrepo.Client, applicati
 		input.SemanticVersion = aws.String(version)
 	}
 
-	log.Printf("[DEBUG] Getting Serverless findApplication Repository Application: %s", input)
 	resp, err := conn.GetApplication(ctx, input)
-	if tfawserr.ErrCodeEquals(err, serverlessrepo.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:    err,
 			LastRequest:  input,

--- a/internal/service/serverlessrepo/find.go
+++ b/internal/service/serverlessrepo/find.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
-func findApplication(ctx context.Context, conn *serverlessrepo.ServerlessApplicationRepository, applicationID, version string) (*serverlessrepo.GetApplicationOutput, error) {
+func findApplication(ctx context.Context, conn *serverlessrepo.Client, applicationID, version string) (*serverlessrepo.GetApplicationOutput, error) {
 	input := &serverlessrepo.GetApplicationInput{
 		ApplicationId: aws.String(applicationID),
 	}

--- a/internal/service/serverlessrepo/find.go
+++ b/internal/service/serverlessrepo/find.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	serverlessrepo "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	serverlessrepo "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
@@ -22,7 +22,7 @@ func findApplication(ctx context.Context, conn *serverlessrepo.ServerlessApplica
 	}
 
 	log.Printf("[DEBUG] Getting Serverless findApplication Repository Application: %s", input)
-	resp, err := conn.GetApplicationWithContext(ctx, input)
+	resp, err := conn.GetApplication(ctx, input)
 	if tfawserr.ErrCodeEquals(err, serverlessrepo.ErrCodeNotFoundException) {
 		return nil, &retry.NotFoundError{
 			LastError:    err,

--- a/internal/service/serverlessrepo/generate.go
+++ b/internal/service/serverlessrepo/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ServiceTagsSlice
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -SkipAWSServiceImp -ServiceTagsSlice
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/serverlessrepo/service_endpoint_resolver_gen.go
+++ b/internal/service/serverlessrepo/service_endpoint_resolver_gen.go
@@ -8,7 +8,10 @@ import (
 	"net"
 	"net/url"
 
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	serverlessapplicationrepository_sdkv2 "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository"
 	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+	smithyendpoints "github.com/aws/smithy-go/endpoints"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 )
@@ -73,4 +76,71 @@ func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoin
 	}
 
 	return defaultResolver.EndpointFor(service, region, opts...)
+}
+
+var _ serverlessapplicationrepository_sdkv2.EndpointResolverV2 = resolverSDKv2{}
+
+type resolverSDKv2 struct {
+	defaultResolver serverlessapplicationrepository_sdkv2.EndpointResolverV2
+}
+
+func newEndpointResolverSDKv2() resolverSDKv2 {
+	return resolverSDKv2{
+		defaultResolver: serverlessapplicationrepository_sdkv2.NewDefaultEndpointResolverV2(),
+	}
+}
+
+func (r resolverSDKv2) ResolveEndpoint(ctx context.Context, params serverlessapplicationrepository_sdkv2.EndpointParameters) (endpoint smithyendpoints.Endpoint, err error) {
+	params = params.WithDefaults()
+	useFIPS := aws_sdkv2.ToBool(params.UseFIPS)
+
+	if eps := params.Endpoint; aws_sdkv2.ToString(eps) != "" {
+		tflog.Debug(ctx, "setting endpoint", map[string]any{
+			"tf_aws.endpoint": endpoint,
+		})
+
+		if useFIPS {
+			tflog.Debug(ctx, "endpoint set, ignoring UseFIPSEndpoint setting")
+			params.UseFIPS = aws_sdkv2.Bool(false)
+		}
+
+		return r.defaultResolver.ResolveEndpoint(ctx, params)
+	} else if useFIPS {
+		ctx = tflog.SetField(ctx, "tf_aws.use_fips", useFIPS)
+
+		endpoint, err = r.defaultResolver.ResolveEndpoint(ctx, params)
+		if err != nil {
+			return endpoint, err
+		}
+
+		tflog.Debug(ctx, "endpoint resolved", map[string]any{
+			"tf_aws.endpoint": endpoint.URI.String(),
+		})
+
+		hostname := endpoint.URI.Hostname()
+		_, err = net.LookupHost(hostname)
+		if err != nil {
+			if dnsErr, ok := errs.As[*net.DNSError](err); ok && dnsErr.IsNotFound {
+				tflog.Debug(ctx, "default endpoint host not found, disabling FIPS", map[string]any{
+					"tf_aws.hostname": hostname,
+				})
+				params.UseFIPS = aws_sdkv2.Bool(false)
+			} else {
+				err = fmt.Errorf("looking up serverlessapplicationrepository endpoint %q: %s", hostname, err)
+				return
+			}
+		} else {
+			return endpoint, err
+		}
+	}
+
+	return r.defaultResolver.ResolveEndpoint(ctx, params)
+}
+
+func withBaseEndpoint(endpoint string) func(*serverlessapplicationrepository_sdkv2.Options) {
+	return func(o *serverlessapplicationrepository_sdkv2.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}
 }

--- a/internal/service/serverlessrepo/service_endpoint_resolver_gen.go
+++ b/internal/service/serverlessrepo/service_endpoint_resolver_gen.go
@@ -6,77 +6,13 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	serverlessapplicationrepository_sdkv2 "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository"
-	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
 	smithyendpoints "github.com/aws/smithy-go/endpoints"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 )
-
-var _ endpoints_sdkv1.Resolver = resolverSDKv1{}
-
-type resolverSDKv1 struct {
-	ctx context.Context
-}
-
-func newEndpointResolverSDKv1(ctx context.Context) resolverSDKv1 {
-	return resolverSDKv1{
-		ctx: ctx,
-	}
-}
-
-func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoints_sdkv1.Options)) (endpoint endpoints_sdkv1.ResolvedEndpoint, err error) {
-	ctx := r.ctx
-
-	var opt endpoints_sdkv1.Options
-	opt.Set(opts...)
-
-	useFIPS := opt.UseFIPSEndpoint == endpoints_sdkv1.FIPSEndpointStateEnabled
-
-	defaultResolver := endpoints_sdkv1.DefaultResolver()
-
-	if useFIPS {
-		ctx = tflog.SetField(ctx, "tf_aws.use_fips", useFIPS)
-
-		endpoint, err = defaultResolver.EndpointFor(service, region, opts...)
-		if err != nil {
-			return endpoint, err
-		}
-
-		tflog.Debug(ctx, "endpoint resolved", map[string]any{
-			"tf_aws.endpoint": endpoint.URL,
-		})
-
-		var endpointURL *url.URL
-		endpointURL, err = url.Parse(endpoint.URL)
-		if err != nil {
-			return endpoint, err
-		}
-
-		hostname := endpointURL.Hostname()
-		_, err = net.LookupHost(hostname)
-		if err != nil {
-			if dnsErr, ok := errs.As[*net.DNSError](err); ok && dnsErr.IsNotFound {
-				tflog.Debug(ctx, "default endpoint host not found, disabling FIPS", map[string]any{
-					"tf_aws.hostname": hostname,
-				})
-				opts = append(opts, func(o *endpoints_sdkv1.Options) {
-					o.UseFIPSEndpoint = endpoints_sdkv1.FIPSEndpointStateDisabled
-				})
-			} else {
-				err = fmt.Errorf("looking up accessanalyzer endpoint %q: %s", hostname, err)
-				return
-			}
-		} else {
-			return endpoint, err
-		}
-	}
-
-	return defaultResolver.EndpointFor(service, region, opts...)
-}
 
 var _ serverlessapplicationrepository_sdkv2.EndpointResolverV2 = resolverSDKv2{}
 

--- a/internal/service/serverlessrepo/service_endpoints_gen_test.go
+++ b/internal/service/serverlessrepo/service_endpoints_gen_test.go
@@ -18,8 +18,6 @@ import (
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	serverlessapplicationrepository_sdkv2 "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository"
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	serverlessapplicationrepository_sdkv1 "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
@@ -349,25 +347,13 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 		},
 	}
 
-	t.Run("v1", func(t *testing.T) {
-		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-			testcase := testcase
+	for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+		testcase := testcase
 
-			t.Run(name, func(t *testing.T) {
-				testEndpointCase(t, providerRegion, testcase, callServiceV1)
-			})
-		}
-	})
-
-	t.Run("v2", func(t *testing.T) {
-		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-			testcase := testcase
-
-			t.Run(name, func(t *testing.T) {
-				testEndpointCase(t, providerRegion, testcase, callServiceV2)
-			})
-		}
-	})
+		t.Run(name, func(t *testing.T) {
+			testEndpointCase(t, providerRegion, testcase, callService)
+		})
+	}
 }
 
 func defaultEndpoint(region string) (url.URL, error) {
@@ -405,7 +391,7 @@ func defaultFIPSEndpoint(region string) (url.URL, error) {
 	return ep.URI, nil
 }
 
-func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCallParams {
+func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCallParams {
 	t.Helper()
 
 	client := meta.ServerlessRepoClient(ctx)
@@ -428,21 +414,6 @@ func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) api
 	}
 
 	return result
-}
-
-func callServiceV1(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCallParams {
-	t.Helper()
-
-	client := meta.ServerlessRepoConn(ctx)
-
-	req, _ := client.ListApplicationsRequest(&serverlessapplicationrepository_sdkv1.ListApplicationsInput{})
-
-	req.HTTPRequest.URL.Path = "/"
-
-	return apiCallParams{
-		endpoint: req.HTTPRequest.URL.String(),
-		region:   aws_sdkv1.StringValue(client.Config.Region),
-	}
 }
 
 func withNoConfig(_ *caseSetup) {

--- a/internal/service/serverlessrepo/service_endpoints_gen_test.go
+++ b/internal/service/serverlessrepo/service_endpoints_gen_test.go
@@ -4,18 +4,24 @@ package serverlessrepo_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	serverlessapplicationrepository_sdkv2 "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository"
 	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	serverlessapplicationrepository_sdkv1 "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
 	"github.com/hashicorp/go-cty/cty"
@@ -343,52 +349,88 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 		},
 	}
 
-	for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
-		testcase := testcase
+	t.Run("v1", func(t *testing.T) {
+		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+			testcase := testcase
 
-		t.Run(name, func(t *testing.T) {
-			testEndpointCase(t, providerRegion, testcase, callService)
-		})
-	}
+			t.Run(name, func(t *testing.T) {
+				testEndpointCase(t, providerRegion, testcase, callServiceV1)
+			})
+		}
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		for name, testcase := range testcases { //nolint:paralleltest // uses t.Setenv
+			testcase := testcase
+
+			t.Run(name, func(t *testing.T) {
+				testEndpointCase(t, providerRegion, testcase, callServiceV2)
+			})
+		}
+	})
 }
 
 func defaultEndpoint(region string) (url.URL, error) {
-	r := endpoints.DefaultResolver()
+	r := serverlessapplicationrepository_sdkv2.NewDefaultEndpointResolverV2()
 
-	ep, err := r.EndpointFor(serverlessapplicationrepository_sdkv1.EndpointsID, region)
-	if err != nil {
-		return url.URL{}, err
-	}
-
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
-	}
-
-	return *url, nil
-}
-
-func defaultFIPSEndpoint(region string) (url.URL, error) {
-	r := endpoints.DefaultResolver()
-
-	ep, err := r.EndpointFor(serverlessapplicationrepository_sdkv1.EndpointsID, region, func(opt *endpoints.Options) {
-		opt.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	ep, err := r.ResolveEndpoint(context.Background(), serverlessapplicationrepository_sdkv2.EndpointParameters{
+		Region: aws_sdkv2.String(region),
 	})
 	if err != nil {
 		return url.URL{}, err
 	}
 
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
 	}
 
-	return *url, nil
+	return ep.URI, nil
 }
 
-func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCallParams {
+func defaultFIPSEndpoint(region string) (url.URL, error) {
+	r := serverlessapplicationrepository_sdkv2.NewDefaultEndpointResolverV2()
+
+	ep, err := r.ResolveEndpoint(context.Background(), serverlessapplicationrepository_sdkv2.EndpointParameters{
+		Region:  aws_sdkv2.String(region),
+		UseFIPS: aws_sdkv2.Bool(true),
+	})
+	if err != nil {
+		return url.URL{}, err
+	}
+
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
+	}
+
+	return ep.URI, nil
+}
+
+func callServiceV2(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCallParams {
+	t.Helper()
+
+	client := meta.ServerlessRepoClient(ctx)
+
+	var result apiCallParams
+
+	_, err := client.ListApplications(ctx, &serverlessapplicationrepository_sdkv2.ListApplicationsInput{},
+		func(opts *serverlessapplicationrepository_sdkv2.Options) {
+			opts.APIOptions = append(opts.APIOptions,
+				addRetrieveEndpointURLMiddleware(t, &result.endpoint),
+				addRetrieveRegionMiddleware(&result.region),
+				addCancelRequestMiddleware(),
+			)
+		},
+	)
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	} else if !errors.Is(err, errCancelOperation) {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	return result
+}
+
+func callServiceV1(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCallParams {
 	t.Helper()
 
 	client := meta.ServerlessRepoConn(ctx)
@@ -621,6 +663,89 @@ func testEndpointCase(t *testing.T, region string, testcase endpointTestCase, ca
 	if e, a := testcase.expected.region, callParams.region; e != a {
 		t.Errorf("expected region %q, got %q", e, a)
 	}
+}
+
+func addRetrieveEndpointURLMiddleware(t *testing.T, endpoint *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			retrieveEndpointURLMiddleware(t, endpoint),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveEndpointURLMiddleware(t *testing.T, endpoint *string) middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Retrieve Endpoint",
+		func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			t.Helper()
+
+			request, ok := in.Request.(*smithyhttp.Request)
+			if !ok {
+				t.Fatalf("Expected *github.com/aws/smithy-go/transport/http.Request, got %s", fullTypeName(in.Request))
+			}
+
+			url := request.URL
+			url.RawQuery = ""
+			url.Path = "/"
+
+			*endpoint = url.String()
+
+			return next.HandleFinalize(ctx, in)
+		})
+}
+
+func addRetrieveRegionMiddleware(region *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Serialize.Add(
+			retrieveRegionMiddleware(region),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
+	return middleware.SerializeMiddlewareFunc(
+		"Test: Retrieve Region",
+		func(ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler) (middleware.SerializeOutput, middleware.Metadata, error) {
+			*region = awsmiddleware.GetRegion(ctx)
+
+			return next.HandleSerialize(ctx, in)
+		},
+	)
+}
+
+var errCancelOperation = fmt.Errorf("Test: Canceling request")
+
+func addCancelRequestMiddleware() func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			cancelRequestMiddleware(),
+			middleware.After,
+		)
+	}
+}
+
+// cancelRequestMiddleware creates a Smithy middleware that intercepts the request before sending and cancels it
+func cancelRequestMiddleware() middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Cancel Requests",
+		func(_ context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, errCancelOperation
+		})
+}
+
+func fullTypeName(i interface{}) string {
+	return fullValueTypeName(reflect.ValueOf(i))
+}
+
+func fullValueTypeName(v reflect.Value) string {
+	if v.Kind() == reflect.Ptr {
+		return "*" + fullValueTypeName(reflect.Indirect(v))
+	}
+
+	requestType := v.Type()
+	return fmt.Sprintf("%s.%s", requestType.PkgPath(), requestType.Name())
 }
 
 func generateSharedConfigFile(config configFile) string {

--- a/internal/service/serverlessrepo/service_package_gen.go
+++ b/internal/service/serverlessrepo/service_package_gen.go
@@ -5,6 +5,8 @@ package serverlessrepo
 import (
 	"context"
 
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	serverlessapplicationrepository_sdkv2 "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository"
 	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
 	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
 	serverlessapplicationrepository_sdkv1 "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
@@ -64,6 +66,16 @@ func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*s
 	}
 
 	return serverlessapplicationrepository_sdkv1.New(sess.Copy(&cfg)), nil
+}
+
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*serverlessapplicationrepository_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
+
+	return serverlessapplicationrepository_sdkv2.NewFromConfig(cfg,
+		serverlessapplicationrepository_sdkv2.WithEndpointResolverV2(newEndpointResolverSDKv2()),
+		withBaseEndpoint(config[names.AttrEndpoint].(string)),
+	), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/serverlessrepo/service_package_gen.go
+++ b/internal/service/serverlessrepo/service_package_gen.go
@@ -7,10 +7,6 @@ import (
 
 	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
 	serverlessapplicationrepository_sdkv2 "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository"
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	serverlessapplicationrepository_sdkv1 "github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -48,24 +44,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 
 func (p *servicePackage) ServicePackageName() string {
 	return names.ServerlessRepo
-}
-
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*serverlessapplicationrepository_sdkv1.ServerlessApplicationRepository, error) {
-	sess := config[names.AttrSession].(*session_sdkv1.Session)
-
-	cfg := aws_sdkv1.Config{}
-
-	if endpoint := config[names.AttrEndpoint].(string); endpoint != "" {
-		tflog.Debug(ctx, "setting endpoint", map[string]any{
-			"tf_aws.endpoint": endpoint,
-		})
-		cfg.Endpoint = aws_sdkv1.String(endpoint)
-	} else {
-		cfg.EndpointResolver = newEndpointResolverSDKv1(ctx)
-	}
-
-	return serverlessapplicationrepository_sdkv1.New(sess.Copy(&cfg)), nil
 }
 
 // NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.

--- a/internal/service/serverlessrepo/tags_gen.go
+++ b/internal/service/serverlessrepo/tags_gen.go
@@ -4,8 +4,8 @@ package serverlessrepo
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/serverlessapplicationrepository"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository/types"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/types/option"
 )
@@ -13,11 +13,11 @@ import (
 // []*SERVICE.Tag handling
 
 // Tags returns serverlessrepo service tags.
-func Tags(tags tftags.KeyValueTags) []*serverlessapplicationrepository.Tag {
-	result := make([]*serverlessapplicationrepository.Tag, 0, len(tags))
+func Tags(tags tftags.KeyValueTags) []awstypes.Tag {
+	result := make([]awstypes.Tag, 0, len(tags))
 
 	for k, v := range tags.Map() {
-		tag := &serverlessapplicationrepository.Tag{
+		tag := awstypes.Tag{
 			Key:   aws.String(k),
 			Value: aws.String(v),
 		}
@@ -29,11 +29,11 @@ func Tags(tags tftags.KeyValueTags) []*serverlessapplicationrepository.Tag {
 }
 
 // KeyValueTags creates tftags.KeyValueTags from serverlessapplicationrepository service tags.
-func KeyValueTags(ctx context.Context, tags []*serverlessapplicationrepository.Tag) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags []awstypes.Tag) tftags.KeyValueTags {
 	m := make(map[string]*string, len(tags))
 
 	for _, tag := range tags {
-		m[aws.StringValue(tag.Key)] = tag.Value
+		m[aws.ToString(tag.Key)] = tag.Value
 	}
 
 	return tftags.New(ctx, m)
@@ -41,7 +41,7 @@ func KeyValueTags(ctx context.Context, tags []*serverlessapplicationrepository.T
 
 // getTagsIn returns serverlessrepo service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) []*serverlessapplicationrepository.Tag {
+func getTagsIn(ctx context.Context) []awstypes.Tag {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -52,7 +52,7 @@ func getTagsIn(ctx context.Context) []*serverlessapplicationrepository.Tag {
 }
 
 // setTagsOut sets serverlessrepo service tags in Context.
-func setTagsOut(ctx context.Context, tags []*serverlessapplicationrepository.Tag) {
+func setTagsOut(ctx context.Context, tags []awstypes.Tag) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = option.Some(KeyValueTags(ctx, tags))
 	}

--- a/names/data/names_data.hcl
+++ b/names/data/names_data.hcl
@@ -8360,7 +8360,7 @@ service "serverlessrepo" {
 
   sdk {
     id             = "ServerlessApplicationRepository"
-    client_version = [1,2]
+    client_version = [2]
   }
 
   names {

--- a/names/data/names_data.hcl
+++ b/names/data/names_data.hcl
@@ -8360,7 +8360,7 @@ service "serverlessrepo" {
 
   sdk {
     id             = "ServerlessApplicationRepository"
-    client_version = [1]
+    client_version = [1,2]
   }
 
   names {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #36210
Relates #38363

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccServerlessRepo" PKG=serverlessrepo

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/serverlessrepo/... -v -count 1 -parallel 20  -run=TestAccServerlessRepo -timeout 360m
--- PASS: TestAccServerlessRepoApplicationDataSource_basic (14.25s)
--- PASS: TestAccServerlessRepoApplicationDataSource_versioned (20.22s)
--- PASS: TestAccServerlessRepoCloudFormationStack_paired (88.61s)
--- PASS: TestAccServerlessRepoCloudFormationStack_basic (95.04s)
--- PASS: TestAccServerlessRepoCloudFormationStack_disappears (101.57s)
--- PASS: TestAccServerlessRepoCloudFormationStack_update (160.21s)
--- PASS: TestAccServerlessRepoCloudFormationStack_tags (179.63s)
--- PASS: TestAccServerlessRepoCloudFormationStack_versioned (221.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/serverlessrepo	227.849s
```
