### PR TITLE
docs: [aws_rds_cluster] Change the sample string for the Master Password

### DIFF
--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -37,7 +37,7 @@ resource "aws_rds_cluster" "default" {
   availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
   database_name           = "mydb"
   master_username         = "foo"
-  master_password         = "bar"
+  master_password         = "must_be_eight_characters"
   backup_retention_period = 5
   preferred_backup_window = "07:00-09:00"
 }
@@ -51,7 +51,7 @@ resource "aws_rds_cluster" "default" {
   availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
   database_name           = "mydb"
   master_username         = "foo"
-  master_password         = "bar"
+  master_password         = "must_be_eight_characters"
   backup_retention_period = 5
   preferred_backup_window = "07:00-09:00"
 }
@@ -66,7 +66,7 @@ resource "aws_rds_cluster" "postgresql" {
   availability_zones      = ["us-west-2a", "us-west-2b", "us-west-2c"]
   database_name           = "mydb"
   master_username         = "foo"
-  master_password         = "bar"
+  master_password         = "must_be_eight_characters"
   backup_retention_period = 5
   preferred_backup_window = "07:00-09:00"
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This Pull Request is to edit the following document:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster.html

In the current document example, the master password is set to "bar".

<img width="957" alt="スクリーンショット 2024-07-18 15 08 31" src="https://github.com/user-attachments/assets/acf70407-0d85-4088-a6fe-2b217bcfe7bb">

However, according to AWS specifications, the master password must be at least 8 characters long, which causes an error during terraform apply.

> Must contain from 8 to 41 characters.
https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBCluster.html

Error during terraform apply

```
aws_rds_cluster.postgresql: Creating...
╷
│ Error: creating RDS Cluster (aurora-cluster-demo): InvalidParameterValue: The parameter MasterUserPassword is not a valid password because it is shorter than 8 characters.
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

There are no changes to the source code.
