### PR TITLE
resource/aws_dynamodb_table_replica: Autoscaled source table

### DIFF
--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -417,6 +417,7 @@ func resourceTable() *schema.Resource {
 			"stream_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"stream_label": {
 				Type:     schema.TypeString,

--- a/internal/service/dynamodb/table_replica_test.go
+++ b/internal/service/dynamodb/table_replica_test.go
@@ -128,7 +128,7 @@ func TestAccDynamoDBTableReplica_pitrKMS(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableReplicaExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "point_in_time_recovery", acctest.CtFalse),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrKMSKeyARN, "aws_kms_key.alternate", names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrKMSKeyARN, "aws_kms_key.test", names.AttrARN),
 				),
 			},
 			{
@@ -136,7 +136,7 @@ func TestAccDynamoDBTableReplica_pitrKMS(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableReplicaExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "point_in_time_recovery", acctest.CtTrue),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrKMSKeyARN, "aws_kms_key.alternate", names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrKMSKeyARN, "aws_kms_key.test", names.AttrARN),
 				),
 			},
 			{
@@ -144,7 +144,7 @@ func TestAccDynamoDBTableReplica_pitrKMS(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTableReplicaExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "point_in_time_recovery", acctest.CtFalse),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrKMSKeyARN, "aws_kms_key.alternate", names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrKMSKeyARN, "aws_kms_key.test", names.AttrARN),
 				),
 			},
 			{
@@ -409,7 +409,7 @@ func testAccTableReplicaConfig_basic(rName string) string {
 		acctest.ConfigMultipleRegionProvider(3),
 		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
-  global_table_arn = aws_dynamodb_table.test.arn
+  global_table_arn = aws_dynamodb_table.source.arn
 
   tags = {
     Name = %[1]q
@@ -417,7 +417,7 @@ resource "aws_dynamodb_table_replica" "test" {
   }
 }
 
-resource "aws_dynamodb_table" "test" {
+resource "aws_dynamodb_table" "source" {
   provider         = "awsalternate"
   name             = %[1]q
   hash_key         = "TestTableHashKey"
@@ -443,11 +443,11 @@ func testAccTableReplicaConfig_pitr(rName string) string {
 		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
   provider               = "awsalternate"
-  global_table_arn       = aws_dynamodb_table.test.arn
+  global_table_arn       = aws_dynamodb_table.source.arn
   point_in_time_recovery = true
 }
 
-resource "aws_dynamodb_table" "test" {
+resource "aws_dynamodb_table" "source" {
   name             = %[1]q
   hash_key         = "TestTableHashKey"
   billing_mode     = "PAY_PER_REQUEST"
@@ -472,18 +472,18 @@ func testAccTableReplicaConfig_pitrKMS(rName string, pitr bool) string {
 		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
   provider               = awsalternate
-  global_table_arn       = aws_dynamodb_table.test.arn
+  global_table_arn       = aws_dynamodb_table.source.arn
   point_in_time_recovery = %[2]t
-  kms_key_arn            = aws_kms_key.alternate.arn
+  kms_key_arn            = aws_kms_key.test.arn
 }
 
-resource "aws_kms_key" "alternate" {
+resource "aws_kms_key" "test" {
   provider                = awsalternate
   description             = %[1]q
   deletion_window_in_days = 7
 }
 
-resource "aws_dynamodb_table" "test" {
+resource "aws_dynamodb_table" "source" {
   name             = %[1]q
   hash_key         = "TestTableHashKey"
   billing_mode     = "PAY_PER_REQUEST"
@@ -497,7 +497,7 @@ resource "aws_dynamodb_table" "test" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = aws_kms_key.test.arn
+    kms_key_arn = aws_kms_key.source.arn
   }
 
   lifecycle {
@@ -505,7 +505,7 @@ resource "aws_dynamodb_table" "test" {
   }
 }
 
-resource "aws_kms_key" "test" {
+resource "aws_kms_key" "source" {
   description             = %[1]q
   deletion_window_in_days = 7
 }
@@ -518,11 +518,11 @@ func testAccTableReplicaConfig_pitrDefault(rName string, pitr bool) string {
 		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
   provider               = awsalternate
-  global_table_arn       = aws_dynamodb_table.test.arn
+  global_table_arn       = aws_dynamodb_table.source.arn
   point_in_time_recovery = %[2]t
 }
 
-resource "aws_dynamodb_table" "test" {
+resource "aws_dynamodb_table" "source" {
   name             = %[1]q
   hash_key         = "TestTableHashKey"
   billing_mode     = "PAY_PER_REQUEST"
@@ -551,7 +551,7 @@ func testAccTableReplicaConfig_tags1(rName string) string {
 		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
   provider         = "awsalternate"
-  global_table_arn = aws_dynamodb_table.test.arn
+  global_table_arn = aws_dynamodb_table.source.arn
 
   tags = {
     Name = %[1]q
@@ -559,7 +559,7 @@ resource "aws_dynamodb_table_replica" "test" {
   }
 }
 
-resource "aws_dynamodb_table" "test" {
+resource "aws_dynamodb_table" "source" {
   name             = %[1]q
   hash_key         = "TestTableHashKey"
   billing_mode     = "PAY_PER_REQUEST"
@@ -589,7 +589,7 @@ func testAccTableReplicaConfig_tags2(rName string) string {
 		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
   provider         = "awsalternate"
-  global_table_arn = aws_dynamodb_table.test.arn
+  global_table_arn = aws_dynamodb_table.source.arn
 
   tags = {
     Name      = %[1]q
@@ -600,7 +600,7 @@ resource "aws_dynamodb_table_replica" "test" {
   }
 }
 
-resource "aws_dynamodb_table" "test" {
+resource "aws_dynamodb_table" "source" {
   name             = %[1]q
   hash_key         = "TestTableHashKey"
   billing_mode     = "PAY_PER_REQUEST"
@@ -629,14 +629,14 @@ func testAccTableReplicaConfig_tags3(rName string) string {
 		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
   provider         = "awsalternate"
-  global_table_arn = aws_dynamodb_table.test.arn
+  global_table_arn = aws_dynamodb_table.source.arn
 
   tags = {
     Name = %[1]q
   }
 }
 
-resource "aws_dynamodb_table" "test" {
+resource "aws_dynamodb_table" "source" {
   name             = %[1]q
   hash_key         = "TestTableHashKey"
   billing_mode     = "PAY_PER_REQUEST"
@@ -664,7 +664,7 @@ func testAccTableReplicaConfig_tableClass(rName, class string) string {
 		acctest.ConfigMultipleRegionProvider(3),
 		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
-  global_table_arn     = aws_dynamodb_table.test.arn
+  global_table_arn     = aws_dynamodb_table.source.arn
   table_class_override = %[2]q
 
   tags = {
@@ -672,7 +672,7 @@ resource "aws_dynamodb_table_replica" "test" {
   }
 }
 
-resource "aws_dynamodb_table" "test" {
+resource "aws_dynamodb_table" "source" {
   provider         = "awsalternate"
   name             = %[1]q
   hash_key         = "ArticLake"
@@ -701,16 +701,9 @@ func testAccTableReplicaConfig_keys(rName, key string) string {
 		acctest.ConfigMultipleRegionProvider(2),
 		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
-  global_table_arn       = aws_dynamodb_table.test.arn
+  global_table_arn       = aws_dynamodb_table.source.arn
   kms_key_arn            = aws_kms_key.%[2]s.arn
   point_in_time_recovery = true
-}
-
-resource "aws_kms_key" "alternate" {
-  provider                = awsalternate
-  description             = "Julie test KMS key A"
-  multi_region            = false
-  deletion_window_in_days = 7
 }
 
 resource "aws_kms_key" "test1" {
@@ -725,7 +718,7 @@ resource "aws_kms_key" "test2" {
   deletion_window_in_days = 7
 }
 
-resource "aws_dynamodb_table" "test" {
+resource "aws_dynamodb_table" "source" {
   provider         = awsalternate
   name             = %[1]q
   hash_key         = "ParticipantId"
@@ -741,7 +734,7 @@ resource "aws_dynamodb_table" "test" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = aws_kms_key.alternate.arn
+    kms_key_arn = aws_kms_key.source.arn
   }
 
   attribute {
@@ -757,6 +750,13 @@ resource "aws_dynamodb_table" "test" {
   lifecycle {
     ignore_changes = [replica]
   }
+}
+
+resource "aws_kms_key" "source" {
+  provider                = awsalternate
+  description             = "Julie test KMS key A"
+  multi_region            = false
+  deletion_window_in_days = 7
 }
 `, rName, key))
 }

--- a/internal/service/dynamodb/table_replica_test.go
+++ b/internal/service/dynamodb/table_replica_test.go
@@ -1009,11 +1009,6 @@ func testAccTableReplicaConfig_billingModeProvisionedSource(rName string) string
 		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
   global_table_arn = aws_dynamodb_table.source.arn
-
-  tags = {
-    Name = %[1]q
-    Pozo = "Amargo"
-  }
 }
 
 resource "aws_dynamodb_table" "source" {

--- a/internal/service/dynamodb/table_replica_test.go
+++ b/internal/service/dynamodb/table_replica_test.go
@@ -408,6 +408,15 @@ func testAccTableReplicaConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(3),
 		fmt.Sprintf(`
+resource "aws_dynamodb_table_replica" "test" {
+  global_table_arn = aws_dynamodb_table.test.arn
+
+  tags = {
+    Name = %[1]q
+    Pozo = "Amargo"
+  }
+}
+
 resource "aws_dynamodb_table" "test" {
   provider         = "awsalternate"
   name             = %[1]q
@@ -425,15 +434,6 @@ resource "aws_dynamodb_table" "test" {
     ignore_changes = [replica]
   }
 }
-
-resource "aws_dynamodb_table_replica" "test" {
-  global_table_arn = aws_dynamodb_table.test.arn
-
-  tags = {
-    Name = %[1]q
-    Pozo = "Amargo"
-  }
-}
 `, rName))
 }
 
@@ -441,6 +441,12 @@ func testAccTableReplicaConfig_pitr(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(3),
 		fmt.Sprintf(`
+resource "aws_dynamodb_table_replica" "test" {
+  provider               = "awsalternate"
+  global_table_arn       = aws_dynamodb_table.test.arn
+  point_in_time_recovery = true
+}
+
 resource "aws_dynamodb_table" "test" {
   name             = %[1]q
   hash_key         = "TestTableHashKey"
@@ -457,12 +463,6 @@ resource "aws_dynamodb_table" "test" {
     ignore_changes = [replica]
   }
 }
-
-resource "aws_dynamodb_table_replica" "test" {
-  provider               = "awsalternate"
-  global_table_arn       = aws_dynamodb_table.test.arn
-  point_in_time_recovery = true
-}
 `, rName))
 }
 
@@ -470,7 +470,15 @@ func testAccTableReplicaConfig_pitrKMS(rName string, pitr bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(3),
 		fmt.Sprintf(`
-resource "aws_kms_key" "test" {
+resource "aws_dynamodb_table_replica" "test" {
+  provider               = awsalternate
+  global_table_arn       = aws_dynamodb_table.test.arn
+  point_in_time_recovery = %[2]t
+  kms_key_arn            = aws_kms_key.alternate.arn
+}
+
+resource "aws_kms_key" "alternate" {
+  provider                = awsalternate
   description             = %[1]q
   deletion_window_in_days = 7
 }
@@ -497,17 +505,9 @@ resource "aws_dynamodb_table" "test" {
   }
 }
 
-resource "aws_kms_key" "alternate" {
-  provider                = awsalternate
+resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
-}
-
-resource "aws_dynamodb_table_replica" "test" {
-  provider               = awsalternate
-  global_table_arn       = aws_dynamodb_table.test.arn
-  point_in_time_recovery = %[2]t
-  kms_key_arn            = aws_kms_key.alternate.arn
 }
 `, rName, pitr))
 }
@@ -516,6 +516,12 @@ func testAccTableReplicaConfig_pitrDefault(rName string, pitr bool) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(3),
 		fmt.Sprintf(`
+resource "aws_dynamodb_table_replica" "test" {
+  provider               = awsalternate
+  global_table_arn       = aws_dynamodb_table.test.arn
+  point_in_time_recovery = %[2]t
+}
+
 resource "aws_dynamodb_table" "test" {
   name             = %[1]q
   hash_key         = "TestTableHashKey"
@@ -536,12 +542,6 @@ resource "aws_dynamodb_table" "test" {
     ignore_changes = [replica]
   }
 }
-
-resource "aws_dynamodb_table_replica" "test" {
-  provider               = awsalternate
-  global_table_arn       = aws_dynamodb_table.test.arn
-  point_in_time_recovery = %[2]t
-}
 `, rName, pitr))
 }
 
@@ -549,27 +549,6 @@ func testAccTableReplicaConfig_tags1(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(3),
 		fmt.Sprintf(`
-resource "aws_dynamodb_table" "test" {
-  name             = %[1]q
-  hash_key         = "TestTableHashKey"
-  billing_mode     = "PAY_PER_REQUEST"
-  stream_enabled   = true
-  stream_view_type = "NEW_AND_OLD_IMAGES"
-
-  attribute {
-    name = "TestTableHashKey"
-    type = "S"
-  }
-
-  tags = {
-    Name = %[1]q
-  }
-
-  lifecycle {
-    ignore_changes = [replica]
-  }
-}
-
 resource "aws_dynamodb_table_replica" "test" {
   provider         = "awsalternate"
   global_table_arn = aws_dynamodb_table.test.arn
@@ -579,13 +558,7 @@ resource "aws_dynamodb_table_replica" "test" {
     tape = "Valladolid"
   }
 }
-`, rName))
-}
 
-func testAccTableReplicaConfig_tags2(rName string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigMultipleRegionProvider(3),
-		fmt.Sprintf(`
 resource "aws_dynamodb_table" "test" {
   name             = %[1]q
   hash_key         = "TestTableHashKey"
@@ -607,6 +580,13 @@ resource "aws_dynamodb_table" "test" {
   }
 }
 
+`, rName))
+}
+
+func testAccTableReplicaConfig_tags2(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
   provider         = "awsalternate"
   global_table_arn = aws_dynamodb_table.test.arn
@@ -619,13 +599,7 @@ resource "aws_dynamodb_table_replica" "test" {
     shooting  = "Stars"
   }
 }
-`, rName))
-}
 
-func testAccTableReplicaConfig_tags3(rName string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigMultipleRegionProvider(3),
-		fmt.Sprintf(`
 resource "aws_dynamodb_table" "test" {
   name             = %[1]q
   hash_key         = "TestTableHashKey"
@@ -646,13 +620,40 @@ resource "aws_dynamodb_table" "test" {
     ignore_changes = [replica]
   }
 }
+`, rName))
+}
 
+func testAccTableReplicaConfig_tags3(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3),
+		fmt.Sprintf(`
 resource "aws_dynamodb_table_replica" "test" {
   provider         = "awsalternate"
   global_table_arn = aws_dynamodb_table.test.arn
 
   tags = {
     Name = %[1]q
+  }
+}
+
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+
+  lifecycle {
+    ignore_changes = [replica]
   }
 }
 `, rName))
@@ -662,6 +663,15 @@ func testAccTableReplicaConfig_tableClass(rName, class string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(3),
 		fmt.Sprintf(`
+resource "aws_dynamodb_table_replica" "test" {
+  global_table_arn     = aws_dynamodb_table.test.arn
+  table_class_override = %[2]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
 resource "aws_dynamodb_table" "test" {
   provider         = "awsalternate"
   name             = %[1]q
@@ -683,15 +693,6 @@ resource "aws_dynamodb_table" "test" {
     ignore_changes = [replica]
   }
 }
-
-resource "aws_dynamodb_table_replica" "test" {
-  global_table_arn     = aws_dynamodb_table.test.arn
-  table_class_override = %[2]q
-
-  tags = {
-    Name = %[1]q
-  }
-}
 `, rName, class))
 }
 
@@ -699,6 +700,12 @@ func testAccTableReplicaConfig_keys(rName, key string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(2),
 		fmt.Sprintf(`
+resource "aws_dynamodb_table_replica" "test" {
+  global_table_arn       = aws_dynamodb_table.test.arn
+  kms_key_arn            = aws_kms_key.%[2]s.arn
+  point_in_time_recovery = true
+}
+
 resource "aws_kms_key" "alternate" {
   provider                = awsalternate
   description             = "Julie test KMS key A"
@@ -750,12 +757,6 @@ resource "aws_dynamodb_table" "test" {
   lifecycle {
     ignore_changes = [replica]
   }
-}
-
-resource "aws_dynamodb_table_replica" "test" {
-  global_table_arn       = aws_dynamodb_table.test.arn
-  kms_key_arn            = aws_kms_key.%[2]s.arn
-  point_in_time_recovery = true
 }
 `, rName, key))
 }

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1678,6 +1678,49 @@ func TestAccDynamoDBTable_encryption(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBTable_Replica_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var conf awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 3)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 3), // 3 due to shared test configuration
+		CheckDestroy:             testAccCheckTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_replica_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, resourceName, &conf),
+					acctest.CheckResourceAttrRegionalARN(resourceName, names.AttrARN, "dynamodb", fmt.Sprintf("table/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "billing_mode", "PAY_PER_REQUEST"),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", acctest.Ct1),
+					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "replica.*", map[string]*regexp.Regexp{
+						names.AttrARN: regexache.MustCompile(fmt.Sprintf(`:dynamodb:%s:`, acctest.AlternateRegion())),
+					}),
+					resource.TestCheckResourceAttr(resourceName, "stream_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "stream_view_type", "NEW_AND_OLD_IMAGES"),
+				),
+			},
+			{
+				Config:            testAccTableConfig_replica_basic(rName),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccDynamoDBTable_Replica_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -3739,6 +3782,31 @@ resource "aws_dynamodb_table" "test" {
   }
 }
 `, rName, attr1, attr2)
+}
+
+func testAccTableConfig_replica_basic(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(3), // Prevent "Provider configuration not present" errors
+		fmt.Sprintf(`
+data "aws_region" "alternate" {
+  provider = "awsalternate"
+}
+
+resource "aws_dynamodb_table" "test" {
+  name             = %[1]q
+  hash_key         = "TestTableHashKey"
+ billing_mode     = "PAY_PER_REQUEST"
+ 
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name = data.aws_region.alternate.name
+  }
+}
+`, rName))
 }
 
 func testAccTableConfig_replica0(rName string) string {

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -3793,10 +3793,10 @@ data "aws_region" "alternate" {
 }
 
 resource "aws_dynamodb_table" "test" {
-  name             = %[1]q
-  hash_key         = "TestTableHashKey"
- billing_mode     = "PAY_PER_REQUEST"
- 
+  name         = %[1]q
+  hash_key     = "TestTableHashKey"
+  billing_mode = "PAY_PER_REQUEST"
+
   attribute {
     name = "TestTableHashKey"
     type = "S"


### PR DESCRIPTION
### Description

When the source table for a DynamoDB table replica is configured with auto scaled read and write capacities, there can be a race condition with creating the replica unless the replica depends on the auto scaling policies.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dynamodb TESTS=TestAccDynamoDBTableReplica_

--- PASS: TestAccDynamoDBTableReplica_autoscaleSourceWithoutDependsOn (32.34s)
--- PASS: TestAccDynamoDBTableReplica_billingModeProvisionedSource (36.07s)
--- PASS: TestAccDynamoDBTableReplica_pitr (177.88s)
--- PASS: TestAccDynamoDBTableReplica_autoscaleSource (183.20s)
--- PASS: TestAccDynamoDBTableReplica_basic (197.26s)
--- PASS: TestAccDynamoDBTableReplica_disappears (205.88s)
--- PASS: TestAccDynamoDBTableReplica_pitrDefault (317.39s)
--- PASS: TestAccDynamoDBTableReplica_pitrKMS (317.84s)
--- PASS: TestAccDynamoDBTableReplica_keys (320.24s)
--- PASS: TestAccDynamoDBTableReplica_tags (327.02s)
--- PASS: TestAccDynamoDBTableReplica_tableClass (442.41s)
```
