### PR TITLE
Added `AMPLIFY_MANAGED` as the default value for `aws_amplify_domain_association.certificate_settings.type`

### DIFF
--- a/.changelog/38410.txt
+++ b/.changelog/38410.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_amplify_domain_association: Added `AMPLIFY_MANAGED` as the default value for `certificate_settings.type`
+```

--- a/internal/service/amplify/domain_association.go
+++ b/internal/service/amplify/domain_association.go
@@ -62,6 +62,7 @@ func resourceDomainAssociation() *schema.Resource {
 						names.AttrType: {
 							Type:             schema.TypeString,
 							Required:         true,
+							Default:          "AMPLIFY_MANAGED",
 							ValidateDiagFunc: enum.Validate[types.CertificateType](),
 						},
 						"custom_certificate_arn": {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Added `AMPLIFY_MANAGED` as the default value for the type attribute. Without the default value, the resource will be replaced on the next plan/apply. 

The issue occurs when users update the provider version to 5.57 or above, without making any changes to the resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38387

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://docs.aws.amazon.com/amplify/latest/APIReference/API_CertificateSettings.html 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
