### PR TITLE
38242 - The example does not correspond recomendation from AWS. Use ~All instead of -All

### DIFF
--- a/website/docs/r/ses_domain_mail_from.html.markdown
+++ b/website/docs/r/ses_domain_mail_from.html.markdown
@@ -42,7 +42,7 @@ resource "aws_route53_record" "example_ses_domain_mail_from_txt" {
   name    = aws_ses_domain_mail_from.example.mail_from_domain
   type    = "TXT"
   ttl     = "600"
-  records = ["v=spf1 include:amazonses.com -all"]
+  records = ["v=spf1 include:amazonses.com ~all"]
 }
 ```
 


### PR DESCRIPTION

Closes #38242

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_domain_mail_from#domain-identity-mail-from

Changed ~All instead of -All

