### PR TITLE
chime: add voice connector sweeper

### DIFF
--- a/internal/service/chime/sweep.go
+++ b/internal/service/chime/sweep.go
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package chime
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/chimesdkvoice"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/sdk"
+)
+
+func RegisterSweepers() {
+	resource.AddTestSweepers("aws_chime_voice_connector", &resource.Sweeper{
+		Name: "aws_chime_voice_connector",
+		F:    sweepVoiceConnectors,
+	})
+}
+
+func sweepVoiceConnectors(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(ctx, region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+
+	conn := client.ChimeSDKVoiceClient(ctx)
+	sweepResources := make([]sweep.Sweepable, 0)
+	in := &chimesdkvoice.ListVoiceConnectorsInput{}
+
+	pages := chimesdkvoice.NewListVoiceConnectorsPaginator(conn, in)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Chime Voice Connector sweep for %s: %s", region, err)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error retrieving Chime Voice Connectors: %w", err)
+		}
+
+		for _, vc := range page.VoiceConnectors {
+			id := aws.ToString(vc.VoiceConnectorId)
+
+			r := ResourceVoiceConnector()
+			d := r.Data(nil)
+			d.SetId(id)
+
+			log.Printf("[INFO] Deleting Chime Voice Connector: %s", id)
+			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
+		}
+	}
+
+	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
+		return fmt.Errorf("error sweeping Chime Voice Connectors for %s: %w", region, err)
+	}
+
+	return nil
+}

--- a/internal/sweep/register_gen_test.go
+++ b/internal/sweep/register_gen_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/service/batch"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/bcmdataexports"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/budgets"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/chime"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/cloud9"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront"
@@ -183,6 +184,7 @@ func registerSweepers() {
 	batch.RegisterSweepers()
 	bcmdataexports.RegisterSweepers()
 	budgets.RegisterSweepers()
+	chime.RegisterSweepers()
 	cloud9.RegisterSweepers()
 	cloudformation.RegisterSweepers()
 	cloudfront.RegisterSweepers()


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds a sweeper for the `aws_chime_voice_connector` resource. AWS has a regional limit of 3 voice connectors, so this sweeper will prevent scheduled acceptance tests from continuously hitting this limit in cases where voice connectors are inadvertently left behind.

```
=== RUN   TestAccChime_serial/VoiceConnector/basic
    voice_connector_test.go:30: Step 1/2 error: Error running apply: exit status 1
        Error: creating Chime Voice connector: operation error Chime SDK Voice: CreateVoiceConnector, https response error StatusCode: 400, RequestID: 84e3d0e6-dc62-4e29-b9cf-e2f76ab770dd, BadRequestException: checkCreateVoiceConnectorRegionalLimit:: aws account 187416307283 reached its regional voice connector limit 3
          with aws_chime_voice_connector.test,
          on terraform_plugin_test.tf line 12, in resource "aws_chime_voice_connector" "test":
          12: resource "aws_chime_voice_connector" "test" {
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sweep SWEEPARGS=-sweep-run=aws_chime_voice_connector
WARNING: This will destroy infrastructure. Use only in development accounts.                                                                                                         go1.22.5 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run=aws_chime_voice_connector -timeout 360m
2024/07/18 15:46:19 [DEBUG] Running Sweepers for region (us-west-2):
<snip>

2024/07/18 15:46:21 Completed Sweepers for region (us-west-1) in 398.482166ms
2024/07/18 15:46:21 Sweeper Tests for region (us-west-1) ran successfully:
2024/07/18 15:46:21     - aws_chime_voice_connector
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      7.861s
```

