### PR TITLE
r/aws_rds_cluster: Wait for no pending modified values on Update if `apply_immediately` is `true`

### DIFF
--- a/.changelog/38437.txt
+++ b/.changelog/38437.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_rds_cluster: Mark `ca_certificate_identifier` as Computed
+```
+
+```release-note:bug
+resource/aws_rds_cluster: Wait for no pending modified values on Update if `apply_immediately` is `true`. This fixes `InvalidParameterCombination` errors when updating `engine_version`
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -117,6 +117,7 @@ func resourceCluster() *schema.Resource {
 			"ca_certificate_identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"ca_certificate_valid_till": {
 				Type:     schema.TypeString,

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -27,6 +27,7 @@ import (
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -40,7 +41,7 @@ const (
 // @SDKResource("aws_rds_cluster", name="Cluster")
 // @Tags(identifierAttribute="arn")
 // @Testing(tagsTest=false)
-func ResourceCluster() *schema.Resource {
+func resourceCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterCreate,
 		ReadWithoutTimeout:   resourceClusterRead,
@@ -1174,7 +1175,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			return sdkdiag.AppendErrorf(diags, "updating RDS Cluster (%s): %s", d.Id(), err)
 		}
 
-		if _, err := waitDBClusterUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		if _, err := waitDBClusterUpdated(ctx, conn, d.Id(), true, d.Timeout(schema.TimeoutCreate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for RDS Cluster (%s) update: %s", d.Id(), err)
 		}
 	}
@@ -1333,8 +1334,9 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		"replication_source_identifier",
 		"skip_final_snapshot",
 		names.AttrTags, names.AttrTagsAll) {
+		applyImmediately := d.Get(names.AttrApplyImmediately).(bool)
 		input := &rds.ModifyDBClusterInput{
-			ApplyImmediately:    aws.Bool(d.Get(names.AttrApplyImmediately).(bool)),
+			ApplyImmediately:    aws.Bool(applyImmediately),
 			DBClusterIdentifier: aws.String(d.Id()),
 		}
 
@@ -1509,7 +1511,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			return sdkdiag.AppendErrorf(diags, "updating RDS Cluster (%s): %s", d.Id(), err)
 		}
 
-		if _, err := waitDBClusterUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if _, err := waitDBClusterUpdated(ctx, conn, d.Id(), applyImmediately, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for RDS Cluster (%s) update: %s", d.Id(), err)
 		}
 	}
@@ -1636,7 +1638,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 						return false, fmt.Errorf("modifying RDS Cluster (%s) DeletionProtection=false: %s", d.Id(), err)
 					}
 
-					if _, err := waitDBClusterUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+					if _, err := waitDBClusterUpdated(ctx, conn, d.Id(), false, d.Timeout(schema.TimeoutDelete)); err != nil {
 						return false, fmt.Errorf("waiting for RDS Cluster (%s) update: %s", d.Id(), err)
 					}
 				}
@@ -1785,7 +1787,7 @@ func findDBClusters(ctx context.Context, conn *rds.RDS, input *rds.DescribeDBClu
 	return output, nil
 }
 
-func statusDBCluster(ctx context.Context, conn *rds.RDS, id string) retry.StateRefreshFunc {
+func statusDBCluster(ctx context.Context, conn *rds.RDS, id string, waitNoPendingModifiedValues bool) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := FindDBClusterByID(ctx, conn, id)
 
@@ -1797,23 +1799,29 @@ func statusDBCluster(ctx context.Context, conn *rds.RDS, id string) retry.StateR
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status), nil
+		status := aws.StringValue(output.Status)
+
+		if status == clusterStatusAvailable && waitNoPendingModifiedValues && !itypes.IsZero(output.PendingModifiedValues) {
+			status = clusterStatusAvailableWithPendingModifiedValues
+		}
+
+		return output, status, nil
 	}
 }
 
 func waitDBClusterCreated(ctx context.Context, conn *rds.RDS, id string, timeout time.Duration) (*rds.DBCluster, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{
-			ClusterStatusBackingUp,
-			ClusterStatusCreating,
-			ClusterStatusMigrating,
-			ClusterStatusModifying,
-			ClusterStatusPreparingDataMigration,
-			ClusterStatusRebooting,
-			ClusterStatusResettingMasterCredentials,
+			clusterStatusBackingUp,
+			clusterStatusCreating,
+			clusterStatusMigrating,
+			clusterStatusModifying,
+			clusterStatusPreparingDataMigration,
+			clusterStatusRebooting,
+			clusterStatusResettingMasterCredentials,
 		},
-		Target:     []string{ClusterStatusAvailable},
-		Refresh:    statusDBCluster(ctx, conn, id),
+		Target:     []string{clusterStatusAvailable},
+		Refresh:    statusDBCluster(ctx, conn, id, false),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -1828,19 +1836,24 @@ func waitDBClusterCreated(ctx context.Context, conn *rds.RDS, id string, timeout
 	return nil, err
 }
 
-func waitDBClusterUpdated(ctx context.Context, conn *rds.RDS, id string, timeout time.Duration) (*rds.DBCluster, error) { //nolint:unparam
+func waitDBClusterUpdated(ctx context.Context, conn *rds.RDS, id string, waitNoPendingModifiedValues bool, timeout time.Duration) (*rds.DBCluster, error) { //nolint:unparam
+	pendingStatuses := []string{
+		clusterStatusBackingUp,
+		clusterStatusConfiguringIAMDatabaseAuth,
+		clusterStatusModifying,
+		clusterStatusRenaming,
+		clusterStatusResettingMasterCredentials,
+		clusterStatusScalingCompute,
+		clusterStatusUpgrading,
+	}
+	if waitNoPendingModifiedValues {
+		pendingStatuses = append(pendingStatuses, clusterStatusAvailableWithPendingModifiedValues)
+	}
+
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{
-			ClusterStatusBackingUp,
-			ClusterStatusConfiguringIAMDatabaseAuth,
-			ClusterStatusModifying,
-			ClusterStatusRenaming,
-			ClusterStatusResettingMasterCredentials,
-			ClusterStatusScalingCompute,
-			ClusterStatusUpgrading,
-		},
-		Target:     []string{ClusterStatusAvailable},
-		Refresh:    statusDBCluster(ctx, conn, id),
+		Pending:    pendingStatuses,
+		Target:     []string{clusterStatusAvailable},
+		Refresh:    statusDBCluster(ctx, conn, id, waitNoPendingModifiedValues),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -1858,15 +1871,15 @@ func waitDBClusterUpdated(ctx context.Context, conn *rds.RDS, id string, timeout
 func waitDBClusterDeleted(ctx context.Context, conn *rds.RDS, id string, timeout time.Duration) (*rds.DBCluster, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{
-			ClusterStatusAvailable,
-			ClusterStatusBackingUp,
-			ClusterStatusDeleting,
-			ClusterStatusModifying,
-			ClusterStatusPromoting,
-			ClusterStatusScalingCompute,
+			clusterStatusAvailable,
+			clusterStatusBackingUp,
+			clusterStatusDeleting,
+			clusterStatusModifying,
+			clusterStatusPromoting,
+			clusterStatusScalingCompute,
 		},
 		Target:     []string{},
-		Refresh:    statusDBCluster(ctx, conn, id),
+		Refresh:    statusDBCluster(ctx, conn, id, false),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,

--- a/internal/service/rds/cluster_snapshot.go
+++ b/internal/service/rds/cluster_snapshot.go
@@ -296,8 +296,8 @@ func statusDBClusterSnapshot(ctx context.Context, conn *rds.RDS, id string) retr
 
 func waitDBClusterSnapshotCreated(ctx context.Context, conn *rds.RDS, id string, timeout time.Duration) (*rds.DBClusterSnapshot, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{ClusterSnapshotStatusCreating},
-		Target:     []string{ClusterSnapshotStatusAvailable},
+		Pending:    []string{clusterSnapshotStatusCreating},
+		Target:     []string{clusterSnapshotStatusAvailable},
 		Refresh:    statusDBClusterSnapshot(ctx, conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -10,31 +10,34 @@ import (
 )
 
 const (
-	ClusterRoleStatusActive  = "ACTIVE"
-	ClusterRoleStatusDeleted = "DELETED"
-	ClusterRoleStatusPending = "PENDING"
+	clusterRoleStatusActive  = "ACTIVE"
+	clusterRoleStatusDeleted = "DELETED"
+	clusterRoleStatusPending = "PENDING"
 )
 
 const (
-	ClusterStatusAvailable                  = "available"
-	ClusterStatusBackingUp                  = "backing-up"
-	ClusterStatusConfiguringIAMDatabaseAuth = "configuring-iam-database-auth"
-	ClusterStatusCreating                   = "creating"
-	ClusterStatusDeleting                   = "deleting"
-	ClusterStatusMigrating                  = "migrating"
-	ClusterStatusModifying                  = "modifying"
-	ClusterStatusPreparingDataMigration     = "preparing-data-migration"
-	ClusterStatusPromoting                  = "promoting"
-	ClusterStatusRebooting                  = "rebooting"
-	ClusterStatusRenaming                   = "renaming"
-	ClusterStatusResettingMasterCredentials = "resetting-master-credentials"
-	ClusterStatusScalingCompute             = "scaling-compute"
-	ClusterStatusUpgrading                  = "upgrading"
+	clusterStatusAvailable                  = "available"
+	clusterStatusBackingUp                  = "backing-up"
+	clusterStatusConfiguringIAMDatabaseAuth = "configuring-iam-database-auth"
+	clusterStatusCreating                   = "creating"
+	clusterStatusDeleting                   = "deleting"
+	clusterStatusMigrating                  = "migrating"
+	clusterStatusModifying                  = "modifying"
+	clusterStatusPreparingDataMigration     = "preparing-data-migration"
+	clusterStatusPromoting                  = "promoting"
+	clusterStatusRebooting                  = "rebooting"
+	clusterStatusRenaming                   = "renaming"
+	clusterStatusResettingMasterCredentials = "resetting-master-credentials"
+	clusterStatusScalingCompute             = "scaling-compute"
+	clusterStatusUpgrading                  = "upgrading"
+
+	// Non-standard status values.
+	clusterStatusAvailableWithPendingModifiedValues = "tf-available-with-pending-modified-values"
 )
 
 const (
-	ClusterSnapshotStatusAvailable = "available"
-	ClusterSnapshotStatusCreating  = "creating"
+	clusterSnapshotStatusAvailable = "available"
+	clusterSnapshotStatusCreating  = "creating"
 )
 
 const (

--- a/internal/service/rds/exports_test.go
+++ b/internal/service/rds/exports_test.go
@@ -6,6 +6,7 @@ package rds
 // Exports for use in tests only.
 var (
 	ResourceCertificate             = resourceCertificate
+	ResourceCluster                 = resourceCluster
 	ResourceEventSubscription       = resourceEventSubscription
 	ResourceProxy                   = resourceProxy
 	ResourceProxyDefaultTargetGroup = resourceProxyDefaultTargetGroup

--- a/internal/service/rds/find.go
+++ b/internal/service/rds/find.go
@@ -21,7 +21,7 @@ func FindDBClusterRoleByDBClusterIDAndRoleARN(ctx context.Context, conn *rds.RDS
 
 	for _, associatedRole := range dbCluster.AssociatedRoles {
 		if aws.StringValue(associatedRole.RoleArn) == roleARN {
-			if status := aws.StringValue(associatedRole.Status); status == ClusterRoleStatusDeleted {
+			if status := aws.StringValue(associatedRole.Status); status == clusterRoleStatusDeleted {
 				return nil, &retry.NotFoundError{
 					Message: status,
 				}

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -205,7 +205,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Name:     "Default Certificate",
 		},
 		{
-			Factory:  ResourceCluster,
+			Factory:  resourceCluster,
 			TypeName: "aws_rds_cluster",
 			Name:     "Cluster",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -229,7 +229,7 @@ func sweepClusters(region string) error {
 		for _, v := range page.DBClusters {
 			arn := aws.StringValue(v.DBClusterArn)
 			id := aws.StringValue(v.DBClusterIdentifier)
-			r := ResourceCluster()
+			r := resourceCluster()
 			d := r.Data(nil)
 			d.SetId(id)
 			d.Set(names.AttrApplyImmediately, true)

--- a/internal/service/rds/wait.go
+++ b/internal/service/rds/wait.go
@@ -13,8 +13,8 @@ import (
 
 func waitDBClusterRoleAssociationCreated(ctx context.Context, conn *rds.RDS, dbClusterID, roleARN string, timeout time.Duration) (*rds.DBClusterRole, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{ClusterRoleStatusPending},
-		Target:     []string{ClusterRoleStatusActive},
+		Pending:    []string{clusterRoleStatusPending},
+		Target:     []string{clusterRoleStatusActive},
 		Refresh:    statusDBClusterRole(ctx, conn, dbClusterID, roleARN),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
@@ -32,7 +32,7 @@ func waitDBClusterRoleAssociationCreated(ctx context.Context, conn *rds.RDS, dbC
 
 func waitDBClusterRoleAssociationDeleted(ctx context.Context, conn *rds.RDS, dbClusterID, roleARN string, timeout time.Duration) (*rds.DBClusterRole, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{ClusterRoleStatusActive, ClusterRoleStatusPending},
+		Pending:    []string{clusterRoleStatusActive, clusterRoleStatusPending},
 		Target:     []string{},
 		Refresh:    statusDBClusterRole(ctx, conn, dbClusterID, roleARN),
 		Timeout:    timeout,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When waiting for `aws_rds_cluster` to update and `apply_immediately` is `true`, ensure that there are no pending modified values if the cluster's status is `available`.

I _think_ we will need to do the same for `aws_rds_cluster_instance` and `aws_db_instance` to resolve e.g. https://github.com/hashicorp/terraform-provider-aws/issues/31529.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/28339.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% ACCTEST_TIMEOUT=1080m make testacc TESTARGS='-run=TestAccRDSCluster_' PKG=rds ACCTEST_PARALLELISM=4
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/rds/... -v -count 1 -parallel 4  -run=TestAccRDSCluster_ -timeout 1080m
=== RUN   TestAccRDSCluster_basic
=== PAUSE TestAccRDSCluster_basic
=== RUN   TestAccRDSCluster_disappears
=== PAUSE TestAccRDSCluster_disappears
=== RUN   TestAccRDSCluster_identifierGenerated
=== PAUSE TestAccRDSCluster_identifierGenerated
=== RUN   TestAccRDSCluster_identifierPrefix
=== PAUSE TestAccRDSCluster_identifierPrefix
=== RUN   TestAccRDSCluster_tags
=== PAUSE TestAccRDSCluster_tags
=== RUN   TestAccRDSCluster_allowMajorVersionUpgrade
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgrade
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== RUN   TestAccRDSCluster_onlyMajorVersion
=== PAUSE TestAccRDSCluster_onlyMajorVersion
=== RUN   TestAccRDSCluster_minorVersion
=== PAUSE TestAccRDSCluster_minorVersion
=== RUN   TestAccRDSCluster_availabilityZones
=== PAUSE TestAccRDSCluster_availabilityZones
=== RUN   TestAccRDSCluster_availabilityZones_caCertificateIdentifier
=== PAUSE TestAccRDSCluster_availabilityZones_caCertificateIdentifier
=== RUN   TestAccRDSCluster_storageTypeIo1
=== PAUSE TestAccRDSCluster_storageTypeIo1
=== RUN   TestAccRDSCluster_storageTypeIo2
=== PAUSE TestAccRDSCluster_storageTypeIo2
=== RUN   TestAccRDSCluster_storageTypeAuroraReturnsBlank
=== PAUSE TestAccRDSCluster_storageTypeAuroraReturnsBlank
=== RUN   TestAccRDSCluster_storageTypeAuroraIopt1
=== PAUSE TestAccRDSCluster_storageTypeAuroraIopt1
=== RUN   TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
=== PAUSE TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
=== RUN   TestAccRDSCluster_allocatedStorage
=== PAUSE TestAccRDSCluster_allocatedStorage
=== RUN   TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
=== PAUSE TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
=== RUN   TestAccRDSCluster_iops
=== PAUSE TestAccRDSCluster_iops
=== RUN   TestAccRDSCluster_dbClusterInstanceClass
=== PAUSE TestAccRDSCluster_dbClusterInstanceClass
=== RUN   TestAccRDSCluster_backtrackWindow
=== PAUSE TestAccRDSCluster_backtrackWindow
=== RUN   TestAccRDSCluster_dbSubnetGroupName
=== PAUSE TestAccRDSCluster_dbSubnetGroupName
=== RUN   TestAccRDSCluster_pointInTimeRestore
=== PAUSE TestAccRDSCluster_pointInTimeRestore
=== RUN   TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
=== PAUSE TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
=== RUN   TestAccRDSCluster_takeFinalSnapshot
=== PAUSE TestAccRDSCluster_takeFinalSnapshot
=== RUN   TestAccRDSCluster_missingUserNameCausesError
=== PAUSE TestAccRDSCluster_missingUserNameCausesError
=== RUN   TestAccRDSCluster_domain
=== PAUSE TestAccRDSCluster_domain
=== RUN   TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
=== PAUSE TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
=== RUN   TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
=== PAUSE TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
=== RUN   TestAccRDSCluster_updateIAMRoles
=== PAUSE TestAccRDSCluster_updateIAMRoles
=== RUN   TestAccRDSCluster_kmsKey
=== PAUSE TestAccRDSCluster_kmsKey
=== RUN   TestAccRDSCluster_networkType
=== PAUSE TestAccRDSCluster_networkType
=== RUN   TestAccRDSCluster_encrypted
=== PAUSE TestAccRDSCluster_encrypted
=== RUN   TestAccRDSCluster_copyTagsToSnapshot
=== PAUSE TestAccRDSCluster_copyTagsToSnapshot
=== RUN   TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== PAUSE TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== RUN   TestAccRDSCluster_backupsUpdate
=== PAUSE TestAccRDSCluster_backupsUpdate
=== RUN   TestAccRDSCluster_iamAuth
=== PAUSE TestAccRDSCluster_iamAuth
=== RUN   TestAccRDSCluster_deletionProtection
=== PAUSE TestAccRDSCluster_deletionProtection
=== RUN   TestAccRDSCluster_engineMode
=== PAUSE TestAccRDSCluster_engineMode
=== RUN   TestAccRDSCluster_engineVersion
=== PAUSE TestAccRDSCluster_engineVersion
=== RUN   TestAccRDSCluster_engineVersionWithPrimaryInstance
=== PAUSE TestAccRDSCluster_engineVersionWithPrimaryInstance
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
=== RUN   TestAccRDSCluster_ManagedMasterPassword_managed
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_managed
=== RUN   TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
=== RUN   TestAccRDSCluster_ManagedMasterPassword_convertToManaged
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_convertToManaged
=== RUN   TestAccRDSCluster_port
=== PAUSE TestAccRDSCluster_port
=== RUN   TestAccRDSCluster_scaling
=== PAUSE TestAccRDSCluster_scaling
=== RUN   TestAccRDSCluster_serverlessV2ScalingConfiguration
=== PAUSE TestAccRDSCluster_serverlessV2ScalingConfiguration
=== RUN   TestAccRDSCluster_Scaling_defaultMinCapacity
=== PAUSE TestAccRDSCluster_Scaling_defaultMinCapacity
=== RUN   TestAccRDSCluster_snapshotIdentifier
=== PAUSE TestAccRDSCluster_snapshotIdentifier
=== RUN   TestAccRDSCluster_SnapshotIdentifier_deletionProtection
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_deletionProtection
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineMode_serverless
    cluster_test.go:2051: serverless does not support snapshot restore on an empty volume
--- SKIP: TestAccRDSCluster_SnapshotIdentifierEngineMode_serverless (0.00s)
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
=== RUN   TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
=== RUN   TestAccRDSCluster_SnapshotIdentifier_masterPassword
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_masterPassword
=== RUN   TestAccRDSCluster_SnapshotIdentifier_masterUsername
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_masterUsername
=== RUN   TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
=== RUN   TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
=== RUN   TestAccRDSCluster_SnapshotIdentifier_tags
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_tags
=== RUN   TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
=== RUN   TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
=== PAUSE TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
=== RUN   TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
=== RUN   TestAccRDSCluster_enableHTTPEndpoint
=== PAUSE TestAccRDSCluster_enableHTTPEndpoint
=== RUN   TestAccRDSCluster_enableHTTPEndpointProvisioned
=== PAUSE TestAccRDSCluster_enableHTTPEndpointProvisioned
=== RUN   TestAccRDSCluster_password
=== PAUSE TestAccRDSCluster_password
=== RUN   TestAccRDSCluster_NoDeleteAutomatedBackups
=== PAUSE TestAccRDSCluster_NoDeleteAutomatedBackups
=== RUN   TestAccRDSCluster_engineLifecycleSupport_disabled
=== PAUSE TestAccRDSCluster_engineLifecycleSupport_disabled
=== RUN   TestAccRDSCluster_localWriteForwarding
=== PAUSE TestAccRDSCluster_localWriteForwarding
=== CONT  TestAccRDSCluster_basic
=== CONT  TestAccRDSCluster_deletionProtection
=== CONT  TestAccRDSCluster_iops
=== CONT  TestAccRDSCluster_SnapshotIdentifier_deletionProtection
--- PASS: TestAccRDSCluster_basic (184.70s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
--- PASS: TestAccRDSCluster_deletionProtection (199.51s)
=== CONT  TestAccRDSCluster_snapshotIdentifier
--- PASS: TestAccRDSCluster_SnapshotIdentifier_deletionProtection (409.99s)
=== CONT  TestAccRDSCluster_Scaling_defaultMinCapacity
--- PASS: TestAccRDSCluster_snapshotIdentifier (402.86s)
=== CONT  TestAccRDSCluster_serverlessV2ScalingConfiguration
--- PASS: TestAccRDSCluster_Scaling_defaultMinCapacity (294.96s)
=== CONT  TestAccRDSCluster_scaling
--- PASS: TestAccRDSCluster_serverlessV2ScalingConfiguration (180.99s)
=== CONT  TestAccRDSCluster_port
--- PASS: TestAccRDSCluster_port (208.78s)
=== CONT  TestAccRDSCluster_ManagedMasterPassword_convertToManaged
--- PASS: TestAccRDSCluster_scaling (291.52s)
=== CONT  TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
--- PASS: TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey (161.75s)
=== CONT  TestAccRDSCluster_ManagedMasterPassword_managed
--- PASS: TestAccRDSCluster_ManagedMasterPassword_convertToManaged (191.37s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
--- PASS: TestAccRDSCluster_ManagedMasterPassword_managed (144.41s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
--- PASS: TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs (326.48s)
=== CONT  TestAccRDSCluster_localWriteForwarding
--- PASS: TestAccRDSCluster_iops (1776.22s)
=== CONT  TestAccRDSCluster_engineLifecycleSupport_disabled
--- PASS: TestAccRDSCluster_localWriteForwarding (188.51s)
=== CONT  TestAccRDSCluster_NoDeleteAutomatedBackups
--- PASS: TestAccRDSCluster_engineLifecycleSupport_disabled (194.72s)
=== CONT  TestAccRDSCluster_password
--- PASS: TestAccRDSCluster_NoDeleteAutomatedBackups (201.91s)
=== CONT  TestAccRDSCluster_enableHTTPEndpointProvisioned
--- PASS: TestAccRDSCluster_password (179.14s)
=== CONT  TestAccRDSCluster_enableHTTPEndpoint
--- PASS: TestAccRDSCluster_enableHTTPEndpointProvisioned (131.12s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
--- PASS: TestAccRDSCluster_enableHTTPEndpoint (280.50s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
--- PASS: TestAccRDSCluster_SnapshotIdentifier_encryptedRestore (412.68s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_masterPassword
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier (2584.53s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_tags
--- PASS: TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags (356.30s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterPassword (371.94s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
--- PASS: TestAccRDSCluster_SnapshotIdentifier_tags (372.69s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_masterUsername
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow (504.85s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow (402.80s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterUsername (333.13s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal (305.47s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
--- PASS: TestAccRDSCluster_SnapshotIdentifier_kmsKeyID (340.93s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add (148.16s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_different (416.17s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned (351.16s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned (164.42s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update (169.96s)
=== CONT  TestAccRDSCluster_engineVersionWithPrimaryInstance
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding (2972.73s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove (163.23s)
=== CONT  TestAccRDSCluster_engineVersion
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global (124.57s)
=== CONT  TestAccRDSCluster_minorVersion
--- PASS: TestAccRDSCluster_engineVersion (468.52s)
=== CONT  TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
--- PASS: TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora (190.02s)
=== CONT  TestAccRDSCluster_allocatedStorage
--- PASS: TestAccRDSCluster_minorVersion (934.48s)
=== CONT  TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
--- PASS: TestAccRDSCluster_engineVersionWithPrimaryInstance (1288.86s)
=== CONT  TestAccRDSCluster_storageTypeAuroraIopt1
--- PASS: TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1 (204.02s)
=== CONT  TestAccRDSCluster_storageTypeAuroraReturnsBlank
--- PASS: TestAccRDSCluster_storageTypeAuroraReturnsBlank (132.96s)
=== CONT  TestAccRDSCluster_storageTypeIo2
--- PASS: TestAccRDSCluster_storageTypeAuroraIopt1 (162.65s)
=== CONT  TestAccRDSCluster_storageTypeIo1
--- PASS: TestAccRDSCluster_allocatedStorage (1470.50s)
=== CONT  TestAccRDSCluster_availabilityZones_caCertificateIdentifier
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters (2745.44s)
=== CONT  TestAccRDSCluster_availabilityZones
--- PASS: TestAccRDSCluster_availabilityZones (132.99s)
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
--- PASS: TestAccRDSCluster_storageTypeIo2 (1352.48s)
=== CONT  TestAccRDSCluster_iamAuth
--- PASS: TestAccRDSCluster_iamAuth (131.87s)
=== CONT  TestAccRDSCluster_backupsUpdate
--- PASS: TestAccRDSCluster_storageTypeIo1 (1506.85s)
=== CONT  TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
--- PASS: TestAccRDSCluster_backupsUpdate (209.71s)
=== CONT  TestAccRDSCluster_copyTagsToSnapshot
--- PASS: TestAccRDSCluster_copyTagsToSnapshot (247.72s)
=== CONT  TestAccRDSCluster_encrypted
--- PASS: TestAccRDSCluster_encrypted (142.11s)
=== CONT  TestAccRDSCluster_networkType
--- PASS: TestAccRDSCluster_networkType (222.14s)
=== CONT  TestAccRDSCluster_kmsKey
--- PASS: TestAccRDSCluster_kmsKey (173.35s)
=== CONT  TestAccRDSCluster_updateIAMRoles
--- PASS: TestAccRDSCluster_availabilityZones_caCertificateIdentifier (1815.47s)
=== CONT  TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
--- PASS: TestAccRDSCluster_updateIAMRoles (137.89s)
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL (206.15s)
=== CONT  TestAccRDSCluster_domain
--- PASS: TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports (385.90s)
=== CONT  TestAccRDSCluster_missingUserNameCausesError
--- PASS: TestAccRDSCluster_missingUserNameCausesError (3.91s)
=== CONT  TestAccRDSCluster_takeFinalSnapshot
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql (1966.04s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgrade
--- PASS: TestAccRDSCluster_takeFinalSnapshot (243.22s)
=== CONT  TestAccRDSCluster_onlyMajorVersion
--- PASS: TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID (2213.63s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
--- PASS: TestAccRDSCluster_onlyMajorVersion (944.43s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
--- PASS: TestAccRDSCluster_allowMajorVersionUpgrade (2012.99s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
--- PASS: TestAccRDSCluster_domain (2638.65s)
=== CONT  TestAccRDSCluster_identifierPrefix
--- PASS: TestAccRDSCluster_identifierPrefix (133.13s)
=== CONT  TestAccRDSCluster_tags
--- PASS: TestAccRDSCluster_tags (188.00s)
=== CONT  TestAccRDSCluster_dbSubnetGroupName
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters (2131.49s)
=== CONT  TestAccRDSCluster_pointInTimeRestore
--- PASS: TestAccRDSCluster_dbSubnetGroupName (141.70s)
=== CONT  TestAccRDSCluster_dbClusterInstanceClass
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm (1769.92s)
=== CONT  TestAccRDSCluster_identifierGenerated
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately (895.12s)
=== CONT  TestAccRDSCluster_disappears
--- PASS: TestAccRDSCluster_identifierGenerated (103.90s)
=== CONT  TestAccRDSCluster_engineMode
--- PASS: TestAccRDSCluster_disappears (111.59s)
=== CONT  TestAccRDSCluster_backtrackWindow
--- PASS: TestAccRDSCluster_pointInTimeRestore (285.20s)
--- PASS: TestAccRDSCluster_backtrackWindow (138.79s)
--- PASS: TestAccRDSCluster_engineMode (404.28s)
--- PASS: TestAccRDSCluster_dbClusterInstanceClass (4024.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	15507.215s
```
