### PR TITLE
resource/aws_bedrockagent_agent_action_group: updates `function_schema` to allow other tagged union types

### DIFF
--- a/internal/service/bedrockagent/agent_action_group_test.go
+++ b/internal/service/bedrockagent/agent_action_group_test.go
@@ -48,7 +48,7 @@ func TestAccBedrockAgentAgentActionGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgentAgentActionGroup_s3APISchema(t *testing.T) {
+func TestAccBedrockAgentAgentActionGroup_APISchema_s3(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent_action_group.test"
@@ -61,7 +61,7 @@ func TestAccBedrockAgentAgentActionGroup_s3APISchema(t *testing.T) {
 		CheckDestroy:             testAccCheckAgentActionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgentActionGroupConfig_s3APISchema(rName),
+				Config: testAccAgentActionGroupConfig_APISchema_s3(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAgentActionGroupExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "action_group_name", rName),
@@ -92,7 +92,7 @@ func TestAccBedrockAgentAgentActionGroup_update(t *testing.T) {
 		CheckDestroy:             testAccCheckAgentActionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgentActionGroupConfig_s3APISchema(rName),
+				Config: testAccAgentActionGroupConfig_APISchema_s3(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAgentActionGroupExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "action_group_name", rName),
@@ -164,7 +164,7 @@ func TestAccBedrockAgentAgentActionGroup_FunctionSchema_memberFunctions(t *testi
 	})
 }
 
-func TestAccBedrockAgentAgentActionGroup_returnControl(t *testing.T) {
+func TestAccBedrockAgentAgentActionGroup_ActionGroupExecutor_customControl(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent_action_group.test"
@@ -177,7 +177,7 @@ func TestAccBedrockAgentAgentActionGroup_returnControl(t *testing.T) {
 		CheckDestroy:             testAccCheckAgentActionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgentActionGroupConfig_returnControl(rName),
+				Config: testAccAgentActionGroupConfig_ActionGroupExecutor_customControl(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAgentActionGroupExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "action_group_name", rName),
@@ -261,7 +261,7 @@ resource "aws_bedrockagent_agent_action_group" "test" {
 `, rName))
 }
 
-func testAccAgentActionGroupConfig_s3APISchema(rName string) string {
+func testAccAgentActionGroupConfig_APISchema_s3(rName string) string {
 	return acctest.ConfigCompose(testAccAgentConfig_basic(rName, "anthropic.claude-v2", "basic claude"),
 		testAccAgentActionGroupConfig_lambda(rName),
 		fmt.Sprintf(`
@@ -363,7 +363,7 @@ resource "aws_bedrockagent_agent_action_group" "test" {
 `, rName))
 }
 
-func testAccAgentActionGroupConfig_returnControl(rName string) string {
+func testAccAgentActionGroupConfig_ActionGroupExecutor_customControl(rName string) string {
 	return acctest.ConfigCompose(testAccAgentConfig_basic(rName, "anthropic.claude-v2", "basic claude"),
 		testAccAgentActionGroupConfig_lambda(rName),
 		fmt.Sprintf(`

--- a/internal/service/bedrockagent/agent_action_group_test.go
+++ b/internal/service/bedrockagent/agent_action_group_test.go
@@ -122,7 +122,7 @@ func TestAccBedrockAgentAgentActionGroup_update(t *testing.T) {
 	})
 }
 
-func TestAccBedrockAgentAgentActionGroup_functionSchema(t *testing.T) {
+func TestAccBedrockAgentAgentActionGroup_FunctionSchema_memberFunctions(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrockagent_agent_action_group.test"
@@ -135,22 +135,23 @@ func TestAccBedrockAgentAgentActionGroup_functionSchema(t *testing.T) {
 		CheckDestroy:             testAccCheckAgentActionGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgentActionGroupConfig_functionSchema(rName),
+				Config: testAccAgentActionGroupConfig_FunctionSchema_memberFunctions(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAgentActionGroupExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "action_group_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "function_schema.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.0.name", "sayHello"),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.0.description", "Says Hello"),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.0.parameters.#", acctest.Ct2),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.0.parameters.0.map_block_key", names.AttrMessage),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.0.parameters.0.type", "string"),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.0.parameters.0.description", "The Hello message"),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.0.parameters.0.required", acctest.CtTrue),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.0.parameters.1.map_block_key", "unused"),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.0.parameters.1.type", "integer"),
-					resource.TestCheckResourceAttr(resourceName, "function_schema.0.functions.0.parameters.1.required", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.0.name", "sayHello"),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.0.description", "Says Hello"),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.0.parameters.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.0.parameters.0.map_block_key", names.AttrMessage),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.0.parameters.0.type", "string"),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.0.parameters.0.description", "The Hello message"),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.0.parameters.0.required", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.0.parameters.1.map_block_key", "unused"),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.0.parameters.1.type", "integer"),
+					resource.TestCheckResourceAttr(resourceName, "function_schema.0.member_functions.0.functions.0.parameters.1.required", acctest.CtFalse),
 				),
 			},
 			{
@@ -326,7 +327,7 @@ resource "aws_lambda_function" "test_lambda" {
 `, rName)
 }
 
-func testAccAgentActionGroupConfig_functionSchema(rName string) string {
+func testAccAgentActionGroupConfig_FunctionSchema_memberFunctions(rName string) string {
 	return acctest.ConfigCompose(testAccAgentConfig_basic(rName, "anthropic.claude-v2", "basic claude"),
 		testAccAgentActionGroupConfig_lambda(rName),
 		fmt.Sprintf(`
@@ -340,19 +341,21 @@ resource "aws_bedrockagent_agent_action_group" "test" {
     lambda = aws_lambda_function.test_lambda.arn
   }
   function_schema {
-    functions {
-      name        = "sayHello"
-      description = "Says Hello"
-      parameters {
-        map_block_key = "message"
-        type          = "string"
-        description   = "The Hello message"
-        required      = true
-      }
-      parameters {
-        map_block_key = "unused"
-        type          = "integer"
-        required      = false
+    member_functions {
+      functions {
+        name        = "sayHello"
+        description = "Says Hello"
+        parameters {
+          map_block_key = "message"
+          type          = "string"
+          description   = "The Hello message"
+          required      = true
+        }
+        parameters {
+          map_block_key = "unused"
+          type          = "integer"
+          required      = false
+        }
       }
     }
   }

--- a/website/docs/r/bedrockagent_agent_action_group.html.markdown
+++ b/website/docs/r/bedrockagent_agent_action_group.html.markdown
@@ -60,20 +60,22 @@ resource "aws_bedrockagent_agent_action_group" "example" {
     lambda = "arn:aws:lambda:us-west-2:123456789012:function:example-function"
   }
   function_schema {
-    functions {
-      name        = "example-function"
-      description = "Example function"
-      parameters {
-        map_block_key = "param1"
-        type          = "string"
-        description   = "The first parameter"
-        required      = true
-      }
-      parameters {
-        map_block_key = "param2"
-        type          = "integer"
-        description   = "The second parameter"
-        required      = false
+    member_functions {
+      functions {
+        name        = "example-function"
+        description = "Example function"
+        parameters {
+          map_block_key = "param1"
+          type          = "string"
+          description   = "The first parameter"
+          required      = true
+        }
+        parameters {
+          map_block_key = "param2"
+          type          = "integer"
+          description   = "The second parameter"
+          required      = false
+        }
       }
     }
   }
@@ -111,7 +113,9 @@ The following arguments are optional:
 * `action_group_state` - (Optional) Whether the action group is available for the agent to invoke or not when sending an [InvokeAgent](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_InvokeAgent.html) request. Valid values: `ENABLED`, `DISABLED`.
 * `api_schema` - (Optional) Either details about the S3 object containing the OpenAPI schema for the action group or the JSON or YAML-formatted payload defining the schema. For more information, see [Action group OpenAPI schemas](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-api-schema.html). See [`api_schema` Block](#api_schema-block) for details.
 * `description` - (Optional) Description of the action group.
-* `function_schema` - (Optional) Functions that each define parameters that the agent needs to invoke from the user. Each function represents an action in an action group. See [`function_schema` Block](#function_schema-block) for details.
+* `function_schema` - (Optional) Describes the function schema for the action group.
+  Each function represents an action in an action group.
+  See [`function_schema` Block](#function_schema-block) for details.
 * `parent_action_group_signature` - (Optional) To allow your agent to request the user for additional information when trying to complete a task, set this argument to `AMAZON.UserInput`. You must leave the `description`, `api_schema`, and `action_group_executor` arguments blank for this action group. Valid values: `AMAZON.UserInput`.
 * `skip_resource_in_use_check` - (Optional) Whether the in-use check is skipped when deleting the action group.
 
@@ -141,6 +145,14 @@ The `s3` configuration block supports the following arguments:
 ### `function_schema` Block
 
 The `function_schema` configuration block supports the following arguments:
+
+* `member_functions` - (Optional) Contains a list of functions.
+  Each function describes and action in the action group.
+  See [`member_functions` Block](#member_functions-block) for details.
+
+### `member_functions` Block
+
+The `member_functions` configuration block supports the following arguments:
 
 * `functions` - (Optional) Functions that each define an action in the action group. See [`functions` Block](#functions-block) for details.
 

--- a/website/docs/r/bedrockagent_agent_action_group.html.markdown
+++ b/website/docs/r/bedrockagent_agent_action_group.html.markdown
@@ -124,16 +124,19 @@ The following arguments are optional:
 The `action_group_executor` configuration block supports the following arguments:
 
 * `custom_control` - (Optional) Custom control method for handling the information elicited from the user. Valid values: `RETURN_CONTROL`.
-
-  To skip using a Lambda function and instead return the predicted action group, in addition to the parameters and information required for it, in the `InvokeAgent` response, specify, specify `RETURN_CONTROL`.
+  To skip using a Lambda function and instead return the predicted action group, in addition to the parameters and information required for it, in the `InvokeAgent` response, specify `RETURN_CONTROL`.
+  Only one of `custom_control` or `lambda` can be specified.
 * `lambda` - (Optional) ARN of the Lambda function containing the business logic that is carried out upon invoking the action.
+  Only one of `lambda` or `custom_control` can be specified.
 
 ### `api_schema` Block
 
 The `api_schema` configuration block supports the following arguments:
 
 * `payload` - (Optional) JSON or YAML-formatted payload defining the OpenAPI schema for the action group.
+  Only one of `payload` or `s3` can be specified.
 * `s3` - (Optional) Details about the S3 object containing the OpenAPI schema for the action group. See [`s3` Block](#s3-block) for details.
+  Only one of `s3` or `payload` can be specified.
 
 ### `s3` Block
 


### PR DESCRIPTION
### Description

The `aws_bedrockagent_agent_action_group` parameter `function_schema` is a tagged union type, so needs an extra level of indirection to capture the types.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagent TESTS=TestAccBedrockAgentAgentActionGroup_

--- PASS: TestAccBedrockAgentAgentActionGroup_ActionGroupExecutor_customControl (35.69s)
--- PASS: TestAccBedrockAgentAgentActionGroup_APISchema_s3 (42.56s)
--- PASS: TestAccBedrockAgentAgentActionGroup_basic (49.53s)
--- PASS: TestAccBedrockAgentAgentActionGroup_update (56.04s)
--- PASS: TestAccBedrockAgentAgentActionGroup_FunctionSchema_memberFunctions (57.87s)
```
