### PR TITLE
AutoFlex: Adds `TypedExpander` interface for models which can expand into multiple target types

### DIFF
--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -85,7 +85,8 @@ func autoExpandConvert(ctx context.Context, from, to any, flexer autoFlexer) dia
 	// Top-level struct to struct conversion.
 	if valFrom.IsValid() && valTo.IsValid() {
 		if typFrom, typTo := valFrom.Type(), valTo.Type(); typFrom.Kind() == reflect.Struct && typTo.Kind() == reflect.Struct &&
-			!typFrom.Implements(reflect.TypeFor[basetypes.ListValuable]()) {
+			!typFrom.Implements(reflect.TypeFor[basetypes.ListValuable]()) &&
+			!typFrom.Implements(reflect.TypeFor[basetypes.SetValuable]()) {
 			diags.Append(autoFlexConvertStruct(ctx, from, to, flexer)...)
 			return diags
 		}

--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -818,9 +818,11 @@ func (expander autoExpander) nestedObjectToStruct(ctx context.Context, vFrom fwt
 
 	// Create a new target structure and walk its fields.
 	to := reflect.New(tStruct)
-	diags.Append(autoFlexConvertStruct(ctx, from, to.Interface(), expander)...)
-	if diags.HasError() {
-		return diags
+	if !reflect.ValueOf(from).IsNil() {
+		diags.Append(autoFlexConvertStruct(ctx, from, to.Interface(), expander)...)
+		if diags.HasError() {
+			return diags
+		}
 	}
 
 	// Set value.

--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -24,6 +24,11 @@ type Expander interface {
 	Expand(ctx context.Context) (any, diag.Diagnostics)
 }
 
+// Expander is implemented by types that customize their expansion and can have multiple target types
+type TypedExpander interface {
+	ExpandTo(ctx context.Context, targetType reflect.Type) (any, diag.Diagnostics)
+}
+
 // Expand "expands" a resource's "business logic" data structure,
 // implemented using Terraform Plugin Framework data types, into
 // an AWS SDK for Go v2 API data structure.
@@ -83,6 +88,11 @@ func (expander autoExpander) convert(ctx context.Context, valFrom, vTo reflect.V
 
 	if fromExpander, ok := valFrom.Interface().(Expander); ok {
 		diags.Append(expandExpander(ctx, fromExpander, vTo)...)
+		return diags
+	}
+
+	if fromTypedExpander, ok := valFrom.Interface().(TypedExpander); ok {
+		diags.Append(expandTypedExpander(ctx, fromTypedExpander, vTo)...)
 		return diags
 	}
 
@@ -939,6 +949,50 @@ func expandExpander(ctx context.Context, fromExpander Expander, toVal reflect.Va
 
 	if expanded == nil {
 		diags.Append(diagExpandsToNil(reflect.TypeOf(fromExpander)))
+		return diags
+	}
+
+	expandedVal := reflect.ValueOf(expanded)
+
+	targetType := toVal.Type()
+	if targetType.Kind() == reflect.Interface {
+		expandedType := reflect.TypeOf(expanded)
+		if !expandedType.Implements(targetType) {
+			diags.Append(diagExpandedTypeDoesNotImplement(expandedType, targetType))
+			return diags
+		}
+
+		toVal.Set(expandedVal)
+
+		return diags
+	}
+
+	if targetType.Kind() == reflect.Struct {
+		expandedVal = expandedVal.Elem()
+	}
+	expandedType := expandedVal.Type()
+
+	if !expandedType.AssignableTo(targetType) {
+		diags.Append(diagCannotBeAssigned(expandedType, targetType))
+		return diags
+	}
+
+	toVal.Set(expandedVal)
+
+	return diags
+}
+
+func expandTypedExpander(ctx context.Context, fromTypedExpander TypedExpander, toVal reflect.Value) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	expanded, d := fromTypedExpander.ExpandTo(ctx, toVal.Type())
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	if expanded == nil {
+		diags.Append(diagExpandsToNil(reflect.TypeOf(fromTypedExpander)))
 		return diags
 	}
 

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -1087,6 +1087,106 @@ func TestExpandSetOfStringEnum(t *testing.T) {
 	runAutoExpandTestCases(t, testCases)
 }
 
+func TestExpandListOfNestedObject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testCases := autoFlexTestCases{
+		{
+			TestName: "valid value to []struct",
+			Source: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{
+				{
+					Field1: types.StringValue("value1"),
+				},
+				{
+					Field1: types.StringValue("value2"),
+				},
+			}),
+			Target: &[]TestFlexAWS01{},
+			WantTarget: &[]TestFlexAWS01{
+				{
+					Field1: "value1",
+				},
+				{
+					Field1: "value2",
+				},
+			},
+		},
+		{
+			TestName:   "empty value to []struct",
+			Source:     fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{}),
+			Target:     &[]TestFlexAWS01{},
+			WantTarget: &[]TestFlexAWS01{},
+		},
+		{
+			TestName:   "null value to []struct",
+			Source:     fwtypes.NewListNestedObjectValueOfNull[TestFlexTF01](ctx),
+			Target:     &[]TestFlexAWS01{},
+			WantTarget: &[]TestFlexAWS01{},
+		},
+
+		{
+			TestName: "valid value to []*struct",
+			Source: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{
+				{
+					Field1: types.StringValue("value1"),
+				},
+				{
+					Field1: types.StringValue("value2"),
+				},
+			}),
+			Target: &[]*TestFlexAWS01{},
+			WantTarget: &[]*TestFlexAWS01{
+				{
+					Field1: "value1",
+				},
+				{
+					Field1: "value2",
+				},
+			},
+		},
+		{
+			TestName:   "empty value to []*struct",
+			Source:     fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{}),
+			Target:     &[]*TestFlexAWS01{},
+			WantTarget: &[]*TestFlexAWS01{},
+		},
+		{
+			TestName:   "null value to []*struct",
+			Source:     fwtypes.NewListNestedObjectValueOfNull[TestFlexTF01](ctx),
+			Target:     &[]*TestFlexAWS01{},
+			WantTarget: &[]*TestFlexAWS01{},
+		},
+
+		{
+			TestName: "single list value to single struct",
+			Source: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{
+				{
+					Field1: types.StringValue("value1"),
+				},
+			}),
+			Target: &TestFlexAWS01{},
+			WantTarget: &TestFlexAWS01{
+				Field1: "value1",
+			},
+		},
+		{
+			TestName:   "empty list value to single struct",
+			Source:     fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{}),
+			Target:     &[]TestFlexAWS01{},
+			WantTarget: &[]TestFlexAWS01{},
+		},
+		{
+			TestName:   "null value to single struct",
+			Source:     fwtypes.NewListNestedObjectValueOfNull[TestFlexTF01](ctx),
+			Target:     &[]TestFlexAWS01{},
+			WantTarget: &[]TestFlexAWS01{},
+		},
+	}
+	runAutoExpandTestCases(t, testCases)
+}
+
 func TestExpandSimpleNestedBlockWithStringEnum(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -1187,6 +1187,106 @@ func TestExpandListOfNestedObject(t *testing.T) {
 	runAutoExpandTestCases(t, testCases)
 }
 
+func TestExpandSetOfNestedObject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testCases := autoFlexTestCases{
+		{
+			TestName: "valid value to []struct",
+			Source: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{
+				{
+					Field1: types.StringValue("value1"),
+				},
+				{
+					Field1: types.StringValue("value2"),
+				},
+			}),
+			Target: &[]TestFlexAWS01{},
+			WantTarget: &[]TestFlexAWS01{
+				{
+					Field1: "value1",
+				},
+				{
+					Field1: "value2",
+				},
+			},
+		},
+		{
+			TestName:   "empty value to []struct",
+			Source:     fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{}),
+			Target:     &[]TestFlexAWS01{},
+			WantTarget: &[]TestFlexAWS01{},
+		},
+		{
+			TestName:   "null value to []struct",
+			Source:     fwtypes.NewSetNestedObjectValueOfNull[TestFlexTF01](ctx),
+			Target:     &[]TestFlexAWS01{},
+			WantTarget: &[]TestFlexAWS01{},
+		},
+
+		{
+			TestName: "valid value to []*struct",
+			Source: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{
+				{
+					Field1: types.StringValue("value1"),
+				},
+				{
+					Field1: types.StringValue("value2"),
+				},
+			}),
+			Target: &[]*TestFlexAWS01{},
+			WantTarget: &[]*TestFlexAWS01{
+				{
+					Field1: "value1",
+				},
+				{
+					Field1: "value2",
+				},
+			},
+		},
+		{
+			TestName:   "empty value to []*struct",
+			Source:     fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{}),
+			Target:     &[]*TestFlexAWS01{},
+			WantTarget: &[]*TestFlexAWS01{},
+		},
+		{
+			TestName:   "null value to []*struct",
+			Source:     fwtypes.NewSetNestedObjectValueOfNull[TestFlexTF01](ctx),
+			Target:     &[]*TestFlexAWS01{},
+			WantTarget: &[]*TestFlexAWS01{},
+		},
+
+		{
+			TestName: "single list value to single struct",
+			Source: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{
+				{
+					Field1: types.StringValue("value1"),
+				},
+			}),
+			Target: &TestFlexAWS01{},
+			WantTarget: &TestFlexAWS01{
+				Field1: "value1",
+			},
+		},
+		{
+			TestName:   "empty list value to single struct",
+			Source:     fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{}),
+			Target:     &[]TestFlexAWS01{},
+			WantTarget: &[]TestFlexAWS01{},
+		},
+		{
+			TestName:   "null value to single struct",
+			Source:     fwtypes.NewSetNestedObjectValueOfNull[TestFlexTF01](ctx),
+			Target:     &[]TestFlexAWS01{},
+			WantTarget: &[]TestFlexAWS01{},
+		},
+	}
+	runAutoExpandTestCases(t, testCases)
+}
+
 func TestExpandSimpleNestedBlockWithStringEnum(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -1563,8 +1563,8 @@ func TestExpandInterface(t *testing.T) {
 		},
 		{
 			TestName: "non-empty set Source and non-empty interface Target",
-			Source: testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
-				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{
+			Source: testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{
+				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{
 					{
 						Field1: types.StringValue("value1"),
 					},

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -1264,7 +1264,7 @@ func TestExpandInterface(t *testing.T) {
 		},
 		{
 			TestName: "single list Source and single interface Target",
-			Source: testFlexTFInterfaceListNestedObject{
+			Source: testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{
 					{
 						Field1: types.StringValue("value1"),
@@ -1280,7 +1280,7 @@ func TestExpandInterface(t *testing.T) {
 		},
 		{
 			TestName: "single list non-Expander Source and single interface Target",
-			Source: testFlexTFInterfaceListNestedObjectNonFlexer{
+			Source: testFlexTFListNestedObject[TestFlexTF01]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{
 					{
 						Field1: types.StringValue("value1"),
@@ -1303,7 +1303,7 @@ func TestExpandInterface(t *testing.T) {
 		},
 		{
 			TestName: "single set Source and single interface Target",
-			Source: testFlexTFInterfaceSetNestedObject{
+			Source: testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{
 					{
 						Field1: types.StringValue("value1"),
@@ -1319,7 +1319,7 @@ func TestExpandInterface(t *testing.T) {
 		},
 		{
 			TestName: "empty list Source and empty interface Target",
-			Source: testFlexTFInterfaceListNestedObject{
+			Source: testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{}),
 			},
 			Target: &testFlexAWSInterfaceSlice{},
@@ -1329,7 +1329,7 @@ func TestExpandInterface(t *testing.T) {
 		},
 		{
 			TestName: "non-empty list Source and non-empty interface Target",
-			Source: testFlexTFInterfaceListNestedObject{
+			Source: testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{
 					{
 						Field1: types.StringValue("value1"),
@@ -1353,7 +1353,7 @@ func TestExpandInterface(t *testing.T) {
 		},
 		{
 			TestName: "empty set Source and empty interface Target",
-			Source: testFlexTFInterfaceSetNestedObject{
+			Source: testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{}),
 			},
 			Target: &testFlexAWSInterfaceSlice{},
@@ -1363,7 +1363,7 @@ func TestExpandInterface(t *testing.T) {
 		},
 		{
 			TestName: "non-empty set Source and non-empty interface Target",
-			Source: testFlexTFInterfaceListNestedObject{
+			Source: testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{
 					{
 						Field1: types.StringValue("value1"),
@@ -1387,7 +1387,7 @@ func TestExpandInterface(t *testing.T) {
 		},
 		{
 			TestName: "object value Source and struct Target",
-			Source: testFlexTFInterfaceObjectValue{
+			Source: testFlexTFObjectValue[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewObjectValueOfMust(ctx, &testFlexTFInterfaceFlexer{
 					Field1: types.StringValue("value1"),
 				}),
@@ -1682,6 +1682,446 @@ func TestExpandExpander(t *testing.T) {
 			TestName: "object value Source and *struct Target",
 			Source: testFlexTFExpanderObjectValue{
 				Field1: fwtypes.NewObjectValueOfMust(ctx, &testFlexTFFlexer{
+					Field1: types.StringValue("value1"),
+				}),
+			},
+			Target: &testFlexAWSExpanderSinglePtr{},
+			WantTarget: &testFlexAWSExpanderSinglePtr{
+				Field1: &testFlexAWSExpander{
+					AWSField: "value1",
+				},
+			},
+		},
+	}
+	runAutoExpandTestCases(t, testCases)
+}
+
+func TestExpandInterfaceTypedExpander(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var targetInterface testFlexAWSInterfaceInterface
+
+	testCases := autoFlexTestCases{
+		{
+			TestName: "top level",
+			Source: testFlexTFInterfaceTypedExpander{
+				Field1: types.StringValue("value1"),
+			},
+			Target: &targetInterface,
+			WantTarget: testFlexAWSInterfaceInterfacePtr(&testFlexAWSInterfaceInterfaceImpl{
+				AWSField: "value1",
+			}),
+		},
+		{
+			TestName: "top level return value does not implement target interface",
+			Source: testFlexTFInterfaceIncompatibleTypedExpander{
+				Field1: types.StringValue("value1"),
+			},
+			Target: &targetInterface,
+			expectedDiags: diag.Diagnostics{
+				diagExpandedTypeDoesNotImplement(reflect.TypeFor[*testFlexAWSInterfaceIncompatibleImpl](), reflect.TypeFor[testFlexAWSInterfaceInterface]()),
+				diag.NewErrorDiagnostic("AutoFlEx", "Expand[flex.testFlexTFInterfaceIncompatibleTypedExpander, *flex.testFlexAWSInterfaceInterface]"),
+			},
+		},
+		{
+			TestName: "single list Source and single interface Target",
+			Source: testFlexTFListNestedObject[testFlexTFInterfaceTypedExpander]{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+				}),
+			},
+			Target: &testFlexAWSInterfaceSingle{},
+			WantTarget: &testFlexAWSInterfaceSingle{
+				Field1: &testFlexAWSInterfaceInterfaceImpl{
+					AWSField: "value1",
+				},
+			},
+		},
+		{
+			TestName: "single list non-Expander Source and single interface Target",
+			Source: testFlexTFListNestedObject[TestFlexTF01]{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{
+					{
+						Field1: types.StringValue("value1"),
+					},
+				}),
+			},
+			Target: &testFlexAWSInterfaceSingle{},
+			WantTarget: &testFlexAWSInterfaceSingle{
+				Field1: nil,
+			},
+			expectedLogLines: []map[string]any{
+				{
+					"@level":   "info",
+					"@module":  "provider",
+					"@message": "AutoFlex Expand; incompatible types",
+					"from":     map[string]any{},
+					"to":       float64(reflect.Interface),
+				},
+			},
+		},
+		{
+			TestName: "single set Source and single interface Target",
+			Source: testFlexTFSetNestedObject[testFlexTFInterfaceTypedExpander]{
+				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+				}),
+			},
+			Target: &testFlexAWSInterfaceSingle{},
+			WantTarget: &testFlexAWSInterfaceSingle{
+				Field1: &testFlexAWSInterfaceInterfaceImpl{
+					AWSField: "value1",
+				},
+			},
+		},
+		{
+			TestName: "empty list Source and empty interface Target",
+			Source: testFlexTFListNestedObject[testFlexTFInterfaceTypedExpander]{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceTypedExpander{}),
+			},
+			Target: &testFlexAWSInterfaceSlice{},
+			WantTarget: &testFlexAWSInterfaceSlice{
+				Field1: []testFlexAWSInterfaceInterface{},
+			},
+		},
+		{
+			TestName: "non-empty list Source and non-empty interface Target",
+			Source: testFlexTFListNestedObject[testFlexTFInterfaceTypedExpander]{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+					{
+						Field1: types.StringValue("value2"),
+					},
+				}),
+			},
+			Target: &testFlexAWSInterfaceSlice{},
+			WantTarget: &testFlexAWSInterfaceSlice{
+				Field1: []testFlexAWSInterfaceInterface{
+					&testFlexAWSInterfaceInterfaceImpl{
+						AWSField: "value1",
+					},
+					&testFlexAWSInterfaceInterfaceImpl{
+						AWSField: "value2",
+					},
+				},
+			},
+		},
+		{
+			TestName: "empty set Source and empty interface Target",
+			Source: testFlexTFSetNestedObject[testFlexTFInterfaceTypedExpander]{
+				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceTypedExpander{}),
+			},
+			Target: &testFlexAWSInterfaceSlice{},
+			WantTarget: &testFlexAWSInterfaceSlice{
+				Field1: []testFlexAWSInterfaceInterface{},
+			},
+		},
+		{
+			TestName: "non-empty set Source and non-empty interface Target",
+			Source: testFlexTFListNestedObject[testFlexTFInterfaceTypedExpander]{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+					{
+						Field1: types.StringValue("value2"),
+					},
+				}),
+			},
+			Target: &testFlexAWSInterfaceSlice{},
+			WantTarget: &testFlexAWSInterfaceSlice{
+				Field1: []testFlexAWSInterfaceInterface{
+					&testFlexAWSInterfaceInterfaceImpl{
+						AWSField: "value1",
+					},
+					&testFlexAWSInterfaceInterfaceImpl{
+						AWSField: "value2",
+					},
+				},
+			},
+		},
+		{
+			TestName: "object value Source and struct Target",
+			Source: testFlexTFObjectValue[testFlexTFInterfaceTypedExpander]{
+				Field1: fwtypes.NewObjectValueOfMust(ctx, &testFlexTFInterfaceTypedExpander{
+					Field1: types.StringValue("value1"),
+				}),
+			},
+			Target: &testFlexAWSInterfaceSingle{},
+			WantTarget: &testFlexAWSInterfaceSingle{
+				Field1: &testFlexAWSInterfaceInterfaceImpl{
+					AWSField: "value1",
+				},
+			},
+		},
+	}
+	runAutoExpandTestCases(t, testCases)
+}
+
+func TestExpandTypedExpander(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testCases := autoFlexTestCases{
+		{
+			TestName: "top level struct Target",
+			Source: testFlexTFTypedExpander{
+				Field1: types.StringValue("value1"),
+			},
+			Target: &testFlexAWSExpander{},
+			WantTarget: &testFlexAWSExpander{
+				AWSField: "value1",
+			},
+		},
+		{
+			TestName: "top level incompatible struct Target",
+			Source: testFlexTFTypedExpander{
+				Field1: types.StringValue("value1"),
+			},
+			Target: &testFlexAWSExpanderIncompatible{},
+			expectedDiags: diag.Diagnostics{
+				diagCannotBeAssigned(reflect.TypeFor[testFlexAWSExpander](), reflect.TypeFor[testFlexAWSExpanderIncompatible]()),
+				diag.NewErrorDiagnostic("AutoFlEx", "Expand[flex.testFlexTFTypedExpander, *flex.testFlexAWSExpanderIncompatible]"),
+			},
+		},
+		{
+			TestName: "top level expands to nil",
+			Source: testFlexTFTypedExpanderToNil{
+				Field1: types.StringValue("value1"),
+			},
+			Target: &testFlexAWSExpander{},
+			expectedDiags: diag.Diagnostics{
+				diagExpandsToNil(reflect.TypeFor[testFlexTFTypedExpanderToNil]()),
+				diag.NewErrorDiagnostic("AutoFlEx", "Expand[flex.testFlexTFTypedExpanderToNil, *flex.testFlexAWSExpander]"),
+			},
+		},
+		{
+			TestName: "single list Source and single struct Target",
+			Source: testFlexTFTypedExpanderListNestedObject{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+				}),
+			},
+			Target: &testFlexAWSExpanderSingleStruct{},
+			WantTarget: &testFlexAWSExpanderSingleStruct{
+				Field1: testFlexAWSExpander{
+					AWSField: "value1",
+				},
+			},
+		},
+		{
+			TestName: "single set Source and single struct Target",
+			Source: testFlexTFSetNestedObject[testFlexTFTypedExpander]{
+				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+				}),
+			},
+			Target: &testFlexAWSExpanderSingleStruct{},
+			WantTarget: &testFlexAWSExpanderSingleStruct{
+				Field1: testFlexAWSExpander{
+					AWSField: "value1",
+				},
+			},
+		},
+		{
+			TestName: "single list Source and single *struct Target",
+			Source: testFlexTFTypedExpanderListNestedObject{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+				}),
+			},
+			Target: &testFlexAWSExpanderSinglePtr{},
+			WantTarget: &testFlexAWSExpanderSinglePtr{
+				Field1: &testFlexAWSExpander{
+					AWSField: "value1",
+				},
+			},
+		},
+		{
+			TestName: "single set Source and single *struct Target",
+			Source: testFlexTFTypedExpanderSetNestedObject{
+				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+				}),
+			},
+			Target: &testFlexAWSExpanderSinglePtr{},
+			WantTarget: &testFlexAWSExpanderSinglePtr{
+				Field1: &testFlexAWSExpander{
+					AWSField: "value1",
+				},
+			},
+		},
+		{
+			TestName: "empty list Source and empty struct Target",
+			Source: testFlexTFTypedExpanderListNestedObject{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{}),
+			},
+			Target: &testFlexAWSExpanderStructSlice{},
+			WantTarget: &testFlexAWSExpanderStructSlice{
+				Field1: []testFlexAWSExpander{},
+			},
+		},
+		{
+			TestName: "non-empty list Source and non-empty struct Target",
+			Source: testFlexTFTypedExpanderListNestedObject{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+					{
+						Field1: types.StringValue("value2"),
+					},
+				}),
+			},
+			Target: &testFlexAWSExpanderStructSlice{},
+			WantTarget: &testFlexAWSExpanderStructSlice{
+				Field1: []testFlexAWSExpander{
+					{
+						AWSField: "value1",
+					},
+					{
+						AWSField: "value2",
+					},
+				},
+			},
+		},
+		{
+			TestName: "empty list Source and empty *struct Target",
+			Source: testFlexTFTypedExpanderListNestedObject{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{}),
+			},
+			Target: &testFlexAWSExpanderPtrSlice{},
+			WantTarget: &testFlexAWSExpanderPtrSlice{
+				Field1: []*testFlexAWSExpander{},
+			},
+		},
+		{
+			TestName: "non-empty list Source and non-empty *struct Target",
+			Source: testFlexTFTypedExpanderListNestedObject{
+				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+					{
+						Field1: types.StringValue("value2"),
+					},
+				}),
+			},
+			Target: &testFlexAWSExpanderPtrSlice{},
+			WantTarget: &testFlexAWSExpanderPtrSlice{
+				Field1: []*testFlexAWSExpander{
+					{
+						AWSField: "value1",
+					},
+					{
+						AWSField: "value2",
+					},
+				},
+			},
+		},
+		{
+			TestName: "empty set Source and empty struct Target",
+			Source: testFlexTFTypedExpanderSetNestedObject{
+				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{}),
+			},
+			Target: &testFlexAWSExpanderStructSlice{},
+			WantTarget: &testFlexAWSExpanderStructSlice{
+				Field1: []testFlexAWSExpander{},
+			},
+		},
+		{
+			TestName: "non-empty set Source and non-empty struct Target",
+			Source: testFlexTFTypedExpanderSetNestedObject{
+				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+					{
+						Field1: types.StringValue("value2"),
+					},
+				}),
+			},
+			Target: &testFlexAWSExpanderStructSlice{},
+			WantTarget: &testFlexAWSExpanderStructSlice{
+				Field1: []testFlexAWSExpander{
+					{
+						AWSField: "value1",
+					},
+					{
+						AWSField: "value2",
+					},
+				},
+			},
+		},
+		{
+			TestName: "empty set Source and empty *struct Target",
+			Source: testFlexTFTypedExpanderSetNestedObject{
+				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{}),
+			},
+			Target: &testFlexAWSExpanderPtrSlice{},
+			WantTarget: &testFlexAWSExpanderPtrSlice{
+				Field1: []*testFlexAWSExpander{},
+			},
+		},
+		{
+			TestName: "non-empty set Source and non-empty *struct Target",
+			Source: testFlexTFTypedExpanderSetNestedObject{
+				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFTypedExpander{
+					{
+						Field1: types.StringValue("value1"),
+					},
+					{
+						Field1: types.StringValue("value2"),
+					},
+				}),
+			},
+			Target: &testFlexAWSExpanderPtrSlice{},
+			WantTarget: &testFlexAWSExpanderPtrSlice{
+				Field1: []*testFlexAWSExpander{
+					{
+						AWSField: "value1",
+					},
+					{
+						AWSField: "value2",
+					},
+				},
+			},
+		},
+		{
+			TestName: "object value Source and struct Target",
+			Source: testFlexTFTypedExpanderObjectValue{
+				Field1: fwtypes.NewObjectValueOfMust(ctx, &testFlexTFTypedExpander{
+					Field1: types.StringValue("value1"),
+				}),
+			},
+			Target: &testFlexAWSExpanderSingleStruct{},
+			WantTarget: &testFlexAWSExpanderSingleStruct{
+				Field1: testFlexAWSExpander{
+					AWSField: "value1",
+				},
+			},
+		},
+		{
+			TestName: "object value Source and *struct Target",
+			Source: testFlexTFTypedExpanderObjectValue{
+				Field1: fwtypes.NewObjectValueOfMust(ctx, &testFlexTFTypedExpander{
 					Field1: types.StringValue("value1"),
 				}),
 			},

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -1174,14 +1174,14 @@ func TestExpandListOfNestedObject(t *testing.T) {
 		{
 			TestName:   "empty list value to single struct",
 			Source:     fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{}),
-			Target:     &[]TestFlexAWS01{},
-			WantTarget: &[]TestFlexAWS01{},
+			Target:     &TestFlexAWS01{},
+			WantTarget: &TestFlexAWS01{},
 		},
 		{
 			TestName:   "null value to single struct",
 			Source:     fwtypes.NewListNestedObjectValueOfNull[TestFlexTF01](ctx),
-			Target:     &[]TestFlexAWS01{},
-			WantTarget: &[]TestFlexAWS01{},
+			Target:     &TestFlexAWS01{},
+			WantTarget: &TestFlexAWS01{},
 		},
 	}
 	runAutoExpandTestCases(t, testCases)
@@ -1260,7 +1260,7 @@ func TestExpandSetOfNestedObject(t *testing.T) {
 		},
 
 		{
-			TestName: "single list value to single struct",
+			TestName: "single set value to single struct",
 			Source: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{
 				{
 					Field1: types.StringValue("value1"),
@@ -1272,16 +1272,16 @@ func TestExpandSetOfNestedObject(t *testing.T) {
 			},
 		},
 		{
-			TestName:   "empty list value to single struct",
+			TestName:   "empty set value to single struct",
 			Source:     fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []TestFlexTF01{}),
-			Target:     &[]TestFlexAWS01{},
-			WantTarget: &[]TestFlexAWS01{},
+			Target:     &TestFlexAWS01{},
+			WantTarget: &TestFlexAWS01{},
 		},
 		{
 			TestName:   "null value to single struct",
 			Source:     fwtypes.NewSetNestedObjectValueOfNull[TestFlexTF01](ctx),
-			Target:     &[]TestFlexAWS01{},
-			WantTarget: &[]TestFlexAWS01{},
+			Target:     &TestFlexAWS01{},
+			WantTarget: &TestFlexAWS01{},
 		},
 	}
 	runAutoExpandTestCases(t, testCases)

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -38,7 +38,7 @@ func Flatten(ctx context.Context, apiObject, tfObject any, optFns ...AutoFlexOpt
 	var diags diag.Diagnostics
 	flattener := newAutoFlattener(optFns)
 
-	diags.Append(autoFlexConvert(ctx, apiObject, tfObject, flattener)...)
+	diags.Append(autoFlattenConvert(ctx, apiObject, tfObject, flattener)...)
 	if diags.HasError() {
 		diags.AddError("AutoFlEx", fmt.Sprintf("Flatten[%T, %T]", apiObject, tfObject))
 		return diags
@@ -69,6 +69,29 @@ func newAutoFlattener(optFns []AutoFlexOptionsFunc) *autoFlattener {
 
 func (flattener autoFlattener) getOptions() AutoFlexOptions {
 	return flattener.Options
+}
+
+// autoFlattenConvert converts `from` to `to` using the specified auto-flexer.
+func autoFlattenConvert(ctx context.Context, from, to any, flexer autoFlexer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	valFrom, valTo, d := autoFlexValues(ctx, from, to)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Top-level struct to struct conversion.
+	if valFrom.IsValid() && valTo.IsValid() {
+		if typFrom, typTo := valFrom.Type(), valTo.Type(); typFrom.Kind() == reflect.Struct && typTo.Kind() == reflect.Struct {
+			diags.Append(autoFlexConvertStruct(ctx, from, to, flexer)...)
+			return diags
+		}
+	}
+
+	// Anything else.
+	diags.Append(flexer.convert(ctx, valFrom, valTo)...)
+	return diags
 }
 
 // convert converts a single AWS API value to its Plugin Framework equivalent.

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -1223,8 +1223,8 @@ func TestFlattenInterface(t *testing.T) {
 			Source: testFlexAWSInterfaceSingle{
 				Field1: nil,
 			},
-			Target: &testFlexTFInterfaceListNestedObject{},
-			WantTarget: &testFlexTFInterfaceListNestedObject{
+			Target: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfNull[testFlexTFInterfaceFlexer](ctx),
 			},
 		},
@@ -1235,8 +1235,8 @@ func TestFlattenInterface(t *testing.T) {
 					AWSField: "value1",
 				},
 			},
-			Target: &testFlexTFInterfaceListNestedObject{},
-			WantTarget: &testFlexTFInterfaceListNestedObject{
+			Target: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{
 					{
 						Field1: types.StringValue("value1"),
@@ -1249,8 +1249,8 @@ func TestFlattenInterface(t *testing.T) {
 			Source: testFlexAWSInterfaceSingle{
 				Field1: nil,
 			},
-			Target: &testFlexTFInterfaceListNestedObjectNonFlexer{},
-			WantTarget: &testFlexTFInterfaceListNestedObjectNonFlexer{
+			Target: &testFlexTFListNestedObject[TestFlexTF01]{},
+			WantTarget: &testFlexTFListNestedObject[TestFlexTF01]{
 				Field1: fwtypes.NewListNestedObjectValueOfNull[TestFlexTF01](ctx),
 			},
 		},
@@ -1261,8 +1261,8 @@ func TestFlattenInterface(t *testing.T) {
 					AWSField: "value1",
 				},
 			},
-			Target: &testFlexTFInterfaceListNestedObjectNonFlexer{},
-			WantTarget: &testFlexTFInterfaceListNestedObjectNonFlexer{
+			Target: &testFlexTFListNestedObject[TestFlexTF01]{},
+			WantTarget: &testFlexTFListNestedObject[TestFlexTF01]{
 				Field1: fwtypes.NewListNestedObjectValueOfNull[TestFlexTF01](ctx),
 			},
 			expectedLogLines: []map[string]any{
@@ -1287,8 +1287,8 @@ func TestFlattenInterface(t *testing.T) {
 			Source: testFlexAWSInterfaceSingle{
 				Field1: nil,
 			},
-			Target: &testFlexTFInterfaceSetNestedObject{},
-			WantTarget: &testFlexTFInterfaceSetNestedObject{
+			Target: &testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewSetNestedObjectValueOfNull[testFlexTFInterfaceFlexer](ctx),
 			},
 		},
@@ -1299,8 +1299,8 @@ func TestFlattenInterface(t *testing.T) {
 					AWSField: "value1",
 				},
 			},
-			Target: &testFlexTFInterfaceSetNestedObject{},
-			WantTarget: &testFlexTFInterfaceSetNestedObject{
+			Target: &testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{
 					{
 						Field1: types.StringValue("value1"),
@@ -1314,8 +1314,8 @@ func TestFlattenInterface(t *testing.T) {
 			Source: testFlexAWSInterfaceSlice{
 				Field1: nil,
 			},
-			Target: &testFlexTFInterfaceListNestedObject{},
-			WantTarget: &testFlexTFInterfaceListNestedObject{
+			Target: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfNull[testFlexTFInterfaceFlexer](ctx),
 			},
 		},
@@ -1324,8 +1324,8 @@ func TestFlattenInterface(t *testing.T) {
 			Source: testFlexAWSInterfaceSlice{
 				Field1: []testFlexAWSInterfaceInterface{},
 			},
-			Target: &testFlexTFInterfaceListNestedObject{},
-			WantTarget: &testFlexTFInterfaceListNestedObject{
+			Target: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{}),
 			},
 		},
@@ -1341,8 +1341,8 @@ func TestFlattenInterface(t *testing.T) {
 					},
 				},
 			},
-			Target: &testFlexTFInterfaceListNestedObject{},
-			WantTarget: &testFlexTFInterfaceListNestedObject{
+			Target: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{
 					{
 						Field1: types.StringValue("value1"),
@@ -1359,8 +1359,8 @@ func TestFlattenInterface(t *testing.T) {
 			Source: testFlexAWSInterfaceSlice{
 				Field1: nil,
 			},
-			Target: &testFlexTFInterfaceSetNestedObject{},
-			WantTarget: &testFlexTFInterfaceSetNestedObject{
+			Target: &testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewSetNestedObjectValueOfNull[testFlexTFInterfaceFlexer](ctx),
 			},
 		},
@@ -1369,8 +1369,8 @@ func TestFlattenInterface(t *testing.T) {
 			Source: testFlexAWSInterfaceSlice{
 				Field1: []testFlexAWSInterfaceInterface{},
 			},
-			Target: &testFlexTFInterfaceSetNestedObject{},
-			WantTarget: &testFlexTFInterfaceSetNestedObject{
+			Target: &testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFSetNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewSetNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{}),
 			},
 		},
@@ -1386,8 +1386,8 @@ func TestFlattenInterface(t *testing.T) {
 					},
 				},
 			},
-			Target: &testFlexTFInterfaceListNestedObject{},
-			WantTarget: &testFlexTFInterfaceListNestedObject{
+			Target: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFListNestedObject[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewListNestedObjectValueOfValueSliceMust(ctx, []testFlexTFInterfaceFlexer{
 					{
 						Field1: types.StringValue("value1"),
@@ -1403,8 +1403,8 @@ func TestFlattenInterface(t *testing.T) {
 			Source: testFlexAWSInterfaceSingle{
 				Field1: nil,
 			},
-			Target: &testFlexTFInterfaceObjectValue{},
-			WantTarget: &testFlexTFInterfaceObjectValue{
+			Target: &testFlexTFObjectValue[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFObjectValue[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewObjectValueOfNull[testFlexTFInterfaceFlexer](ctx),
 			},
 		},
@@ -1415,8 +1415,8 @@ func TestFlattenInterface(t *testing.T) {
 					AWSField: "value1",
 				},
 			},
-			Target: &testFlexTFInterfaceObjectValue{},
-			WantTarget: &testFlexTFInterfaceObjectValue{
+			Target: &testFlexTFObjectValue[testFlexTFInterfaceFlexer]{},
+			WantTarget: &testFlexTFObjectValue[testFlexTFInterfaceFlexer]{
 				Field1: fwtypes.NewObjectValueOfMust(ctx, &testFlexTFInterfaceFlexer{
 					Field1: types.StringValue("value1"),
 				}),

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -71,29 +71,6 @@ var (
 // AutoFlexOptionsFunc is a type alias for an autoFlexer functional option.
 type AutoFlexOptionsFunc func(*AutoFlexOptions)
 
-// autoFlexConvert converts `from` to `to` using the specified auto-flexer.
-func autoFlexConvert(ctx context.Context, from, to any, flexer autoFlexer) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	valFrom, valTo, d := autoFlexValues(ctx, from, to)
-	diags.Append(d...)
-	if diags.HasError() {
-		return diags
-	}
-
-	// Top-level struct to struct conversion.
-	if valFrom.IsValid() && valTo.IsValid() {
-		if typFrom, typTo := valFrom.Type(), valTo.Type(); typFrom.Kind() == reflect.Struct && typTo.Kind() == reflect.Struct {
-			diags.Append(autoFlexConvertStruct(ctx, from, to, flexer)...)
-			return diags
-		}
-	}
-
-	// Anything else.
-	diags.Append(flexer.convert(ctx, valFrom, valTo)...)
-	return diags
-}
-
 // autoFlexValues returns the underlying `reflect.Value`s of `from` and `to`.
 func autoFlexValues(_ context.Context, from, to any) (reflect.Value, reflect.Value, diag.Diagnostics) {
 	var diags diag.Diagnostics

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -142,6 +142,11 @@ func autoFlexConvertStruct(ctx context.Context, from any, to any, flexer autoFle
 		return diags
 	}
 
+	if fromTypedExpander, ok := valFrom.Interface().(TypedExpander); ok {
+		diags.Append(expandTypedExpander(ctx, fromTypedExpander, valTo)...)
+		return diags
+	}
+
 	if valTo.Kind() == reflect.Interface {
 		tflog.Info(ctx, "AutoFlex Expand; incompatible types", map[string]any{
 			"from": valFrom.Type(),

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -6,6 +6,7 @@ package flex
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"time"
 
 	smithydocument "github.com/aws/smithy-go/document"
@@ -364,20 +365,16 @@ type TestFlexAWS22 struct {
 	Field1 map[string]map[string]*string
 }
 
-type testFlexTFInterfaceListNestedObject struct {
-	Field1 fwtypes.ListNestedObjectValueOf[testFlexTFInterfaceFlexer] `tfsdk:"field1"`
+type testFlexTFListNestedObject[T any] struct {
+	Field1 fwtypes.ListNestedObjectValueOf[T] `tfsdk:"field1"`
 }
 
-type testFlexTFInterfaceListNestedObjectNonFlexer struct {
-	Field1 fwtypes.ListNestedObjectValueOf[TestFlexTF01] `tfsdk:"field1"`
+type testFlexTFSetNestedObject[T any] struct {
+	Field1 fwtypes.SetNestedObjectValueOf[T] `tfsdk:"field1"`
 }
 
-type testFlexTFInterfaceSetNestedObject struct {
-	Field1 fwtypes.SetNestedObjectValueOf[testFlexTFInterfaceFlexer] `tfsdk:"field1"`
-}
-
-type testFlexTFInterfaceObjectValue struct {
-	Field1 fwtypes.ObjectValueOf[testFlexTFInterfaceFlexer] `tfsdk:"field1"`
+type testFlexTFObjectValue[T any] struct {
+	Field1 fwtypes.ObjectValueOf[T] `tfsdk:"field1"`
 }
 
 type testFlexTFInterfaceFlexer struct {
@@ -468,17 +465,17 @@ func (t *testFlexTFFlexer) Flatten(ctx context.Context, v any) (diags diag.Diagn
 	}
 }
 
-type testFlexTFExpanderListNestedObject struct {
-	Field1 fwtypes.ListNestedObjectValueOf[testFlexTFFlexer] `tfsdk:"field1"`
-}
+type testFlexTFExpanderListNestedObject testFlexTFListNestedObject[testFlexTFFlexer]
 
-type testFlexTFExpanderSetNestedObject struct {
-	Field1 fwtypes.SetNestedObjectValueOf[testFlexTFFlexer] `tfsdk:"field1"`
-}
+type testFlexTFExpanderSetNestedObject testFlexTFSetNestedObject[testFlexTFFlexer]
 
-type testFlexTFExpanderObjectValue struct {
-	Field1 fwtypes.ObjectValueOf[testFlexTFFlexer] `tfsdk:"field1"`
-}
+type testFlexTFExpanderObjectValue testFlexTFObjectValue[testFlexTFFlexer]
+
+type testFlexTFTypedExpanderListNestedObject testFlexTFListNestedObject[testFlexTFTypedExpander]
+
+type testFlexTFTypedExpanderSetNestedObject testFlexTFSetNestedObject[testFlexTFTypedExpander]
+
+type testFlexTFTypedExpanderObjectValue testFlexTFObjectValue[testFlexTFTypedExpander]
 
 type testFlexTFExpanderToString struct {
 	Field1 types.String `tfsdk:"field1"`
@@ -498,6 +495,57 @@ var _ Expander = testFlexTFExpanderToNil{}
 
 func (t testFlexTFExpanderToNil) Expand(ctx context.Context) (any, diag.Diagnostics) {
 	return nil, nil
+}
+
+type testFlexTFTypedExpander struct {
+	Field1 types.String `tfsdk:"field1"`
+}
+
+var _ TypedExpander = testFlexTFTypedExpander{}
+
+func (t testFlexTFTypedExpander) ExpandTo(ctx context.Context, targetType reflect.Type) (any, diag.Diagnostics) {
+	return &testFlexAWSExpander{
+		AWSField: t.Field1.ValueString(),
+	}, nil
+}
+
+type testFlexTFTypedExpanderToNil struct {
+	Field1 types.String `tfsdk:"field1"`
+}
+
+var _ TypedExpander = testFlexTFTypedExpanderToNil{}
+
+func (t testFlexTFTypedExpanderToNil) ExpandTo(ctx context.Context, targetType reflect.Type) (any, diag.Diagnostics) {
+	return nil, nil
+}
+
+type testFlexTFInterfaceTypedExpander struct {
+	Field1 types.String `tfsdk:"field1"`
+}
+
+var _ TypedExpander = testFlexTFInterfaceTypedExpander{}
+
+func (t testFlexTFInterfaceTypedExpander) ExpandTo(ctx context.Context, targetType reflect.Type) (any, diag.Diagnostics) {
+	switch targetType {
+	case reflect.TypeFor[testFlexAWSInterfaceInterface]():
+		return &testFlexAWSInterfaceInterfaceImpl{
+			AWSField: t.Field1.ValueString(),
+		}, nil
+	}
+
+	return nil, nil
+}
+
+type testFlexTFInterfaceIncompatibleTypedExpander struct {
+	Field1 types.String `tfsdk:"field1"`
+}
+
+var _ TypedExpander = testFlexTFInterfaceIncompatibleTypedExpander{}
+
+func (t testFlexTFInterfaceIncompatibleTypedExpander) ExpandTo(ctx context.Context, targetType reflect.Type) (any, diag.Diagnostics) {
+	return &testFlexAWSInterfaceIncompatibleImpl{
+		AWSField: t.Field1.ValueString(),
+	}, nil
 }
 
 type testFlexAWSExpander struct {

--- a/internal/service/verifiedpermissions/identity_source.go
+++ b/internal/service/verifiedpermissions/identity_source.go
@@ -570,26 +570,16 @@ func (m configuration) ExpandTo(ctx context.Context, targetType reflect.Type) (r
 func (m configuration) expandToConfiguration(ctx context.Context) (result awstypes.Configuration, diags diag.Diagnostics) {
 	switch {
 	case !m.CognitoUserPoolConfiguration.IsNull():
-		cognitoUserPoolConfigurationData, d := m.CognitoUserPoolConfiguration.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
 		var result awstypes.ConfigurationMemberCognitoUserPoolConfiguration
-		diags.Append(flex.Expand(ctx, cognitoUserPoolConfigurationData, &result.Value)...)
+		diags.Append(flex.Expand(ctx, m.CognitoUserPoolConfiguration, &result.Value)...)
 		if diags.HasError() {
 			return nil, diags
 		}
 		return &result, diags
 
 	case !m.OpenIDConnectConfiguration.IsNull():
-		openIDConnectConfigurationData, d := m.OpenIDConnectConfiguration.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
 		var result awstypes.ConfigurationMemberOpenIdConnectConfiguration
-		diags.Append(flex.Expand(ctx, openIDConnectConfigurationData, &result.Value)...)
+		diags.Append(flex.Expand(ctx, m.OpenIDConnectConfiguration, &result.Value)...)
 		if diags.HasError() {
 			return nil, diags
 		}
@@ -602,26 +592,16 @@ func (m configuration) expandToConfiguration(ctx context.Context) (result awstyp
 func (m configuration) expandToUpdateConfiguration(ctx context.Context) (result awstypes.UpdateConfiguration, diags diag.Diagnostics) {
 	switch {
 	case !m.CognitoUserPoolConfiguration.IsNull():
-		cognitoUserPoolConfigurationData, d := m.CognitoUserPoolConfiguration.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
 		var result awstypes.UpdateConfigurationMemberCognitoUserPoolConfiguration
-		diags.Append(flex.Expand(ctx, cognitoUserPoolConfigurationData, &result.Value)...)
+		diags.Append(flex.Expand(ctx, m.CognitoUserPoolConfiguration, &result.Value)...)
 		if diags.HasError() {
 			return nil, diags
 		}
 		return &result, diags
 
 	case !m.OpenIDConnectConfiguration.IsNull():
-		openIDConnectConfigurationData, d := m.OpenIDConnectConfiguration.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
 		var result awstypes.UpdateConfigurationMemberOpenIdConnectConfiguration
-		diags.Append(flex.Expand(ctx, openIDConnectConfigurationData, &result.Value)...)
+		diags.Append(flex.Expand(ctx, m.OpenIDConnectConfiguration, &result.Value)...)
 		if diags.HasError() {
 			return nil, diags
 		}
@@ -649,26 +629,16 @@ func (m openIDConnectTokenSelection) ExpandTo(ctx context.Context, targetType re
 func (m openIDConnectTokenSelection) expandToOpenIDConnectTokenSelection(ctx context.Context) (result awstypes.OpenIdConnectTokenSelection, diags diag.Diagnostics) {
 	switch {
 	case !m.AccessTokenOnly.IsNull():
-		openIDConnectAccessTokenConfigurationData, d := m.AccessTokenOnly.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
 		var result awstypes.OpenIdConnectTokenSelectionMemberAccessTokenOnly
-		diags.Append(flex.Expand(ctx, openIDConnectAccessTokenConfigurationData, &result.Value)...)
+		diags.Append(flex.Expand(ctx, m.AccessTokenOnly, &result.Value)...)
 		if diags.HasError() {
 			return nil, diags
 		}
 		return &result, diags
 
 	case !m.IdentityTokenOnly.IsNull():
-		openIDConnectIdentityTokenConfigurationData, d := m.IdentityTokenOnly.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
 		var result awstypes.OpenIdConnectTokenSelectionMemberIdentityTokenOnly
-		diags.Append(flex.Expand(ctx, openIDConnectIdentityTokenConfigurationData, &result.Value)...)
+		diags.Append(flex.Expand(ctx, m.IdentityTokenOnly, &result.Value)...)
 		if diags.HasError() {
 			return nil, diags
 		}
@@ -681,26 +651,16 @@ func (m openIDConnectTokenSelection) expandToOpenIDConnectTokenSelection(ctx con
 func (m openIDConnectTokenSelection) expandToUpdateOpenIDConnectTokenSelection(ctx context.Context) (result awstypes.UpdateOpenIdConnectTokenSelection, diags diag.Diagnostics) {
 	switch {
 	case !m.AccessTokenOnly.IsNull():
-		openIDConnectAccessTokenConfigurationData, d := m.AccessTokenOnly.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
 		var result awstypes.UpdateOpenIdConnectTokenSelectionMemberAccessTokenOnly
-		diags.Append(flex.Expand(ctx, openIDConnectAccessTokenConfigurationData, &result.Value)...)
+		diags.Append(flex.Expand(ctx, m.AccessTokenOnly, &result.Value)...)
 		if diags.HasError() {
 			return nil, diags
 		}
 		return &result, diags
 
 	case !m.IdentityTokenOnly.IsNull():
-		openIDConnectIdentityTokenConfigurationData, d := m.IdentityTokenOnly.ToPtr(ctx)
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
 		var result awstypes.UpdateOpenIdConnectTokenSelectionMemberIdentityTokenOnly
-		diags.Append(flex.Expand(ctx, openIDConnectIdentityTokenConfigurationData, &result.Value)...)
+		diags.Append(flex.Expand(ctx, m.IdentityTokenOnly, &result.Value)...)
 		if diags.HasError() {
 			return nil, diags
 		}


### PR DESCRIPTION
### Description

For some resources, the Create and Update calls take different parameter types. Adds `TypedExpander` interface to allow model types to customize their expansion when there may be different targets

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=verifiedpermissions TESTS=TestAccVerifiedPermissionsIdentitySource_

--- PASS: TestAccVerifiedPermissionsIdentitySource_disappears (13.44s)
--- PASS: TestAccVerifiedPermissionsIdentitySource_Cognito_basic (15.37s)
--- PASS: TestAccVerifiedPermissionsIdentitySource_OpenID_basic (15.43s)
--- PASS: TestAccVerifiedPermissionsIdentitySource_Cognito_convertToOpenID (26.30s)
--- PASS: TestAccVerifiedPermissionsIdentitySource_Cognito_update (26.41s)
--- PASS: TestAccVerifiedPermissionsIdentitySource_OpenID_convertToCognito (30.36s)
--- PASS: TestAccVerifiedPermissionsIdentitySource_OpenID_update (32.07s)
```
