### PR TITLE
docs: add missing serde argument

### DIFF
--- a/website/docs/r/glue_classifier.html.markdown
+++ b/website/docs/r/glue_classifier.html.markdown
@@ -10,11 +10,11 @@ description: |-
 
 Provides a Glue Classifier resource.
 
-~> **NOTE:** It is only valid to create one type of classifier (csv, grok, JSON, or XML). Changing classifier types will recreate the classifier.
+~> **NOTE:** It is only valid to create one type of classifier (CSV, grok, JSON, or XML). Changing classifier types will recreate the classifier.
 
 ## Example Usage
 
-### Csv Classifier
+### CSV Classifier
 
 ```terraform
 resource "aws_glue_classifier" "example" {
@@ -73,7 +73,7 @@ resource "aws_glue_classifier" "example" {
 
 This resource supports the following arguments:
 
-* `csv_classifier` - (Optional) A classifier for Csv content. Defined below.
+* `csv_classifier` - (Optional) A classifier for CSV content. Defined below.
 * `grok_classifier` – (Optional) A classifier that uses grok patterns. Defined below.
 * `json_classifier` – (Optional) A classifier for JSON content. Defined below.
 * `name` – (Required) The name of the classifier.
@@ -85,10 +85,11 @@ This resource supports the following arguments:
 * `contains_header` - (Optional) Indicates whether the CSV file contains a header. This can be one of "ABSENT", "PRESENT", or "UNKNOWN".
 * `custom_datatype_configured` - (Optional) Enables the custom datatype to be configured.
 * `custom_datatypes` - (Optional) A list of supported custom datatypes. Valid values are `BINARY`, `BOOLEAN`, `DATE`, `DECIMAL`, `DOUBLE`, `FLOAT`, `INT`, `LONG`, `SHORT`, `STRING`, `TIMESTAMP`.
-* `delimiter` - (Optional) The delimiter used in the Csv to separate columns.
+* `delimiter` - (Optional) The delimiter used in the CSV to separate columns.
 * `disable_value_trimming` - (Optional) Specifies whether to trim column values.
 * `header` - (Optional) A list of strings representing column names.
 * `quote_symbol` - (Optional) A custom symbol to denote what combines content into a single column value. It must be different from the column delimiter.
+* `serde` – (Optional) The SerDe for processing CSV. Valid values are `OpenCSVSerDe`, `LazySimpleSerDe`, `None`.
 
 ### grok_classifier
 


### PR DESCRIPTION
### Description

- Add the argument `serde` and valid values to the resource description.
- Streamline different ways of writing CVS  (csv,Csv, CSV) into one.

### Relations

- Closes #38431  
  (Issue on missing documentation)
- Relates to #33787  
  (Implementation of functionality)

### References

- [AWS Glue WebAPI reference](https://docs.aws.amazon.com/glue/latest/webapi/API_CsvClassifier.html)

### Output from Acceptance Testing

- Not applicable, only documentation was updated.