### PR TITLE
fix: Change etag to read-only for aws_cloudfront_response_headers_policy

### DIFF
--- a/.changelog/38448.txt
+++ b/.changelog/38448.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_response_headers_policy: Change the `etag` argument to read-only
+```

--- a/.changelog/38448.txt
+++ b/.changelog/38448.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-resource/aws_cloudfront_response_headers_policy: Change the `etag` argument to read-only
+```release-note:breaking-change
+resource/aws_cloudfront_response_headers_policy: The `etag` argument is now computed only
 ```

--- a/internal/service/cloudfront/response_headers_policy.go
+++ b/internal/service/cloudfront/response_headers_policy.go
@@ -154,7 +154,6 @@ func resourceResponseHeadersPolicy() *schema.Resource {
 			},
 			"etag": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			names.AttrName: {

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -19,8 +19,12 @@ Upgrade topics:
 - [Dropping Support For Amazon SimpleDB](#dropping-support-for-amazon-simpledb)
 - [Dropping Support For Amazon Worklink](#dropping-support-for-amazon-worklink)
 - [AWS OpsWorks Stacks End of Life](#aws-opsworks-stacks-end-of-life)
+- [data-source/aws_batch_compute_environment](#data-sourceaws_batch_compute_environment)
+- [resource/aws_batch_compute_environment](#resourceaws_batch_compute_environment)
+- [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
 - [resource/aws_redshift_cluster](#resourceaws_redshift_cluster)
 - [resource/aws_redshift_service_account](#resourceaws_redshift_service_account)
+- [resource/aws_spot_instance_request](#resourceaws_spot_instance_request)
 
 <!-- /TOC -->
 
@@ -105,6 +109,19 @@ As the AWS OpsWorks Stacks service has reached [End Of Life](https://docs.aws.am
 * `aws_opsworks_static_web_layer`
 * `aws_opsworks_user_profile`
 
+## data-source/aws_batch_compute_environment
+
+* `compute_environment_name` has been renamed to `name`.
+
+## resource/aws_batch_compute_environment
+
+* `compute_environment_name` has been renamed to `name`.
+* `compute_environment_name_prefix` has been renamed to `name_prefix`.
+
+## resource/aws_cloudfront_response_headers_policy
+
+* The `etag` argument is now computed only.
+
 ## resource/aws_redshift_cluster
 
 * The `publicly_accessible` attribute now defaults to `false`.
@@ -118,12 +135,3 @@ The `aws_redshift_service_account` resource has been removed. AWS [recommends](h
 ## resource/aws_spot_instance_request
 
 * Remove `block_duration_minutes` from configuration as it no longer exists.
-
-## resource/aws_batch_compute_environment
-
-* `compute_environment_name` has been renamed to `name`.
-* `compute_environment_name_prefix` has been renamed to `name_prefix`.
-
-## resource/aws_batch_comptete_environment_data_source
-
-* `compute_environment_name` has been renamed to `name`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to change the `etag` argument of the `aws_cloudfront_response_headers_policy` resource to read-only, since users cannot really set it according to the AWS API reference.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38244

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
See https://github.com/hashicorp/terraform-provider-aws/issues/38244#issuecomment-2241328041 for list of resources referenced during the investigation.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccCloudFrontResponseHeadersPolicy PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontResponseHeadersPolicy'  -timeout 360m
=== RUN   TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== PAUSE TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== RUN   TestAccCloudFrontResponseHeadersPolicy_cors
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_cors
=== RUN   TestAccCloudFrontResponseHeadersPolicy_customHeaders
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_customHeaders
=== RUN   TestAccCloudFrontResponseHeadersPolicy_RemoveHeadersConfig
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_RemoveHeadersConfig
=== RUN   TestAccCloudFrontResponseHeadersPolicy_securityHeaders
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_securityHeaders
=== RUN   TestAccCloudFrontResponseHeadersPolicy_serverTimingHeaders
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_serverTimingHeaders
=== RUN   TestAccCloudFrontResponseHeadersPolicy_disappears
=== PAUSE TestAccCloudFrontResponseHeadersPolicy_disappears
=== CONT  TestAccCloudFrontResponseHeadersPolicyDataSource_basic
=== CONT  TestAccCloudFrontResponseHeadersPolicy_securityHeaders
=== CONT  TestAccCloudFrontResponseHeadersPolicy_customHeaders
=== CONT  TestAccCloudFrontResponseHeadersPolicy_RemoveHeadersConfig
=== CONT  TestAccCloudFrontResponseHeadersPolicy_disappears
=== CONT  TestAccCloudFrontResponseHeadersPolicy_cors
=== CONT  TestAccCloudFrontResponseHeadersPolicy_serverTimingHeaders
--- PASS: TestAccCloudFrontResponseHeadersPolicyDataSource_basic (20.54s)
--- PASS: TestAccCloudFrontResponseHeadersPolicy_disappears (21.17s)
--- PASS: TestAccCloudFrontResponseHeadersPolicy_RemoveHeadersConfig (24.26s)
--- PASS: TestAccCloudFrontResponseHeadersPolicy_customHeaders (24.34s)
--- PASS: TestAccCloudFrontResponseHeadersPolicy_securityHeaders (34.47s)
--- PASS: TestAccCloudFrontResponseHeadersPolicy_cors (34.56s)
--- PASS: TestAccCloudFrontResponseHeadersPolicy_serverTimingHeaders (54.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 54.959s

$
```
