### PR TITLE
fix: Add nil checks to fix perpetual diff of rule arg for aws_ce_cost_category

### DIFF
--- a/.changelog/38449.txt
+++ b/.changelog/38449.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ce_cost_category: Fix perpetual diff with the `rule` argument on update 
+```

--- a/internal/service/ce/cost_category.go
+++ b/internal/service/ce/cost_category.go
@@ -716,9 +716,16 @@ func flattenCostCategoryRule(apiObject *awstypes.CostCategoryRule) map[string]in
 	tfMap := map[string]interface{}{}
 
 	tfMap["inherited_value"] = flattenCostCategoryInheritedValueDimension(apiObject.InheritedValue)
-	tfMap[names.AttrRule] = []interface{}{flattenExpression(apiObject.Rule)}
+
+	if v := apiObject.Rule; v != nil {
+		tfMap[names.AttrRule] = []interface{}{flattenExpression(apiObject.Rule)}
+	}
+
 	tfMap[names.AttrType] = string(apiObject.Type)
-	tfMap[names.AttrValue] = aws.ToString(apiObject.Value)
+
+	if v := apiObject.Value; v != nil {
+		tfMap[names.AttrValue] = aws.ToString(v)
+	}
 
 	return tfMap
 }
@@ -745,7 +752,10 @@ func flattenCostCategoryInheritedValueDimension(apiObject *awstypes.CostCategory
 	var tfList []map[string]interface{}
 	tfMap := map[string]interface{}{}
 
-	tfMap["dimension_key"] = aws.ToString(apiObject.DimensionKey)
+	if v := apiObject.DimensionKey; v != nil {
+		tfMap["dimension_key"] = aws.ToString(v)
+	}
+
 	tfMap["dimension_name"] = string(apiObject.DimensionName)
 
 	tfList = append(tfList, tfMap)
@@ -797,7 +807,10 @@ func flattenCostCategoryValues(apiObject *awstypes.CostCategoryValues) []map[str
 	var tfList []map[string]interface{}
 	tfMap := map[string]interface{}{}
 
-	tfMap[names.AttrKey] = aws.ToString(apiObject.Key)
+	if v := apiObject.Key; v != nil {
+		tfMap[names.AttrKey] = aws.ToString(v)
+	}
+
 	tfMap["match_options"] = flex.FlattenStringyValueList(apiObject.MatchOptions)
 	tfMap[names.AttrValues] = apiObject.Values
 
@@ -831,7 +844,10 @@ func flattenTagValues(apiObject *awstypes.TagValues) []map[string]interface{} {
 	var tfList []map[string]interface{}
 	tfMap := map[string]interface{}{}
 
-	tfMap[names.AttrKey] = aws.ToString(apiObject.Key)
+	if v := apiObject.Key; v != nil {
+		tfMap[names.AttrKey] = aws.ToString(v)
+	}
+
 	tfMap["match_options"] = flex.FlattenStringyValueList(apiObject.MatchOptions)
 	tfMap[names.AttrValues] = apiObject.Values
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix perpetual diff with the `rule` argument when updating a `aws_ce_cost_category` resource, because of a subtle state differences with the nested `rule` argument being set during flattening regardless of whether the API response value is set. For good measure, I added similar checks for other optional values in all flatten functions where appropriate.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38215

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccCECostCategory_ PKG=ce
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ce/... -v -count 1 -parallel 20 -run='TestAccCECostCategory_'  -timeout 360m
=== RUN   TestAccCECostCategory_basic
=== PAUSE TestAccCECostCategory_basic
=== RUN   TestAccCECostCategory_effectiveStart
=== PAUSE TestAccCECostCategory_effectiveStart
=== RUN   TestAccCECostCategory_disappears
=== PAUSE TestAccCECostCategory_disappears
=== RUN   TestAccCECostCategory_complete
=== PAUSE TestAccCECostCategory_complete
=== RUN   TestAccCECostCategory_notWithAnd
=== PAUSE TestAccCECostCategory_notWithAnd
=== RUN   TestAccCECostCategory_splitCharge
=== PAUSE TestAccCECostCategory_splitCharge
=== RUN   TestAccCECostCategory_tags
=== PAUSE TestAccCECostCategory_tags
=== CONT  TestAccCECostCategory_basic
=== CONT  TestAccCECostCategory_notWithAnd
=== CONT  TestAccCECostCategory_splitCharge
=== CONT  TestAccCECostCategory_tags
=== CONT  TestAccCECostCategory_disappears
=== CONT  TestAccCECostCategory_complete
=== CONT  TestAccCECostCategory_effectiveStart
--- PASS: TestAccCECostCategory_disappears (19.20s)
--- PASS: TestAccCECostCategory_notWithAnd (24.39s)
--- PASS: TestAccCECostCategory_basic (24.46s)
--- PASS: TestAccCECostCategory_effectiveStart (34.83s)
--- PASS: TestAccCECostCategory_complete (36.57s)
--- PASS: TestAccCECostCategory_splitCharge (39.05s)
--- PASS: TestAccCECostCategory_tags (44.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ce 44.690s

$
```
