### PR TITLE
docs: Add max_webservers and min_webservers for aws_mwaa_environment

### DIFF
--- a/website/docs/r/mwaa_environment.html.markdown
+++ b/website/docs/r/mwaa_environment.html.markdown
@@ -133,11 +133,13 @@ This resource supports the following arguments:
 * `environment_class` - (Optional) Environment class for the cluster. Possible options are `mw1.small`, `mw1.medium`, `mw1.large`. Will be set by default to `mw1.small`. Please check the [AWS Pricing](https://aws.amazon.com/de/managed-workflows-for-apache-airflow/pricing/) for more information about the environment classes.
 * `execution_role_arn` - (Required) The Amazon Resource Name (ARN) of the task execution role that the Amazon MWAA and its environment can assume. Check the [official AWS documentation](https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-create-role.html) for the detailed role specification.
 * `kms_key` - (Optional) The Amazon Resource Name (ARN) of your KMS key that you want to use for encryption. Will be set to the ARN of the managed KMS key `aws/airflow` by default. Please check the [Official Documentation](https://docs.aws.amazon.com/mwaa/latest/userguide/custom-keys-certs.html) for more information.
-* `logging_configuration` - (Optional) The Apache Airflow logs you want to send to Amazon CloudWatch Logs.
+* `logging_configuration` - (Optional) The Apache Airflow logs you want to send to Amazon CloudWatch Logs. See [`logging_configuration` Block](#logging_configuration-block) for details.
+* `max_webservers` - (Optional) The maximum number of web servers that you want to run in your environment. Value need to be between `2` and `5`. Will be `2` by default.
 * `max_workers` - (Optional) The maximum number of workers that can be automatically scaled up. Value need to be between `1` and `25`. Will be `10` by default.
+* `min_webservers` - (Optional) The minimum number of web servers that you want to run in your environment. Value need to be between `2` and `5`. Will be `2` by default.
 * `min_workers` - (Optional) The minimum number of workers that you want to run in your environment. Will be `1` by default.
 * `name` - (Required) The name of the Apache Airflow Environment
-* `network_configuration` - (Required) Specifies the network configuration for your Apache Airflow Environment. This includes two private subnets as well as security groups for the Airflow environment. Each subnet requires internet connection, otherwise the deployment will fail. See [Network configuration](#network-configuration) below for details.
+* `network_configuration` - (Required) Specifies the network configuration for your Apache Airflow Environment. This includes two private subnets as well as security groups for the Airflow environment. Each subnet requires internet connection, otherwise the deployment will fail. See [`network_configuration` Block](#network_configuration-block) for details.
 * `plugins_s3_object_version` - (Optional) The plugins.zip file version you want to use.
 * `plugins_s3_path` - (Optional) The relative path to the plugins.zip file on your Amazon S3 storage bucket. For example, plugins.zip. If a relative path is provided in the request, then plugins_s3_object_version is required. For more information, see [Importing DAGs on Amazon MWAA](https://docs.aws.amazon.com/mwaa/latest/userguide/configuring-dag-import.html).
 * `requirements_s3_object_version` - (Optional) The requirements.txt file version you want to use.
@@ -150,9 +152,9 @@ This resource supports the following arguments:
 * `weekly_maintenance_window_start` - (Optional) Specifies the start date for the weekly maintenance window.
 * `tags` - (Optional) A map of resource tags to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### Logging configurations
+### `logging_configuration` Block
 
-The `logging_configuration` block supports the following arguments.
+The `logging_configuration` configuration block supports the following arguments.
 
 * `dag_processing_logs` - (Optional) (Optional) Log configuration options for processing DAGs. See [Module logging configuration](#module-logging-configuration) for more information. Disabled by default.
 * `scheduler_logs` - (Optional) Log configuration options for the schedulers. See [Module logging configuration](#module-logging-configuration) for more information. Disabled by default.
@@ -167,9 +169,9 @@ A configuration block to use for logging with respect to the various Apache Airf
 * `enabled` - (Required) Enabling or disabling the collection of logs
 * `log_level` - (Optional) Logging level. Valid values: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`. Will be `INFO` by default.
 
-### Network configuration
+### `network_configuration` Block
 
-The `network_configuration` block supports the following arguments. More information about the required subnet and security group settings can be found in the [official AWS documentation](https://docs.aws.amazon.com/mwaa/latest/userguide/vpc-create.html).
+The `network_configuration` configuration block supports the following arguments. More information about the required subnet and security group settings can be found in the [official AWS documentation](https://docs.aws.amazon.com/mwaa/latest/userguide/vpc-create.html).
 
 * `security_group_ids` - (Required) Security groups IDs for the environment. At least one of the security group needs to allow MWAA resources to talk to each other, otherwise MWAA cannot be provisioned.
 * `subnet_ids` - (Required)  The private subnet IDs in which the environment should be created. MWAA requires two subnets.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the missing `max_webservers` and `min_webservers` arguments to the `aws_mwaa_environment` resource documentation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38152

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [Environment](https://docs.aws.amazon.com/mwaa/latest/API/API_Environment.html) for wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a
