### PR TITLE
feat: Add event_bridge_destination block for aws_sesv2_configuration_set_event_destination

### DIFF
--- a/.changelog/38458.txt
+++ b/.changelog/38458.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sesv2_configuration_set_event_destination: Add `event_destination.event_bridge_destination` configuration block
+```

--- a/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
+++ b/website/docs/r/sesv2_configuration_set_event_destination.html.markdown
@@ -12,7 +12,7 @@ Terraform resource for managing an AWS SESv2 (Simple Email V2) Configuration Set
 
 ## Example Usage
 
-### Cloud Watch Destination
+### CloudWatch Destination
 
 ```terraform
 resource "aws_sesv2_configuration_set" "example" {
@@ -30,6 +30,28 @@ resource "aws_sesv2_configuration_set_event_destination" "example" {
         dimension_name          = "example"
         dimension_value_source  = "MESSAGE_TAG"
       }
+    }
+
+    enabled              = true
+    matching_event_types = ["SEND"]
+  }
+}
+```
+
+### EventBridge Destination
+
+```terraform
+data "aws_cloudwatch_event_bus" "default" {
+  name = "default"
+}
+
+resource "aws_sesv2_configuration_set_event_destination" "example" {
+  configuration_set_name = aws_sesv2_configuration_set.example.configuration_set_name
+  event_destination_name = "example"
+
+  event_destination {
+    event_bridge_destination {
+      event_bus_arn = data.aws_cloudwatch_event_bus.default.arn
     }
 
     enabled              = true
@@ -111,52 +133,56 @@ The following arguments are required:
 
 * `configuration_set_name` - (Required) The name of the configuration set.
 * `event_destination` - (Required) A name that identifies the event destination within the configuration set.
-* `event_destination_name` - (Required) An object that defines the event destination. See [event_destination](#event_destination) below.
+* `event_destination_name` - (Required) An object that defines the event destination. See [`event_destination` Block](#event_destination-block) for details.
 
-### event_destination
+### `event_destination` Block
 
-The following arguments are required:
+The `event_destination` configuration block supports the following arguments:
 
 * `matching_event_types` - (Required) - An array that specifies which events the Amazon SES API v2 should send to the destinations. Valid values: `SEND`, `REJECT`, `BOUNCE`, `COMPLAINT`, `DELIVERY`, `OPEN`, `CLICK`, `RENDERING_FAILURE`, `DELIVERY_DELAY`, `SUBSCRIPTION`.
-
-The following arguments are optional:
-
-* `cloud_watch_destination` - (Optional) An object that defines an Amazon CloudWatch destination for email events. See [cloud_watch_destination](#cloud_watch_destination) below
+* `cloud_watch_destination` - (Optional) An object that defines an Amazon CloudWatch destination for email events. See [`cloud_watch_destination` Block](#cloud_watch_destination-block) for details.
 * `enabled` - (Optional) When the event destination is enabled, the specified event types are sent to the destinations. Default: `false`.
-* `kinesis_firehose_destination` - (Optional) An object that defines an Amazon Kinesis Data Firehose destination for email events. See [kinesis_firehose_destination](#kinesis_firehose_destination) below.
-* `pinpoint_destination` - (Optional) An object that defines an Amazon Pinpoint project destination for email events. See [pinpoint_destination](#pinpoint_destination) below.
-* `sns_destination` - (Optional) An object that defines an Amazon SNS destination for email events. See [sns_destination](#sns_destination) below.
+* `event_bridge_configuration` - (Optional) An object that defines an Amazon EventBridge destination for email events. You can use Amazon EventBridge to send notifications when certain email events occur. See [`event_bridge_configuration` Block](#event_bridge_configuration-block) for details.
+* `kinesis_firehose_destination` - (Optional) An object that defines an Amazon Kinesis Data Firehose destination for email events. See [`kinesis_firehose_destination` Block](#kinesis_firehose_destination-block) for details.
+* `pinpoint_destination` - (Optional) An object that defines an Amazon Pinpoint project destination for email events. See [`pinpoint_destination` Block](#pinpoint_destination-block) for details.
+* `sns_destination` - (Optional) An object that defines an Amazon SNS destination for email events. See [`sns_destination` Block](#sns_destination-block) for details.
 
-### cloud_watch_destination
+### `cloud_watch_destination` Block
 
-The following arguments are required:
+The `cloud_watch_destination` configuration block supports the following arguments:
 
-* `dimension_configuration` - (Required) An array of objects that define the dimensions to use when you send email events to Amazon CloudWatch. See [dimension_configuration](#dimension_configuration) below.
+* `dimension_configuration` - (Required) An array of objects that define the dimensions to use when you send email events to Amazon CloudWatch. See [`dimension_configuration` Block](#dimension_configuration-block) for details.
 
-### dimension_configuration
+### `dimension_configuration` Block
 
-The following arguments are required:
+The `dimension_configuration` configuration block supports the following arguments:
 
 * `default_dimension_value` - (Required) The default value of the dimension that is published to Amazon CloudWatch if you don't provide the value of the dimension when you send an email.
 * `dimension_name` - (Required) The name of an Amazon CloudWatch dimension associated with an email sending metric.
 * `dimension_value_source` - (Required) The location where the Amazon SES API v2 finds the value of a dimension to publish to Amazon CloudWatch. Valid values: `MESSAGE_TAG`, `EMAIL_HEADER`, `LINK_TAG`.
 
-### kinesis_firehose_destination
+### `event_bridge_configuration` Block
 
-The following arguments are required:
+The `event_bridge_configuration` configuration block supports the following arguments:
+
+* `event_bus_arn` - (Required) The Amazon Resource Name (ARN) of the Amazon EventBridge bus to publish email events to. Only the default bus is supported.
+
+### `kinesis_firehose_destination` Block
+
+The `kinesis_firehose_destination` configuration block supports the following arguments:
 
 * `delivery_stream_arn` - (Required) The Amazon Resource Name (ARN) of the Amazon Kinesis Data Firehose stream that the Amazon SES API v2 sends email events to.
 * `iam_role_arn` - (Required) The Amazon Resource Name (ARN) of the IAM role that the Amazon SES API v2 uses to send email events to the Amazon Kinesis Data Firehose stream.
 
-### pinpoint_destination
+### `pinpoint_destination` Block
 
-The following arguments are required:
+The `pinpoint_destination` configuration block supports the following arguments:
 
 * `pinpoint_application_arn` - (Required) The Amazon Resource Name (ARN) of the Amazon Pinpoint project to send email events to.
 
-### sns_destination
+### `sns_destination` Block
 
-The following arguments are required:
+The `sns_destination` configuration block supports the following arguments:
 
 * `topic_arn` - (Required) The Amazon Resource Name (ARN) of the Amazon SNS topic to publish email events to.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `event_destination.event_bridge_destination` block to the `aws_sesv2_configuration_set_event_destination` resource to support tracking email sending activity by delivering sending events to EventBridge.

I opted to use `event_bridge_destination` instead of `eventbridge_destination` since the AWSCC provider also uses [`event_bridge_destination`](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/ses_configuration_set_event_destination#event_bridge_destination) as the arg/block name.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38021

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [EventDestinationDefinition](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_EventDestinationDefinition.html) for specs.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccSESV2ConfigurationSetEventDestination_ PKG=sesv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/sesv2/... -v -count 1 -parallel 20 -run='TestAccSESV2ConfigurationSetEventDestination_'  -timeout 360m
=== RUN   TestAccSESV2ConfigurationSetEventDestination_basic
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_basic
=== RUN   TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination
=== RUN   TestAccSESV2ConfigurationSetEventDestination_eventBridgeDestination
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_eventBridgeDestination
=== RUN   TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination
=== RUN   TestAccSESV2ConfigurationSetEventDestination_pinpointDestination
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_pinpointDestination
=== RUN   TestAccSESV2ConfigurationSetEventDestination_snsDestination
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_snsDestination
=== RUN   TestAccSESV2ConfigurationSetEventDestination_disappears
=== PAUSE TestAccSESV2ConfigurationSetEventDestination_disappears
=== CONT  TestAccSESV2ConfigurationSetEventDestination_basic
=== CONT  TestAccSESV2ConfigurationSetEventDestination_pinpointDestination
=== CONT  TestAccSESV2ConfigurationSetEventDestination_disappears
=== CONT  TestAccSESV2ConfigurationSetEventDestination_eventBridgeDestination
=== CONT  TestAccSESV2ConfigurationSetEventDestination_snsDestination
=== CONT  TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination
=== CONT  TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination
--- PASS: TestAccSESV2ConfigurationSetEventDestination_disappears (21.88s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_eventBridgeDestination (25.82s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_cloudWatchDestination (36.38s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_basic (36.57s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_snsDestination (38.07s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_pinpointDestination (38.69s)
--- PASS: TestAccSESV2ConfigurationSetEventDestination_kinesisFirehoseDestination (114.99s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      115.230s

$
```