### PR TITLE
[New Resource] Add Clean Rooms Configured Table Analysis Rule Resource

### DIFF
--- a/.changelog/38462.txt
+++ b/.changelog/38462.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_cleanrooms_configured_table_analysis_rule
+```

--- a/internal/service/cleanrooms/configured_table_analysis_rule.go
+++ b/internal/service/cleanrooms/configured_table_analysis_rule.go
@@ -1,0 +1,762 @@
+package cleanrooms
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cleanrooms"
+	"github.com/aws/aws-sdk-go-v2/service/cleanrooms/types"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_cleanrooms_configured_table_analysis_rule")
+// @Tags(identifierAttribute="arn")
+func ResourceConfiguredTableAnalysisRule() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceConfiguredTableAnalysisRuleCreate,
+		ReadWithoutTimeout:   resourceConfiguredTableAnalysisRuleRead,
+		UpdateWithoutTimeout: resourceConfiguredTableAnalysisRuleUpdate,
+		DeleteWithoutTimeout: resourceConfiguredTableAnalysisRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Minute),
+			Update: schema.DefaultTimeout(2 * time.Minute),
+			Delete: schema.DefaultTimeout(2 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrID: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"analysis_rule_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"configured_table_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"analysis_rule_policy": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: false,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"v1": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: false,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"list": {
+										Type:     schema.TypeList,
+										Optional: true,
+										ForceNew: true,
+										MaxItems: 1,
+										ExactlyOneOf: []string{
+											"analysis_rule_policy.0.v1.0.list",
+											"analysis_rule_policy.0.v1.0.aggregation",
+											"analysis_rule_policy.0.v1.0.custom",
+										},
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"join_columns": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+												"allowed_join_operators": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+												"list_columns": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+											},
+										},
+									},
+									"aggregation": {
+										Type:     schema.TypeList,
+										Optional: true,
+										ForceNew: true,
+										MaxItems: 1,
+										ExactlyOneOf: []string{
+											"analysis_rule_policy.0.v1.0.list",
+											"analysis_rule_policy.0.v1.0.aggregation",
+											"analysis_rule_policy.0.v1.0.custom",
+										},
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"aggregate_columns": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"column_names": {
+																Type:     schema.TypeList,
+																Optional: true,
+																ForceNew: false,
+																Elem: &schema.Schema{
+																	Type: schema.TypeString,
+																},
+															},
+															"function": {
+																Type:     schema.TypeString,
+																Optional: true,
+																ForceNew: false,
+															},
+														},
+													},
+												},
+												"join_aggregate_columns": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+												"join_required": {
+													Type:     schema.TypeString,
+													Optional: true,
+													ForceNew: false,
+												},
+												"allowed_join_operators": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+												"dimension_columns": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+												"scalar_functions": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+												"output_constraints": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"column_name": {
+																Type:     schema.TypeString,
+																Optional: true,
+																ForceNew: false,
+															},
+															"minimum": {
+																Type:     schema.TypeInt,
+																Optional: true,
+																ForceNew: false,
+															},
+															"type": {
+																Type:     schema.TypeString,
+																Optional: true,
+																ForceNew: false,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"custom": {
+										Type:     schema.TypeList,
+										Optional: true,
+										ForceNew: true,
+										MaxItems: 1,
+										ExactlyOneOf: []string{
+											"analysis_rule_policy.0.v1.0.list",
+											"analysis_rule_policy.0.v1.0.aggregation",
+											"analysis_rule_policy.0.v1.0.custom",
+										},
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"allowed_custom_analyses": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+												"allowed_analyses_providers": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+												"differential_privacy": {
+													Type:     schema.TypeList,
+													Optional: true,
+													ForceNew: false,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"columns": {
+																Type:     schema.TypeList,
+																Optional: true,
+																ForceNew: false,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"name": {
+																			Type:     schema.TypeString,
+																			Optional: true,
+																			ForceNew: false,
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+const (
+	ResNameConfiguredTableAnalysisRule = "Configured Table Analysis Rule"
+)
+
+func resourceConfiguredTableAnalysisRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).CleanRoomsClient(ctx)
+
+	input := &cleanrooms.CreateConfiguredTableAnalysisRuleInput{
+		ConfiguredTableIdentifier: aws.String(d.Get("configured_table_identifier").(string)),
+	}
+
+	if v, ok := d.GetOk("analysis_rule_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.AnalysisRulePolicy = expandAnalysisRulePolicy(v.([]interface{}))
+	}
+
+	analysisRuleType, err := expandAnalysisRuleType(d.Get("analysis_rule_type").(string))
+	if err != nil {
+		return create.DiagError(names.CleanRooms, create.ErrActionCreating, ResNameConfiguredTableAnalysisRule, d.Get("name").(string), err)
+	}
+
+	if analysisRuleType == "LIST" {
+		if listPolicy := d.Get("analysis_rule_policy.0.v1.0.list").([]interface{}); len(listPolicy) == 0 {
+			return diag.Errorf("analysis rule type is LIST but got empty analysis rule policy for list.")
+		}
+	}
+	if analysisRuleType == "AGGREGATION" {
+		if listPolicy := d.Get("analysis_rule_policy.0.v1.0.aggregation").([]interface{}); len(listPolicy) == 0 {
+			return diag.Errorf("analysis rule type is AGGREGATION but got empty analysis rule policy for aggregation.")
+		}
+	}
+	if analysisRuleType == "CUSTOM" {
+		if listPolicy := d.Get("analysis_rule_policy.0.v1.0.custom").([]interface{}); len(listPolicy) == 0 {
+			return diag.Errorf("analysis rule type is CUSTOM but got empty analysis rule policy for custom.")
+		}
+	}
+
+	input.AnalysisRuleType = analysisRuleType
+
+	out, err := conn.CreateConfiguredTableAnalysisRule(ctx, input)
+
+	if err != nil {
+		return create.DiagError(names.CleanRooms, create.ErrActionCreating, ResNameConfiguredTableAnalysisRule, d.Get("name").(string), err)
+	}
+
+	if out == nil || out.AnalysisRule == nil {
+		return create.DiagError(names.CleanRooms, create.ErrActionCreating, ResNameConfiguredTableAnalysisRule, d.Get("name").(string), errors.New("empty output"))
+	}
+
+	d.SetId(aws.ToString(out.AnalysisRule.ConfiguredTableId))
+
+	return nil
+}
+
+func resourceConfiguredTableAnalysisRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.AWSClient).CleanRoomsClient(ctx)
+
+	out, err := findAnalysisRuleByID(ctx, conn, d.Get("configured_table_identifier").(string), d.Get("analysis_rule_type").(string))
+
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] CleanRooms Configured Table Analysis Rule (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return create.DiagError(names.CleanRooms, create.ErrActionReading, ResNameConfiguredTableAnalysisRule, d.Id(), err)
+	}
+
+	analysisRule := out.AnalysisRule
+	d.Set(names.AttrARN, analysisRule.ConfiguredTableArn)
+	d.Set(names.AttrID, analysisRule.ConfiguredTableId)
+	d.Set("create_time", analysisRule.CreateTime.Format(time.RFC3339))
+	d.Set("analysis_rule_type", analysisRule.Type)
+
+	return nil
+}
+
+func resourceConfiguredTableAnalysisRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).CleanRoomsClient(ctx)
+
+	input := &cleanrooms.UpdateConfiguredTableAnalysisRuleInput{
+		ConfiguredTableIdentifier: aws.String(d.Id()),
+	}
+
+	analysisRuleType, analysisErr := expandAnalysisRuleType(d.Get("analysis_rule_type").(string))
+	if analysisErr != nil {
+		return create.DiagError(names.CleanRooms, create.ErrActionCreating, ResNameConfiguredTableAnalysisRule, d.Get("name").(string), analysisErr)
+	}
+	input.AnalysisRuleType = analysisRuleType
+
+	if d.HasChange("analysis_rule_policy") {
+		if v, ok := d.GetOk("analysis_rule_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			input.AnalysisRulePolicy = expandAnalysisRulePolicy(v.([]interface{}))
+		}
+	}
+
+	_, err := conn.UpdateConfiguredTableAnalysisRule(ctx, input)
+	if err != nil {
+		return create.DiagError(names.CleanRooms, create.ErrActionUpdating, ResNameConfiguredTableAnalysisRule, d.Id(), err)
+	}
+
+	return append(diags, resourceConfiguredTableAnalysisRuleRead(ctx, d, meta)...)
+}
+
+func resourceConfiguredTableAnalysisRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).CleanRoomsClient(ctx)
+
+	log.Printf("[INFO] Deleting Configured Table Analysis Rule %s", d.Id())
+
+	ruleType, _ := expandAnalysisRuleType(d.Get("analysis_rule_type").(string))
+
+	_, err := conn.DeleteConfiguredTableAnalysisRule(ctx, &cleanrooms.DeleteConfiguredTableAnalysisRuleInput{
+		ConfiguredTableIdentifier: aws.String(d.Get("configured_table_identifier").(string)),
+		AnalysisRuleType:          ruleType,
+	})
+
+	if errs.IsA[*types.AccessDeniedException](err) {
+		return diags
+	}
+
+	if err != nil {
+		return create.AppendDiagError(diags, names.CleanRooms, create.ErrActionDeleting, ResNameConfiguredTableAnalysisRule, d.Id(), err)
+	}
+
+	return diags
+}
+
+func expandAnalysisRuleType(rule string) (types.ConfiguredTableAnalysisRuleType, error) {
+	switch rule {
+	case "AGGREGATION":
+		return types.ConfiguredTableAnalysisRuleTypeAggregation, nil
+	case "LIST":
+		return types.ConfiguredTableAnalysisRuleTypeList, nil
+	case "CUSTOM":
+		return types.ConfiguredTableAnalysisRuleTypeCustom, nil
+	default:
+		return types.ConfiguredTableAnalysisRuleTypeAggregation, fmt.Errorf("invalid analysis_rule_type: %s", rule)
+	}
+}
+
+func expandAnalysisRulePolicy(tfList []interface{}) types.ConfiguredTableAnalysisRulePolicy {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	log.Printf("tfMap expandAnalysisRulePolicy: %+v\n", tfMap)
+
+	if v, ok := tfMap["v1"].([]interface{}); ok && len(v) > 0 {
+		return &types.ConfiguredTableAnalysisRulePolicyMemberV1{
+			Value: expandAnalysisPolicyV1(v),
+		}
+	} else {
+		return nil
+	}
+}
+
+func expandAnalysisPolicyV1(tfList []interface{}) types.ConfiguredTableAnalysisRulePolicyV1 {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	log.Printf("tfMap expandAnalysisPolicyV1: %+v\n", tfMap)
+
+	if v, ok := tfMap["list"].([]interface{}); ok && len(v) > 0 {
+		return &types.ConfiguredTableAnalysisRulePolicyV1MemberList{
+			Value: *expandAnalysisPolicyList(v),
+		}
+	} else if v, ok := tfMap["aggregation"].([]interface{}); ok && len(v) > 0 {
+		return &types.ConfiguredTableAnalysisRulePolicyV1MemberAggregation{
+			Value: *expandAnalysisPolicyAggregation(v),
+		}
+	} else if v, ok := tfMap["custom"].([]interface{}); ok && len(v) > 0 {
+		return &types.ConfiguredTableAnalysisRulePolicyV1MemberCustom{
+			Value: *expandAnalysisPolicyCustom(v),
+		}
+	} else {
+		return nil
+	}
+
+}
+
+func expandAnalysisPolicyList(tfList []interface{}) *types.AnalysisRuleList {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	a := &types.AnalysisRuleList{}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	if v, ok := tfMap["join_columns"].([]interface{}); ok && len(v) > 0 {
+		a.JoinColumns = convertInterfaceSliceToStringSlice(v)
+	}
+	if v, ok := tfMap["allowed_join_operators"].([]interface{}); ok && len(v) > 0 {
+		a.AllowedJoinOperators = expandAllowedJoinOperators(v)
+	}
+	if v, ok := tfMap["list_columns"].([]interface{}); ok && len(v) > 0 {
+		a.ListColumns = convertInterfaceSliceToStringSlice(v)
+	}
+
+	return a
+}
+
+func convertInterfaceSliceToStringSlice(interfaces []interface{}) []string {
+	strings := make([]string, len(interfaces))
+	for i, v := range interfaces {
+		if str, ok := v.(string); ok {
+			strings[i] = str
+		} else {
+			continue
+		}
+	}
+	return strings
+}
+
+func expandAllowedJoinOperators(data []interface{}) []types.JoinOperator {
+	var joinOperator []types.JoinOperator
+	for _, v := range data {
+		switch v {
+		case "OR":
+			joinOperator = append(joinOperator, types.JoinOperatorOr)
+		case "AND":
+			joinOperator = append(joinOperator, types.JoinOperatorAnd)
+		}
+	}
+	return joinOperator
+}
+
+func expandAnalysisPolicyAggregation(tfList []interface{}) *types.AnalysisRuleAggregation {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	a := &types.AnalysisRuleAggregation{}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	if v, ok := tfMap["aggregate_columns"].([]interface{}); ok && len(v) > 0 {
+		a.AggregateColumns = expandAggregateColumns(v)
+	}
+
+	if v, ok := tfMap["join_aggregate_columns"].([]interface{}); ok && len(v) > 0 {
+		a.JoinColumns = convertInterfaceSliceToStringSlice(v)
+	}
+
+	if v, ok := tfMap["join_required"].(string); ok && len(v) > 0 {
+		a.JoinRequired = expandJoinedRequiredOption(v)
+	}
+
+	if v, ok := tfMap["dimension_columns"].([]interface{}); ok && len(v) > 0 {
+		a.DimensionColumns = convertInterfaceSliceToStringSlice(v)
+	}
+
+	if v, ok := tfMap["scalar_functions"].([]interface{}); ok && len(v) > 0 {
+		a.ScalarFunctions = expandScalarFunctions(convertInterfaceSliceToStringSlice(v))
+	}
+
+	if v, ok := tfMap["allowed_join_operators"].([]interface{}); ok && len(v) > 0 {
+		a.AllowedJoinOperators = expandAllowedJoinOperators(v)
+	}
+
+	if v, ok := tfMap["output_constraints"].([]interface{}); ok && len(v) > 0 {
+		a.OutputConstraints = expandOutputConstraints(v)
+	}
+
+	return a
+
+}
+
+func expandAggregateColumns(tfList []interface{}) []types.AggregateColumn {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	a := make([]types.AggregateColumn, 0, len(tfList))
+
+	for _, tfListRaw := range tfList {
+
+		tfMap, ok := tfListRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		a = append(a, types.AggregateColumn{
+			ColumnNames: convertInterfaceSliceToStringSlice(tfMap["column_names"].([]interface{})),
+			Function:    expandFunction(tfMap["function"].(string)),
+		})
+
+	}
+
+	return a
+
+}
+
+func expandFunction(value string) types.AggregateFunctionName {
+	switch value {
+	case "SUM":
+		return types.AggregateFunctionNameSum
+	case "SUM_DISTINCT":
+		return types.AggregateFunctionNameSumDistinct
+	case "COUNT":
+		return types.AggregateFunctionNameCount
+	case "COUNT_DISTINCT":
+		return types.AggregateFunctionNameCountDistinct
+	case "AVG":
+		return types.AggregateFunctionNameAvg
+	default:
+		return types.AggregateFunctionNameSum
+	}
+}
+
+func expandOutputConstraints(tfList []interface{}) []types.AggregationConstraint {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	a := make([]types.AggregationConstraint, 0, len(tfList))
+
+	for _, tfListRaw := range tfList {
+
+		tfMap, ok := tfListRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		minimum := int32(tfMap["minimum"].(int))
+
+		a = append(a, types.AggregationConstraint{
+			ColumnName: aws.String(tfMap["column_name"].(string)),
+			Minimum:    &minimum,
+			Type:       expandOutputConstraintsType(tfMap["type"].(string)),
+		})
+
+	}
+
+	return a
+
+}
+
+func expandOutputConstraintsType(value string) types.AggregationType {
+	switch value {
+	case "COUNT_DISTINCT":
+		return types.AggregationTypeCountDistinct
+	default:
+		return types.AggregationTypeCountDistinct
+	}
+}
+
+func expandJoinedRequiredOption(value string) types.JoinRequiredOption {
+	switch value {
+	case "QUERY_RUNNER":
+		return types.JoinRequiredOptionQueryRunner
+	default:
+		return types.JoinRequiredOptionQueryRunner
+	}
+}
+
+func expandScalarFunctions(data []string) []types.ScalarFunctions {
+	var scalarFunction []types.ScalarFunctions
+	for _, v := range data {
+		switch v {
+		case "TRUNC":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsTrunc)
+		case "ABS":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsAbs)
+		case "CEILING":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsCeiling)
+		case "FLOOR":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsFloor)
+		case "LN":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsLn)
+		case "LOG":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsLog)
+		case "ROUND":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsRound)
+		case "SQRT":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsSqrt)
+		case "CAST":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsCast)
+		case "LOWER":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsLower)
+		case "RTRIM":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsRtrim)
+		case "UPPER":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsUpper)
+		case "COALESCE":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsCoalesce)
+		}
+	}
+	return scalarFunction
+}
+
+func expandAnalysisPolicyCustom(tfList []interface{}) *types.AnalysisRuleCustom {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	a := &types.AnalysisRuleCustom{}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	if v, ok := tfMap["allowed_custom_analyses"].([]interface{}); ok && len(v) > 0 {
+		a.AllowedAnalyses = convertInterfaceSliceToStringSlice(v)
+	}
+
+	if v, ok := tfMap["allowed_analyses_providers"].([]interface{}); ok && len(v) > 0 {
+		a.AllowedAnalysisProviders = convertInterfaceSliceToStringSlice(v)
+	}
+
+	if v, ok := tfMap["differential_privacy"].([]interface{}); ok && len(v) > 0 {
+		a.DifferentialPrivacy = expandExpandDifferentialPrivacy(v)
+	}
+
+	return a
+}
+
+func expandExpandDifferentialPrivacy(tfList []interface{}) *types.DifferentialPrivacyConfiguration {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	config := &types.DifferentialPrivacyConfiguration{}
+
+	if v, ok := tfMap["columns"].([]interface{}); ok && len(v) > 0 {
+		config.Columns = expandDifferentialPrivacyColumns(v)
+	}
+
+	return config
+}
+
+func expandDifferentialPrivacyColumns(tfList []interface{}) []types.DifferentialPrivacyColumn {
+	var columns []types.DifferentialPrivacyColumn
+
+	for _, v := range tfList {
+		if columnMap, ok := v.(map[string]interface{}); ok {
+			column := types.DifferentialPrivacyColumn{}
+			if name, ok := columnMap["name"].(string); ok {
+				column.Name = &name
+			}
+			columns = append(columns, column)
+		}
+	}
+
+	return columns
+}

--- a/internal/service/cleanrooms/configured_table_analysis_rule.go
+++ b/internal/service/cleanrooms/configured_table_analysis_rule.go
@@ -668,32 +668,54 @@ func expandScalarFunctions(data []string) []types.ScalarFunctions {
 	var scalarFunction []types.ScalarFunctions
 	for _, v := range data {
 		switch v {
-		case "TRUNC":
-			scalarFunction = append(scalarFunction, types.ScalarFunctionsTrunc)
 		case "ABS":
 			scalarFunction = append(scalarFunction, types.ScalarFunctionsAbs)
+		case "CAST":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsCast)
 		case "CEILING":
 			scalarFunction = append(scalarFunction, types.ScalarFunctionsCeiling)
+		case "COALESCE":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsCoalesce)
+		case "CONVERT":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsConvert)
+		case "CURRENT_DATE":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsCurrentDate)
+		case "DATE_ADD":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsDateadd)
+		case "EXTRACT":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsExtract)
 		case "FLOOR":
 			scalarFunction = append(scalarFunction, types.ScalarFunctionsFloor)
+		case "GETDATE":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsGetdate)
 		case "LN":
 			scalarFunction = append(scalarFunction, types.ScalarFunctionsLn)
 		case "LOG":
 			scalarFunction = append(scalarFunction, types.ScalarFunctionsLog)
-		case "ROUND":
-			scalarFunction = append(scalarFunction, types.ScalarFunctionsRound)
-		case "SQRT":
-			scalarFunction = append(scalarFunction, types.ScalarFunctionsSqrt)
-		case "CAST":
-			scalarFunction = append(scalarFunction, types.ScalarFunctionsCast)
 		case "LOWER":
 			scalarFunction = append(scalarFunction, types.ScalarFunctionsLower)
+		case "ROUND":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsRound)
 		case "RTRIM":
 			scalarFunction = append(scalarFunction, types.ScalarFunctionsRtrim)
+		case "SQRT":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsSqrt)
+		case "SUBSTRING":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsSubstring)
+		case "TO_CHAR":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsToChar)
+		case "TO_DATE":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsToDate)
+		case "TO_NUMBER":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsToNumber)
+		case "TO_TIMESTAMP":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsToTimestamp)
+		case "TRIM":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsTrim)
+		case "TRUNC":
+			scalarFunction = append(scalarFunction, types.ScalarFunctionsTrunc)
 		case "UPPER":
 			scalarFunction = append(scalarFunction, types.ScalarFunctionsUpper)
-		case "COALESCE":
-			scalarFunction = append(scalarFunction, types.ScalarFunctionsCoalesce)
 		}
 	}
 	return scalarFunction

--- a/internal/service/cleanrooms/configured_table_analysis_rule_test.go
+++ b/internal/service/cleanrooms/configured_table_analysis_rule_test.go
@@ -1,0 +1,2036 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cleanrooms_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cleanrooms"
+	"github.com/aws/aws-sdk-go-v2/service/cleanrooms/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfcleanrooms "github.com/hashicorp/terraform-provider-aws/internal/service/cleanrooms"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "LIST"
+	var joinColumns = "[\"my_column_1\", \"my_column_2\"]"
+	var allowedJoinOperators = "[\"AND\"]"
+	var listColumns = "[\"my_column_3\", \"my_column_4\"]"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType, joinColumns,
+					allowedJoinOperators, listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.1", "my_column_4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleType(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_customAnalysisRuleType(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "CUSTOM"
+	var customAnalysis = "[\"ANY_QUERY\"]"
+	var analysisProviders = "[\"123456789012\"]"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_custom(analysisRuleType, customAnalysis, analysisProviders),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_customEnableDifferentialPrivacy(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "CUSTOM"
+	var customAnalysis = "[\"ANY_QUERY\"]"
+	var analysisProviders = "[\"123456789012\"]"
+	var columns = "my_column_1"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_customDifferentialPrivacy(analysisRuleType, customAnalysis, analysisProviders, columns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.differential_privacy.0.columns.0.name", "my_column_1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_listOperatorDisappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "LIST"
+	var joinColumns = "[\"my_column_1\", \"my_column_2\"]"
+	var allowedJoinOperators = "[\"AND\"]"
+	var listColumns = "[\"my_column_3\", \"my_column_4\"]"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType, joinColumns,
+					allowedJoinOperators, listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider,
+						tfcleanrooms.ResourceConfiguredTableAnalysisRule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationOperatorDisappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider,
+						tfcleanrooms.ResourceConfiguredTableAnalysisRule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_customOperatorDisappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "CUSTOM"
+	var customAnalysis = "[\"ANY_QUERY\"]"
+	var analysisProviders = "[\"123456789012\"]"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_custom(analysisRuleType, customAnalysis, analysisProviders),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider,
+						tfcleanrooms.ResourceConfiguredTableAnalysisRule(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_updateListToAggregation(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "LIST"
+	var joinColumns = "[\"my_column_1\", \"my_column_2\"]"
+	var allowedJoinOperators = "[\"AND\"]"
+	var listColumns = "[\"my_column_3\", \"my_column_4\"]"
+
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType, joinColumns,
+					allowedJoinOperators, listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.1", "my_column_4"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation("AGGREGATION", aggregateColumns,
+					aggregateFunction, joinAggregateColumns, "[\"AND\"]", dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, "AGGREGATION",
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_updateListToCustom(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "LIST"
+	var joinColumns = "[\"my_column_1\", \"my_column_2\"]"
+	var allowedJoinOperators = "[\"AND\"]"
+	var listColumns = "[\"my_column_3\", \"my_column_4\"]"
+
+	var customAnalysis = "[\"ANY_QUERY\"]"
+	var analysisProviders = "[\"123456789012\"]"
+
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType, joinColumns,
+					allowedJoinOperators, listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.1", "my_column_4"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_custom("CUSTOM", customAnalysis, analysisProviders),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, "CUSTOM", &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_updateAggregationToList(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+
+	var joinColumns = "[\"my_column_1\", \"my_column_2\"]"
+	var listColumns = "[\"my_column_3\", \"my_column_4\"]"
+
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic("LIST", joinColumns,
+					allowedJoinOperators, listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, "LIST", &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.1", "my_column_4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_updateAggregationToCustom(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+
+	var customAnalysis = "[\"ANY_QUERY\"]"
+	var analysisProviders = "[\"123456789012\"]"
+
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_custom("CUSTOM", customAnalysis, analysisProviders),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, "CUSTOM", &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_updateCustomToList(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "CUSTOM"
+	var customAnalysis = "[\"ANY_QUERY\"]"
+	var analysisProviders = "[\"123456789012\"]"
+
+	var joinColumns = "[\"my_column_1\", \"my_column_2\"]"
+	var allowedJoinOperators = "[\"AND\"]"
+	var listColumns = "[\"my_column_3\", \"my_column_4\"]"
+
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_custom(analysisRuleType, customAnalysis, analysisProviders),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic("LIST", joinColumns,
+					allowedJoinOperators, listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, "LIST", &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.1", "my_column_4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_updateCustomToAggregation(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "CUSTOM"
+	var customAnalysis = "[\"ANY_QUERY\"]"
+	var analysisProviders = "[\"123456789012\"]"
+
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_custom(analysisRuleType, customAnalysis, analysisProviders),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation("AGGREGATION", aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, "AGGREGATION",
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_updateJoinColumns(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "LIST"
+	var joinColumns = "[\"my_column_1\", \"my_column_2\"]"
+	var allowedJoinOperators = "[\"AND\"]"
+	var listColumns = "[\"my_column_3\", \"my_column_4\"]"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType, joinColumns,
+					allowedJoinOperators, listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.1", "my_column_4"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType, "[\"my_column_1\"]",
+					allowedJoinOperators, listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.1", "my_column_4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_updateJoinOperators(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "LIST"
+	var joinColumns = "[\"my_column_1\", \"my_column_2\"]"
+	var allowedJoinOperators = "[\"AND\"]"
+	var listColumns = "[\"my_column_3\", \"my_column_4\"]"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType, joinColumns,
+					allowedJoinOperators, listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.1", "my_column_4"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType, joinColumns,
+					"[\"AND\", \"OR\"]", listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.1", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.1", "my_column_4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_updateListColumns(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "LIST"
+	var joinColumns = "[\"my_column_1\", \"my_column_2\"]"
+	var allowedJoinOperators = "[\"AND\"]"
+	var listColumns = "[\"my_column_3\", \"my_column_4\"]"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType, joinColumns,
+					allowedJoinOperators, listColumns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.1", "my_column_4"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType, joinColumns,
+					allowedJoinOperators, "[\"my_column_3\"]"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "LIST"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.join_columns.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.allowed_join_operators.0", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.list.0.list_columns.0", "my_column_3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleTypeMultipleAggregateColumns(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateColumnsTwo = "[\"my_column_6\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregationMultipleAggregateColumns(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType, aggregateColumnsTwo),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.1.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.1.column_names.0", "my_column_6"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.1.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleTypeMultipleOutputConstraints(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var outputConstraintsColumnNameTwo = "my_column_5"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregationMultipleOutputConstraints(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType, outputConstraintsColumnNameTwo),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.1.column_name", "my_column_5"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.1.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.1.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAggregateColumnsColumnNames(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, "[\"my_column_1\", \"my_column_2\"]",
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.1", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAggregateColumnsFunction(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					"COUNT", joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "COUNT"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateJoinAggregateColumns(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, "[\"my_column_2\", \"my_column_6\"]", allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.1", "my_column_6"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAllowedJoinOperators(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, "[\"OR\", \"AND\"]", dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.1", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateDimensionColumns(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, "[\"my_column_3\", \"my_column_6\"]", scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.1", "my_column_6"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateScalarFunctions(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, "[\"TRUNC\", \"ABS\"]",
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.1", "ABS"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateOutputConstraintsColumnName(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					"my_column_5", outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_5"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateOutputConstraintsMinimum(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "AGGREGATION"
+	var aggregateColumns = "[\"my_column_1\"]"
+	var aggregateFunction = "SUM"
+	var joinAggregateColumns = "[\"my_column_2\"]"
+	var allowedJoinOperators = "[\"OR\"]"
+	var dimensionColumns = "[\"my_column_3\"]"
+	var scalarFunctions = "[\"TRUNC\"]"
+	var outputConstraintsColumnName = "my_column_4"
+	var outputConstraintsMinimum = "2"
+	var outputConstraintsType = "COUNT_DISTINCT"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType, aggregateColumns,
+					aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns, scalarFunctions,
+					outputConstraintsColumnName, "10", outputConstraintsType),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType,
+						&configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "AGGREGATION"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.column_names.0", "my_column_1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.aggregate_columns.0.function", "SUM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_aggregate_columns.0", "my_column_2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.join_required", "QUERY_RUNNER"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.allowed_join_operators.0", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.dimension_columns.0", "my_column_3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.scalar_functions.0", "TRUNC"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.column_name", "my_column_4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.minimum", "10"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.aggregation.0.output_constraints.0.type", "COUNT_DISTINCT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_customUpdateAnalysisProvider(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "CUSTOM"
+	var customAnalysis = "[\"ANY_QUERY\"]"
+	var analysisProviders = "[\"123456789012\"]"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_custom(analysisRuleType, customAnalysis, analysisProviders),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_custom(analysisRuleType, customAnalysis, "[\"123456789012\", \"098765432109\"]"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.1", "098765432109"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_customUpdateDifferentialPrivacy(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "CUSTOM"
+	var customAnalysis = "[\"ANY_QUERY\"]"
+	var analysisProviders = "[\"123456789012\"]"
+	var columns = "my_column_1"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_customDifferentialPrivacy(analysisRuleType, customAnalysis, analysisProviders, columns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.differential_privacy.0.columns.0.name", "my_column_1"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_customDifferentialPrivacy(analysisRuleType, customAnalysis, analysisProviders, "my_column_2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.differential_privacy.0.columns.0.name", "my_column_2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCleanRoomsConfiguredTableAnalysisRule_customDisableDifferentialPrivacy(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var configuredTableAnalysisRule cleanrooms.GetConfiguredTableAnalysisRuleOutput
+	var analysisRuleType = "CUSTOM"
+	var customAnalysis = "[\"ANY_QUERY\"]"
+	var analysisProviders = "[\"123456789012\"]"
+	var columns = "my_column_1"
+	var resourceName = "aws_cleanrooms_configured_table_analysis_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccConfiguredTableAnalysisRuleDestroy(ctx, analysisRuleType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_customDifferentialPrivacy(analysisRuleType, customAnalysis, analysisProviders, columns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.differential_privacy.0.columns.0.name", "my_column_1"),
+				),
+			},
+			{
+				Config: testAccConfiguredTableAnalysisRuleConfig_custom(analysisRuleType, customAnalysis, analysisProviders),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfiguredTableAnalysisRuleExists(ctx, resourceName, analysisRuleType, &configuredTableAnalysisRule),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_custom_analyses.0", "ANY_QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "analysis_rule_policy.0.v1.0.custom.0.allowed_analyses_providers.0", "123456789012"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckConfiguredTableAnalysisRuleExists(ctx context.Context, name string, analysisRuleType string, configuredTableAnalysisRule *cleanrooms.GetConfiguredTableAnalysisRuleOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.CleanRooms, create.ErrActionCheckingExistence,
+				tfcleanrooms.ResNameConfiguredTableAnalysisRule, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.CleanRooms, create.ErrActionCheckingExistence,
+				tfcleanrooms.ResNameConfiguredTableAnalysisRule, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CleanRoomsClient(ctx)
+		resp, err := conn.GetConfiguredTableAnalysisRule(ctx, &cleanrooms.GetConfiguredTableAnalysisRuleInput{
+			ConfiguredTableIdentifier: aws.String(rs.Primary.ID),
+			AnalysisRuleType:          types.ConfiguredTableAnalysisRuleType(analysisRuleType),
+		})
+
+		if err != nil {
+			return create.Error(names.CleanRooms, create.ErrActionCheckingExistence,
+				tfcleanrooms.ResNameConfiguredTableAnalysisRule, rs.Primary.ID, err)
+		}
+
+		*configuredTableAnalysisRule = *resp
+
+		return nil
+	}
+}
+
+func testAccConfiguredTableAnalysisRuleConfig_basic(analysisRuleType string, joinColumns string,
+	allowedJoinOperators string, listColumns string) string {
+	return testAccConfiguredTableAnalysisRuleConfig(analysisRuleType, joinColumns, allowedJoinOperators, listColumns)
+}
+
+func testAccConfiguredTableAnalysisRuleConfig_aggregation(analysisRuleType string, aggregateColumns string, aggregateFunction string,
+	joinAggregateColumns string, allowedJoinOperators string, dimensionColumns string, scalarFunctions string,
+	outputConstraintsColumnName string, outputConstraintsMinimum string, outputConstraintsType string) string {
+	return testAccConfiguredTableAnalysisRuleAggregation(analysisRuleType, aggregateColumns, aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns,
+		scalarFunctions, outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType)
+}
+
+func testAccConfiguredTableAnalysisRuleConfig_aggregationMultipleAggregateColumns(analysisRuleType string, aggregateColumns string, aggregateFunction string,
+	joinAggregateColumns string, allowedJoinOperators string, dimensionColumns string, scalarFunctions string,
+	outputConstraintsColumnName string, outputConstraintsMinimum string, outputConstraintsType string, aggregateColumnsTwo string) string {
+	return testAccConfiguredTableAnalysisRuleAggregationMultipleAggregateColumns(analysisRuleType, aggregateColumns, aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns,
+		scalarFunctions, outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType, aggregateColumnsTwo)
+}
+
+func testAccConfiguredTableAnalysisRuleConfig_aggregationMultipleOutputConstraints(analysisRuleType string, aggregateColumns string, aggregateFunction string,
+	joinAggregateColumns string, allowedJoinOperators string, dimensionColumns string, scalarFunctions string,
+	outputConstraintsColumnName string, outputConstraintsMinimum string, outputConstraintsType string, outputConstraintsColumnNameTwo string) string {
+	return testAccConfiguredTableAnalysisRuleAggregationMultipleOutputConstraints(analysisRuleType, aggregateColumns, aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns,
+		scalarFunctions, outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType, outputConstraintsColumnNameTwo)
+}
+
+func testAccConfiguredTableAnalysisRuleConfig_custom(analysisRuleType string, customAnalysis string,
+	analysisProvider string) string {
+	return testAccConfiguredTableAnalysisRuleCustom(analysisRuleType, customAnalysis, analysisProvider)
+}
+
+func testAccConfiguredTableAnalysisRuleConfig_customDifferentialPrivacy(analysisRuleType string, customAnalysis string,
+	analysisProvider string, columns string) string {
+	return testAccConfiguredTableAnalysisRuleCustomDifferentialPrivacy(analysisRuleType, customAnalysis,
+		analysisProvider, columns)
+}
+
+func testAccConfiguredTableAnalysisRuleDestroy(ctx context.Context, analysisRuleType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CleanRoomsClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != tfcleanrooms.ResNameConfiguredTableAnalysisRule {
+				continue
+			}
+
+			_, err := conn.GetConfiguredTableAnalysisRule(ctx, &cleanrooms.GetConfiguredTableAnalysisRuleInput{
+				ConfiguredTableIdentifier: aws.String(rs.Primary.ID),
+				AnalysisRuleType:          types.ConfiguredTableAnalysisRuleType(analysisRuleType),
+			})
+
+			if err == nil {
+				return create.Error(names.CleanRooms, create.ErrActionCheckingExistence,
+					tfcleanrooms.ResNameConfiguredTableAnalysisRule, rs.Primary.ID, errors.New("not destroyed"))
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccConfiguredTableAnalysisRuleCustomDifferentialPrivacy(analysisRuleType string, customAnalysis string,
+	analysisProvider string, columns string) string {
+	return fmt.Sprintf(`
+resource "aws_cleanrooms_configured_table" "test_configured_table" {
+  name            = "terraform-example-table"
+  description     = "I made this table with terraform!"
+  analysis_method = "DIRECT_QUERY"
+  allowed_columns = [
+    "my_column_1",
+    "my_column_2",
+    "my_column_3",
+    "my_column_4",
+    "my_column_5",
+    "my_column_6"
+  ]
+
+  table_reference {
+    database_name = "test-db"
+    table_name    = "test-table"
+  }
+}
+
+resource "aws_cleanrooms_configured_table_analysis_rule" "test" {
+  name                        = "test"
+  analysis_rule_type          = %[1]q
+  configured_table_identifier = aws_cleanrooms_configured_table.test_configured_table.id
+
+  analysis_rule_policy {
+    v1 {
+      custom {
+        allowed_custom_analyses    = jsondecode(%[2]q)
+        allowed_analyses_providers = jsondecode(%[3]q)
+		differential_privacy {
+          columns {
+            name = %[4]q
+          }
+        }
+      }
+    }
+  }
+}
+	`, analysisRuleType, customAnalysis, analysisProvider, columns)
+}
+
+func testAccConfiguredTableAnalysisRuleCustom(analysisRuleType string, customAnalysis string,
+	analysisProvider string) string {
+	return fmt.Sprintf(`
+resource "aws_cleanrooms_configured_table" "test_configured_table" {
+  name            = "terraform-example-table"
+  description     = "I made this table with terraform!"
+  analysis_method = "DIRECT_QUERY"
+  allowed_columns = [
+    "my_column_1",
+    "my_column_2",
+    "my_column_3",
+    "my_column_4",
+    "my_column_5",
+    "my_column_6"
+  ]
+
+  table_reference {
+    database_name = "test-db"
+    table_name    = "test-table"
+  }
+}
+
+resource "aws_cleanrooms_configured_table_analysis_rule" "test" {
+  name                        = "test"
+  analysis_rule_type          = %[1]q
+  configured_table_identifier = aws_cleanrooms_configured_table.test_configured_table.id
+
+  analysis_rule_policy {
+    v1 {
+      custom {
+        allowed_custom_analyses    = jsondecode(%[2]q)
+        allowed_analyses_providers = jsondecode(%[3]q)
+      }
+    }
+  }
+}
+	`, analysisRuleType, customAnalysis, analysisProvider)
+}
+
+func testAccConfiguredTableAnalysisRuleAggregationMultipleOutputConstraints(analysisRuleType string,
+	aggregateColumns string, aggregateFunction string, joinAggregateColumns string, allowedJoinOperators string,
+	dimensionColumns string, scalarFunctions string, outputConstraintsColumnName string, outputConstraintsMinimum string,
+	outputConstraintsType string, outputConstraintsColumnNameTwo string) string {
+	return fmt.Sprintf(`
+resource "aws_cleanrooms_configured_table" "test_configured_table" {
+  name            = "terraform-example-table"
+  description     = "I made this table with terraform!"
+  analysis_method = "DIRECT_QUERY"
+  allowed_columns = [
+    "my_column_1",
+    "my_column_2",
+    "my_column_3",
+    "my_column_4",
+    "my_column_5",
+    "my_column_6"
+  ]
+
+  table_reference {
+    database_name = "test-db"
+    table_name    = "test-table"
+  }
+}
+
+resource "aws_cleanrooms_configured_table_analysis_rule" "test" {
+  name                        = "test"
+  analysis_rule_type          = %[1]q
+  configured_table_identifier = aws_cleanrooms_configured_table.test_configured_table.id
+
+  analysis_rule_policy {
+    v1 {
+      aggregation {
+        aggregate_columns {
+          column_names = jsondecode(%[2]q)
+          function     = %[3]q
+        }
+        join_aggregate_columns = jsondecode(%[4]q)
+        join_required          = "QUERY_RUNNER"
+        allowed_join_operators = jsondecode(%[5]q)
+        dimension_columns      = jsondecode(%[6]q)
+        scalar_functions       = jsondecode(%[7]q)
+        output_constraints {
+          column_name = %[8]q
+          minimum     = %[9]q
+          type        = %[10]q
+        }
+		output_constraints {
+          column_name = %[11]q
+          minimum     = %[9]q
+          type        = %[10]q
+        }
+      }
+    }
+  }
+}
+	`, analysisRuleType, aggregateColumns, aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns,
+		scalarFunctions, outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType, outputConstraintsColumnNameTwo)
+}
+
+func testAccConfiguredTableAnalysisRuleAggregationMultipleAggregateColumns(analysisRuleType string,
+	aggregateColumns string, aggregateFunction string, joinAggregateColumns string, allowedJoinOperators string,
+	dimensionColumns string, scalarFunctions string, outputConstraintsColumnName string, outputConstraintsMinimum string,
+	outputConstraintsType string, aggregateColumnsTwo string) string {
+	return fmt.Sprintf(`
+resource "aws_cleanrooms_configured_table" "test_configured_table" {
+  name            = "terraform-example-table"
+  description     = "I made this table with terraform!"
+  analysis_method = "DIRECT_QUERY"
+  allowed_columns = [
+    "my_column_1",
+    "my_column_2",
+    "my_column_3",
+    "my_column_4",
+    "my_column_5",
+    "my_column_6"
+  ]
+
+  table_reference {
+    database_name = "test-db"
+    table_name    = "test-table"
+  }
+}
+
+resource "aws_cleanrooms_configured_table_analysis_rule" "test" {
+  name                        = "test"
+  analysis_rule_type          = %[1]q
+  configured_table_identifier = aws_cleanrooms_configured_table.test_configured_table.id
+
+  analysis_rule_policy {
+    v1 {
+      aggregation {
+        aggregate_columns {
+          column_names = jsondecode(%[2]q)
+          function     = %[3]q
+        }
+		aggregate_columns {
+          column_names = jsondecode(%[11]q)
+          function     = %[3]q
+        }
+        join_aggregate_columns = jsondecode(%[4]q)
+        join_required          = "QUERY_RUNNER"
+        allowed_join_operators = jsondecode(%[5]q)
+        dimension_columns      = jsondecode(%[6]q)
+        scalar_functions       = jsondecode(%[7]q)
+        output_constraints {
+          column_name = %[8]q
+          minimum     = %[9]q
+          type        = %[10]q
+        } 
+      }
+    }
+  }
+}
+	`, analysisRuleType, aggregateColumns, aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns,
+		scalarFunctions, outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType, aggregateColumnsTwo)
+}
+
+func testAccConfiguredTableAnalysisRuleAggregation(analysisRuleType string, aggregateColumns string, aggregateFunction string,
+	joinAggregateColumns string, allowedJoinOperators string, dimensionColumns string, scalarFunctions string,
+	outputConstraintsColumnName string, outputConstraintsMinimum string, outputConstraintsType string) string {
+	return fmt.Sprintf(`
+resource "aws_cleanrooms_configured_table" "test_configured_table" {
+  name            = "terraform-example-table"
+  description     = "I made this table with terraform!"
+  analysis_method = "DIRECT_QUERY"
+  allowed_columns = [
+    "my_column_1",
+    "my_column_2",
+    "my_column_3",
+    "my_column_4",
+    "my_column_5",
+    "my_column_6"
+  ]
+
+  table_reference {
+    database_name = "test-db"
+    table_name    = "test-table"
+  }
+}
+
+resource "aws_cleanrooms_configured_table_analysis_rule" "test" {
+  name                        = "test"
+  analysis_rule_type          = %[1]q
+  configured_table_identifier = aws_cleanrooms_configured_table.test_configured_table.id
+
+  analysis_rule_policy {
+    v1 {
+      aggregation {
+        aggregate_columns {
+          column_names = jsondecode(%[2]q)
+          function     = %[3]q
+        }
+        join_aggregate_columns = jsondecode(%[4]q)
+        join_required          = "QUERY_RUNNER"
+        allowed_join_operators = jsondecode(%[5]q)
+        dimension_columns      = jsondecode(%[6]q)
+        scalar_functions       = jsondecode(%[7]q)
+        output_constraints {
+          column_name = %[8]q
+          minimum     = %[9]q
+          type        = %[10]q
+        } 
+      }
+    }
+  }
+}
+	`, analysisRuleType, aggregateColumns, aggregateFunction, joinAggregateColumns, allowedJoinOperators, dimensionColumns,
+		scalarFunctions, outputConstraintsColumnName, outputConstraintsMinimum, outputConstraintsType)
+}
+
+func testAccConfiguredTableAnalysisRuleConfig(analysisRuleType string, joinColumns string,
+	allowedJoinOperators string, listColumns string) string {
+	return fmt.Sprintf(`
+resource "aws_cleanrooms_configured_table" "test_configured_table" {
+  name            = "terraform-example-table"
+  description     = "I made this table with terraform!"
+  analysis_method = "DIRECT_QUERY"
+  allowed_columns = [
+    "my_column_1",
+    "my_column_2",
+    "my_column_3",
+    "my_column_4",
+    "my_column_5",
+    "my_column_6"
+  ]
+
+  table_reference {
+    database_name = "test-db"
+    table_name    = "test-table"
+  }
+}
+
+resource "aws_cleanrooms_configured_table_analysis_rule" "test" {
+  name                        = "test"
+  analysis_rule_type 		  = %[1]q
+  configured_table_identifier = aws_cleanrooms_configured_table.test_configured_table.id
+
+  analysis_rule_policy {
+    v1 {
+	  list {
+	    join_columns = jsondecode(%[2]q)
+	    allowed_join_operators = jsondecode(%[3]q)
+	    list_columns = jsondecode(%[4]q)
+	  }
+    }
+  }
+}
+	`, analysisRuleType, joinColumns, allowedJoinOperators, listColumns)
+}

--- a/internal/service/cleanrooms/find.go
+++ b/internal/service/cleanrooms/find.go
@@ -1,0 +1,40 @@
+package cleanrooms
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cleanrooms"
+	"github.com/aws/aws-sdk-go-v2/service/cleanrooms/types"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+)
+
+func findAnalysisRuleByID(ctx context.Context, conn *cleanrooms.Client, id string, analysisRule string) (*cleanrooms.GetConfiguredTableAnalysisRuleOutput, error) {
+	analysisRuleType, _ := expandAnalysisRuleType(analysisRule)
+
+	in := &cleanrooms.GetConfiguredTableAnalysisRuleInput{
+		ConfiguredTableIdentifier: aws.String(id),
+		AnalysisRuleType:          analysisRuleType,
+	}
+	out, err := conn.GetConfiguredTableAnalysisRule(ctx, in)
+
+	if errs.IsA[*types.AccessDeniedException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: in,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if out == nil || out.AnalysisRule == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}

--- a/internal/service/cleanrooms/service_package_gen.go
+++ b/internal/service/cleanrooms/service_package_gen.go
@@ -42,6 +42,13 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 				IdentifierAttribute: names.AttrARN,
 			},
 		},
+		{
+			Factory:  ResourceConfiguredTableAnalysisRule,
+			TypeName: "aws_cleanrooms_configured_table_analysis_rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			},
+		},
 	}
 }
 

--- a/website/docs/r/cleanrooms_configured_table_analysis_rule.html.markdown
+++ b/website/docs/r/cleanrooms_configured_table_analysis_rule.html.markdown
@@ -1,0 +1,146 @@
+---
+subcategory: "Clean Rooms"
+layout: "aws"
+page_title: "AWS: aws_cleanrooms_configured_table_analysis_rule"
+description: |-
+  Provides a Clean Rooms Configured Table Analysis Rule.
+---
+
+# Resource: aws_cleanrooms_configured_table_analysis_rule
+
+Creates a new analysis rule for a configured table. Currently, only one analysis rule can be created for a given configured table.
+
+## Example Usage
+
+### Configured Table Analysis Rule type LIST
+
+```terraform
+resource "aws_cleanrooms_configured_table_analysis_rule" "example" {
+  name                        = "example"
+  analysis_rule_type          = "LIST"
+  configured_table_identifier = "example_configured_table_id"
+
+  analysis_rule_policy {
+    v1 {
+      list {
+        join_columns = [ "my_column_1" ]
+        allowed_join_operators = [ "AND" ]
+        list_columns = [ "my_column_3" ]
+      }
+    }
+  }
+}
+```
+
+### Configured Table Analysis Rule type AGGREGATION
+
+```terraform
+resource "aws_cleanrooms_configured_table_analysis_rule" "example" {
+  name                        = "example"
+  analysis_rule_type          = "AGGREGATION"
+  configured_table_identifier = "example_configured_table_id"
+
+  analysis_rule_policy {
+    v1 {
+      aggregation {
+        aggregate_columns {
+          column_names = [ "my_column_1" ]
+          function     = "SUM"
+        }
+        join_aggregate_columns = [ "my_column_2" ]
+        join_required          = "QUERY_RUNNER"
+        allowed_join_operators = [ "OR" ]
+        dimension_columns      = [ "my_column_3" ]
+        scalar_functions       = [ "TRUNC" ]
+        output_constraints {
+          column_name = "my_column_4"
+          minimum     = "2"
+          type        = "COUNT_DISTINCT"
+        }
+      }
+    }
+  }
+}
+```
+
+### Configured Table Analysis Rule type CUSTOM
+
+```terraform
+resource "aws_cleanrooms_configured_table_analysis_rule" "example" {
+  name                        = "example"
+  analysis_rule_type          = "CUSTOM"
+  configured_table_identifier = "example_configured_table_id"
+
+  analysis_rule_policy {
+    v1 {
+      custom {
+        allowed_custom_analyses    = [ "ANY_QUERY" ]
+        allowed_analyses_providers = [ "123456789012" ]
+        differential_privacy {
+          columns {
+            name = "my_column_1"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `name` - (Required) - The name of the analysis rule.
+* `analysis_rule_type` - (Required - Forces new resource) - The type of analysis rule. Possible values are LIST, AGGREGATION and CUSTOM.
+* `configured_table_identifier` - (Required - Forces new resource) - The identifier for the configured table to create the analysis rule for. Currently accepts the configured table ID.
+* `analysis_rule_policy` - (Required) - The entire created configured table analysis rule object.
+* `v1` - (Required) - Controls on the query specifications that can be run on a configured table.
+* `list` - (Optional - Forces new resource) - Analysis rule type that enables only list queries on a configured table.
+    - `join_columns` - (Optional - Required if analysis_rule_type is LIST) - Columns that can be used to join a configured table with the table of the member who can query and other members’ configured tables.
+    - `allowed_join_operators` - (Optional - Required if analysis_rule_type is LIST) - The logical operators (if any) that are to be used in an INNER JOIN match condition. Default is AND.
+    - `list_columns` - (Optional - Required if analysis_rule_type is LIST) - Columns that can be listed in the output.
+* `aggregation` - (Optional - Forces new resource) - Analysis rule type that enables only aggregation queries on a configured table.
+    - `aggregate_columns` - (Optional - Required if analysis_rule_type is AGGREGATION) - The columns that query runners are allowed to use in aggregation queries. Multiple aggregate columns are allowed.
+        - `column_names` - (Optional) - Column names in configured table of aggregate columns.
+        - `function` - (Optional) - Aggregation function that can be applied to aggregate column in query.
+    - `join_columns` - (Optional - Required if analysis_rule_type is AGGREGATION) - Columns in configured table that can be used in join statements and/or as aggregate columns. They can never be outputted directly.
+    - `join_required` - (Optional - Required if analysis_rule_type is AGGREGATION) - Control that requires member who runs query to do a join with their configured table and/or other configured table in query.
+    - `allowed_join_operators` - (Optional - Required if analysis_rule_type is AGGREGATION) - Which logical operators (if any) are to be used in an INNER JOIN match condition. Default is AND.
+    - `dimension_columns` - (Optional - Required if analysis_rule_type is AGGREGATION) - The columns that query runners are allowed to select, group by, or filter by.
+    - `scalar_functions` - (Optional - Required if analysis_rule_type is AGGREGATION) - Set of scalar functions that are allowed to be used on dimension columns and the output of aggregation of metrics.
+    - `output_constraints` - (Optional - Required if analysis_rule_type is AGGREGATION) - Columns that must meet a specific threshold value (after an aggregation function is applied to it) for each output row to be returned. Multiple output constraints are allowed.
+        - `column_name` - (Optional) - Column in aggregation constraint for which there must be a minimum number of distinct values in an output row for it to be in the query output.
+        - `minimum` - (Optional) - The minimum number of distinct values that an output row must be an aggregation of. Minimum threshold of distinct values for a specified column that must exist in an output row for it to be in the query output.
+        - `type` - (Optional) - The type of aggregation the constraint allows. The only valid value is currently COUNT_DISTINCT.
+* `custom` - (Optional - Forces new resource) - A type of analysis rule that enables the table owner to approve custom SQL queries on their configured tables. It supports differential privacy.
+    - `allowed_custom_analyses` - (Optional - Required if analysis_rule_type is CUSTOM) - The ARN of the analysis templates that are allowed by the custom analysis rule.
+    - `allowed_analyses_providers` - (Optional) - The IDs of the Amazon Web Services accounts that are allowed to query by the custom analysis rule. Required when allowed_custom_analyses is ANY_QUERY.
+    - `differential_privacy` - (Optional) - The differential privacy configuration.
+        - `columns` - (Optional) -  The name of the column (such as user_id) that contains the unique identifier of your users whose privacy you want to protect. If you want to turn on diﬀerential privacy for two or more tables in a collaboration, you must conﬁgure the same column as the user identiﬁer column in both analysis rules.
+            - `name` - (Optional) - The name of the column, such as user_id, that contains the unique identifier of your users, whose privacy you want to protect. If you want to turn on differential privacy for two or more tables in a collaboration, you must configure the same column as the user identifier column in both analysis rules.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `2m`)
+- `update` - (Default `2m`)
+- `delete` - (Default `2m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `aws_cleanrooms_configured_table_analysis_rule` using the `id`. For example:
+
+```terraform
+import {
+  to = aws_cleanrooms_configured_table_analysis_rule.example
+  id = "1234abcd-12ab-34cd-56ef-1234567890ab"
+}
+```
+
+Using `terraform import`, import `aws_cleanrooms_configured_table_analysis_rule` using the `id`. For example:
+
+```console
+% terraform import aws_cleanrooms_configured_table_analysis_rule.example 1234abcd-12ab-34cd-56ef-1234567890ab
+```


### PR DESCRIPTION
### Description
This pull request adds a new resource for AWS Clean Rooms service. The change adds analysis rule resource which allows users to create a rule for their configured table.
~There were some errors with the test cases which I couldn't solve which I'll mention below.~
Fixed the disappear functions not working, added the Output in this [comment](https://github.com/hashicorp/terraform-provider-aws/pull/38462#issuecomment-2263148973).


### Relations

Relates #30024

### References
https://docs.aws.amazon.com/clean-rooms/latest/apireference/API_AnalysisRule.html
https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cleanrooms/create-configured-table-analysis-rule.html


### Output from Acceptance Testing

```console
$ make fmt && make testacc TESTS=TestAccCleanRoomsConfiguredTableAnalysisRule PKG=cleanrooms ACCTEST_PARALLELISM=12
make: Fixing source code with gofmt...
gofmt -s -w ./internal ./names ./.ci/providerlint/helper ./.ci/providerlint/main.go ./.ci/providerlint/passes
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/cleanrooms/... -v -count 1 -parallel 12 -run='TestAccCleanRoomsConfiguredTableAnalysisRule'  -timeout 360m
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_basic
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_basic
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleType
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleType
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_customAnalysisRuleType
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_customAnalysisRuleType
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_customEnableDifferentialPrivacy
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_customEnableDifferentialPrivacy
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_updateListToAggregation
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_updateListToAggregation
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_updateListToCustom
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_updateListToCustom
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_updateAggregationToList
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_updateAggregationToList
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_updateAggregationToCustom
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_updateAggregationToCustom
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_updateCustomToList
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_updateCustomToList
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_updateCustomToAggregation
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_updateCustomToAggregation
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_updateJoinColumns
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_updateJoinColumns
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_updateJoinOperators
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_updateJoinOperators
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_updateListColumns
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_updateListColumns
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleTypeMultipleAggregateColumns
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleTypeMultipleAggregateColumns
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleTypeMultipleOutputConstraints
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleTypeMultipleOutputConstraints
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAggregateColumnsColumnNames
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAggregateColumnsColumnNames
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAggregateColumnsFunction
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAggregateColumnsFunction
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateJoinAggregateColumns
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateJoinAggregateColumns
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAllowedJoinOperators
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAllowedJoinOperators
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateDimensionColumns
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateDimensionColumns
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateScalarFunctions
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateScalarFunctions
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateOutputConstraintsColumnName
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateOutputConstraintsColumnName
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateOutputConstraintsMinimum
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateOutputConstraintsMinimum
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_customUpdateAnalysisProvider
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_customUpdateAnalysisProvider
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_customUpdateDifferentialPrivacy
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_customUpdateDifferentialPrivacy
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_customDisableDifferentialPrivacy
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_customDisableDifferentialPrivacy
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_basic
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleTypeMultipleAggregateColumns
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateScalarFunctions
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateJoinAggregateColumns
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleTypeMultipleOutputConstraints
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_updateListToAggregation
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateOutputConstraintsMinimum
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAggregateColumnsColumnNames
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_updateAggregationToCustom
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_customUpdateAnalysisProvider
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_updateJoinColumns
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_customDisableDifferentialPrivacy
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_basic (29.16s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_customUpdateDifferentialPrivacy
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleTypeMultipleOutputConstraints (32.00s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_updateListColumns
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleTypeMultipleAggregateColumns (36.12s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateDimensionColumns
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_customDisableDifferentialPrivacy (52.45s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAllowedJoinOperators
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateOutputConstraintsMinimum (53.73s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAggregateColumnsFunction
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateScalarFunctions (55.94s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_updateJoinOperators
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_updateListToAggregation (57.55s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_updateCustomToAggregation
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_updateJoinColumns (57.62s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_updateAggregationToList
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateJoinAggregateColumns (57.88s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateOutputConstraintsColumnName
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_updateAggregationToCustom (57.92s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_updateListToCustom
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_customUpdateAnalysisProvider (58.17s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_updateCustomToList
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAggregateColumnsColumnNames (59.32s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_customEnableDifferentialPrivacy
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_customUpdateDifferentialPrivacy (51.76s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_customAnalysisRuleType
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_updateListColumns (51.15s)
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleType
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateDimensionColumns (53.58s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_customEnableDifferentialPrivacy (32.21s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAllowedJoinOperators (50.37s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateAggregateColumnsFunction (51.40s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_updateCustomToAggregation (49.70s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_updateJoinOperators (51.64s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_customAnalysisRuleType (27.61s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_updateAggregationToList (54.22s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationAnalysisRuleType (29.11s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationUpdateOutputConstraintsColumnName (54.65s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_updateListToCustom (54.65s)
--- PASS: TestAccCleanRoomsConfiguredTableAnalysisRule_updateCustomToList (54.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cleanrooms 112.816s
```
I commented `TestAccCleanRoomsConfiguredTableAnalysisRule_listOperatorDisappears`, `TestAccCleanRoomsConfiguredTableAnalysisRule_aggregationOperatorDisappears` and `TestAccCleanRoomsConfiguredTableAnalysisRule_customOperatorDisappears` when running the above command. The below is the issue I am facing when uncommenting one of the function `TestAccCleanRoomsConfiguredTableAnalysisRule_customOperatorDisappears`.

```console
$ make fmt && make testacc TESTS=TestAccCleanRoomsConfiguredTableAnalysisRule_customOperatorDisappears PKG=cleanrooms ACCTEST_PARALLELISM=12
make: Fixing source code with gofmt...
gofmt -s -w ./internal ./names ./.ci/providerlint/helper ./.ci/providerlint/main.go ./.ci/providerlint/passes
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/cleanrooms/... -v -count 1 -parallel 12 -run='TestAccCleanRoomsConfiguredTableAnalysisRule_customOperatorDisappears'  -timeout 360m
=== RUN   TestAccCleanRoomsConfiguredTableAnalysisRule_customOperatorDisappears
=== PAUSE TestAccCleanRoomsConfiguredTableAnalysisRule_customOperatorDisappears
=== CONT  TestAccCleanRoomsConfiguredTableAnalysisRule_customOperatorDisappears
configured_table_analysis_rule_test.go:250: Step 1/1 error: Error running post-apply refresh plan: exit status 1

Error: reading AWS Clean Rooms Configured Table Analysis Rule (1680fc64-d4a2-4b0a-ad8d-76e008889a55): operation error CleanRooms: GetConfiguredTableAnalysisRule, https response error StatusCode: 404, RequestID: 79f278c9-739e-4ea4-9498-4d2c2f3472df, ResourceNotFoundException: No such analysis rule with configuredTableId: 1680fc64-d4a2-4b0a-ad8d-76e008889a55 and type CUSTOM

with aws_cleanrooms_configured_table_analysis_rule.test,
on terraform_plugin_test.tf line 31, in resource "aws_cleanrooms_configured_table_analysis_rule" "test":
31: resource "aws_cleanrooms_configured_table_analysis_rule" "test" {

panic.go:626: Error running post-test destroy, there may be dangling resources: exit status 1

Error: deleting AWS Clean Rooms Configured Table Analysis Rule (1680fc64-d4a2-4b0a-ad8d-76e008889a55): operation error CleanRooms: DeleteConfiguredTableAnalysisRule, https response error StatusCode: 404, RequestID: da1d31cf-d726-4958-b902-9cf35ea2f48b, ResourceNotFoundException: No such analysis rule with configuredTableId: 1680fc64-d4a2-4b0a-ad8d-76e008889a55 and type CUSTOM

--- FAIL: TestAccCleanRoomsConfiguredTableAnalysisRule_customOperatorDisappears (27.88s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/cleanrooms 28.015s
FAIL
make: *** [GNUmakefile:634: testacc] Error 1
```
The remaining two functions also has the similar error, any help is appreciated.
The issue might or might not be related to configured table resource because `TestAccCleanRoomsConfiguredTableAnalysisRule_disappears` is also failing.

```console
$ make testacc TESTS=TestAccCleanRoomsConfiguredTable_disappears PKG=cleanrooms ACCTEST_PARALLELISM=12
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/cleanrooms/... -v -count 1 -parallel 12 -run='TestAccCleanRoomsConfiguredTable_disappears'  -timeout 360m
=== RUN   TestAccCleanRoomsConfiguredTable_disappears
=== PAUSE TestAccCleanRoomsConfiguredTable_disappears
=== CONT  TestAccCleanRoomsConfiguredTable_disappears
configured_table_test.go:65: Error running post-test destroy, there may be dangling resources: exit status 1

Error: deleting AWS Clean Rooms Configured Table (5f6530e3-8d7d-44d7-b375-76f4c2943542): operation error CleanRooms: DeleteConfiguredTable, https response error StatusCode: 404, RequestID: 3cf557ef-5f3b-4397-9009-437a4c94722d, ResourceNotFoundException: No such table '5f6530e3-8d7d-44d7-b375-76f4c2943542'

--- FAIL: TestAccCleanRoomsConfiguredTable_disappears (44.81s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/cleanrooms 44.925s
FAIL
make: *** [GNUmakefile:634: testacc] Error 1
```

Thanks.
