### PR TITLE
Clarify aws_securitylake_subscriber docs

### DIFF
--- a/website/docs/r/securitylake_subscriber.html.markdown
+++ b/website/docs/r/securitylake_subscriber.html.markdown
@@ -38,28 +38,37 @@ resource "aws_securitylake_subscriber" "example" {
 
 This resource supports the following arguments:
 
-* `source` - (Required) The supported AWS services from which logs and events are collected. Security Lake supports log and event collection for natively supported AWS services.
-* `subscriber_identity` - (Required) The AWS identity used to access your data.
+* `access_type` - (Optional) The Amazon S3 or Lake Formation access type.
+* `source` - (Required) The supported AWS services from which logs and events are collected. Security Lake supports log and event collection for natively supported AWS services. See [`source` Blocks](#source-blocks) below.
+* `subscriber_identity` - (Required) The AWS identity used to access your data. See [`subscriber_identity` Block](#subscriber_identity-block) below.
 * `subscriber_description` - (Optional) The description for your subscriber account in Security Lake.
 * `subscriber_name` - (Optional) The name of your Security Lake subscriber account.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-Subsciber Identity support the following:
+### `source` Blocks
+
+`source` blocks support the following arguments:
+
+* `aws_log_source_resource` - (Optional) Amazon Security Lake supports log and event collection for natively supported AWS services. See [`aws_log_source_resource` Block](#aws_log_source_resource-block) below.
+* `custom_log_source_resource` - (Optional) Amazon Security Lake supports custom source types. See [`custom_log_source_resource` Block](#custom_log_source_resource-block) below.
+
+### `subscriber_identity` Block
+
+The `subscriber_identity` block supports the following arguments:
 
 * `external_id` - (Required) The AWS Regions where Security Lake is automatically enabled.
 * `principal` - (Required) Provides encryption details of Amazon Security Lake object.
 
-Sources support the following:
+### `aws_log_source_resource` Block
 
-* `aws_log_source_resource` - (Optional) Amazon Security Lake supports log and event collection for natively supported AWS services.
-* `custom_log_source_resource` - (Optional) Amazon Security Lake supports custom source types.
-
-AWS Log Source Resource support the following:
+The `aws_log_source_resource` block supports the following arguments:
 
 * `source_name` - (Required) Provides data expiration details of Amazon Security Lake object.
 * `source_version` - (Optional) Provides data storage transition details of Amazon Security Lake object.
 
-Custom Log Source Resource support the following:
+### `custom_log_source_resource` Block
+
+The `custom_log_source_resource` block supports the following arguments. See [`custom_log_source_resource` Attribute Reference](#custom_log_source_resource-attribute-reference) below for additional read-only attributes.
 
 * `source_name` - (Required) The name for a third-party custom source. This must be a Regionally unique value.
 * `source_version` - (Optional) The version for a third-party custom source. This must be a Regionally unique value.
@@ -76,14 +85,29 @@ This resource exports the following attributes in addition to the arguments abov
 * `subscriber_endpoint` - The subscriber endpoint to which exception messages are posted.
 * `subscriber_status` - The subscriber status of the Amazon Security Lake subscriber account.
 * `resource_share_name` - The name of the resource share.
-* `attributes` - The attributes of a third-party custom source.
-    * `crawler_arn` - The ARN of the AWS Glue crawler.
-    * `database_arn` - The ARN of the AWS Glue database where results are written.
-    * `table_arn` - The ARN of the AWS Glue table.
-* `provider_details` - The details of the log provider for a third-party custom source.
-    * `location` - The location of the partition in the Amazon S3 bucket for Security Lake.
-    * `role_arn` - The ARN of the IAM role to be used by the entity putting logs into your custom source partition.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+### `custom_log_source_resource` Attribute Reference
+
+The `custom_log_source_resource` block exports the following attributes in addition to the arguments above:
+
+* `attributes` - The attributes of the third-party custom source. See [`attributes` Block](#attributes-block) below.
+* `provider` - The details of the log provider for the third-party custom source. See [`provider` Block](#provider-block) below.
+
+### `attributes` Block
+
+The `attributes` block exports the following attributes:
+
+* `crawler_arn` - The ARN of the AWS Glue crawler.
+* `database_arn` - The ARN of the AWS Glue database where results are written.
+* `table_arn` - The ARN of the AWS Glue table.
+
+### `provider` Block
+
+The `provider` block exports the following attributes:
+
+* `location` - The location of the partition in the Amazon S3 bucket for Security Lake.
+* `role_arn` - The ARN of the IAM role to be used by the entity putting logs into your custom source partition.
 
 ## Timeouts
 


### PR DESCRIPTION
### Description

Updates the `aws_securitylake_subscriber` docs to be a bit more clear. Namely:

- Add documentation for `access_type`
- Create headers and linked to them for block type arguments
- Added similar headers and links for the attributes of the `custom_log_source_resource` block

For the last point above, this is a bit of a unique resource that I'm not certain we have many other examples of. There's a block within another that exports read-only attributes. I tried to make this as clear as possible, but if there are other examples that I'm not finding, I'd be happy to modify this to be more in line with prior art.

### Relations

Closes #38324

### References

- [Schema](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/securitylake/subscriber.go)
- [AWS API docs](https://docs.aws.amazon.com/security-lake/latest/APIReference/API_CreateSubscriber.html) (for the `access_type` definition

### Output from Acceptance Testing

N/a, docs