### PR TITLE
r/aws_ecs_task_definition: `Provider produced inconsistent final plan` for `container_definitions` after v5.59.0

### DIFF
--- a/.changelog/38471.txt
+++ b/.changelog/38471.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_task_definition: Fix `Provider produced inconsistent final plan` errors when `container_definitions` is [unknown](https://developer.hashicorp.com/terraform/language/expressions/references#values-not-yet-known)
+```

--- a/internal/sdkv2/state.go
+++ b/internal/sdkv2/state.go
@@ -5,7 +5,15 @@ package sdkv2
 
 import (
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 )
+
+// NormalizeJsonStringSchemaStateFunc normalizes a JSON string value before storing it in state.
+func NormalizeJsonStringSchemaStateFunc(v interface{}) string {
+	json, _ := structure.NormalizeJsonString(v)
+	return json
+}
 
 // ToUpperSchemaStateFunc converts a string value to uppercase before storing it in state.
 func ToUpperSchemaStateFunc(v interface{}) string {

--- a/internal/sdkv2/state.go
+++ b/internal/sdkv2/state.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NormalizeJsonStringSchemaStateFunc normalizes a JSON string value before storing it in state.
-func NormalizeJsonStringSchemaStateFunc(v interface{}) string {
+func NormalizeJsonStringSchemaStateFunc(v interface{}) string { // nosemgrep:ci.caps2-in-func-name
 	json, _ := structure.NormalizeJsonString(v)
 	return json
 }

--- a/internal/sdkv2/state_test.go
+++ b/internal/sdkv2/state_test.go
@@ -9,6 +9,19 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestNormalizeJsonStringSchemaStateFunc(t *testing.T) {
+	t.Parallel()
+
+	var input interface{} = `{ "key1": "value1", "key2": 42}`
+	want := `{"key1":"value1","key2":42}`
+
+	got := NormalizeJsonStringSchemaStateFunc(input)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("unexpected diff (+want, -got): %s", diff)
+	}
+}
+
 func TestToUpperSchemaStateFunc(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sdkv2/state_test.go
+++ b/internal/sdkv2/state_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestNormalizeJsonStringSchemaStateFunc(t *testing.T) {
+func TestNormalizeJsonStringSchemaStateFunc(t *testing.T) { // nosemgrep:ci.caps2-in-func-name
 	t.Parallel()
 
 	var input interface{} = `{ "key1": "value1", "key2": 42}`

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -27,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tfjson "github.com/hashicorp/terraform-provider-aws/internal/json"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -79,28 +79,18 @@ func resourceTaskDefinition() *schema.Resource {
 				Computed: true,
 			},
 			"container_definitions": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				StateFunc: func(v interface{}) string {
-					// Sort the lists of environment variables as they are serialized to state, so we won't get
-					// spurious reorderings in plans (diff is suppressed if the environment variables haven't changed,
-					// but they still show in the plan if some other property changes).
-					orderedCDs, _ := expandContainerDefinitions(v.(string))
-					containerDefinitions(orderedCDs).orderContainers()
-					containerDefinitions(orderedCDs).orderEnvironmentVariables()
-					containerDefinitions(orderedCDs).orderSecrets()
-					unnormalizedJson, _ := flattenContainerDefinitions(orderedCDs)
-					json, _ := structure.NormalizeJsonString(unnormalizedJson)
-					return json
-				},
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: sdkv2.NormalizeJsonStringSchemaStateFunc,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					networkMode, ok := d.GetOk("network_mode")
-					isAWSVPC := ok && networkMode.(string) == string(awstypes.NetworkModeAwsvpc)
+					isAWSVPC := ok && awstypes.NetworkMode(networkMode.(string)) == awstypes.NetworkModeAwsvpc
 					equal, _ := containerDefinitionsAreEquivalent(old, new, isAWSVPC)
 					return equal
 				},
-				ValidateFunc: validTaskDefinitionContainerDefinitions,
+				DiffSuppressOnRefresh: true,
+				ValidateFunc:          validTaskDefinitionContainerDefinitions,
 			},
 			"cpu": {
 				Type:     schema.TypeString,
@@ -631,7 +621,11 @@ func resourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
-	d.Set("container_definitions", defs)
+	if v := d.Get("container_definitions").(string); tfjson.EqualStrings(v, defs) {
+		d.Set("container_definitions", v)
+	} else {
+		d.Set("container_definitions", defs)
+	}
 
 	setTagsOut(ctx, tags)
 

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -86,7 +86,12 @@ func resourceTaskDefinition() *schema.Resource {
 					// Sort the lists of environment variables as they are serialized to state, so we won't get
 					// spurious reorderings in plans (diff is suppressed if the environment variables haven't changed,
 					// but they still show in the plan if some other property changes).
-					orderedCDs, _ := expandContainerDefinitions(v.(string))
+					orderedCDs, err := expandContainerDefinitions(v.(string))
+					if err != nil {
+						// e.g. The value is unknown ("74D93920-ED26-11E3-AC10-0800200C9A66").
+						// Mimic the pre-v5.59.0 behavior.
+						return "[]"
+					}
 					containerDefinitions(orderedCDs).orderContainers()
 					containerDefinitions(orderedCDs).orderEnvironmentVariables()
 					containerDefinitions(orderedCDs).orderSecrets()

--- a/internal/service/ecs/task_definition_equivalency.go
+++ b/internal/service/ecs/task_definition_equivalency.go
@@ -121,18 +121,20 @@ func (cd containerDefinitions) reduce(isAWSVPC bool) {
 }
 
 func (cd containerDefinitions) orderEnvironmentVariables() {
-	for _, def := range cd {
+	for i, def := range cd {
 		sort.Slice(def.Environment, func(i, j int) bool {
 			return aws.ToString(def.Environment[i].Name) < aws.ToString(def.Environment[j].Name)
 		})
+		cd[i].Environment = def.Environment
 	}
 }
 
 func (cd containerDefinitions) orderSecrets() {
-	for _, def := range cd {
+	for i, def := range cd {
 		sort.Slice(def.Secrets, func(i, j int) bool {
 			return aws.ToString(def.Secrets[i].Name) < aws.ToString(def.Secrets[j].Name)
 		})
+		cd[i].Secrets = def.Secrets
 	}
 }
 

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -1030,41 +1030,6 @@ func TestAccECSTaskDefinition_disappears(t *testing.T) {
 	})
 }
 
-// https://github.com/hashicorp/terraform-provider-aws/issues/38461.
-func TestAccECSTaskDefinition_awsSDKForGoV2ContainerDefinitions(t *testing.T) {
-	ctx := acctest.Context(t)
-	var def awstypes.TaskDefinition
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_ecs_task_definition.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:   acctest.ErrorCheck(t, names.ECSServiceID),
-		CheckDestroy: testAccCheckTaskDefinitionDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				ExternalProviders: map[string]resource.ExternalProvider{
-					"aws": {
-						Source:            "hashicorp/aws",
-						VersionConstraint: "5.58.0",
-					},
-				},
-				Config: testAccTaskDefinitionConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
-				),
-			},
-			{
-				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-				Config:                   testAccTaskDefinitionConfig_modified(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
-				),
-			},
-		},
-	})
-}
-
 func TestAccECSTaskDefinition_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var def awstypes.TaskDefinition

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -1030,6 +1030,41 @@ func TestAccECSTaskDefinition_disappears(t *testing.T) {
 	})
 }
 
+// https://github.com/hashicorp/terraform-provider-aws/issues/38461.
+func TestAccECSTaskDefinition_awsSDKForGoV2ContainerDefinitions(t *testing.T) {
+	ctx := acctest.Context(t)
+	var def awstypes.TaskDefinition
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecs_task_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ECSServiceID),
+		CheckDestroy: testAccCheckTaskDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.58.0",
+					},
+				},
+				Config: testAccTaskDefinitionConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccTaskDefinitionConfig_modified(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
+				),
+			},
+		},
+	})
+}
+
 func TestAccECSTaskDefinition_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var def awstypes.TaskDefinition


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The root cause was a change in the behavior of the `container_definitions` attribute's [`StateFunc`](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#statefunc) when the value is [unknown](https://developer.hashicorp.com/terraform/language/expressions/references#values-not-yet-known), for example during `terraform plan` when the attribute's value refers to attributes of other to-be-created resources.

For **v5.58.0** the returned value in such cases was `[]` (an empty array):
```
2024-07-23T14:34:21.637-0400 [INFO]  provider.terraform-provider-aws: [INFO] container_definitions.StateFunc: v: 74D93920-ED26-11E3-AC10-0800200C9A66, err: decoding JSON: invalid character 'D' after top-level value
2024-07-23T14:34:21.637-0400 [INFO]  provider.terraform-provider-aws: [INFO] container_definitions.StateFunc: json: []
```

For **v5.59.0** the returned value in such cases was `null`:
```
2024-07-23T14:27:48.905-0400 [INFO]  provider.terraform-provider-aws: [INFO] container_definitions.StateFunc: v: 74D93920-ED26-11E3-AC10-0800200C9A66, err: json: cannot unmarshal number into Go value of type []types.ContainerDefinition
2024-07-23T14:27:48.905-0400 [INFO]  provider.terraform-provider-aws: [INFO] container_definitions.StateFunc: json: null
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/38461.
Closes #38466.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccECSTaskDefinition_' PKG=ecs ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ecs/... -v -count 1 -parallel 3  -run=TestAccECSTaskDefinition_ -timeout 360m
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== RUN   TestAccECSTaskDefinition_scratchVolume
=== PAUSE TestAccECSTaskDefinition_scratchVolume
=== RUN   TestAccECSTaskDefinition_configuredAtLaunch
=== PAUSE TestAccECSTaskDefinition_configuredAtLaunch
=== RUN   TestAccECSTaskDefinition_DockerVolume_basic
=== PAUSE TestAccECSTaskDefinition_DockerVolume_basic
=== RUN   TestAccECSTaskDefinition_DockerVolume_minimal
=== PAUSE TestAccECSTaskDefinition_DockerVolume_minimal
=== RUN   TestAccECSTaskDefinition_runtimePlatform
=== PAUSE TestAccECSTaskDefinition_runtimePlatform
=== RUN   TestAccECSTaskDefinition_Fargate_runtimePlatform
=== PAUSE TestAccECSTaskDefinition_Fargate_runtimePlatform
=== RUN   TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== PAUSE TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== RUN   TestAccECSTaskDefinition_EFSVolume_minimal
=== PAUSE TestAccECSTaskDefinition_EFSVolume_minimal
=== RUN   TestAccECSTaskDefinition_EFSVolume_basic
=== PAUSE TestAccECSTaskDefinition_EFSVolume_basic
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryption
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryption
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== RUN   TestAccECSTaskDefinition_EFSVolume_accessPoint
=== PAUSE TestAccECSTaskDefinition_EFSVolume_accessPoint
=== RUN   TestAccECSTaskDefinition_fsxWinFileSystem
=== PAUSE TestAccECSTaskDefinition_fsxWinFileSystem
=== RUN   TestAccECSTaskDefinition_DockerVolume_taskScoped
=== PAUSE TestAccECSTaskDefinition_DockerVolume_taskScoped
=== RUN   TestAccECSTaskDefinition_service
=== PAUSE TestAccECSTaskDefinition_service
=== RUN   TestAccECSTaskDefinition_taskRoleARN
=== PAUSE TestAccECSTaskDefinition_taskRoleARN
=== RUN   TestAccECSTaskDefinition_networkMode
=== PAUSE TestAccECSTaskDefinition_networkMode
=== RUN   TestAccECSTaskDefinition_ipcMode
=== PAUSE TestAccECSTaskDefinition_ipcMode
=== RUN   TestAccECSTaskDefinition_pidMode
=== PAUSE TestAccECSTaskDefinition_pidMode
=== RUN   TestAccECSTaskDefinition_constraint
=== PAUSE TestAccECSTaskDefinition_constraint
=== RUN   TestAccECSTaskDefinition_changeVolumesForcesNewResource
=== PAUSE TestAccECSTaskDefinition_changeVolumesForcesNewResource
=== RUN   TestAccECSTaskDefinition_arrays
=== PAUSE TestAccECSTaskDefinition_arrays
=== RUN   TestAccECSTaskDefinition_Fargate_basic
=== PAUSE TestAccECSTaskDefinition_Fargate_basic
=== RUN   TestAccECSTaskDefinition_Fargate_ephemeralStorage
=== PAUSE TestAccECSTaskDefinition_Fargate_ephemeralStorage
=== RUN   TestAccECSTaskDefinition_executionRole
=== PAUSE TestAccECSTaskDefinition_executionRole
=== RUN   TestAccECSTaskDefinition_disappears
=== PAUSE TestAccECSTaskDefinition_disappears
=== RUN   TestAccECSTaskDefinition_tags
=== PAUSE TestAccECSTaskDefinition_tags
=== RUN   TestAccECSTaskDefinition_proxy
=== PAUSE TestAccECSTaskDefinition_proxy
=== RUN   TestAccECSTaskDefinition_inferenceAccelerator
=== PAUSE TestAccECSTaskDefinition_inferenceAccelerator
=== RUN   TestAccECSTaskDefinition_invalidContainerDefinition
=== PAUSE TestAccECSTaskDefinition_invalidContainerDefinition
=== RUN   TestAccECSTaskDefinition_trackLatest
=== PAUSE TestAccECSTaskDefinition_trackLatest
=== RUN   TestAccECSTaskDefinition_unknownContainerDefinitions
=== PAUSE TestAccECSTaskDefinition_unknownContainerDefinitions
=== CONT  TestAccECSTaskDefinition_basic
=== CONT  TestAccECSTaskDefinition_taskRoleARN
=== CONT  TestAccECSTaskDefinition_EFSVolume_basic
--- PASS: TestAccECSTaskDefinition_taskRoleARN (11.89s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_accessPoint
--- PASS: TestAccECSTaskDefinition_basic (17.60s)
=== CONT  TestAccECSTaskDefinition_service
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (20.10s)
=== CONT  TestAccECSTaskDefinition_DockerVolume_taskScoped
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (8.46s)
=== CONT  TestAccECSTaskDefinition_fsxWinFileSystem
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (23.86s)
=== CONT  TestAccECSTaskDefinition_executionRole
--- PASS: TestAccECSTaskDefinition_executionRole (11.55s)
=== CONT  TestAccECSTaskDefinition_unknownContainerDefinitions
--- PASS: TestAccECSTaskDefinition_unknownContainerDefinitions (10.17s)
=== CONT  TestAccECSTaskDefinition_trackLatest
--- PASS: TestAccECSTaskDefinition_trackLatest (10.60s)
=== CONT  TestAccECSTaskDefinition_invalidContainerDefinition
--- PASS: TestAccECSTaskDefinition_invalidContainerDefinition (0.70s)
=== CONT  TestAccECSTaskDefinition_inferenceAccelerator
--- PASS: TestAccECSTaskDefinition_inferenceAccelerator (10.85s)
=== CONT  TestAccECSTaskDefinition_proxy
--- PASS: TestAccECSTaskDefinition_proxy (21.78s)
=== CONT  TestAccECSTaskDefinition_tags
--- PASS: TestAccECSTaskDefinition_service (98.67s)
=== CONT  TestAccECSTaskDefinition_disappears
--- PASS: TestAccECSTaskDefinition_disappears (14.95s)
=== CONT  TestAccECSTaskDefinition_runtimePlatform
--- PASS: TestAccECSTaskDefinition_tags (34.35s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_minimal
--- PASS: TestAccECSTaskDefinition_runtimePlatform (10.33s)
=== CONT  TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (10.53s)
=== CONT  TestAccECSTaskDefinition_Fargate_runtimePlatform
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (19.46s)
=== CONT  TestAccECSTaskDefinition_DockerVolume_basic
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatform (10.66s)
=== CONT  TestAccECSTaskDefinition_DockerVolume_minimal
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (11.57s)
=== CONT  TestAccECSTaskDefinition_configuredAtLaunch
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (11.75s)
=== CONT  TestAccECSTaskDefinition_scratchVolume
--- PASS: TestAccECSTaskDefinition_configuredAtLaunch (10.50s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryption
--- PASS: TestAccECSTaskDefinition_scratchVolume (10.89s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (19.40s)
=== CONT  TestAccECSTaskDefinition_changeVolumesForcesNewResource
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled (20.52s)
=== CONT  TestAccECSTaskDefinition_Fargate_ephemeralStorage
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (16.92s)
=== CONT  TestAccECSTaskDefinition_Fargate_basic
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (10.86s)
=== CONT  TestAccECSTaskDefinition_arrays
--- PASS: TestAccECSTaskDefinition_Fargate_basic (14.14s)
=== CONT  TestAccECSTaskDefinition_pidMode
--- PASS: TestAccECSTaskDefinition_arrays (11.00s)
=== CONT  TestAccECSTaskDefinition_constraint
--- PASS: TestAccECSTaskDefinition_pidMode (11.86s)
=== CONT  TestAccECSTaskDefinition_ipcMode
--- PASS: TestAccECSTaskDefinition_constraint (12.12s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
--- PASS: TestAccECSTaskDefinition_ipcMode (11.51s)
=== CONT  TestAccECSTaskDefinition_networkMode
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal (19.66s)
--- PASS: TestAccECSTaskDefinition_networkMode (11.71s)
--- PASS: TestAccECSTaskDefinition_fsxWinFileSystem (3004.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	3037.985s
```

#### Before the fix

```console
% make testacc TESTARGS='-run=TestAccECSTaskDefinition_unknownContainerDefinitions' PKG=ecs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ecs/... -v -count 1 -parallel 20  -run=TestAccECSTaskDefinition_unknownContainerDefinitions -timeout 360m
=== RUN   TestAccECSTaskDefinition_unknownContainerDefinitions
=== PAUSE TestAccECSTaskDefinition_unknownContainerDefinitions
=== CONT  TestAccECSTaskDefinition_unknownContainerDefinitions
    task_definition_test.go:1231: Step 1/1 error: Error running apply: exit status 1
        
        Error: Provider produced inconsistent final plan
        
        When expanding the plan for aws_ecs_task_definition.test to include new
        values learned so far during apply, provider
        "registry.terraform.io/hashicorp/aws" produced an invalid new value for
        .container_definitions: was cty.StringVal(""), but now
        cty.StringVal("[{\"Command\":null,\"Cpu\":0,\"CredentialSpecs\":null,\"DependsOn\":null,\"DisableNetworking\":null,\"DnsSearchDomains\":null,\"DnsServers\":null,\"DockerLabels\":null,\"DockerSecurityOptions\":null,\"EntryPoint\":null,\"Environment\":[{\"Name\":\"example1\",\"Value\":\"123\"},{\"Name\":\"example2\",\"Value\":\"456\"},{\"Name\":\"example3\",\"Value\":\"789\"}],\"EnvironmentFiles\":null,\"Essential\":null,\"ExtraHosts\":null,\"FirelensConfiguration\":null,\"HealthCheck\":null,\"Hostname\":null,\"Image\":\"jenkins/jenkins\",\"Interactive\":null,\"Links\":null,\"LinuxParameters\":null,\"LogConfiguration\":{\"LogDriver\":\"awslogs\",\"Options\":{\"awslogs-group\":\"tf-acc-test-7020277511731307967\",\"awslogs-region\":\"us-west-2\",\"awslogs-stream-prefix\":\"ecs\"},\"SecretOptions\":null},\"Memory\":null,\"MemoryReservation\":null,\"MountPoints\":null,\"Name\":\"jenkins\",\"PortMappings\":[{\"AppProtocol\":\"\",\"ContainerPort\":1234,\"ContainerPortRange\":null,\"HostPort\":1234,\"Name\":null,\"Protocol\":\"\"}],\"Privileged\":null,\"PseudoTerminal\":null,\"ReadonlyRootFilesystem\":null,\"RepositoryCredentials\":null,\"ResourceRequirements\":null,\"Secrets\":[{\"Name\":\"example4\",\"ValueFrom\":\"arn:aws:ssm:us-west-2:123456789012:parameter/tf-acc-test-7020277511731307967\"}],\"StartTimeout\":null,\"StopTimeout\":null,\"SystemControls\":null,\"Ulimits\":null,\"User\":null,\"VolumesFrom\":null,\"WorkingDirectory\":null}]").
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccECSTaskDefinition_unknownContainerDefinitions (6.04s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	10.822s
FAIL
make: *** [testacc] Error 1
```
