### PR TITLE
Fixed typo in resource note for aws_lambda_runtime_management_config

### DIFF
--- a/website/docs/r/lambda_runtime_management_config.html.markdown
+++ b/website/docs/r/lambda_runtime_management_config.html.markdown
@@ -12,7 +12,7 @@ Terraform resource for managing an AWS Lambda Runtime Management Config.
 Refer to the [AWS Lambda documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) for supported runtimes.
 
 ~> Deletion of this resource returns the runtime update mode to `Auto` (the default behavior).
-To leave the configured runtime management options in-place, use a [`removed` block](https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources) withe destroy lifecycle set to `false`.
+To leave the configured runtime management options in-place, use a [`removed` block](https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources) with the destroy lifecycle set to `false`.
 
 ## Example Usage
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
* Fixed a typo in the resource not for the `aws_lambda_runtime_management_config` resource.

### References
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_runtime_management_config
