### PR TITLE
docs: update account alias output docs

### DIFF
--- a/website/docs/d/iam_account_alias.html.markdown
+++ b/website/docs/d/iam_account_alias.html.markdown
@@ -17,7 +17,7 @@ for the effective account in which Terraform is working.
 ```terraform
 data "aws_iam_account_alias" "current" {}
 
-output "account_id" {
+output "account_alias" {
   value = data.aws_iam_account_alias.current.account_alias
 }
 ```


### PR DESCRIPTION
### Description

Updates documentation on `data "aws_iam_account_alias" "current" {}` documentation page example section ( https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_account_alias ) where output says `account_id` while it echoes the account alias. ( I think this was a copy paste mistake by someone in the past )


