### PR TITLE
rd/aws_cloudwatch_event_bus: Add `kms_key_identifier` argument

### DIFF
--- a/.changelog/38492.txt
+++ b/.changelog/38492.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_cloudwatch_event_bus: Add `kms_key_identifier` argument
+```
+
+```release-note:enhancement
+data-source/aws_cloudwatch_event_bus: Add `kms_key_identifier` attribute
+```

--- a/internal/service/events/bus.go
+++ b/internal/service/events/bus.go
@@ -143,18 +143,20 @@ func resourceBusUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EventsClient(ctx)
 
-	input := &eventbridge.UpdateEventBusInput{
-		Name: aws.String(d.Get(names.AttrName).(string)),
-	}
+	if d.HasChange("kms_key_identifier") {
+		input := &eventbridge.UpdateEventBusInput{
+			Name: aws.String(d.Get(names.AttrName).(string)),
+		}
 
-	if v, ok := d.GetOk("kms_key_identifier"); ok {
-		input.KmsKeyIdentifier = aws.String(v.(string))
-	}
+		if v, ok := d.GetOk("kms_key_identifier"); ok {
+			input.KmsKeyIdentifier = aws.String(v.(string))
+		}
 
-	_, err := conn.UpdateEventBus(ctx, input)
+		_, err := conn.UpdateEventBus(ctx, input)
 
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating EventBridge Event Bus (%s): %s", d.Id(), err)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating EventBridge Event Bus (%s): %s", d.Id(), err)
+		}
 	}
 
 	return append(diags, resourceBusRead(ctx, d, meta)...)

--- a/internal/service/events/bus.go
+++ b/internal/service/events/bus.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -46,6 +47,11 @@ func resourceBus() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validSourceName,
 			},
+			"kms_key_identifier": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 2048),
+			},
 			names.AttrName: {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -72,6 +78,10 @@ func resourceBusCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	if v, ok := d.GetOk("event_source_name"); ok {
 		input.EventSourceName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("kms_key_identifier"); ok {
+		input.KmsKeyIdentifier = aws.String(v.(string))
 	}
 
 	output, err := conn.CreateEventBus(ctx, input)
@@ -123,6 +133,7 @@ func resourceBusRead(ctx context.Context, d *schema.ResourceData, meta interface
 	}
 
 	d.Set(names.AttrARN, output.Arn)
+	d.Set("kms_key_identifier", output.KmsKeyIdentifier)
 	d.Set(names.AttrName, output.Name)
 
 	return diags
@@ -130,8 +141,21 @@ func resourceBusRead(ctx context.Context, d *schema.ResourceData, meta interface
 
 func resourceBusUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EventsClient(ctx)
 
-	// Tags only.
+	input := &eventbridge.UpdateEventBusInput{
+		Name: aws.String(d.Get(names.AttrName).(string)),
+	}
+
+	if v, ok := d.GetOk("kms_key_identifier"); ok {
+		input.KmsKeyIdentifier = aws.String(v.(string))
+	}
+
+	_, err := conn.UpdateEventBus(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating EventBridge Event Bus (%s): %s", d.Id(), err)
+	}
 
 	return append(diags, resourceBusRead(ctx, d, meta)...)
 }

--- a/internal/service/events/bus_data_source.go
+++ b/internal/service/events/bus_data_source.go
@@ -23,6 +23,10 @@ func dataSourceBus() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"kms_key_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrName: {
 				Type:     schema.TypeString,
 				Required: true,
@@ -44,6 +48,7 @@ func dataSourceBusRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	d.SetId(eventBusName)
 	d.Set(names.AttrARN, output.Arn)
+	d.Set("kms_key_identifier", output.KmsKeyIdentifier)
 	d.Set(names.AttrName, output.Name)
 
 	return diags

--- a/internal/service/events/bus_data_source_test.go
+++ b/internal/service/events/bus_data_source_test.go
@@ -35,10 +35,96 @@ func TestAccEventsBusDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccEventsBusDataSource_kmsKeyIdentifier(t *testing.T) {
+	ctx := acctest.Context(t)
+	busName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_cloudwatch_event_bus.test"
+	resourceName := "aws_cloudwatch_event_bus.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EventsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBusDataSourceConfig_kmsKeyIdentifier(busName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "kms_key_identifier", resourceName, "kms_key_identifier"),
+				),
+			},
+		},
+	})
+}
+
 func testAccBusDataSourceConfig_basic(busName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_bus" "test" {
   name = %[1]q
+}
+
+data "aws_cloudwatch_event_bus" "test" {
+  name = aws_cloudwatch_event_bus.test.name
+}
+`, busName)
+}
+
+func testAccBusDataSourceConfig_kmsKeyIdentifier(busName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+}
+
+data "aws_iam_policy_document" "key_policy" {
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+
+    resources = [
+      aws_kms_key.test.arn,
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+
+  statement {
+    actions = [
+      "kms:*",
+    ]
+
+    resources = [
+      aws_kms_key.test.arn
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+}
+
+resource "aws_kms_key_policy" "test" {
+  key_id = aws_kms_key.test.id
+  policy = data.aws_iam_policy_document.key_policy.json
+}
+
+resource "aws_cloudwatch_event_bus" "test" {
+  name = %[1]q
+  kms_key_identifier = aws_kms_key.test.arn
 }
 
 data "aws_cloudwatch_event_bus" "test" {

--- a/internal/service/events/bus_data_source_test.go
+++ b/internal/service/events/bus_data_source_test.go
@@ -123,7 +123,7 @@ resource "aws_kms_key_policy" "test" {
 }
 
 resource "aws_cloudwatch_event_bus" "test" {
-  name = %[1]q
+  name               = %[1]q
   kms_key_identifier = aws_kms_key.test.arn
 }
 

--- a/internal/service/events/bus_test.go
+++ b/internal/service/events/bus_test.go
@@ -357,7 +357,7 @@ resource "aws_kms_key_policy" "test1" {
 }
 
 resource "aws_cloudwatch_event_bus" "test" {
-  name = %[1]q
+  name               = %[1]q
   kms_key_identifier = aws_kms_key.test1.arn
 }
 `, name)
@@ -418,7 +418,7 @@ resource "aws_kms_key_policy" "test2" {
 }
 
 resource "aws_cloudwatch_event_bus" "test" {
-  name = %[1]q
+  name               = %[1]q
   kms_key_identifier = aws_kms_key.test2.arn
 }
 `, name)

--- a/internal/service/events/bus_test.go
+++ b/internal/service/events/bus_test.go
@@ -74,7 +74,7 @@ func TestAccEventsBus_basic(t *testing.T) {
 	})
 }
 
-func TestAccEventBus_kmsKeyIdentifier(t *testing.T) {
+func TestAccEventsBus_kmsKeyIdentifier(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2 eventbridge.DescribeEventBusOutput
 	busName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/events/bus_test.go
+++ b/internal/service/events/bus_test.go
@@ -90,7 +90,7 @@ func TestAccEventsBus_kmsKeyIdentifier(t *testing.T) {
 				Config: testAccBusConfig_kmsKeyIdentifier1(busName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBusExists(ctx, resourceName, &v1),
-					resource.TestCheckResourceAttrPair(resourceName, "kms_key_identifier", "aws_kms_key.test1", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_identifier", "aws_kms_key.test1", names.AttrARN),
 				),
 			},
 			{
@@ -102,7 +102,7 @@ func TestAccEventsBus_kmsKeyIdentifier(t *testing.T) {
 				Config: testAccBusConfig_kmsKeyIdentifier2(busName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBusExists(ctx, resourceName, &v2),
-					resource.TestCheckResourceAttrPair(resourceName, "kms_key_identifier", "aws_kms_key.test2", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_identifier", "aws_kms_key.test2", names.AttrARN),
 				),
 			},
 		},

--- a/website/docs/d/cloudwatch_event_bus.html.markdown
+++ b/website/docs/d/cloudwatch_event_bus.html.markdown
@@ -29,3 +29,4 @@ data "aws_cloudwatch_event_bus" "example" {
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN.
+* `kms_key_identifier` - The identifier of the AWS KMS customer managed key for EventBridge to use to encrypt events on this event bus, if one has been specified.

--- a/website/docs/r/cloudwatch_event_bus.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus.html.markdown
@@ -36,7 +36,8 @@ resource "aws_cloudwatch_event_bus" "examplepartner" {
 This resource supports the following arguments:
 
 * `name` - (Required) The name of the new event bus. The names of custom event buses can't contain the / character. To create a partner event bus, ensure the `name` matches the `event_source_name`.
-* `event_source_name` (Optional) The partner event source that the new event bus will be matched with. Must match `name`.
+* `event_source_name` - (Optional) The partner event source that the new event bus will be matched with. Must match `name`.
+* `kms_key_identifier` - (Optional) The identifier of the AWS KMS customer managed key for EventBridge to use, if you choose to use a customer managed key to encrypt events on this event bus. The identifier can be the key Amazon Resource Name (ARN), KeyId, key alias, or key alias ARN.
 * `tags` - (Optional)  A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description
This PR adds the `kms_key_identifier` argument to the `aws_cloudwatch_event_bus` resource and data source.

### Relations
Closes #37531.

### References
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_CreateEventBus.html
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeEventBus.html
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_UpdateEventBus.html

### Output from Acceptance Testing

```console
% make testacc PKG=events ACCTEST_PARALLELISM=1 TESTARGS="-run=TestAccEventsBus"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/events/... -v -count 1 -parallel 1  -run=TestAccEventsBus -timeout 360m
=== RUN   TestAccEventsBusDataSource_basic
=== PAUSE TestAccEventsBusDataSource_basic
=== RUN   TestAccEventsBusDataSource_kmsKeyIdentifier
=== PAUSE TestAccEventsBusDataSource_kmsKeyIdentifier
=== RUN   TestAccEventsBusPolicy_basic
=== PAUSE TestAccEventsBusPolicy_basic
=== RUN   TestAccEventsBusPolicy_ignoreEquivalent
=== PAUSE TestAccEventsBusPolicy_ignoreEquivalent
=== RUN   TestAccEventsBusPolicy_disappears
=== PAUSE TestAccEventsBusPolicy_disappears
=== RUN   TestAccEventsBusPolicy_disappears_EventBus
=== PAUSE TestAccEventsBusPolicy_disappears_EventBus
=== RUN   TestAccEventsBus_basic
=== PAUSE TestAccEventsBus_basic
=== RUN   TestAccEventsBus_kmsKeyIdentifier
=== PAUSE TestAccEventsBus_kmsKeyIdentifier
=== RUN   TestAccEventsBus_tags
=== PAUSE TestAccEventsBus_tags
=== RUN   TestAccEventsBus_default
=== PAUSE TestAccEventsBus_default
=== RUN   TestAccEventsBus_disappears
=== PAUSE TestAccEventsBus_disappears
=== RUN   TestAccEventsBus_partnerEventSource
    bus_test.go:206: Environment variable EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME is not set
--- SKIP: TestAccEventsBus_partnerEventSource (0.00s)
=== CONT  TestAccEventsBusDataSource_basic
--- PASS: TestAccEventsBusDataSource_basic (17.10s)
=== CONT  TestAccEventsBus_basic
--- PASS: TestAccEventsBus_basic (45.97s)
=== CONT  TestAccEventsBus_disappears
--- PASS: TestAccEventsBus_disappears (16.96s)
=== CONT  TestAccEventsBus_default
--- PASS: TestAccEventsBus_default (0.97s)
=== CONT  TestAccEventsBus_tags
--- PASS: TestAccEventsBus_tags (45.42s)
=== CONT  TestAccEventsBus_kmsKeyIdentifier
--- PASS: TestAccEventsBus_kmsKeyIdentifier (57.15s)
=== CONT  TestAccEventsBusPolicy_ignoreEquivalent
--- PASS: TestAccEventsBusPolicy_ignoreEquivalent (22.98s)
=== CONT  TestAccEventsBusPolicy_disappears_EventBus
--- PASS: TestAccEventsBusPolicy_disappears_EventBus (19.16s)
=== CONT  TestAccEventsBusPolicy_disappears
--- PASS: TestAccEventsBusPolicy_disappears (18.18s)
=== CONT  TestAccEventsBusPolicy_basic
--- PASS: TestAccEventsBusPolicy_basic (34.35s)
=== CONT  TestAccEventsBusDataSource_kmsKeyIdentifier
--- PASS: TestAccEventsBusDataSource_kmsKeyIdentifier (28.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     314.546s
```
