### PR TITLE
Fix `ec2` service acceptance test errors

### DIFF
--- a/internal/service/ec2/ec2_fleet_test.go
+++ b/internal/service/ec2/ec2_fleet_test.go
@@ -2935,10 +2935,13 @@ func TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity(t *testing.
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"terminate_instances"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"fulfilled_capacity",
+					"terminate_instances",
+				},
 			},
 			{
 				Config: testAccFleetConfig_targetCapacitySpecificationTotalTargetCapacity(rName, 2),
@@ -2975,10 +2978,13 @@ func TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType(t *testi
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"terminate_instances"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"fulfilled_capacity",
+					"terminate_instances",
+				},
 			},
 		},
 	})

--- a/internal/service/ec2/vpc_ipv4_cidr_block_association.go
+++ b/internal/service/ec2/vpc_ipv4_cidr_block_association.go
@@ -97,7 +97,6 @@ func resourceVPCIPv4CIDRBlockAssociationCreate(ctx context.Context, d *schema.Re
 		input.Ipv4NetmaskLength = aws.Int32(int32(v.(int)))
 	}
 
-	log.Printf("[DEBUG] Creating EC2 VPC IPv4 CIDR Block Association: %#v", input)
 	output, err := conn.AssociateVpcCidrBlock(ctx, input)
 
 	if err != nil {
@@ -106,9 +105,7 @@ func resourceVPCIPv4CIDRBlockAssociationCreate(ctx context.Context, d *schema.Re
 
 	d.SetId(aws.ToString(output.CidrBlockAssociation.AssociationId))
 
-	_, err = waitVPCCIDRBlockAssociationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
-
-	if err != nil {
+	if _, err := waitVPCCIDRBlockAssociationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for EC2 VPC (%s) IPv4 CIDR block (%s) to become associated: %s", vpcID, d.Id(), err)
 	}
 
@@ -154,9 +151,7 @@ func resourceVPCIPv4CIDRBlockAssociationDelete(ctx context.Context, d *schema.Re
 		return sdkdiag.AppendErrorf(diags, "deleting EC2 VPC IPv4 CIDR Block Association (%s): %s", d.Id(), err)
 	}
 
-	_, err = waitVPCCIDRBlockAssociationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete))
-
-	if err != nil {
+	if _, err := waitVPCCIDRBlockAssociationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for EC2 VPC IPv4 CIDR block (%s) to become disassociated: %s", d.Id(), err)
 	}
 

--- a/internal/service/ec2/vpc_peering_connection_options_test.go
+++ b/internal/service/ec2/vpc_peering_connection_options_test.go
@@ -136,10 +136,11 @@ func TestAccVPCPeeringConnectionOptions_differentRegionSameAccount(t *testing.T)
 				),
 			},
 			{
-				Config:            testAccVPCPeeringConnectionOptionsConfig_differentRegionSameAccount(rName, true, true),
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config:                  testAccVPCPeeringConnectionOptionsConfig_differentRegionSameAccount(rName, true, true),
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"accepter.0.allow_remote_vpc_dns_resolution"},
 			},
 			{
 				Config: testAccVPCPeeringConnectionOptionsConfig_differentRegionSameAccount(rName, false, false),

--- a/internal/service/ec2/vpc_peering_connection_test.go
+++ b/internal/service/ec2/vpc_peering_connection_test.go
@@ -191,6 +191,7 @@ func TestAccVPCPeeringConnection_options(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
+					"accepter.0.allow_remote_vpc_dns_resolution",
 					"auto_accept",
 				},
 			},

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -2965,10 +2965,11 @@ func waitVPCIPv6CIDRBlockAssociationDeleted(ctx context.Context, conn *ec2.Clien
 
 func waitVPCPeeringConnectionActive(ctx context.Context, conn *ec2.Client, id string, timeout time.Duration) (*awstypes.VpcPeeringConnection, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.VpcPeeringConnectionStateReasonCodeInitiatingRequest, awstypes.VpcPeeringConnectionStateReasonCodeProvisioning),
-		Target:  enum.Slice(awstypes.VpcPeeringConnectionStateReasonCodeActive, awstypes.VpcPeeringConnectionStateReasonCodePendingAcceptance),
-		Refresh: statusVPCPeeringConnectionActive(ctx, conn, id),
-		Timeout: timeout,
+		Pending:                   enum.Slice(awstypes.VpcPeeringConnectionStateReasonCodeInitiatingRequest, awstypes.VpcPeeringConnectionStateReasonCodeProvisioning),
+		Target:                    enum.Slice(awstypes.VpcPeeringConnectionStateReasonCodeActive, awstypes.VpcPeeringConnectionStateReasonCodePendingAcceptance),
+		Refresh:                   statusVPCPeeringConnectionActive(ctx, conn, id),
+		Timeout:                   timeout,
+		ContinuousTargetOccurence: 2,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes some of the remaining EC2 service CI acceptance test failures.

```
=== RUN   TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType
=== PAUSE TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType
=== CONT  TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType
    ec2_fleet_test.go:2963: Step 2/2 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
          map[string]string{
        -   "fulfilled_capacity": "0",
        +   "fulfilled_capacity": "32",
          }
--- FAIL: TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType (646.27s)
```
```
=== RUN   TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity
=== PAUSE TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity
=== CONT  TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity
    ec2_fleet_test.go:2923: Step 2/3 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
          map[string]string{
        -   "fulfilled_capacity": "0",
        +   "fulfilled_capacity": "1",
          }
--- FAIL: TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity (644.27s)
```
```
=== RUN   TestAccVPCNetworkInsightsAnalysis_disappears
=== PAUSE TestAccVPCNetworkInsightsAnalysis_disappears
=== CONT  TestAccVPCNetworkInsightsAnalysis_disappears
    vpc_network_insights_analysis_test.go:62: Step 1/1 error: Error running apply: exit status 1
        Error: waiting for EC2 Network Insights Analysis (nia-033e15454d26d8e71) create: unexpected state 'failed', wanted target 'succeeded'. last error: The request failed due to an internal error. Wait a few minutes and try again.
          with aws_ec2_network_insights_analysis.test,
          on terraform_plugin_test.tf line 62, in resource "aws_ec2_network_insights_analysis" "test":
          62: resource "aws_ec2_network_insights_analysis" "test" {
--- FAIL: TestAccVPCNetworkInsightsAnalysis_disappears (160.51s)
```
```
=== RUN   TestAccVPCNetworkInsightsAnalysis_tags
=== PAUSE TestAccVPCNetworkInsightsAnalysis_tags
=== CONT  TestAccVPCNetworkInsightsAnalysis_tags
    vpc_network_insights_analysis_test.go:85: Step 1/4 error: Error running apply: exit status 1
        Error: waiting for EC2 Network Insights Analysis (nia-0e53614891ec6fde8) create: unexpected state 'failed', wanted target 'succeeded'. last error: The request failed due to an internal error. Wait a few minutes and try again.
          with aws_ec2_network_insights_analysis.test,
          on terraform_plugin_test.tf line 62, in resource "aws_ec2_network_insights_analysis" "test":
          62: resource "aws_ec2_network_insights_analysis" "test" {
--- FAIL: TestAccVPCNetworkInsightsAnalysis_tags (157.36s)
```
```
=== RUN   TestAccVPCPeeringConnection_tags
=== PAUSE TestAccVPCPeeringConnection_tags
=== CONT  TestAccVPCPeeringConnection_tags
    vpc_peering_connection_test.go:88: Step 2/4 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
          map[string]string{
        -   "accept_status":                              "pending-acceptance",
        +   "accept_status":                              "active",
        +   "accepter.#":                                 "1",
        +   "accepter.0.%":                               "1",
        +   "accepter.0.allow_remote_vpc_dns_resolution": "false",
          }
--- FAIL: TestAccVPCPeeringConnection_tags (306.61s)
```
```
=== RUN   TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount
=== PAUSE TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount
=== CONT  TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount
    vpc_peering_connection_accepter_test.go:28: Step 1/2 error: Check failed: Check 8/8 error: aws_vpc_peering_connection_accepter.peer: Attribute 'accept_status' expected "active", got "pending-acceptance"
--- FAIL: TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount (141.62s)
```
```
=== RUN   TestAccVPCPeeringConnectionOptions_differentRegionSameAccount
=== PAUSE TestAccVPCPeeringConnectionOptions_differentRegionSameAccount
=== CONT  TestAccVPCPeeringConnectionOptions_differentRegionSameAccount
    vpc_peering_connection_options_test.go:105: Step 2/3 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
          map[string]string{
        -   "accepter.0.allow_remote_vpc_dns_resolution": "false",
        +   "accepter.0.allow_remote_vpc_dns_resolution": "true",
          }
--- FAIL: TestAccVPCPeeringConnectionOptions_differentRegionSameAccount (545.39s)
```
```
=== RUN   TestAccVPCPeeringConnection_options
=== PAUSE TestAccVPCPeeringConnection_options
=== CONT  TestAccVPCPeeringConnection_options
    vpc_peering_connection_test.go:151: Step 2/3 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
          map[string]string{
        -   "accepter.0.allow_remote_vpc_dns_resolution": "true",
        +   "accepter.0.allow_remote_vpc_dns_resolution": "false",
          }
--- FAIL: TestAccVPCPeeringConnection_options (324.80s)
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/35747.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType\|TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType\|TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity -timeout 360m
=== RUN   TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity
=== PAUSE TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity
=== RUN   TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType
=== PAUSE TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType
=== CONT  TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity
=== CONT  TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_targetCapacityUnitType (429.33s)
--- PASS: TestAccEC2Fleet_TargetCapacitySpecification_totalTargetCapacity (473.76s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	479.902s
```
```console
% make testacc TESTARGS='-run=TestAccVPCNetworkInsightsAnalysis_' PKG=ec2 ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ec2/... -v -count 1 -parallel 3  -run=TestAccVPCNetworkInsightsAnalysis_ -timeout 360m
=== RUN   TestAccVPCNetworkInsightsAnalysis_basic
=== PAUSE TestAccVPCNetworkInsightsAnalysis_basic
=== RUN   TestAccVPCNetworkInsightsAnalysis_disappears
=== PAUSE TestAccVPCNetworkInsightsAnalysis_disappears
=== RUN   TestAccVPCNetworkInsightsAnalysis_tags
=== PAUSE TestAccVPCNetworkInsightsAnalysis_tags
=== RUN   TestAccVPCNetworkInsightsAnalysis_filterInARNs
=== PAUSE TestAccVPCNetworkInsightsAnalysis_filterInARNs
=== RUN   TestAccVPCNetworkInsightsAnalysis_waitForCompletion
=== PAUSE TestAccVPCNetworkInsightsAnalysis_waitForCompletion
=== CONT  TestAccVPCNetworkInsightsAnalysis_basic
=== CONT  TestAccVPCNetworkInsightsAnalysis_filterInARNs
=== CONT  TestAccVPCNetworkInsightsAnalysis_waitForCompletion
--- PASS: TestAccVPCNetworkInsightsAnalysis_waitForCompletion (28.99s)
=== CONT  TestAccVPCNetworkInsightsAnalysis_tags
--- PASS: TestAccVPCNetworkInsightsAnalysis_basic (51.50s)
=== CONT  TestAccVPCNetworkInsightsAnalysis_disappears
--- PASS: TestAccVPCNetworkInsightsAnalysis_filterInARNs (93.80s)
--- PASS: TestAccVPCNetworkInsightsAnalysis_tags (66.97s)
--- PASS: TestAccVPCNetworkInsightsAnalysis_disappears (45.35s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	101.635s
```
```console
% make testacc TESTARGS='-run=TestAccVPCPeeringConnection_tags' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPCPeeringConnection_tags -timeout 360m
=== RUN   TestAccVPCPeeringConnection_tags
=== PAUSE TestAccVPCPeeringConnection_tags
=== CONT  TestAccVPCPeeringConnection_tags
--- PASS: TestAccVPCPeeringConnection_tags (33.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	38.597s
```
```console
% make testacc TESTARGS='-run=TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount -timeout 360m
=== RUN   TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount
=== PAUSE TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount
=== CONT  TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount
--- PASS: TestAccVPCPeeringConnectionAccepter_sameRegionSameAccount (17.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	22.247s
```
```console
% make testacc TESTARGS='-run=TestAccVPCPeeringConnectionOptions_differentRegionSameAccount' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPCPeeringConnectionOptions_differentRegionSameAccount -timeout 360m
=== RUN   TestAccVPCPeeringConnectionOptions_differentRegionSameAccount
=== PAUSE TestAccVPCPeeringConnectionOptions_differentRegionSameAccount
=== CONT  TestAccVPCPeeringConnectionOptions_differentRegionSameAccount
--- PASS: TestAccVPCPeeringConnectionOptions_differentRegionSameAccount (57.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	62.359s
```
```console
% make testacc TESTARGS='-run=TestAccVPCPeeringConnection_options' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPCPeeringConnection_options -timeout 360m
=== RUN   TestAccVPCPeeringConnection_options
=== PAUSE TestAccVPCPeeringConnection_options
=== RUN   TestAccVPCPeeringConnection_optionsNoAutoAccept
=== PAUSE TestAccVPCPeeringConnection_optionsNoAutoAccept
=== CONT  TestAccVPCPeeringConnection_options
=== CONT  TestAccVPCPeeringConnection_optionsNoAutoAccept
--- PASS: TestAccVPCPeeringConnection_optionsNoAutoAccept (19.15s)
--- PASS: TestAccVPCPeeringConnection_options (36.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	41.782s
```
