### PR TITLE
Fix scope attribute validation for codebuild webhooks

### DIFF
--- a/.changelog/38513.txt
+++ b/.changelog/38513.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codebuild_webhook: Remove errant validation on `scope_configuration.domain` argument
+```

--- a/internal/service/codebuild/webhook.go
+++ b/internal/service/codebuild/webhook.go
@@ -94,12 +94,12 @@ func resourceWebhook() *schema.Resource {
 							Required: true,
 						},
 						names.AttrDomain: {
-							Type:             schema.TypeString,
-							Optional:         true,
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						names.AttrScope: {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
 							ValidateDiagFunc: enum.Validate[types.WebhookScopeType](),
 						},
 					},

--- a/internal/service/codebuild/webhook.go
+++ b/internal/service/codebuild/webhook.go
@@ -96,11 +96,11 @@ func resourceWebhook() *schema.Resource {
 						names.AttrDomain: {
 							Type:             schema.TypeString,
 							Optional:         true,
-							ValidateDiagFunc: enum.Validate[types.WebhookScopeType](),
 						},
 						names.AttrScope: {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateDiagFunc: enum.Validate[types.WebhookScopeType](),
 						},
 					},
 				},


### PR DESCRIPTION
### Description
When `scope_configuration` was added to the `aws_codebuild_webhook` resource the validation for `scopes` was incorrectly applied to the `domain` section.  As a result the validation is checking if `example.com` matches either `GITHUB_ORGANIZATION` or `GITHUB_GLOBAL` (which would make sense if applied to `scopes` instead of `domains`).  Moving the validation line fixes errors like:
```
│ Error: expected domain to be one of ["GITHUB_ORGANIZATION" "GITHUB_GLOBAL"], got example.com
```
when using a `scope_configuration` like:
```
scope_configuration {                                                                                                                                                                         
  domain = "example.com"
  name   = "my-org-name"
  scope  = "GITHUB_ORGANIZATION"
}
```

### Relations
Relates #38199 (tyvm!)

### References
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_webhook
https://docs.aws.amazon.com/codebuild/latest/userguide/github-global-organization-webhook.html
```
In the webhook's scope configuration, set the scope to either GITHUB_ORGANIZATION or GITHUB_GLOBAL depending on whether it should be an organization or[ global webhook](https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/exploring-user-activity-in-your-enterprise/managing-global-webhooks)
```