### PR TITLE
fix: Adjusts regex for keyspace table column types to allow for 5 layers of nesting

### DIFF
--- a/internal/service/keyspaces/table.go
+++ b/internal/service/keyspaces/table.go
@@ -228,7 +228,7 @@ func resourceTable() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 										ValidateFunc: validation.StringMatch(
-											regexache.MustCompile(`^[0-9a-z]+(\<[0-9a-z]+(, *[0-9a-z]+){0,1}\>)?$`),
+											regexache.MustCompile(`^[0-9a-z]+(<[0-9a-z]+(, *[0-9a-z]+)?( *<([0-9a-z]+(, *[0-9a-z]+)?( *<([0-9a-z]+(, *[0-9a-z]+)?( *<([0-9a-z]+(, *[0-9a-z]+)?( *<([0-9a-z]+(, *[0-9a-z]+)?)?>)?)?>)?)?>)?)?>)?)?>$`),
 											"The type must consist of lower case alphanumerics and an optional list of upto two lower case alphanumerics enclosed in angle brackets '<>'.",
 										),
 									},

--- a/internal/service/keyspaces/table.go
+++ b/internal/service/keyspaces/table.go
@@ -228,7 +228,7 @@ func resourceTable() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 										ValidateFunc: validation.StringMatch(
-											regexache.MustCompile(`^[0-9a-z]+(<[0-9a-z]+(, *[0-9a-z]+)?( *<([0-9a-z]+(, *[0-9a-z]+)?( *<([0-9a-z]+(, *[0-9a-z]+)?( *<([0-9a-z]+(, *[0-9a-z]+)?( *<([0-9a-z]+(, *[0-9a-z]+)?)?>)?)?>)?)?>)?)?>)?)?>$`),
+											regexache.MustCompile(`^[0-9a-z]+(<[0-9a-z]+(, *[0-9a-z]+)?( *<[0-9a-z]+(, *[0-9a-z]+)?( *<[0-9a-z]+(, *[0-9a-z]+)?( *<[0-9a-z]+(, *[0-9a-z]+)?( *<[0-9a-z]+(, *[0-9a-z]+)?)?>)?>)?>)?>)?>?$`),
 											"The type must consist of lower case alphanumerics and an optional list of upto two lower case alphanumerics enclosed in angle brackets '<>'.",
 										),
 									},


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This modifies the regex used by the provider to check for valid column types within AWS Keyspace tables. At current, the regex is limited to only 1 layer of nesting, where AWS supports up to 5 nested layers by default.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35787 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=keyspaces

...
```
