### PR TITLE
chore: Add payer account precheck for CE tests

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/acmpca"
 	acmpcatypes "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
 	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
 	dstypes "github.com/aws/aws-sdk-go-v2/service/directoryservice/types"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -998,6 +999,38 @@ func PreCheckCognitoIdentityProvider(ctx context.Context, t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func PreCheckCECostAllocationTagPayerAccount(ctx context.Context, t *testing.T) {
+	t.Helper()
+
+	conn := Provider.Meta().(*conns.AWSClient).CEClient(ctx)
+
+	_, err := conn.ListCostAllocationTags(ctx, &costexplorer.ListCostAllocationTagsInput{})
+
+	if errs.MessageContains(err, "AccessDeniedException", "Linked account doesn't have access to") {
+		t.Skip("skipping tests; this AWS account must be a payer account")
+	}
+
+	if err != nil {
+		t.Fatalf("listing Cost Explorer Cost Allocation Tags: %s", err)
+	}
+}
+
+func PreCheckCECostCategoryPayerAccount(ctx context.Context, t *testing.T) {
+	t.Helper()
+
+	conn := Provider.Meta().(*conns.AWSClient).CEClient(ctx)
+
+	_, err := conn.ListCostCategoryDefinitions(ctx, &costexplorer.ListCostCategoryDefinitionsInput{})
+
+	if errs.MessageContains(err, "AccessDeniedException", "Linked account doesn't have access to") {
+		t.Skip("skipping tests; this AWS account must be a payer account")
+	}
+
+	if err != nil {
+		t.Fatalf("listing Cost Explorer Cost Categories: %s", err)
 	}
 }
 

--- a/internal/service/ce/cost_allocation_tag_test.go
+++ b/internal/service/ce/cost_allocation_tag_test.go
@@ -24,7 +24,7 @@ func TestAccCECostAllocationTag_basic(t *testing.T) {
 	rName := "Tag01"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckCECostAllocationTagPayerAccount(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCostAllocationTagDestroy(ctx),
 		ErrorCheck:               acctest.ErrorCheck(t, names.CEServiceID),
@@ -71,7 +71,7 @@ func TestAccCECostAllocationTag_disappears(t *testing.T) {
 	rName := "Tag02"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckCECostAllocationTagPayerAccount(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCostAllocationTagDestroy(ctx),
 		ErrorCheck:               acctest.ErrorCheck(t, names.CEServiceID),

--- a/internal/service/ce/cost_category_data_source_test.go
+++ b/internal/service/ce/cost_category_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccCECostCategoryDataSource_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckCECostCategoryPayerAccount(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		ErrorCheck:               acctest.ErrorCheck(t, names.CEServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/ce/cost_category_test.go
+++ b/internal/service/ce/cost_category_test.go
@@ -28,7 +28,7 @@ func TestAccCECostCategory_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckCECostCategoryPayerAccount(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCostCategoryDestroy(ctx),
 		ErrorCheck:               acctest.ErrorCheck(t, names.CEServiceID),
@@ -64,7 +64,7 @@ func TestAccCECostCategory_effectiveStart(t *testing.T) {
 	firstOfLastMonth := firstDayOfMonth(now.AddDate(0, -1, 0))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckCECostCategoryPayerAccount(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCostCategoryDestroy(ctx),
 		ErrorCheck:               acctest.ErrorCheck(t, names.CEServiceID),
@@ -101,7 +101,7 @@ func TestAccCECostCategory_disappears(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckCECostCategoryPayerAccount(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCostCategoryDestroy(ctx),
 		ErrorCheck:               acctest.ErrorCheck(t, names.CEServiceID),
@@ -125,7 +125,7 @@ func TestAccCECostCategory_complete(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckCECostCategoryPayerAccount(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCostCategoryDestroy(ctx),
 		ErrorCheck:               acctest.ErrorCheck(t, names.CEServiceID),
@@ -160,7 +160,7 @@ func TestAccCECostCategory_notWithAnd(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckCECostCategoryPayerAccount(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCostCategoryDestroy(ctx),
 		ErrorCheck:               acctest.ErrorCheck(t, names.CEServiceID),
@@ -188,7 +188,7 @@ func TestAccCECostCategory_splitCharge(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckCECostCategoryPayerAccount(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCostCategoryDestroy(ctx),
 		ErrorCheck:               acctest.ErrorCheck(t, names.CEServiceID),
@@ -223,7 +223,7 @@ func TestAccCECostCategory_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckCECostCategoryPayerAccount(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCostCategoryDestroy(ctx),
 		ErrorCheck:               acctest.ErrorCheck(t, names.CEServiceID),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add prechecks for payer accounts to the acceptance tests for the `aws_ce_cost_allocation_tag` resource, and the `aws_ce_cost_category` resource and data source.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38465

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
In a non-payer/org member account:

```console
$ make testacc TESTS="TestAccCECostAllocationTag|TestAccCECostCategory" PKG=ce
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ce/... -v -count 1 -parallel 20 -run='TestAccCECostAllocationTag|TestAccCECostCategory'  -timeout 360m
=== RUN   TestAccCECostAllocationTag_basic
=== PAUSE TestAccCECostAllocationTag_basic
=== RUN   TestAccCECostAllocationTag_disappears
=== PAUSE TestAccCECostAllocationTag_disappears
=== RUN   TestAccCECostCategoryDataSource_basic
=== PAUSE TestAccCECostCategoryDataSource_basic
=== RUN   TestAccCECostCategory_basic
=== PAUSE TestAccCECostCategory_basic
=== RUN   TestAccCECostCategory_effectiveStart
=== PAUSE TestAccCECostCategory_effectiveStart
=== RUN   TestAccCECostCategory_disappears
=== PAUSE TestAccCECostCategory_disappears
=== RUN   TestAccCECostCategory_complete
=== PAUSE TestAccCECostCategory_complete
=== RUN   TestAccCECostCategory_notWithAnd
=== PAUSE TestAccCECostCategory_notWithAnd
=== RUN   TestAccCECostCategory_splitCharge
=== PAUSE TestAccCECostCategory_splitCharge
=== RUN   TestAccCECostCategory_tags
=== PAUSE TestAccCECostCategory_tags
=== CONT  TestAccCECostAllocationTag_basic
=== CONT  TestAccCECostCategory_disappears
=== CONT  TestAccCECostCategory_basic
=== CONT  TestAccCECostCategoryDataSource_basic
=== CONT  TestAccCECostCategory_effectiveStart
=== CONT  TestAccCECostAllocationTag_disappears
=== CONT  TestAccCECostCategory_notWithAnd
=== CONT  TestAccCECostCategory_splitCharge
=== CONT  TestAccCECostCategory_tags
=== CONT  TestAccCECostCategory_complete
=== NAME  TestAccCECostAllocationTag_basic
    cost_allocation_tag_test.go:27: skipping tests; this AWS account must be a payer account
--- SKIP: TestAccCECostAllocationTag_basic (0.99s)
=== NAME  TestAccCECostAllocationTag_disappears
    cost_allocation_tag_test.go:74: skipping tests; this AWS account must be a payer account
--- SKIP: TestAccCECostAllocationTag_disappears (0.99s)
=== NAME  TestAccCECostCategory_splitCharge
    cost_category_test.go:191: skipping tests; this AWS account must be a payer account
--- SKIP: TestAccCECostCategory_splitCharge (1.01s)
=== NAME  TestAccCECostCategoryDataSource_basic
    cost_category_data_source_test.go:24: skipping tests; this AWS account must be a payer account
--- SKIP: TestAccCECostCategoryDataSource_basic (1.02s)
=== NAME  TestAccCECostCategory_basic
    cost_category_test.go:31: skipping tests; this AWS account must be a payer account
--- SKIP: TestAccCECostCategory_basic (1.02s)
=== NAME  TestAccCECostCategory_notWithAnd
    cost_category_test.go:163: skipping tests; this AWS account must be a payer account
--- SKIP: TestAccCECostCategory_notWithAnd (1.02s)
=== NAME  TestAccCECostCategory_disappears
    cost_category_test.go:104: skipping tests; this AWS account must be a payer account
--- SKIP: TestAccCECostCategory_disappears (1.02s)
=== NAME  TestAccCECostCategory_tags
    cost_category_test.go:226: skipping tests; this AWS account must be a payer account
--- SKIP: TestAccCECostCategory_tags (1.03s)
=== NAME  TestAccCECostCategory_effectiveStart
    cost_category_test.go:67: skipping tests; this AWS account must be a payer account
--- SKIP: TestAccCECostCategory_effectiveStart (1.03s)
=== NAME  TestAccCECostCategory_complete
    cost_category_test.go:128: skipping tests; this AWS account must be a payer account
--- SKIP: TestAccCECostCategory_complete (1.07s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ce 1.282s

$
```

In a payer/org management account:

```console
$ make testacc TESTS="TestAccCECostAllocationTag|TestAccCECostCategory" PKG=ce
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/ce/... -v -count 1 -parallel 20 -run='TestAccCECostAllocationTag|TestAccCECostCategory'  -timeout 360m
=== RUN   TestAccCECostAllocationTag_basic
=== PAUSE TestAccCECostAllocationTag_basic
=== RUN   TestAccCECostAllocationTag_disappears
=== PAUSE TestAccCECostAllocationTag_disappears
=== RUN   TestAccCECostCategoryDataSource_basic
=== PAUSE TestAccCECostCategoryDataSource_basic
=== RUN   TestAccCECostCategory_basic
=== PAUSE TestAccCECostCategory_basic
=== RUN   TestAccCECostCategory_effectiveStart
=== PAUSE TestAccCECostCategory_effectiveStart
=== RUN   TestAccCECostCategory_disappears
=== PAUSE TestAccCECostCategory_disappears
=== RUN   TestAccCECostCategory_complete
=== PAUSE TestAccCECostCategory_complete
=== RUN   TestAccCECostCategory_notWithAnd
=== PAUSE TestAccCECostCategory_notWithAnd
=== RUN   TestAccCECostCategory_splitCharge
=== PAUSE TestAccCECostCategory_splitCharge
=== RUN   TestAccCECostCategory_tags
=== PAUSE TestAccCECostCategory_tags
=== CONT  TestAccCECostAllocationTag_basic
=== CONT  TestAccCECostCategory_disappears
=== CONT  TestAccCECostCategory_tags
=== CONT  TestAccCECostCategory_effectiveStart
=== CONT  TestAccCECostCategoryDataSource_basic
=== CONT  TestAccCECostAllocationTag_disappears
=== CONT  TestAccCECostCategory_notWithAnd
=== CONT  TestAccCECostCategory_complete
=== CONT  TestAccCECostCategory_basic
=== CONT  TestAccCECostCategory_splitCharge
--- PASS: TestAccCECostAllocationTag_disappears (19.95s)
--- PASS: TestAccCECostCategoryDataSource_basic (21.12s)
--- PASS: TestAccCECostCategory_basic (25.67s)
--- PASS: TestAccCECostCategory_notWithAnd (27.97s)
--- PASS: TestAccCECostCategory_disappears (28.72s)
--- PASS: TestAccCECostCategory_complete (36.98s)
--- PASS: TestAccCECostCategory_effectiveStart (37.96s)
--- PASS: TestAccCECostCategory_splitCharge (43.34s)
--- PASS: TestAccCECostAllocationTag_basic (43.69s)
--- PASS: TestAccCECostCategory_tags (50.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ce 50.340s

$
```