### PR TITLE
fix: typo r_studio_package_manager_url in sagemaker domain

### DIFF
--- a/.changelog/38547.txt
+++ b/.changelog/38547.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_domain: Fix missing r_studio_package_manager_url
+```

--- a/.changelog/38547.txt
+++ b/.changelog/38547.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_sagemaker_domain: Fix missing r_studio_package_manager_url
+resource/aws_sagemaker_domain: Properly send `domain_settings.r_studio_server_pro_domain_settings.r_studio_package_manager_url` argument on create
 ```

--- a/internal/service/sagemaker/domain.go
+++ b/internal/service/sagemaker/domain.go
@@ -1238,7 +1238,7 @@ func expandRStudioServerProDomainSettings(l []interface{}) *sagemaker.RStudioSer
 		config.RStudioConnectUrl = aws.String(v)
 	}
 
-	if v, ok := m["r_studio_packageManager_url"].(string); ok && v != "" {
+	if v, ok := m["r_studio_package_manager_url"].(string); ok && v != "" {
 		config.RStudioPackageManagerUrl = aws.String(v)
 	}
 

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -622,7 +622,7 @@ func testAccDomain_rStudioServerProAppSettings(t *testing.T) {
 	})
 }
 
-func TestAccDomain_rStudioServerProDomainSettings(t *testing.T) {
+func testAccDomain_rStudioServerProDomainSettings(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domain sagemaker.DescribeDomainOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -1923,7 +1923,7 @@ resource "aws_sagemaker_domain" "test" {
       r_studio_package_manager_url = %[3]q
       domain_execution_role_arn    = aws_iam_role.test.arn
       default_resource_spec {
-        instance_type = "system" 
+        instance_type = "system"
       }
     }
   }
@@ -1940,7 +1940,7 @@ resource "aws_sagemaker_domain" "test" {
   # it would be too hard to create the logic to find the default Rstudio image: https://docs.aws.amazon.com/sagemaker/latest/dg/rstudio-version.html
   # it changes for every region
   lifecycle {
-    ignore_changes = [ 
+    ignore_changes = [
       domain_settings[0].r_studio_server_pro_domain_settings[0].default_resource_spec[0]
     ]
   }

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -622,6 +622,38 @@ func testAccDomain_rStudioServerProAppSettings(t *testing.T) {
 	})
 }
 
+func TestAccDomain_rStudioServerProDomainSettings(t *testing.T) {
+	ctx := acctest.Context(t)
+	var domain sagemaker.DescribeDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_domain.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_rStudioServerProDomainSettings(rName, "https://connect.domain.com", "https://package.domain.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.0.r_studio_server_pro_domain_settings.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.0.r_studio_server_pro_domain_settings.0.r_studio_connect_url", "https://connect.domain.com"),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.0.r_studio_server_pro_domain_settings.0.r_studio_package_manager_url", "https://package.domain.com"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"retention_policy"},
+			},
+		},
+	})
+}
+
 func testAccDomain_kernelGatewayAppSettings(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domain sagemaker.DescribeDomainOutput
@@ -1874,6 +1906,94 @@ resource "aws_sagemaker_domain" "test" {
   }
 }
 `, rName, state))
+}
+
+func testAccDomainConfig_rStudioServerProDomainSettings(rName, connectURL string, packageURL string) string {
+	return acctest.ConfigCompose(testAccDomainConfig_baseWithLicense(rName), fmt.Sprintf(`
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = aws_subnet.test[*].id
+
+  domain_settings {
+
+    r_studio_server_pro_domain_settings {
+      r_studio_connect_url         = %[2]q
+      r_studio_package_manager_url = %[3]q
+      domain_execution_role_arn    = aws_iam_role.test.arn
+      default_resource_spec {
+        instance_type                 = "system" 
+       }
+    }
+  }
+
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
+
+  # ignoring default image
+  # it would be too hard to create the logic to find the default Rstudio image: https://docs.aws.amazon.com/sagemaker/latest/dg/rstudio-version.html
+  # it changes for every region
+  lifecycle {
+    ignore_changes = [ 
+        domain_settings[0].r_studio_server_pro_domain_settings[0].default_resource_spec[0]
+     ]
+  }
+}
+`, rName, connectURL, packageURL))
+}
+
+func testAccDomainConfig_baseWithLicense(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.test.json
+  inline_policy {
+    name   = "GetLicense"
+    policy = data.aws_iam_policy_document.license.json
+  }
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["sagemaker.${data.aws_partition.current.dns_suffix}"]
+    }
+  }
+}
+
+# needed for RStudio
+data "aws_iam_policy_document" "license" {
+  statement {
+    sid    = "ReadLicense"
+    effect = "Allow"
+    actions = [
+      "license-manager:ExtendLicenseConsumption",
+      "license-manager:ListReceivedLicenses",
+      "license-manager:GetLicense",
+      "license-manager:CheckoutLicense",
+      "license-manager:CheckInLicense",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  role       = aws_iam_role.test.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSageMakerFullAccess"
+}
+`, rName))
 }
 
 func testAccDomainConfig_codeEditorAppSettings(rName string) string {

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -1923,8 +1923,8 @@ resource "aws_sagemaker_domain" "test" {
       r_studio_package_manager_url = %[3]q
       domain_execution_role_arn    = aws_iam_role.test.arn
       default_resource_spec {
-        instance_type                 = "system" 
-       }
+        instance_type = "system" 
+      }
     }
   }
 
@@ -1941,8 +1941,8 @@ resource "aws_sagemaker_domain" "test" {
   # it changes for every region
   lifecycle {
     ignore_changes = [ 
-        domain_settings[0].r_studio_server_pro_domain_settings[0].default_resource_spec[0]
-     ]
+      domain_settings[0].r_studio_server_pro_domain_settings[0].default_resource_spec[0]
+    ]
   }
 }
 `, rName, connectURL, packageURL))

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -19,6 +19,7 @@ func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 	return acctest.ErrorCheckSkipMessagesContaining(t,
 		"is not supported in region",
 		"is not supported for the chosen region",
+		"No available licenses were found",
 	)
 }
 

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -66,6 +66,7 @@ func TestAccSageMaker_serial(t *testing.T) {
 			"domainSettings":                                          testAccDomain_domainSettings,
 			"rSessionAppSettings":                                     testAccDomain_rSessionAppSettings,
 			"rStudioServerProAppSettings":                             testAccDomain_rStudioServerProAppSettings,
+			"rStudioServerProDomainSettings":                          testAccDomain_rStudioServerProDomainSettings,
 			"spaceSettingsKernelGatewayAppSettings":                   testAccDomain_spaceSettingsKernelGatewayAppSettings,
 			"code":                                                    testAccDomain_jupyterServerAppSettings_code,
 			"efs":                                                     testAccDomain_efs,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Attribute `r_studio_package_manager_url` in SageMaker domain shows up in Terraform plan but is not used on API calls to AWS due to a typo.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38546

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

In order to run this tests you'd need a license shared from Posit to your account: https://docs.aws.amazon.com/sagemaker/latest/dg/rstudio-license.html

### Output from Acceptance Testing

Please see comments below.