### PR TITLE
r/aws_elasticache_user_group_association: add configurable timeouts

### DIFF
--- a/.changelog/38559.txt
+++ b/.changelog/38559.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_elasticache_user_group_association: Add configurable create and delete timeouts
+```

--- a/website/docs/r/elasticache_user_group_association.html.markdown
+++ b/website/docs/r/elasticache_user_group_association.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Associate an existing ElastiCache user and an existing user group.
 
-~> **NOTE:** Terraform will detect changes in the `aws_elasticache_user_group` since `aws_elasticache_user_group_association` changes the user IDs associated with the user group. You can ignore these changes with the `lifecycle` `ignore_changes` meta argument as shown in the example.
+~> Terraform will detect changes in the `aws_elasticache_user_group` since `aws_elasticache_user_group_association` changes the user IDs associated with the user group. You can ignore these changes with the `lifecycle` `ignore_changes` meta argument as shown in the example.
 
 ## Example Usage
 
@@ -57,6 +57,13 @@ The following arguments are required:
 ## Attribute Reference
 
 This resource exports no additional attributes.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `10m`)
+* `delete` - (Default `10m`)
 
 ## Import
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The default create and delete values will be 10 minutes, matching the previously hardcoded values.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38555

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc PKG=elasticache TESTS="TestAccElastiCacheUserGroupAssociation_"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUserGroupAssociation_'  -timeout 360m

--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (285.34s)
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (286.65s)
--- PASS: TestAccElastiCacheUserGroupAssociation_multiple (404.72s)
--- PASS: TestAccElastiCacheUserGroupAssociation_update (405.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        411.140s
```
