### PR TITLE
Use generated token for PR labeler

### DIFF
--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -16,14 +16,11 @@ jobs:
   labels:
     name: Labelers
     runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App Token
-        id: token
-        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PEM }}
+    permissions:
+      contents: read
+      pull-requests: write
 
+    steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -34,13 +31,13 @@ jobs:
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           configuration-path: .github/labeler-pr-triage.yml
-          repo-token: ${{ steps.token.outputs.token }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Apply Size Labels
         if: contains(fromJSON('["opened", "edited"]'), github.event.action)
         uses: codelytv/pr-size-labeler@56f6f0fc35c7cc0f72963b8467729e1120cb4bed # v1.10.0
         with:
-          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: "size/XS"
           xs_max_size: "30"
           s_label: "size/S"
@@ -67,7 +64,7 @@ jobs:
           github.event.action == 'opened'
           && steps.author.outputs.maintainer == 'false'
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$ISSUE_URL" --add-label needs-triage
 
       - name: Add prioritized to Maintainer Contributions
@@ -75,7 +72,7 @@ jobs:
           github.event.action == 'opened'
           && steps.author.outputs.maintainer == 'true'
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$ISSUE_URL" --add-label prioritized
 
       - name: Credit Core Contributor Contributions
@@ -83,7 +80,7 @@ jobs:
           github.event.action == 'opened'
           && steps.author.outputs.core_contributor == 'true'
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit "$ISSUE_URL" --add-label external-maintainer
 
@@ -92,7 +89,7 @@ jobs:
           github.event.action == 'opened'
           && steps.author.outputs.partner == 'true'
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit "$ISSUE_URL" --add-label partner
 
@@ -109,7 +106,7 @@ jobs:
           github.event.action == 'assigned'
           && steps.assignee.outputs.maintainer == 'true'
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit "$ISSUE_URL" --add-label prioritized
 
@@ -118,7 +115,7 @@ jobs:
           github.event.action == 'closed'
           && (contains(github.event.pull_request.labels.*.name, 'needs-triage') || contains(github.event.pull_request.labels.*.name, 'waiting-response'))
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$ISSUE_URL" --remove-label needs-triage,waiting-response
 
   project:

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Indicate That Triage is Required
         if: |
-          github.event.action == 'opened'
+          steps.author.conclusion != 'skipped'
           && steps.author.outputs.maintainer == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Add prioritized to Maintainer Contributions
         if: |
-          github.event.action == 'opened'
+          steps.author.conclusion != 'skipped'
           && steps.author.outputs.maintainer == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Credit Core Contributor Contributions
         if: |
-          github.event.action == 'opened'
+          steps.author.conclusion != 'skipped'
           && steps.author.outputs.core_contributor == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Credit Partner Contributions
         if: |
-          github.event.action == 'opened'
+          steps.author.conclusion != 'skipped'
           && steps.author.outputs.partner == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Add prioritized to Maintainer Assignments
         if: |
-          github.event.action == 'assigned'
+          steps.assignee.conclusion != 'skipped'
           && steps.assignee.outputs.maintainer == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Community Check
         id: community_check
-        if: github.event.action == 'opened'
+        if: contains(fromJSON('["opened", "edited"]'), github.event.action)
         uses: ./.github/actions/community_check
         with:
           user_login: ${{ github.event.action == 'assigned' && github.event.assignee.login || github.event.pull_request.user.login }}


### PR DESCRIPTION
### Description

The labeler job hasn't been working quite right (for example [here](https://github.com/hashicorp/terraform-provider-aws/actions/runs/10111695655/job/27964156924), where `needs-triage`, and `external-maintainer` should have been added, but those steps were skipped.

This seems to be caused by the use of the GitHub App token, which will [trigger a `labeled` event](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow), which doesn't happen with the generated token. 

The related workflow in the [AWSCC repository](https://github.com/hashicorp/terraform-provider-awscc/actions/runs/10103293975/job/27940403639) is nearly identical, but uses the generated token and is working. Thus far, that's the only difference I've noticed. When testing locally with `act`, the GitHub App token portion is omitted, and the workflow works fine, which seems to back up the theory that this is the issue.

Thank you to @DanielRieske for bringing this to my attention!

### Output from Acceptance Testing

N/a, workflows. 
