### PR TITLE
feat: add log_configuration.include_execution_data arg for aws_pipes_pipe

### DIFF
--- a/.changelog/38569.txt
+++ b/.changelog/38569.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_pipes_pipe: Add `log_configuration.include_execution_data` argument
+```

--- a/website/docs/r/pipes_pipe.html.markdown
+++ b/website/docs/r/pipes_pipe.html.markdown
@@ -142,6 +142,30 @@ resource "aws_pipes_pipe" "example" {
 }
 ```
 
+### CloudWatch Logs Logging Configuration Usage
+
+```terraform
+resource "aws_cloudwatch_log_group" "example" {
+  name = "example-pipe-target"
+}
+
+resource "aws_pipes_pipe" "example" {
+  depends_on = [aws_iam_role_policy.source, aws_iam_role_policy.target]
+
+  name     = "example-pipe"
+  role_arn = aws_iam_role.example.arn
+  source   = aws_sqs_queue.source.arn
+  target   = aws_sqs_queue.target.arn
+  log_configuration {
+    include_execution_data = ["ALL"]
+    level                  = "INFO"
+    cloudwatch_logs_log_destination {
+      log_group_arn = aws_cloudwatch_log_group.target.arn
+    }
+  }
+}
+```
+
 ### SQS Source and Target Configuration Usage
 
 ```terraform
@@ -205,9 +229,10 @@ You can find out more about EventBridge Pipes Enrichment in the [User Guide](htt
 
 You can find out more about EventBridge Pipes Enrichment in the [User Guide](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-logs.html).
 
-* `level` - (Required) The level of logging detail to include. Valid values `OFF`, `ERROR`, `INFO` and `TRACE`.
 * `cloudwatch_logs_log_destination` - (Optional) Amazon CloudWatch Logs logging configuration settings for the pipe. Detailed below.
 * `firehose_log_destination` - (Optional) Amazon Kinesis Data Firehose logging configuration settings for the pipe. Detailed below.
+* `include_execution_data` - (Optional) String list that specifies whether the execution data (specifically, the `payload`, `awsRequest`, and `awsResponse` fields) is included in the log messages for this pipe. This applies to all log destinations for the pipe. Valid values `ALL`.
+* `level` - (Required) The level of logging detail to include. Valid values `OFF`, `ERROR`, `INFO` and `TRACE`.
 * `s3_log_destination` - (Optional) Amazon S3 logging configuration settings for the pipe. Detailed below.
 
 #### log_configuration.cloudwatch_logs_log_destination Configuration Block


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `include_execution_data` argument to the `log_configuration` block for the `aws_pipes_pipe` resource.

While running the acceptance tests, I found that the `TestAccPipesPipe_rabbitMQSourceEventBusTarget` failed due a deprecated version of RabbitMQ version. I've updated the version to 3.12.13 to fix the test case as part of this PR.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38565

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [PipeLogConfiguration](https://docs.aws.amazon.com/eventbridge/latest/pipes-reference/API_PipeLogConfiguration.html) for specs.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccPipesPipe_ PKG=pipes
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/pipes/... -v -count 1 -parallel 20 -run='TestAccPipesPipe_'  -timeout 360m
=== RUN   TestAccPipesPipe_basicSQS
=== PAUSE TestAccPipesPipe_basicSQS
=== RUN   TestAccPipesPipe_disappears
=== PAUSE TestAccPipesPipe_disappears
=== RUN   TestAccPipesPipe_description
=== PAUSE TestAccPipesPipe_description
=== RUN   TestAccPipesPipe_desiredState
=== PAUSE TestAccPipesPipe_desiredState
=== RUN   TestAccPipesPipe_enrichment
=== PAUSE TestAccPipesPipe_enrichment
=== RUN   TestAccPipesPipe_enrichmentParameters
=== PAUSE TestAccPipesPipe_enrichmentParameters
=== RUN   TestAccPipesPipe_logConfiguration_cloudwatchLogsLogDestination
=== PAUSE TestAccPipesPipe_logConfiguration_cloudwatchLogsLogDestination
=== RUN   TestAccPipesPipe_update_logConfiguration_cloudwatchLogsLogDestination
=== PAUSE TestAccPipesPipe_update_logConfiguration_cloudwatchLogsLogDestination
=== RUN   TestAccPipesPipe_logConfiguration_includeExecutionData
=== PAUSE TestAccPipesPipe_logConfiguration_includeExecutionData
=== RUN   TestAccPipesPipe_sourceParameters_filterCriteria
=== PAUSE TestAccPipesPipe_sourceParameters_filterCriteria
=== RUN   TestAccPipesPipe_nameGenerated
=== PAUSE TestAccPipesPipe_nameGenerated
=== RUN   TestAccPipesPipe_namePrefix
=== PAUSE TestAccPipesPipe_namePrefix
=== RUN   TestAccPipesPipe_roleARN
=== PAUSE TestAccPipesPipe_roleARN
=== RUN   TestAccPipesPipe_tags
=== PAUSE TestAccPipesPipe_tags
=== RUN   TestAccPipesPipe_targetUpdate
=== PAUSE TestAccPipesPipe_targetUpdate
=== RUN   TestAccPipesPipe_targetParameters_inputTemplate
=== PAUSE TestAccPipesPipe_targetParameters_inputTemplate
=== RUN   TestAccPipesPipe_kinesisSourceAndTarget
=== PAUSE TestAccPipesPipe_kinesisSourceAndTarget
=== RUN   TestAccPipesPipe_dynamoDBSourceCloudWatchLogsTarget
=== PAUSE TestAccPipesPipe_dynamoDBSourceCloudWatchLogsTarget
=== RUN   TestAccPipesPipe_activeMQSourceStepFunctionTarget
=== PAUSE TestAccPipesPipe_activeMQSourceStepFunctionTarget
=== RUN   TestAccPipesPipe_rabbitMQSourceEventBusTarget
=== PAUSE TestAccPipesPipe_rabbitMQSourceEventBusTarget
=== RUN   TestAccPipesPipe_mskSourceHTTPTarget
    pipe_test.go:1106: DependencyViolation errors deleting subnets and security group
--- SKIP: TestAccPipesPipe_mskSourceHTTPTarget (0.00s)
=== RUN   TestAccPipesPipe_selfManagedKafkaSourceLambdaFunctionTarget
    pipe_test.go:1182: DependencyViolation errors deleting subnets and security group
--- SKIP: TestAccPipesPipe_selfManagedKafkaSourceLambdaFunctionTarget (0.00s)
=== RUN   TestAccPipesPipe_sqsSourceRedshiftTarget
=== PAUSE TestAccPipesPipe_sqsSourceRedshiftTarget
=== RUN   TestAccPipesPipe_SourceSageMakerTarget
    pipe_test.go:1329: aws_sagemaker_pipeline resource not yet implemented
--- SKIP: TestAccPipesPipe_SourceSageMakerTarget (0.00s)
=== RUN   TestAccPipesPipe_sqsSourceBatchJobTarget
=== PAUSE TestAccPipesPipe_sqsSourceBatchJobTarget
=== RUN   TestAccPipesPipe_sqsSourceECSTaskTarget
    pipe_test.go:1480: ValidationException: [numeric instance is lower than the required minimum (minimum: 1, found: 0)]
--- SKIP: TestAccPipesPipe_sqsSourceECSTaskTarget (0.00s)
=== CONT  TestAccPipesPipe_basicSQS
=== CONT  TestAccPipesPipe_namePrefix
=== CONT  TestAccPipesPipe_dynamoDBSourceCloudWatchLogsTarget
=== CONT  TestAccPipesPipe_targetUpdate
=== CONT  TestAccPipesPipe_tags
=== CONT  TestAccPipesPipe_logConfiguration_includeExecutionData
=== CONT  TestAccPipesPipe_update_logConfiguration_cloudwatchLogsLogDestination
=== CONT  TestAccPipesPipe_desiredState
=== CONT  TestAccPipesPipe_kinesisSourceAndTarget
=== CONT  TestAccPipesPipe_enrichmentParameters
=== CONT  TestAccPipesPipe_sqsSourceRedshiftTarget
=== CONT  TestAccPipesPipe_roleARN
=== CONT  TestAccPipesPipe_rabbitMQSourceEventBusTarget
=== CONT  TestAccPipesPipe_logConfiguration_cloudwatchLogsLogDestination
=== CONT  TestAccPipesPipe_enrichment
=== CONT  TestAccPipesPipe_nameGenerated
=== CONT  TestAccPipesPipe_description
=== CONT  TestAccPipesPipe_targetParameters_inputTemplate
=== CONT  TestAccPipesPipe_disappears
=== CONT  TestAccPipesPipe_sourceParameters_filterCriteria
=== CONT  TestAccPipesPipe_sqsSourceBatchJobTarget
--- PASS: TestAccPipesPipe_dynamoDBSourceCloudWatchLogsTarget (60.48s)
=== CONT  TestAccPipesPipe_activeMQSourceStepFunctionTarget
--- PASS: TestAccPipesPipe_kinesisSourceAndTarget (97.03s)
--- PASS: TestAccPipesPipe_disappears (99.43s)
--- PASS: TestAccPipesPipe_nameGenerated (99.76s)
--- PASS: TestAccPipesPipe_basicSQS (100.45s)
--- PASS: TestAccPipesPipe_logConfiguration_cloudwatchLogsLogDestination (104.93s)
--- PASS: TestAccPipesPipe_namePrefix (106.40s)
--- PASS: TestAccPipesPipe_tags (135.28s)
--- PASS: TestAccPipesPipe_enrichmentParameters (137.39s)
--- PASS: TestAccPipesPipe_update_logConfiguration_cloudwatchLogsLogDestination (139.14s)
--- PASS: TestAccPipesPipe_roleARN (150.15s)
--- PASS: TestAccPipesPipe_enrichment (158.55s)
--- PASS: TestAccPipesPipe_targetUpdate (159.35s)
--- PASS: TestAccPipesPipe_targetParameters_inputTemplate (165.20s)
--- PASS: TestAccPipesPipe_description (177.29s)
--- PASS: TestAccPipesPipe_desiredState (179.34s)
--- PASS: TestAccPipesPipe_sqsSourceBatchJobTarget (165.45s)
--- PASS: TestAccPipesPipe_logConfiguration_includeExecutionData (190.80s)
--- PASS: TestAccPipesPipe_sourceParameters_filterCriteria (219.84s)
--- PASS: TestAccPipesPipe_sqsSourceRedshiftTarget (239.11s)
--- PASS: TestAccPipesPipe_rabbitMQSourceEventBusTarget (722.28s)
--- PASS: TestAccPipesPipe_activeMQSourceStepFunctionTarget (1016.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pipes      1077.299s

$
```
