### PR TITLE
feat: Add enhanced_metrics_config config block for aws_appsync_graphql_api

### DIFF
--- a/.changelog/38570.txt
+++ b/.changelog/38570.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appsync_graphql_api: Add `enhanced_metrics_config` configuration block
+```

--- a/internal/service/appsync/appsync_test.go
+++ b/internal/service/appsync/appsync_test.go
@@ -45,6 +45,7 @@ func TestAccAppSync_serial(t *testing.T) {
 			"AuthenticationType_amazonCognitoUserPools":           testAccGraphQLAPI_AuthenticationType_amazonCognitoUserPools,
 			"AuthenticationType_openIDConnect":                    testAccGraphQLAPI_AuthenticationType_openIDConnect,
 			"AuthenticationType_awsLambda":                        testAccGraphQLAPI_AuthenticationType_lambda,
+			"enhancedMetricsConfig":                               testAccGraphQLAPI_enhancedMetricsConfig,
 			"log":                                                 testAccGraphQLAPI_log,
 			"Log_fieldLogLevel":                                   testAccGraphQLAPI_Log_fieldLogLevel,
 			"Log_excludeVerboseContent":                           testAccGraphQLAPI_Log_excludeVerboseContent,

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -212,32 +212,28 @@ resource "aws_appsync_graphql_api" "example" {
 
 ## Argument Reference
 
-This resource supports the following arguments:
+The following arguments are required:
 
 * `authentication_type` - (Required) Authentication type. Valid values: `API_KEY`, `AWS_IAM`, `AMAZON_COGNITO_USER_POOLS`, `OPENID_CONNECT`, `AWS_LAMBDA`
 * `name` - (Required) User-supplied name for the GraphSQL API.
+
+The following arguments are optional:
+
+* `additional_authentication_provider` - (Optional) One or more additional authentication providers for the GraphSQL API. See [`additional_authentication_provider` Block](#additional_authentication_provider-block) for details.
+* `enhanced_metrics_config` - (Optional) Enables and controls the enhanced metrics feature. See [`enhanced_metrics_config` Block](#enhanced_metrics_config-block) for details.
+* `introspection_config` - (Optional) Sets the value of the GraphQL API to enable (`ENABLED`) or disable (`DISABLED`) introspection. If no value is provided, the introspection configuration will be set to ENABLED by default. This field will produce an error if the operation attempts to use the introspection feature while this field is disabled. For more information about introspection, see [GraphQL introspection](https://graphql.org/learn/introspection/).
+* `lambda_authorizer_config` - (Optional) Nested argument containing Lambda authorizer configuration. See [`lambda_authorizer_config` Block](#lambda_authorizer_config-block) for details.
 * `log_config` - (Optional) Nested argument containing logging configuration. See [`log_config` Block](#log_config-block) for details.
 * `openid_connect_config` - (Optional) Nested argument containing OpenID Connect configuration. See [`openid_connect_config` Block](#openid_connect_config-block) for details.
-* `user_pool_config` - (Optional) Amazon Cognito User Pool configuration. See [`user_pool_config` Block](#user_pool_config-block) for details.
-* `lambda_authorizer_config` - (Optional) Nested argument containing Lambda authorizer configuration. See [`lambda_authorizer_config` Block](#lambda_authorizer_config-block) for details.
-* `schema` - (Optional) Schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration.
-* `additional_authentication_provider` - (Optional) One or more additional authentication providers for the GraphSQL API. See [`additional_authentication_provider` Block](#additional_authentication_provider-block) for details.
-* `introspection_config` - (Optional) Sets the value of the GraphQL API to enable (`ENABLED`) or disable (`DISABLED`) introspection. If no value is provided, the introspection configuration will be set to ENABLED by default. This field will produce an error if the operation attempts to use the introspection feature while this field is disabled. For more information about introspection, see [GraphQL introspection](https://graphql.org/learn/introspection/).
 * `query_depth_limit` - (Optional) The maximum depth a query can have in a single request. Depth refers to the amount of nested levels allowed in the body of query. The default value is `0` (or unspecified), which indicates there's no depth limit. If you set a limit, it can be between `1` and `75` nested levels. This field will produce a limit error if the operation falls out of bounds.
 
   Note that fields can still be set to nullable or non-nullable. If a non-nullable field produces an error, the error will be thrown upwards to the first nullable field available.
 * `resolver_count_limit` - (Optional) The maximum number of resolvers that can be invoked in a single request. The default value is `0` (or unspecified), which will set the limit to `10000`. When specified, the limit value can be between `1` and `10000`. This field will produce a limit error if the operation falls out of bounds.
+* `schema` - (Optional) Schema definition, in GraphQL schema language format. Terraform cannot perform drift detection of this configuration.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `xray_enabled` - (Optional) Whether tracing with X-ray is enabled. Defaults to false.
+* `user_pool_config` - (Optional) Amazon Cognito User Pool configuration. See [`user_pool_config` Block](#user_pool_config-block) for details.
 * `visibility` - (Optional) Sets the value of the GraphQL API to public (`GLOBAL`) or private (`PRIVATE`). If no value is provided, the visibility will be set to `GLOBAL` by default. This value cannot be changed once the API has been created.
-
-### `log_config` Block
-
-The `log_config` configuration block supports the following arguments:
-
-* `cloudwatch_logs_role_arn` - (Required) Amazon Resource Name of the service role that AWS AppSync will assume to publish to Amazon CloudWatch logs in your account.
-* `field_log_level` - (Required) Field logging level. Valid values: `ALL`, `ERROR`, `NONE`.
-* `exclude_verbose_content` - (Optional) Set to TRUE to exclude sections that contain information such as headers, context, and evaluated mapping templates, regardless of logging  level. Valid values: `true`, `false`. Default value: `false`
+* `xray_enabled` - (Optional) Whether tracing with X-ray is enabled. Defaults to false.
 
 ### `additional_authentication_provider` Block
 
@@ -246,6 +242,30 @@ The `additional_authentication_provider` configuration block supports the follow
 * `authentication_type` - (Required) Authentication type. Valid values: `API_KEY`, `AWS_IAM`, `AMAZON_COGNITO_USER_POOLS`, `OPENID_CONNECT`, `AWS_LAMBDA`
 * `openid_connect_config` - (Optional) Nested argument containing OpenID Connect configuration. See [`openid_connect_config` Block](#openid_connect_config-block) for details.
 * `user_pool_config` - (Optional) Amazon Cognito User Pool configuration. See [`user_pool_config` Block](#user_pool_config-block) for details.
+
+### `enhanced_metrics_config` Block
+
+The `enhanced_metrics_config` configuration block supports the following arguments. See [EnhancedMetricsConfig](https://docs.aws.amazon.com/appsync/latest/APIReference/API_EnhancedMetricsConfig.html) for more information.
+
+* `data_source_level_metrics_behavior` - (Optional) How data source metrics will be emitted to CloudWatch. Valid values: `FULL_REQUEST_DATA_SOURCE_METRICS`, `PER_DATA_SOURCE_METRICS`
+* `operation_level_metrics_config` - (Optional) How operation metrics will be emitted to CloudWatch. Valid values: `ENABLED`, `DISABLED`
+* `resolver_level_metrics_behavior` - (Optional) How resolver metrics will be emitted to CloudWatch. Valid values: `FULL_REQUEST_RESOLVER_METRICS`, `PER_RESOLVER_METRICS`
+
+### `lambda_authorizer_config` Block
+
+The `lambda_authorizer_config` configuration block supports the following arguments:
+
+* `authorizer_uri` - (Required) ARN of the Lambda function to be called for authorization. Note: This Lambda function must have a resource-based policy assigned to it, to allow `lambda:InvokeFunction` from service principal `appsync.amazonaws.com`.
+* `authorizer_result_ttl_in_seconds` - (Optional) Number of seconds a response should be cached for. The default is 5 minutes (300 seconds). The Lambda function can override this by returning a `ttlOverride` key in its response. A value of 0 disables caching of responses. Minimum value of 0. Maximum value of 3600.
+* `identity_validation_expression` - (Optional) Regular expression for validation of tokens before the Lambda function is called.
+
+### `log_config` Block
+
+The `log_config` configuration block supports the following arguments:
+
+* `cloudwatch_logs_role_arn` - (Required) Amazon Resource Name of the service role that AWS AppSync will assume to publish to Amazon CloudWatch logs in your account.
+* `field_log_level` - (Required) Field logging level. Valid values: `ALL`, `ERROR`, `NONE`.
+* `exclude_verbose_content` - (Optional) Set to TRUE to exclude sections that contain information such as headers, context, and evaluated mapping templates, regardless of logging  level. Valid values: `true`, `false`. Default value: `false`
 
 ### `openid_connect_config` Block
 
@@ -264,14 +284,6 @@ The `user_pool_config` configuration block supports the following arguments:
 * `user_pool_id` - (Required) User pool ID.
 * `app_id_client_regex` - (Optional) Regular expression for validating the incoming Amazon Cognito User Pool app client ID.
 * `aws_region` - (Optional) AWS region in which the user pool was created.
-
-### `lambda_authorizer_config` Block
-
-The `lambda_authorizer_config` configuration block supports the following arguments:
-
-* `authorizer_uri` - (Required) ARN of the Lambda function to be called for authorization. Note: This Lambda function must have a resource-based policy assigned to it, to allow `lambda:InvokeFunction` from service principal `appsync.amazonaws.com`.
-* `authorizer_result_ttl_in_seconds` - (Optional) Number of seconds a response should be cached for. The default is 5 minutes (300 seconds). The Lambda function can override this by returning a `ttlOverride` key in its response. A value of 0 disables caching of responses. Minimum value of 0. Maximum value of 3600.
-* `identity_validation_expression` - (Optional) Regular expression for validation of tokens before the Lambda function is called.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `enhanced_metrics_config` configuration block to the `aws_appsync_graphql_api` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38566

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [EnhancedMetricsConfig](https://docs.aws.amazon.com/appsync/latest/APIReference/API_EnhancedMetricsConfig.html) for specs.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccAppSync_serial/GraphQLAPI/basic|TestAccAppSync_serial/GraphQLAPI/enhancedMetricsConfig" PKG=appsync
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/appsync/... -v -count 1 -parallel 20 -run='TestAccAppSync_serial/GraphQLAPI/basic|TestAccAppSync_serial/GraphQLAPI/enhancedMetricsConfig'  -timeout 360m
=== RUN   TestAccAppSync_serial
=== PAUSE TestAccAppSync_serial
=== CONT  TestAccAppSync_serial
=== RUN   TestAccAppSync_serial/GraphQLAPI
=== RUN   TestAccAppSync_serial/GraphQLAPI/basic
=== RUN   TestAccAppSync_serial/GraphQLAPI/enhancedMetricsConfig
--- PASS: TestAccAppSync_serial (46.24s)
    --- PASS: TestAccAppSync_serial/GraphQLAPI (46.24s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/basic (17.48s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/enhancedMetricsConfig (28.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appsync    46.516s

$
```
