### PR TITLE
fix: Fix create timestamp cmp for aws_appstream_image data source

### DIFF
--- a/.changelog/38571.txt
+++ b/.changelog/38571.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_appstream_image: Fix issue where the most recent image is not returned
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix the create timestamp comparison logic that determines the most recent image for the `aws_appstream_image` data source.

Since the acceptance tests does not really check for the actual image to see whether it's the most recent, I've done a manual test by comparing the result from the following TF configuration and the console.

```terraform
data "aws_appstream_image" "test" {
  name_regex  = "^AppStream-Graphics-.*-WinServer.*$"
  type        = "PUBLIC"
  most_recent = true
}

output "image_id" {
  value = data.aws_appstream_image.test.name
}
```

Results from re-apply after the code fix:
```console
PS C:\working\tf-test> terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/aws in C:\Users\Anthony\go\bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible   
│ with published releases.
╵
data.aws_appstream_image.test: Reading...
data.aws_appstream_image.test: Read complete after 0s [name=AppStream-Graphics-G5-WinServer2022-06-17-2024]

Changes to Outputs:
  ~ image_id = "AppStream-Graphics-G5-WinServer2016-06-17-2024" -> "AppStream-Graphics-G5-WinServer2022-06-17-2024"

You can apply this plan to save these new output values to the Terraform state, without changing any real infrastructure.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

image_id = "AppStream-Graphics-G5-WinServer2022-06-17-2024"

PS C:\working\tf-test>
```

![image](https://github.com/user-attachments/assets/efb1f335-6401-4aa6-8212-8f1eaf1e4505)


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38561

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the source code for the `aws_ecr_image` data source for timestamp comparison logic.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccAppStreamImageDataSource PKG=appstream
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamImageDataSource'  -timeout 360m
=== RUN   TestAccAppStreamImageDataSource_basic
=== PAUSE TestAccAppStreamImageDataSource_basic
=== CONT  TestAccAppStreamImageDataSource_basic
--- PASS: TestAccAppStreamImageDataSource_basic (12.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  12.246s

$
```
