### PR TITLE
Fix pull request target labeler

### DIFF
--- a/.github/actions/community_check/action.yml
+++ b/.github/actions/community_check/action.yml
@@ -38,16 +38,16 @@ runs:
       id: core_contributor
       if: inputs.core_contributors != ''
       shell: bash
-      run: echo "check=$(echo $INPUT_CORE_CONTRIBUTORS | base64 --decode | jq --arg u $INPUT_USER_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+      run: echo "check=$(echo ${{ inputs.core_contributors }} | base64 --decode | jq --arg u ${{ inputs.user_login }} '. | contains([$u])')" >> "$GITHUB_OUTPUT"
 
     - name: Maintainers
       id: maintainer
       if: inputs.maintainers != ''
       shell: bash
-      run: echo "check=$(echo $INPUT_MAINTAINERS | base64 --decode | jq --arg u $INPUT_USER_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+      run: echo "check=$(echo ${{ inputs.maintainers }} | base64 --decode | jq --arg u ${{ inputs.user_login }} '. | contains([$u])')" >> "$GITHUB_OUTPUT"
 
     - name: Partners
       id: partner
       if: inputs.partners != ''
       shell: bash
-      run: echo "check=$(echo $INPUT_PARTNERS | base64 --decode | jq --arg u $INPUT_USER_LOGIN '. | contains([$u])')" >> "$GITHUB_OUTPUT"
+      run: echo "check=$(echo ${{ inputs.partners }} | base64 --decode | jq --arg u ${{ inputs.user_login }} '. | contains([$u])')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -16,14 +16,11 @@ jobs:
   labels:
     name: Labelers
     runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App Token
-        id: token
-        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PEM }}
+    permissions:
+      contents: read
+      pull-requests: write
 
+    steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -34,13 +31,13 @@ jobs:
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           configuration-path: .github/labeler-pr-triage.yml
-          repo-token: ${{ steps.token.outputs.token }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Apply Size Labels
         if: contains(fromJSON('["opened", "edited"]'), github.event.action)
         uses: codelytv/pr-size-labeler@56f6f0fc35c7cc0f72963b8467729e1120cb4bed # v1.10.0
         with:
-          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: "size/XS"
           xs_max_size: "30"
           s_label: "size/S"
@@ -67,7 +64,7 @@ jobs:
           github.event.action == 'opened'
           && steps.author.outputs.maintainer == 'false'
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$ISSUE_URL" --add-label needs-triage
 
       - name: Add prioritized to Maintainer Contributions
@@ -75,7 +72,7 @@ jobs:
           github.event.action == 'opened'
           && steps.author.outputs.maintainer == 'true'
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$ISSUE_URL" --add-label prioritized
 
       - name: Credit Core Contributor Contributions
@@ -83,7 +80,7 @@ jobs:
           github.event.action == 'opened'
           && steps.author.outputs.core_contributor == 'true'
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit "$ISSUE_URL" --add-label external-maintainer
 
@@ -92,7 +89,7 @@ jobs:
           github.event.action == 'opened'
           && steps.author.outputs.partner == 'true'
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit "$ISSUE_URL" --add-label partner
 
@@ -109,7 +106,7 @@ jobs:
           github.event.action == 'assigned'
           && steps.assignee.outputs.maintainer == 'true'
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit "$ISSUE_URL" --add-label prioritized
 
@@ -118,7 +115,7 @@ jobs:
           github.event.action == 'closed'
           && (contains(github.event.pull_request.labels.*.name, 'needs-triage') || contains(github.event.pull_request.labels.*.name, 'waiting-response'))
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$ISSUE_URL" --remove-label needs-triage,waiting-response
 
   project:

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Indicate That Triage is Required
         if: |
-          github.event.action == 'opened'
+          steps.author.conclusion != 'skipped'
           && steps.author.outputs.maintainer == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Add prioritized to Maintainer Contributions
         if: |
-          github.event.action == 'opened'
+          steps.author.conclusion != 'skipped'
           && steps.author.outputs.maintainer == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Credit Core Contributor Contributions
         if: |
-          github.event.action == 'opened'
+          steps.author.conclusion != 'skipped'
           && steps.author.outputs.core_contributor == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Credit Partner Contributions
         if: |
-          github.event.action == 'opened'
+          steps.author.conclusion != 'skipped'
           && steps.author.outputs.partner == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
 
       - name: Add prioritized to Maintainer Assignments
         if: |
-          github.event.action == 'assigned'
+          steps.assignee.conclusion != 'skipped'
           && steps.assignee.outputs.maintainer == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Community Check
         id: community_check
-        if: github.event.action == 'opened'
+        if: contains(fromJSON('["opened", "edited"]'), github.event.action)
         uses: ./.github/actions/community_check
         with:
           user_login: ${{ github.event.action == 'assigned' && github.event.assignee.login || github.event.pull_request.user.login }}

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Indicate That Triage is Required
         if: |
-          steps.author.conclusion != 'skipped'
+          github.event.action == 'opened'
           && steps.author.outputs.maintainer == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,16 +69,16 @@ jobs:
 
       - name: Add prioritized to Maintainer Contributions
         if: |
-          steps.author.conclusion != 'skipped'
-          && steps.author.outputs.maintainer == 'true'
+          steps.author.outputs.maintainer == 'true'
+          && !contains(github.event.pull_request.labels.*.name, 'prioritized')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$ISSUE_URL" --add-label prioritized
 
       - name: Credit Core Contributor Contributions
         if: |
-          steps.author.conclusion != 'skipped'
-          && steps.author.outputs.core_contributor == 'true'
+          steps.author.outputs.core_contributor == 'true'
+          && !contains(github.event.pull_request.labels.*.name, 'external-maintainer')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -86,8 +86,8 @@ jobs:
 
       - name: Credit Partner Contributions
         if: |
-          steps.author.conclusion != 'skipped'
-          && steps.author.outputs.partner == 'true'
+          steps.author.outputs.partner == 'true'
+          && !contains(github.event.pull_request.labels.*.name, 'external-maintainer')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -102,9 +102,7 @@ jobs:
           maintainers: ${{ secrets.MAINTAINERS }}
 
       - name: Add prioritized to Maintainer Assignments
-        if: |
-          steps.assignee.conclusion != 'skipped'
-          && steps.assignee.outputs.maintainer == 'true'
+        if: steps.assignee.outputs.maintainer == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -51,7 +51,6 @@ jobs:
 
       - name: "Community Check: Author"
         id: author
-        if: github.event.action == 'opened'
         uses: ./.github/actions/community_check
         with:
           user_login: ${{ github.event.pull_request.user.login }}
@@ -59,7 +58,7 @@ jobs:
           core_contributors: ${{ secrets.CORE_CONTRIBUTORS }}
           partners: ${{ secrets.PARTNERS }}
 
-      - name: Indicate That Triage is Required
+      - name: Add needs-triage to New Contributions
         if: |
           github.event.action == 'opened'
           && steps.author.outputs.maintainer == 'false'
@@ -67,9 +66,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$ISSUE_URL" --add-label needs-triage
 
-      - name: Add prioritized to Maintainer Contributions
+      - name: Add prioritized to New Maintainer Contributions
         if: |
-          steps.author.outputs.maintainer == 'true'
+          github.event.action == 'opened'
+          && steps.author.outputs.maintainer == 'true'
           && !contains(github.event.pull_request.labels.*.name, 'prioritized')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -87,7 +87,7 @@ jobs:
       - name: Credit Partner Contributions
         if: |
           steps.author.outputs.partner == 'true'
-          && !contains(github.event.pull_request.labels.*.name, 'external-maintainer')
+          && !contains(github.event.pull_request.labels.*.name, 'partner')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -101,7 +101,7 @@ jobs:
           user_login: ${{ github.event.assignee.login }}
           maintainers: ${{ secrets.MAINTAINERS }}
 
-      - name: Add prioritized to Maintainer Assignments
+      - name: Add prioritized When Assigned to a Maintainer
         if: steps.assignee.outputs.maintainer == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Community Check
         id: community_check
-        if: contains(fromJSON('["opened", "edited"]'), github.event.action)
+        if: contains(fromJSON('["opened", "assigned"]'), github.event.action)
         uses: ./.github/actions/community_check
         with:
           user_login: ${{ github.event.action == 'assigned' && github.event.assignee.login || github.event.pull_request.user.login }}


### PR DESCRIPTION
### Description

While looking into the PR linked below, I realized that the community check wasn't working quite as expected. The culprit was the use of the `$INPUT_` variables, which works with `nektos/act`, but doesn't appear to work as expected in reality. I tested this solution in my private test repo (which reproduced the incorrect behavior), and this resolves it.

While troubleshooting, I made a few other changes that I thought were worth keeping, and so are included:

- The Labelers job was generating a token using a GitHub App. It was the only job in this workflow to do so, so wasn't saving us any time or making anything more secure. That's been replaced with using the automatically generated token and restricting its permissions at the job level.
- Core Contributor and Partner PRs now get their respective labels on any event, gated by whether they're already labeled
- Fixed a bug where the step to add maintainer assignments to the project board would never fire

### Relations

Relates #38562

### Output from Acceptance Testing

N/a, workflows
