### PR TITLE
[WIP] b aws_lakeformation_permissions support IAMPrincipals special principal

### DIFF
--- a/internal/service/lakeformation/permissions_test.go
+++ b/internal/service/lakeformation/permissions_test.go
@@ -141,6 +141,35 @@ func testAccPermissions_databaseIAMAllowed(t *testing.T) {
 	})
 }
 
+func TestAccPermissions_databaseIAMPrincipals(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lakeformation_permissions.test"
+	dbName := "aws_glue_catalog_database.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPermissionsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPermissionsConfig_databaseIAMPrincipals(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPermissionsExists(ctx, resourceName),
+					testAccCheckIAMPrincipalsGrantPrincipal(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "catalog_resource", "false"),
+					resource.TestCheckResourceAttr(resourceName, "database.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "database.0.name", dbName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", string(awstypes.PermissionAll)),
+					resource.TestCheckResourceAttr(resourceName, "permissions_with_grant_option.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccPermissions_databaseMultiple(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -416,6 +445,37 @@ func testAccPermissions_tableIAMAllowed(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "permissions.0", string(awstypes.PermissionAll)),
 					resource.TestCheckResourceAttr(resourceName, "permissions_with_grant_option.#", acctest.Ct0),
+				),
+			},
+		},
+	})
+}
+
+// TODO remove capital T on acceptance test name
+func TestAccPermissions_tableIAMPrincipals(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lakeformation_permissions.test"
+	dbName := "aws_glue_catalog_table.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.LakeFormation) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPermissionsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPermissionsConfig_tableIAMPrincipals(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPermissionsExists(ctx, resourceName),
+					testAccCheckIAMPrincipalsGrantPrincipal(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "catalog_resource", "false"),
+					resource.TestCheckResourceAttr(resourceName, "table.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "table.0.database_name", dbName, "database_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "table.0.name", dbName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", string(awstypes.PermissionAll)),
+					resource.TestCheckResourceAttr(resourceName, "permissions_with_grant_option.#", "0"),
 				),
 			},
 		},
@@ -807,6 +867,27 @@ func testAccPermissions_twcWildcardSelectPlus(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckIAMPrincipalsGrantPrincipal(ctx context.Context, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+
+		if !ok {
+			return fmt.Errorf("acceptance test: resource not found: %s", resourceName)
+		}
+
+		if v, ok := rs.Primary.Attributes["principal"]; ok && v != "" {
+			expectedPrincipalValue := acctest.AccountID() + ":IAMPrincipals"
+			if v == expectedPrincipalValue {
+				return nil
+			} else {
+				return fmt.Errorf("acceptance test: unexpected principal value for (%s). Is %s, should be %s", rs.Primary.ID, v, expectedPrincipalValue)
+			}
+		}
+
+		return fmt.Errorf("acceptance test: error finding IAMPrincipals grant (%s)", rs.Primary.ID)
+	}
 }
 
 func testAccCheckPermissionsDestroy(ctx context.Context) resource.TestCheckFunc {
@@ -1334,6 +1415,7 @@ resource "aws_lakeformation_permissions" "test" {
 
 func testAccPermissionsConfig_databaseIAMAllowed(rName string) string {
 	return fmt.Sprintf(`
+
 data "aws_partition" "current" {}
 
 data "aws_caller_identity" "current" {}
@@ -1375,6 +1457,61 @@ resource "aws_glue_catalog_table" "test" {
 resource "aws_lakeformation_permissions" "test" {
   permissions = ["ALL"]
   principal   = "IAM_ALLOWED_PRINCIPALS"
+
+  database {
+    name = aws_glue_catalog_database.test.name
+  }
+
+  # for consistency, ensure that admins are setup before testing
+  depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+`, rName)
+}
+
+func testAccPermissionsConfig_databaseIAMPrincipals(rName string) string {
+	return fmt.Sprintf(`
+
+data "aws_partition" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+  admins = [data.aws_iam_session_context.current.issuer_arn]
+}
+
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = aws_glue_catalog_database.test.name
+
+  storage_descriptor {
+    columns {
+      name = "event"
+      type = "string"
+    }
+
+    columns {
+      name = "timestamp"
+      type = "date"
+    }
+
+    columns {
+      name = "transactionamount"
+      type = "double"
+    }
+  }
+}
+
+resource "aws_lakeformation_permissions" "test" {
+  permissions = ["ALL"]
+  principal   = "${data.aws_caller_identity.current.account_id}:IAMPrincipals"
 
   database {
     name = aws_glue_catalog_database.test.name
@@ -1818,6 +1955,58 @@ resource "aws_glue_catalog_table" "test" {
 resource "aws_lakeformation_permissions" "test" {
   permissions = ["ALL"]
   principal   = "IAM_ALLOWED_PRINCIPALS"
+
+  table {
+    database_name = aws_glue_catalog_database.test.name
+    name          = aws_glue_catalog_table.test.name
+  }
+}
+`, rName)
+}
+
+func testAccPermissionsConfig_tableIAMPrincipals(rName string) string {
+	return fmt.Sprintf(`
+data "aws_partition" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+  admins = [data.aws_iam_session_context.current.issuer_arn]
+}
+
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = %[1]q
+  database_name = aws_glue_catalog_database.test.name
+
+  storage_descriptor {
+    columns {
+      name = "event"
+      type = "string"
+    }
+
+    columns {
+      name = "timestamp"
+      type = "date"
+    }
+
+    columns {
+      name = "transactionamount"
+      type = "double"
+    }
+  }
+}
+
+resource "aws_lakeformation_permissions" "test" {
+  permissions = ["ALL"]
+  principal   = "${data.aws_caller_identity.current.account_id}:IAMPrincipals"
 
   table {
     database_name = aws_glue_catalog_database.test.name

--- a/internal/service/lakeformation/validate.go
+++ b/internal/service/lakeformation/validate.go
@@ -17,6 +17,15 @@ func validPrincipal(v interface{}, k string) (ws []string, errors []error) {
 		return ws, errors
 	}
 
+	// IAMPrincipals special grant has format {account_id}:IAMPrincipals
+	if len(value) == 26 && value[13:26] == "IAMPrincipals" && value[12] == ':' {
+		return ws, errors
+		wsAccount, errorsAccount := verify.ValidAccountID(value[0:12], k)
+		if len(errorsAccount) == 0 {
+			return wsAccount, errorsAccount
+		}
+	}
+
 	// https://docs.aws.amazon.com/lake-formation/latest/dg/lf-permissions-reference.html
 	// Principal is an AWS account
 	// --principal DataLakePrincipalIdentifier=111122223333

--- a/internal/service/lakeformation/validate_test.go
+++ b/internal/service/lakeformation/validate_test.go
@@ -19,9 +19,10 @@ func TestValidPrincipal(t *testing.T) {
 	}
 
 	validNames := []string{
-		"IAM_ALLOWED_PRINCIPALS", // Special principal
-		"123456789012",           // lintignore:AWSAT005          // Example Account ID (Valid looking but not real)
-		"111122223333",           // lintignore:AWSAT005          // Example Account ID (Valid looking but not real)
+		"IAM_ALLOWED_PRINCIPALS",     // Special principal
+		"123456789012:IAMPrincipals", // Special principal, Example Account ID (Valid looking but not real)
+		"123456789012",               // lintignore:AWSAT005          // Example Account ID (Valid looking but not real)
+		"111122223333",               // lintignore:AWSAT005          // Example Account ID (Valid looking but not real)
 		"arn:aws-us-gov:iam::357342307427:role/tf-acc-test-3217321001347236965",          // lintignore:AWSAT005          // IAM Role
 		"arn:aws:iam::123456789012:user/David",                                           // lintignore:AWSAT005          // IAM User
 		"arn:aws-us-gov:iam:us-west-2:357342307427:role/tf-acc-test-3217321001347236965", // lintignore:AWSAT003,AWSAT005 // Non-global IAM Role?
@@ -42,7 +43,9 @@ func TestValidPrincipal(t *testing.T) {
 	invalidNames := []string{
 		"IAM_NOT_ALLOWED_PRINCIPALS", // doesn't exist
 		names.AttrARN,
-		"1234567890125", //not an account id
+		"1234567890125",               //not an account id
+		"IAMPrincipals",               // incorrect representation
+		"1234567890125:IAMPrincipals", // incorrect representation, account id invalid length
 		"arn:aws",
 		"arn:aws:logs",            //lintignore:AWSAT005
 		"arn:aws:logs:region:*:*", //lintignore:AWSAT005


### PR DESCRIPTION
Issue:  https://github.com/hashicorp/terraform-provider-aws/issues/29767

Lake Formation supports two special principal values that are not ARNs and are defined by the Lake Formation service:
- IAMAllowedPrincipals (already supported by `aws_lakeformation_permissions` resource, since its [creation](https://github.com/hashicorp/terraform-provider-aws/pull/13396/files#diff-89223e5e24bbc2ac9c3ac2a3e676a5b29529b8ab86def7f803d200bd4d3e1728R370))
- {account_id}:IAMPrincipals (**Added in this PR**)

> Principal is an IAM group - ALLIAMPrincipals
> When you grant permissions to ALLIAMPrincipals group on a Data Catalog resource, every principal in the account gets 
> access to the Data Catalog resource using Lake Formation permissions and IAM permissions.
> Example:
>> --principal DataLakePrincipalIdentifier=123456789012:IAMPrincipals

https://docs.aws.amazon.com/lake-formation/latest/dg/lf-permissions-reference.html
