### PR TITLE
chore: Add domain creation allowlist precheck for CloudSearch tests

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -24,6 +24,7 @@ import (
 	accounttypes "github.com/aws/aws-sdk-go-v2/service/account/types"
 	"github.com/aws/aws-sdk-go-v2/service/acmpca"
 	acmpcatypes "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
+	"github.com/aws/aws-sdk-go-v2/service/cloudsearch"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
 	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
@@ -1039,6 +1040,22 @@ func PreCheckCECostCategoryPayerAccount(ctx context.Context, t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("listing Cost Explorer Cost Categories: %s", err)
+	}
+}
+
+func PreCheckCloudSearchAccountAllowListed(ctx context.Context, t *testing.T) {
+	t.Helper()
+
+	conn := Provider.Meta().(*conns.AWSClient).CloudSearchClient(ctx)
+
+	_, err := conn.ListDomainNames(ctx, &cloudsearch.ListDomainNamesInput{})
+
+	if errs.MessageContains(err, "NotAuthorized", "New domain creation not supported on this account") {
+		t.Skip("skipping tests; this AWS account does not support new CloudSearch domain creation")
+	}
+
+	if err != nil {
+		t.Fatalf("listing CloudSearch Domain Names: %s", err)
 	}
 }
 

--- a/internal/service/cloudsearch/domain_service_access_policy_test.go
+++ b/internal/service/cloudsearch/domain_service_access_policy_test.go
@@ -24,7 +24,11 @@ func TestAccCloudSearchDomainServiceAccessPolicy_basic(t *testing.T) {
 	rName := acctest.ResourcePrefix + "-" + sdkacctest.RandString(28-(len(acctest.ResourcePrefix)+1))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID)
+			acctest.PreCheckCloudSearchAccountAllowListed(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainServiceAccessPolicyDestroy(ctx),
@@ -51,7 +55,11 @@ func TestAccCloudSearchDomainServiceAccessPolicy_update(t *testing.T) {
 	rName := acctest.ResourcePrefix + "-" + sdkacctest.RandString(28-(len(acctest.ResourcePrefix)+1))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID)
+			acctest.PreCheckCloudSearchAccountAllowListed(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainServiceAccessPolicyDestroy(ctx),

--- a/internal/service/cloudsearch/domain_test.go
+++ b/internal/service/cloudsearch/domain_test.go
@@ -26,7 +26,11 @@ func TestAccCloudSearchDomain_basic(t *testing.T) {
 	rName := testAccDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID)
+			acctest.PreCheckCloudSearchAccountAllowListed(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
@@ -65,7 +69,11 @@ func TestAccCloudSearchDomain_disappears(t *testing.T) {
 	rName := testAccDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID)
+			acctest.PreCheckCloudSearchAccountAllowListed(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
@@ -89,7 +97,11 @@ func TestAccCloudSearchDomain_indexFields(t *testing.T) {
 	rName := testAccDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID)
+			acctest.PreCheckCloudSearchAccountAllowListed(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
@@ -161,7 +173,11 @@ func TestAccCloudSearchDomain_sourceFields(t *testing.T) {
 	rName := testAccDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID)
+			acctest.PreCheckCloudSearchAccountAllowListed(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),
@@ -236,7 +252,11 @@ func TestAccCloudSearchDomain_update(t *testing.T) {
 	rName := testAccDomainName()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudSearchEndpointID)
+			acctest.PreCheckCloudSearchAccountAllowListed(ctx, t)
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudSearchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckDomainDestroy(ctx),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
his PR is to add a precheck, which ensures that the account is allowlisted to create new CloudSearch domains (generally equates to the account having an existing CloudSerach domain prior to July 25, 2024), to the acceptance tests for the `aws_cloudsearch_domain` and `aws_cloudsearch_domain_service_access_policy` resources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38584

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**Note:** Unfortunately I don't have an account with existing CloudSearch domain, so I cannot test the case where it passes the check.

```console
$ make testacc TESTS="TestAccCloudSearchDomain_|TestAccCloudSearchDomainServiceAccessPolicy_" PKG=cloudsearch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/cloudsearch/... -v -count 1 -parallel 20 -run='TestAccCloudSearchDomain_|TestAccCloudSearchDomainServiceAccessPolicy_'  -timeout 360m
=== RUN   TestAccCloudSearchDomainServiceAccessPolicy_basic
=== PAUSE TestAccCloudSearchDomainServiceAccessPolicy_basic
=== RUN   TestAccCloudSearchDomainServiceAccessPolicy_update
=== PAUSE TestAccCloudSearchDomainServiceAccessPolicy_update
=== RUN   TestAccCloudSearchDomain_basic
=== PAUSE TestAccCloudSearchDomain_basic
=== RUN   TestAccCloudSearchDomain_disappears
=== PAUSE TestAccCloudSearchDomain_disappears
=== RUN   TestAccCloudSearchDomain_indexFields
=== PAUSE TestAccCloudSearchDomain_indexFields
=== RUN   TestAccCloudSearchDomain_sourceFields
=== PAUSE TestAccCloudSearchDomain_sourceFields
=== RUN   TestAccCloudSearchDomain_update
=== PAUSE TestAccCloudSearchDomain_update
=== CONT  TestAccCloudSearchDomainServiceAccessPolicy_basic
=== CONT  TestAccCloudSearchDomain_indexFields
=== CONT  TestAccCloudSearchDomain_update
=== CONT  TestAccCloudSearchDomain_basic
=== CONT  TestAccCloudSearchDomain_disappears
=== CONT  TestAccCloudSearchDomainServiceAccessPolicy_update
=== CONT  TestAccCloudSearchDomain_sourceFields
    domain_test.go:179: skipping tests; this AWS account does not support new CloudSearch domain creation
--- SKIP: TestAccCloudSearchDomain_sourceFields (1.22s)
=== NAME  TestAccCloudSearchDomainServiceAccessPolicy_update
    domain_service_access_policy_test.go:61: skipping tests; this AWS account does not support new CloudSearch domain creation
=== NAME  TestAccCloudSearchDomainServiceAccessPolicy_basic
    domain_service_access_policy_test.go:30: skipping tests; this AWS account does not support new CloudSearch domain creation
--- SKIP: TestAccCloudSearchDomainServiceAccessPolicy_update (1.22s)
--- SKIP: TestAccCloudSearchDomainServiceAccessPolicy_basic (1.22s)
=== NAME  TestAccCloudSearchDomain_update
    domain_test.go:258: skipping tests; this AWS account does not support new CloudSearch domain creation
--- SKIP: TestAccCloudSearchDomain_update (1.22s)
=== NAME  TestAccCloudSearchDomain_basic
    domain_test.go:32: skipping tests; this AWS account does not support new CloudSearch domain creation
--- SKIP: TestAccCloudSearchDomain_basic (1.23s)
=== NAME  TestAccCloudSearchDomain_disappears
    domain_test.go:75: skipping tests; this AWS account does not support new CloudSearch domain creation
--- SKIP: TestAccCloudSearchDomain_disappears (1.23s)
=== NAME  TestAccCloudSearchDomain_indexFields
    domain_test.go:103: skipping tests; this AWS account does not support new CloudSearch domain creation
--- SKIP: TestAccCloudSearchDomain_indexFields (1.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudsearch        1.498s

$
```
