### PR TITLE
Core CoreNetworkPolicyException when a policy has a single wildcard in `when_sent_to`

### DIFF
--- a/.changelog/38595.txt
+++ b/.changelog/38595.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+datasource/aws_networkmanager_core_network_policy_document: Fix `CoreNetworkPolicyException` when putting policy with single wildcard in `when_sent_to`
+```

--- a/internal/service/networkmanager/core_network_policy_model.go
+++ b/internal/service/networkmanager/core_network_policy_model.go
@@ -100,6 +100,7 @@ type coreNetworkPolicyAttachmentPolicyAction struct {
 func (c coreNetworkPolicySegmentAction) MarshalJSON() ([]byte, error) {
 	type Alias coreNetworkPolicySegmentAction
 	var share interface{}
+	var whenSentTo *coreNetworkPolicySegmentActionWhenSentTo
 
 	if v := c.ShareWith; v != nil {
 		v := v.([]string)
@@ -114,6 +115,17 @@ func (c coreNetworkPolicySegmentAction) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	if v := c.WhenSentTo; v != nil {
+		if s := v.Segments; s != nil {
+			s := s.([]string)
+			if s[0] == "*" {
+				whenSentTo = &coreNetworkPolicySegmentActionWhenSentTo{Segments: s[0]}
+			} else {
+				whenSentTo = c.WhenSentTo
+			}
+		}
+	}
+
 	return json.Marshal(&Alias{
 		Action:                c.Action,
 		Mode:                  c.Mode,
@@ -122,7 +134,7 @@ func (c coreNetworkPolicySegmentAction) MarshalJSON() ([]byte, error) {
 		Segment:               c.Segment,
 		ShareWith:             share,
 		Via:                   c.Via,
-		WhenSentTo:            c.WhenSentTo,
+		WhenSentTo:            whenSentTo,
 	})
 }
 


### PR DESCRIPTION
### Description
Customise marshalling for single wildcards to match services expectation.

### Relations
Closes #38145

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
```console
make testacc TESTS=TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource PKG=networkmanager
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/networkmanager/... -v -count 1 -parallel 20 -run='TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource'  -timeout 360m
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_serviceInsertion
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_serviceInsertion
=== RUN   TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_whenSentTo
=== PAUSE TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_whenSentTo
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_whenSentTo
=== CONT  TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_serviceInsertion
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_basic (9.58s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_whenSentTo (9.58s)
--- PASS: TestAccNetworkManagerCoreNetworkPolicyDocumentDataSource_serviceInsertion (9.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     14.322s
```
