### PR TITLE
docs: add footnotes extension 

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -434,7 +434,7 @@ PKG=rds make semgrep-code-quality
 
 #### Naming Scan Caps/AWS/EC2
 
-Idiomatic Go uses [_mixed caps_](naming.md#mixed_caps) for multiword names, not camel case. In camel case, a name with the words "SMTP thing" would be `SmtpThing`. This is wrong in Go. In mixed caps, and therefore idiomatic Go, `SMTPThing` is correct. This scan ensures that many acronyms and initialisms are capitalized correctly in code.
+Idiomatic Go uses [_mixed caps_](naming.md#mixed-caps) for multiword names, not camel case. In camel case, a name with the words "SMTP thing" would be `SmtpThing`. This is wrong in Go. In mixed caps, and therefore idiomatic Go, `SMTPThing` is correct. This scan ensures that many acronyms and initialisms are capitalized correctly in code.
 
 Use the `semgrep-naming-cae` target to run the same check CI runs:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ plugins:
 
 markdown_extensions:
   - admonition
+  - footnotes
   - pymdownx.highlight
   - pymdownx.superfences
   - pymdownx.tabbed:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This will allow the footnotes in the relationship design standards design document to render properly.

Before:

<img width="796" alt="image" src="https://github.com/user-attachments/assets/2101cdd5-4fc8-4015-bc0f-854817f7cc72">


After: 

<img width="789" alt="image" src="https://github.com/user-attachments/assets/99bd72de-0ca9-492c-82c6-21ae41961901">
