### PR TITLE
fix: Reset EventBridge pipe input template only on change detected

### DIFF
--- a/.changelog/38598.txt
+++ b/.changelog/38598.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_pipes_pipe: Reset EventBridge pipe input template only on change detected
+```

--- a/.changelog/38598.txt
+++ b/.changelog/38598.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_pipes_pipe: Reset EventBridge pipe input template only on change detected
+resource/aws_pipes_pipe: Don't reset `target_parameters` if the configured value has not changed
 ```

--- a/internal/service/pipes/pipe.go
+++ b/internal/service/pipes/pipe.go
@@ -250,10 +250,6 @@ func resourcePipeUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 			Name:         aws.String(d.Id()),
 			RoleArn:      aws.String(d.Get(names.AttrRoleARN).(string)),
 			Target:       aws.String(d.Get(names.AttrTarget).(string)),
-			// Reset state in case it's a deletion, have to set the input to an empty string otherwise it doesn't get overwritten.
-			TargetParameters: &awstypes.PipeTargetParameters{
-				InputTemplate: aws.String(""),
-			},
 		}
 
 		if d.HasChange("enrichment") {
@@ -279,6 +275,10 @@ func resourcePipeUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 
 		if d.HasChange("target_parameters") {
+			// Reset state in case it's a deletion, have to set the input to an empty string otherwise it doesn't get overwritten.
+			input.TargetParameters = &awstypes.PipeTargetParameters{
+				InputTemplate: aws.String(""),
+			}
 			if v, ok := d.GetOk("target_parameters"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 				input.TargetParameters = expandPipeTargetParameters(v.([]interface{})[0].(map[string]interface{}))
 			}


### PR DESCRIPTION
### Description
Ensures the inputTemplate field of EventBridge pipes is reset only on change detected, so it's not removed on updates to other pipe attributes (such as filter criteria).

### Relations

Closes #33938

### References


### Output from Acceptance Testing
```console
tin@tin-mbp ~/D/terraform-provider-aws (fix_eventbridge_input_template) [2]> make testacc TESTS=TestAccPipesPipe_targetParameters PKG=pipes
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/pipes/... -v -count 1 -parallel 20 -run='TestAccPipesPipe_targetParameters'  -timeout 360m
=== RUN   TestAccPipesPipe_targetParameters_inputTemplate
=== PAUSE TestAccPipesPipe_targetParameters_inputTemplate
=== RUN   TestAccPipesPipe_targetParameters_inputTemplate_preserveUnchanged
=== PAUSE TestAccPipesPipe_targetParameters_inputTemplate_preserveUnchanged
=== CONT  TestAccPipesPipe_targetParameters_inputTemplate
=== CONT  TestAccPipesPipe_targetParameters_inputTemplate_preserveUnchanged
--- PASS: TestAccPipesPipe_targetParameters_inputTemplate (142.32s)
--- PASS: TestAccPipesPipe_targetParameters_inputTemplate_preserveUnchanged (204.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pipes      208.257s
...
```

Output of current mainline code against updated tests (to confirm bug):
```console
tin@tin-mbp ~/D/terraform-provider-aws (fix_eventbridge_input_template) [2]> make testacc TESTS=TestAccPipesPipe_targetParameters PKG=pipes
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/pipes/... -v -count 1 -parallel 20 -run='TestAccPipesPipe_targetParameters'  -timeout 360m
=== RUN   TestAccPipesPipe_targetParameters_inputTemplate
=== PAUSE TestAccPipesPipe_targetParameters_inputTemplate
=== RUN   TestAccPipesPipe_targetParameters_inputTemplate_preserveUnchanged
=== PAUSE TestAccPipesPipe_targetParameters_inputTemplate_preserveUnchanged
=== CONT  TestAccPipesPipe_targetParameters_inputTemplate
=== CONT  TestAccPipesPipe_targetParameters_inputTemplate_preserveUnchanged
    pipe_test.go:794: Step 2/6 error: Check failed: Check 2/2 error: aws_pipes_pipe.test: Attribute 'target_parameters.0.input_template' not found
--- FAIL: TestAccPipesPipe_targetParameters_inputTemplate_preserveUnchanged (105.22s)
--- PASS: TestAccPipesPipe_targetParameters_inputTemplate (142.20s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/pipes      145.925s
FAIL
make: *** [testacc] Error 1
```