### PR TITLE
[aws_rds_cluster_instance ]Prevent forced renew due to identifier change

### DIFF
--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -512,9 +512,11 @@ func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 			return sdkdiag.AppendErrorf(diags, "updating RDS Cluster Instance (%s): %s", d.Id(), err)
 		}
 
-		if _, err := waitDBClusterInstanceUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		output, err := waitDBClusterInstanceUpdated(ctx, conn, d.Get(names.AttrIdentifier).(string), d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for RDS Cluster Instance (%s) update: %s", d.Id(), err)
 		}
+		d.SetId(aws.StringValue(output.DBInstanceIdentifier))
 	}
 
 	return append(diags, resourceClusterInstanceRead(ctx, d, meta)...)

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -132,7 +132,6 @@ func ResourceClusterInstance() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"identifier_prefix"},
 				ValidateFunc:  validIdentifier,
 			},
@@ -457,6 +456,10 @@ func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		if d.HasChange("db_parameter_group_name") {
 			input.DBParameterGroupName = aws.String(d.Get("db_parameter_group_name").(string))
+		}
+
+		if d.HasChange(names.AttrIdentifier) {
+			input.NewDBInstanceIdentifier = aws.String(d.Get(names.AttrIdentifier).(string))
 		}
 
 		if d.HasChange("instance_class") {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In the aws_rds_cluster_instance resource, changing the identifier would force a resource recreation. With this pull request, the recreation is no longer necessary.

As mentioned in this issue (https://github.com/hashicorp/terraform-provider-aws/issues/34935), changes can be made using the ModifyDBInstance API.
I have confirmed it works with AWS SDK for Go V1 as well.

```go

modifyDBInstanceInput := &rds.ModifyDBInstanceInput{
	DBInstanceIdentifier:    aws.String("id1"),
	NewDBInstanceIdentifier: aws.String("id2"),
	ApplyImmediately:        aws.Bool(true),
}

ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
defer cancel()

_, err = svc.ModifyDBInstanceWithContext(ctx, modifyDBInstanceInput)

```

#### Reproduction steps

1. Deploy a Aurora Cluster and Instance.

Create main.tf

```main.tf

resource "aws_rds_cluster" "cluster" {
  cluster_identifier  = "database-1"
  engine              = "aurora-mysql"
}

resource "aws_rds_cluster_instance" "instance" {
  identifier         = "id1"
  engine             = "aurora-mysql"
  cluster_identifier = aws_rds_cluster.cluster.cluster_identifier
  instance_class     = "db.t3.large"
  apply_immediately  = true
}

```

Deploy

```console
terraform apply
```

2. Rename identifier of aws_rds_cluster_instance

edit main.tf

```

resource "aws_rds_cluster_instance" "instance" {
  identifier         = "id2" # 🌟 edit here
  engine             = "aurora-mysql"
  cluster_identifier = aws_rds_cluster.cluster.cluster_identifier
  instance_class     = "db.t3.large"
  apply_immediately  = true
}


```

Deploy

```console
terraform apply
```

#### Before

```

-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_rds_cluster_instance.instance must be replaced
-/+ resource "aws_rds_cluster_instance" "instance" {
      ~ id                                    = "id2" -> (known after apply)
      ~ identifier                            = "id1" -> "id2" # forces replacement
     ...
    }

Plan: 1 to add, 0 to change, 1 to destroy.

```

#### After

```

  # aws_rds_cluster_instance.instance will be updated in-place
  ~ resource "aws_rds_cluster_instance" "instance" {
        id                                    = "id1"
      ~ identifier                            = "id1" -> "id2"
        tags                                  = {}
        # (31 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34935

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console

% make testacc TESTS=TestAccRDSClusterInstance_basic PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSClusterInstance_basic'  -timeout 360m
=== RUN   TestAccRDSClusterInstance_basic
=== PAUSE TestAccRDSClusterInstance_basic
=== CONT  TestAccRDSClusterInstance_basic
--- PASS: TestAccRDSClusterInstance_basic (1326.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1326.136s

```
