### PR TITLE
[New Resource]: DataZone Glossary

### DIFF
--- a/.changelog/38602.txt
+++ b/.changelog/38602.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_datazone_glossary
+```

--- a/internal/service/datazone/exports_test.go
+++ b/internal/service/datazone/exports_test.go
@@ -10,4 +10,5 @@ var (
 	IsResourceMissing                         = isResourceMissing
 	ResourceProject                           = newResourceProject
 	ResourceGlossary                          = newResourceGlossary
+	FindGlossaryByID                          = findGlossaryByID
 )

--- a/internal/service/datazone/exports_test.go
+++ b/internal/service/datazone/exports_test.go
@@ -9,4 +9,5 @@ var (
 	ResourceEnvironmentBlueprintConfiguration = newResourceEnvironmentBlueprintConfiguration
 	IsResourceMissing                         = isResourceMissing
 	ResourceProject                           = newResourceProject
+	ResourceGlossary                          = newResourceGlossary
 )

--- a/internal/service/datazone/glossary.go
+++ b/internal/service/datazone/glossary.go
@@ -78,7 +78,7 @@ func (r *resourceGlossary) Schema(ctx context.Context, req resource.SchemaReques
 				CustomType: fwtypes.StringEnumType[awstypes.GlossaryStatus](),
 				Optional:   true,
 			},
-			"domain_id": schema.StringAttribute{
+			"domain_identifier": schema.StringAttribute{
 				Required: true,
 			},
 			names.AttrID: framework.IDAttribute(),
@@ -101,7 +101,6 @@ func (r *resourceGlossary) Create(ctx context.Context, req resource.CreateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	in.DomainIdentifier = plan.DomainId.ValueStringPointer()
 	out, err := conn.CreateGlossary(ctx, in)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -134,7 +133,7 @@ func (r *resourceGlossary) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	out, err := findGlossaryByID(ctx, conn, state.Id.ValueString(), state.DomainId.ValueString())
+	out, err := findGlossaryByID(ctx, conn, state.Id.ValueString(), state.DomainIdentifier.ValueString())
 	if tfresource.NotFound(err) {
 		resp.State.RemoveResource(ctx)
 		return
@@ -164,13 +163,12 @@ func (r *resourceGlossary) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	if !plan.Description.Equal(state.Description) || !plan.Name.Equal(state.Name) || !plan.Description.Equal(state.Description) {
+	if !plan.Description.Equal(state.Description) || !plan.Name.Equal(state.Name) {
 		in := &datazone.UpdateGlossaryInput{}
 		resp.Diagnostics.Append(flex.Expand(ctx, &plan, in)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		in.DomainIdentifier = plan.DomainId.ValueStringPointer()
 		in.Identifier = plan.Id.ValueStringPointer()
 		out, err := conn.UpdateGlossary(ctx, in)
 
@@ -210,7 +208,6 @@ func (r *resourceGlossary) Delete(ctx context.Context, req resource.DeleteReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	in.DomainIdentifier = state.DomainId.ValueStringPointer()
 	in.Identifier = state.Id.ValueStringPointer()
 	in.Status = "DISABLED"
 
@@ -227,7 +224,7 @@ func (r *resourceGlossary) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	in2 := &datazone.DeleteGlossaryInput{
-		DomainIdentifier: state.DomainId.ValueStringPointer(),
+		DomainIdentifier: state.DomainIdentifier.ValueStringPointer(),
 		Identifier:       state.Id.ValueStringPointer(),
 	}
 
@@ -250,7 +247,7 @@ func (r *resourceGlossary) ImportState(ctx context.Context, req resource.ImportS
 	if len(parts) != 3 {
 		resp.Diagnostics.AddError("Resource Import Invalid ID", fmt.Sprintf(`Unexpected format for import ID (%s), use: "DomainIdentifier,Id,OwningProjectIdentifier"`, req.ID))
 	}
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain_identifier"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.AttrID), parts[1])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("owning_project_identifier"), parts[2])...)
 }
@@ -284,6 +281,6 @@ type glossaryData struct {
 	Name                    types.String                                `tfsdk:"name"`
 	OwningProjectIdentifier types.String                                `tfsdk:"owning_project_identifier"`
 	Status                  fwtypes.StringEnum[awstypes.GlossaryStatus] `tfsdk:"status"`
-	DomainId                types.String                                `tfsdk:"domain_id"`
+	DomainIdentifier        types.String                                `tfsdk:"domain_identifier"`
 	Id                      types.String                                `tfsdk:"id"`
 }

--- a/internal/service/datazone/glossary.go
+++ b/internal/service/datazone/glossary.go
@@ -81,12 +81,7 @@ func (r *resourceGlossary) Schema(ctx context.Context, req resource.SchemaReques
 			"domain_id": schema.StringAttribute{
 				Required: true,
 			},
-			names.AttrID: schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
+			names.AttrID: framework.IDAttribute(),
 		},
 	}
 }

--- a/internal/service/datazone/glossary.go
+++ b/internal/service/datazone/glossary.go
@@ -3,36 +3,7 @@
 
 package datazone
 
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
-
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/datazone/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// awstypes.<Type Name>.
 	"context"
 	"errors"
 	"fmt"
@@ -60,21 +31,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// TIP: ==== FILE STRUCTURE ====
-// All resources should follow this basic outline. Improve this resource's
-// maintainability by sticking to it.
-//
-// 1. Package declaration
-// 2. Imports
-// 3. Main resource struct with schema method
-// 4. Create, read, update, delete methods (in that order)
-// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
-
-// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @FrameworkResource("aws_datazone_glossary", name="Glossary")
 func newResourceGlossary(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceGlossary{}
-
 	return r, nil
 }
 

--- a/internal/service/datazone/glossary.go
+++ b/internal/service/datazone/glossary.go
@@ -1,0 +1,335 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone
+
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/datazone/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// awstypes.<Type Name>.
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datazone"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/datazone/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// TIP: ==== FILE STRUCTURE ====
+// All resources should follow this basic outline. Improve this resource's
+// maintainability by sticking to it.
+//
+// 1. Package declaration
+// 2. Imports
+// 3. Main resource struct with schema method
+// 4. Create, read, update, delete methods (in that order)
+// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource("aws_datazone_glossary", name="Glossary")
+func newResourceGlossary(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceGlossary{}
+
+	return r, nil
+}
+
+const (
+	ResNameGlossary = "Glossary"
+)
+
+type resourceGlossary struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceGlossary) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_datazone_glossary"
+}
+
+func (r *resourceGlossary) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrDescription: schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexache.MustCompile(`^[\x21-\x7E]+$`), "must conform to: ^[\x21-\x7E]+$ "),
+					stringvalidator.LengthBetween(1, 128),
+				},
+			},
+			names.AttrName: schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 256),
+				},
+			},
+			"owning_project_identifier": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexache.MustCompile(`^[a-zA-Z0-9_-]{1,36}$`), "must conform to: ^[a-zA-Z0-9_-]{1,36}$ "),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrStatus: schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.GlossaryStatus](),
+				Optional:   true,
+			},
+			"domain_id": schema.StringAttribute{
+				Required: true,
+			},
+			names.AttrID: schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceGlossary) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var plan glossaryData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &datazone.CreateGlossaryInput{}
+
+	resp.Diagnostics.Append(flex.Expand(ctx, &plan, in)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	in.DomainIdentifier = plan.DomainId.ValueStringPointer()
+	out, err := conn.CreateGlossary(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionCreating, ResNameGlossary, plan.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionCreating, ResNameGlossary, plan.Name.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceGlossary) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var state glossaryData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findGlossaryByID(ctx, conn, state.Id.ValueString(), state.DomainId.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionSetting, ResNameProject, state.Id.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceGlossary) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+
+	var plan, state glossaryData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.Description.Equal(state.Description) || !plan.Name.Equal(state.Name) || !plan.Description.Equal(state.Description) {
+		in := &datazone.UpdateGlossaryInput{}
+		resp.Diagnostics.Append(flex.Expand(ctx, &plan, in)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		in.DomainIdentifier = plan.DomainId.ValueStringPointer()
+		in.Identifier = plan.Id.ValueStringPointer()
+		out, err := conn.UpdateGlossary(ctx, in)
+
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.DataZone, create.ErrActionUpdating, ResNameProject, plan.Id.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.DataZone, create.ErrActionUpdating, ResNameProject, plan.Id.String(), nil),
+				errors.New("empty output from glossary update").Error(),
+			)
+			return
+		}
+		resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceGlossary) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().DataZoneClient(ctx)
+	var state glossaryData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &datazone.UpdateGlossaryInput{}
+	resp.Diagnostics.Append(flex.Expand(ctx, &state, in)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	in.DomainIdentifier = state.DomainId.ValueStringPointer()
+	in.Identifier = state.Id.ValueStringPointer()
+	in.Status = "DISABLED"
+
+	_, err := conn.UpdateGlossary(ctx, in)
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionDeleting, ResNameGlossary, state.Id.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	in2 := &datazone.DeleteGlossaryInput{
+		DomainIdentifier: state.DomainId.ValueStringPointer(),
+		Identifier:       state.Id.ValueStringPointer(),
+	}
+
+	_, err2 := conn.DeleteGlossary(ctx, in2)
+	if err2 != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err2) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.DataZone, create.ErrActionDeleting, ResNameGlossary, state.Id.String(), err),
+			err2.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceGlossary) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, ",")
+
+	if len(parts) != 3 {
+		resp.Diagnostics.AddError("Resource Import Invalid ID", fmt.Sprintf(`Unexpected format for import ID (%s), use: "DomainIdentifier,Id,OwningProjectIdentifier"`, req.ID))
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain_id"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.AttrID), parts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("owning_project_identifier"), parts[2])...)
+}
+
+func findGlossaryByID(ctx context.Context, conn *datazone.Client, id string, domain_id string) (*datazone.GetGlossaryOutput, error) {
+	in := &datazone.GetGlossaryInput{
+		Identifier:       aws.String(id),
+		DomainIdentifier: aws.String(domain_id),
+	}
+
+	out, err := conn.GetGlossary(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+type glossaryData struct {
+	Description             types.String                                `tfsdk:"description"`
+	Name                    types.String                                `tfsdk:"name"`
+	OwningProjectIdentifier types.String                                `tfsdk:"owning_project_identifier"`
+	Status                  fwtypes.StringEnum[awstypes.GlossaryStatus] `tfsdk:"status"`
+	DomainId                types.String                                `tfsdk:"domain_id"`
+	Id                      types.String                                `tfsdk:"id"`
+}

--- a/internal/service/datazone/glossary_test.go
+++ b/internal/service/datazone/glossary_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package datazone_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/datazone"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/datazone/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfdatazone "github.com/hashicorp/terraform-provider-aws/internal/service/datazone"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDataZoneGlossary_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var glossary datazone.GetGlossaryOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	token := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_datazone_glossary.test"
+	projectName := "aws_datazone_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DataZoneEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlossaryDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlossaryConfig_basic(rName, token, pName, dName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlossaryExists(ctx, resourceName, &glossary),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttrPair(resourceName, "owning_project_identifier", projectName, names.AttrID),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_id", projectName, "domain_identifier"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testAccAuthorizerGlossaryImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
+			},
+		},
+	})
+}
+func TestAccDataZoneGlossary_update(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var glossary, glossary2 datazone.GetGlossaryOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	token := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resourceName := "aws_datazone_glossary.test"
+	projectName := "aws_datazone_project.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DataZoneEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlossaryDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlossaryConfig_basic(rName, token, pName, dName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlossaryExists(ctx, resourceName, &glossary),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "desc"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttrPair(resourceName, "owning_project_identifier", projectName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "ENABLED"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_id", projectName, "domain_identifier"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testAccAuthorizerGlossaryImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
+			},
+			{
+				Config: testAccGlossaryConfig_update(rName, token, pName, dName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlossaryExists(ctx, resourceName, &glossary2),
+					testAccCheckGlossaryNotRecreated(&glossary, &glossary2),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, names.AttrDescription),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttrPair(resourceName, "owning_project_identifier", projectName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "DISABLED"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_id", projectName, "domain_identifier"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testAccAuthorizerGlossaryImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
+			},
+		},
+	})
+}
+
+func TestAccDataZoneGlossary_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var glossary datazone.GetGlossaryOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	token := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	pName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datazone_glossary.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.DataZoneEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGlossaryDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlossaryConfig_basic(rName, token, pName, dName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlossaryExists(ctx, resourceName, &glossary),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfdatazone.ResourceGlossary, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckGlossaryDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_datazone_glossary" {
+				continue
+			}
+			_, err := findGlossaryByID(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["domain_id"])
+			if errs.IsA[*awstypes.ResourceNotFoundException](err) || errs.IsA[*awstypes.AccessDeniedException](err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameGlossary, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameGlossary, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGlossaryExists(ctx context.Context, name string, glossary *datazone.GetGlossaryOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameGlossary, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameGlossary, name, errors.New("not set"))
+		}
+		if rs.Primary.Attributes["domain_id"] == "" {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameProject, name, errors.New("domain identifier not set"))
+		}
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+		resp, err := findGlossaryByID(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["domain_id"])
+
+		if err != nil {
+			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameGlossary, rs.Primary.ID, err)
+		}
+
+		*glossary = *resp
+
+		return nil
+	}
+}
+
+func findGlossaryByID(ctx context.Context, conn *datazone.Client, id string, domain_id string) (*datazone.GetGlossaryOutput, error) {
+	in := &datazone.GetGlossaryInput{
+		Identifier:       aws.String(id),
+		DomainIdentifier: aws.String(domain_id),
+	}
+
+	out, err := conn.GetGlossary(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: in,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil {
+		return nil, tfresource.NewEmptyResultError(in)
+	}
+
+	return out, nil
+}
+
+func testAccCheckGlossaryNotRecreated(before, after *datazone.GetGlossaryOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.ToString(before.Id), aws.ToString(after.Id); before != after {
+			return create.Error(names.DataZone, create.ErrActionCheckingNotRecreated, tfdatazone.ResNameGlossary, before, errors.New("recreated"))
+		}
+
+		return nil
+	}
+}
+
+func testAccAuthorizerGlossaryImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return strings.Join([]string{rs.Primary.Attributes["domain_id"], rs.Primary.ID, rs.Primary.Attributes["owning_project_identifier"]}, ","), nil
+	}
+}
+
+func testAccGlossaryConfig_basic(rName, token, dName, pName string) string {
+	return acctest.ConfigCompose(testAccProjectConfig_basic(pName, dName), fmt.Sprintf(`
+
+
+
+
+resource "aws_datazone_glossary" "test" {
+  description               = "desc"
+  name                      = %[1]q
+  owning_project_identifier = aws_datazone_project.test.id
+  status                    = "ENABLED"
+  domain_id                 = aws_datazone_project.test.domain_identifier
+}
+`, rName, token))
+}
+
+func testAccGlossaryConfig_update(rName, token, dName, pName string) string {
+	return acctest.ConfigCompose(testAccProjectConfig_basic(pName, dName), fmt.Sprintf(`
+
+
+
+
+resource "aws_datazone_glossary" "test" {
+  description               = "description"
+  name                      = %[1]q
+  owning_project_identifier = aws_datazone_project.test.id
+  status                    = "DISABLED"
+  domain_id                 = aws_datazone_project.test.domain_identifier
+}
+`, rName, token))
+}

--- a/internal/service/datazone/glossary_test.go
+++ b/internal/service/datazone/glossary_test.go
@@ -61,11 +61,10 @@ func TestAccDataZoneGlossary_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateIdFunc:       testAccAuthorizerGlossaryImportStateIdFunc(resourceName),
-				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAuthorizerGlossaryImportStateIdFunc(resourceName),
 			},
 		},
 	})
@@ -107,11 +106,10 @@ func TestAccDataZoneGlossary_update(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateIdFunc:       testAccAuthorizerGlossaryImportStateIdFunc(resourceName),
-				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAuthorizerGlossaryImportStateIdFunc(resourceName),
 			},
 			{
 				Config: testAccGlossaryConfig_update(rName, token, pName, dName),
@@ -127,11 +125,10 @@ func TestAccDataZoneGlossary_update(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateIdFunc:       testAccAuthorizerGlossaryImportStateIdFunc(resourceName),
-				ImportStateVerifyIgnore: []string{names.AttrApplyImmediately, "user"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccAuthorizerGlossaryImportStateIdFunc(resourceName),
 			},
 		},
 	})

--- a/internal/service/datazone/glossary_test.go
+++ b/internal/service/datazone/glossary_test.go
@@ -56,7 +56,7 @@ func TestAccDataZoneGlossary_basic(t *testing.T) {
 					testAccCheckGlossaryExists(ctx, resourceName, &glossary),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrPair(resourceName, "owning_project_identifier", projectName, names.AttrID),
-					resource.TestCheckResourceAttrPair(resourceName, "domain_id", projectName, "domain_identifier"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_identifier", projectName, "domain_identifier"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 				),
 			},
@@ -102,7 +102,7 @@ func TestAccDataZoneGlossary_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrPair(resourceName, "owning_project_identifier", projectName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "ENABLED"),
-					resource.TestCheckResourceAttrPair(resourceName, "domain_id", projectName, "domain_identifier"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_identifier", projectName, "domain_identifier"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 				),
 			},
@@ -122,7 +122,7 @@ func TestAccDataZoneGlossary_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrPair(resourceName, "owning_project_identifier", projectName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "DISABLED"),
-					resource.TestCheckResourceAttrPair(resourceName, "domain_id", projectName, "domain_identifier"),
+					resource.TestCheckResourceAttrPair(resourceName, "domain_identifier", projectName, "domain_identifier"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 				),
 			},
@@ -178,7 +178,7 @@ func testAccCheckGlossaryDestroy(ctx context.Context) resource.TestCheckFunc {
 			if rs.Type != "aws_datazone_glossary" {
 				continue
 			}
-			_, err := findGlossaryByID(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["domain_id"])
+			_, err := findGlossaryByID(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["domain_identifier"])
 			if errs.IsA[*awstypes.ResourceNotFoundException](err) || errs.IsA[*awstypes.AccessDeniedException](err) {
 				return nil
 			}
@@ -203,11 +203,11 @@ func testAccCheckGlossaryExists(ctx context.Context, name string, glossary *data
 		if rs.Primary.ID == "" {
 			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameGlossary, name, errors.New("not set"))
 		}
-		if rs.Primary.Attributes["domain_id"] == "" {
+		if rs.Primary.Attributes["domain_identifier"] == "" {
 			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameProject, name, errors.New("domain identifier not set"))
 		}
 		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
-		resp, err := findGlossaryByID(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["domain_id"])
+		resp, err := findGlossaryByID(ctx, conn, rs.Primary.ID, rs.Primary.Attributes["domain_identifier"])
 
 		if err != nil {
 			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameGlossary, rs.Primary.ID, err)
@@ -261,38 +261,30 @@ func testAccAuthorizerGlossaryImportStateIdFunc(resourceName string) resource.Im
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		return strings.Join([]string{rs.Primary.Attributes["domain_id"], rs.Primary.ID, rs.Primary.Attributes["owning_project_identifier"]}, ","), nil
+		return strings.Join([]string{rs.Primary.Attributes["domain_identifier"], rs.Primary.ID, rs.Primary.Attributes["owning_project_identifier"]}, ","), nil
 	}
 }
 
 func testAccGlossaryConfig_basic(rName, token, dName, pName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_basic(pName, dName), fmt.Sprintf(`
-
-
-
-
 resource "aws_datazone_glossary" "test" {
   description               = "desc"
   name                      = %[1]q
   owning_project_identifier = aws_datazone_project.test.id
   status                    = "ENABLED"
-  domain_id                 = aws_datazone_project.test.domain_identifier
+  domain_identifier         = aws_datazone_project.test.domain_identifier
 }
 `, rName, token))
 }
 
 func testAccGlossaryConfig_update(rName, token, dName, pName string) string {
 	return acctest.ConfigCompose(testAccProjectConfig_basic(pName, dName), fmt.Sprintf(`
-
-
-
-
 resource "aws_datazone_glossary" "test" {
   description               = "description"
   name                      = %[1]q
   owning_project_identifier = aws_datazone_project.test.id
   status                    = "DISABLED"
-  domain_id                 = aws_datazone_project.test.domain_identifier
+  domain_identifier         = aws_datazone_project.test.domain_identifier
 }
 `, rName, token))
 }

--- a/internal/service/datazone/service_package_gen.go
+++ b/internal/service/datazone/service_package_gen.go
@@ -37,12 +37,12 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Name:    "Environment Blueprint Configuration",
 		},
 		{
-			Factory: newResourceProject,
-			Name:    "Project",
-		},
-		{
 			Factory: newResourceGlossary,
 			Name:    "Glossary",
+		},
+		{
+			Factory: newResourceProject,
+			Name:    "Project",
 		},
 	}
 }

--- a/internal/service/datazone/service_package_gen.go
+++ b/internal/service/datazone/service_package_gen.go
@@ -40,6 +40,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Factory: newResourceProject,
 			Name:    "Project",
 		},
+		{
+			Factory: newResourceGlossary,
+			Name:    "Glossary",
+		},
 	}
 }
 

--- a/website/docs/r/datazone_glossary.html.markdown
+++ b/website/docs/r/datazone_glossary.html.markdown
@@ -109,7 +109,6 @@ The following arguments are optional:
 * `description` - (Optional) Description of the glossary. Must have a length between 0 and 4096.
 * `status` - (Optional) Status of business glossary. Valid values are DISABLED and ENABLED.
 
-
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:

--- a/website/docs/r/datazone_glossary.html.markdown
+++ b/website/docs/r/datazone_glossary.html.markdown
@@ -1,0 +1,148 @@
+---
+subcategory: "DataZone"
+layout: "aws"
+page_title: "AWS: aws_datazone_glossary"
+description: |-
+  Terraform resource for managing an AWS DataZone Glossary.
+---
+# Resource: aws_datazone_glossary
+
+Terraform resource for managing an AWS DataZone Glossary.
+
+## Example Usage
+
+```terraform
+
+resource "aws_iam_role" "domain_execution_role" {
+  name = "example_name"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+        Effect = "Allow"
+        Principal = {
+          Service = "datazone.amazonaws.com"
+        }
+      },
+      {
+        Action = ["sts:AssumeRole", "sts:TagSession"]
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudformation.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  inline_policy {
+    name = "example_name"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "datazone:*",
+            "ram:*",
+            "sso:*",
+            "kms:*",
+          ]
+          Effect   = "Allow"
+          Resource = "*"
+        },
+      ]
+    })
+  }
+}
+
+
+resource "aws_datazone_domain" "test" {
+  name                  = "example_name"
+  domain_execution_role = aws_iam_role.domain_execution_role.arn
+}
+
+resource "aws_security_group" "test" {
+  name = "example_name"
+}
+
+resource "aws_datazone_project" "test" {
+  domain_identifier   = aws_datazone_domain.test.id
+  glossary_terms      = ["2N8w6XJCwZf"]
+  name                = "example_name"
+  description         = "desc"
+  skip_deletion_check = true
+}
+
+
+resource "aws_datazone_glossary" "test" {
+  client_token              = "example_token"
+  description               = "description"
+  name                      = "example_name"
+  owning_project_identifier = aws_datazone_project.test.id
+  status                    = "DISABLED"
+  domain_identifier         = aws_datazone_project.test.domain_identifier
+}
+```
+
+
+### Basic Usage
+
+
+
+```terraform
+resource "aws_datazone_glossary" "test" {
+  client_token              = "example_token"
+  description               = "description"
+  name                      = "example_name"
+  owning_project_identifier = aws_datazone_project.test.id
+  status                    = "DISABLED"
+  domain_identifier         = aws_datazone_project.test.domain_identifier
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `client_token` - (Required) Unique case-sensitive identifier that is provided to ensure the idempotency of the request. Must follow regex pattern of ^[\x21-\x7E]+$ and have length between 1 and 128.
+* `name` - (Required) Name of the glossary. Must have length between 1 and 256.
+* `owning_project_identifier` - (Required) ID of the project that owns business glossary. Must follow regex of ^[a-zA-Z0-9_-]{1,36}$.
+
+
+
+The following arguments are optional:
+
+* `description` - (Optional) Description of the glossary. Must have a length between 0 and 4096.
+* `status` - (Optional) Status of business glossary. Valid values are DISABLED and ENABLED.
+
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `id` - Id of the Glossary.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DataZone Glossary using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_datazone_glossary.example
+  id = "domain-id,glossary-id,owning_project_identifier"
+}
+```
+
+Using `terraform import`, import DataZone Glossary using the `example_id_arg`. For example:
+
+```console
+% terraform import aws_datazone_glossary.example domain-id,glossary-id,owning-project-identifier
+```

--- a/website/docs/r/datazone_glossary.html.markdown
+++ b/website/docs/r/datazone_glossary.html.markdown
@@ -74,7 +74,6 @@ resource "aws_datazone_project" "test" {
 
 
 resource "aws_datazone_glossary" "test" {
-  client_token              = "example_token"
   description               = "description"
   name                      = "example_name"
   owning_project_identifier = aws_datazone_project.test.id

--- a/website/docs/r/datazone_glossary.html.markdown
+++ b/website/docs/r/datazone_glossary.html.markdown
@@ -87,7 +87,6 @@ resource "aws_datazone_glossary" "test" {
 
 ```terraform
 resource "aws_datazone_glossary" "test" {
-  client_token              = "example_token"
   description               = "description"
   name                      = "example_name"
   owning_project_identifier = aws_datazone_project.test.id
@@ -100,7 +99,6 @@ resource "aws_datazone_glossary" "test" {
 
 The following arguments are required:
 
-* `client_token` - (Required) Unique case-sensitive identifier that is provided to ensure the idempotency of the request. Must follow regex pattern of ^[\x21-\x7E]+$ and have length between 1 and 128.
 * `name` - (Required) Name of the glossary. Must have length between 1 and 256.
 * `owning_project_identifier` - (Required) ID of the project that owns business glossary. Must follow regex of ^[a-zA-Z0-9_-]{1,36}$.
 

--- a/website/docs/r/datazone_glossary.html.markdown
+++ b/website/docs/r/datazone_glossary.html.markdown
@@ -55,7 +55,6 @@ resource "aws_iam_role" "domain_execution_role" {
   }
 }
 
-
 resource "aws_datazone_domain" "test" {
   name                  = "example_name"
   domain_execution_role = aws_iam_role.domain_execution_role.arn
@@ -84,10 +83,7 @@ resource "aws_datazone_glossary" "test" {
 }
 ```
 
-
 ### Basic Usage
-
-
 
 ```terraform
 resource "aws_datazone_glossary" "test" {
@@ -108,8 +104,6 @@ The following arguments are required:
 * `name` - (Required) Name of the glossary. Must have length between 1 and 256.
 * `owning_project_identifier` - (Required) ID of the project that owns business glossary. Must follow regex of ^[a-zA-Z0-9_-]{1,36}$.
 
-
-
 The following arguments are optional:
 
 * `description` - (Optional) Description of the glossary. Must have a length between 0 and 4096.
@@ -122,14 +116,6 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `id` - Id of the Glossary.
 
-## Timeouts
-
-[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
-
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
-
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DataZone Glossary using the `example_id_arg`. For example:
@@ -141,7 +127,7 @@ import {
 }
 ```
 
-Using `terraform import`, import DataZone Glossary using the `example_id_arg`. For example:
+Using `terraform import`, import DataZone Glossary using the import Datazone Glossary using a comma-delimited string combining the domain id, glossary id, and the id of the project it's under. For example:
 
 ```console
 % terraform import aws_datazone_glossary.example domain-id,glossary-id,owning-project-identifier


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resource will allow practitioners to create DataZone Glossary for a DataZone Domain via Terraform.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #37423 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccDataZoneGlossary PKG=datazone
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/datazone/... -v -count 1 -parallel 20 -run='TestAccDataZoneGlossary'  -timeout 360m
=== RUN   TestAccDataZoneGlossary_basic
=== PAUSE TestAccDataZoneGlossary_basic
=== RUN   TestAccDataZoneGlossary_update
=== PAUSE TestAccDataZoneGlossary_update
=== RUN   TestAccDataZoneGlossary_disappears
=== PAUSE TestAccDataZoneGlossary_disappears
=== CONT  TestAccDataZoneGlossary_basic
=== CONT  TestAccDataZoneGlossary_disappears
=== CONT  TestAccDataZoneGlossary_update
--- PASS: TestAccDataZoneGlossary_disappears (27.28s)
--- PASS: TestAccDataZoneGlossary_basic (28.41s)
--- PASS: TestAccDataZoneGlossary_update (38.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datazone   44.480s
```
