### PR TITLE
[Docs] Improve route_53_zone and route_53_zone_association examples

### DIFF
--- a/website/docs/r/route53_zone.html.markdown
+++ b/website/docs/r/route53_zone.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Route53 Hosted Zone. For managing Domain Name System Security Extensions (DNSSEC), see the [`aws_route53_key_signing_key`](route53_key_signing_key.html) and [`aws_route53_hosted_zone_dnssec`](route53_hosted_zone_dnssec.html) resources.
 
+~> **NOTE:** Terraform provides both exclusive VPC associations defined in-line in this resource via `vpc` configuration blocks and a separate [Zone VPC Association](/docs/providers/aws/r/route53_zone_association.html) resource. At this time, you cannot use in-line VPC associations in conjunction with any `aws_route53_zone_association` resources with the same zone ID otherwise it will cause a perpetual difference in plan output. You can optionally use the generic Terraform resource [lifecycle configuration block](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html) with `ignore_changes` to manage additional associations via the `aws_route53_zone_association` resource.
+
 ## Example Usage
 
 ### Public Zone
@@ -50,9 +52,7 @@ resource "aws_route53_record" "dev-ns" {
 
 ### Private Zone
 
-~> **NOTE:** Terraform provides both exclusive VPC associations defined in-line in this resource via `vpc` configuration blocks and a separate [Zone VPC Association](/docs/providers/aws/r/route53_zone_association.html) resource. At this time, you cannot use in-line VPC associations in conjunction with any `aws_route53_zone_association` resources with the same zone ID otherwise it will cause a perpetual difference in plan output. You can optionally use the generic Terraform resource [lifecycle configuration block](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html) with `ignore_changes` to manage additional associations via the `aws_route53_zone_association` resource.
-
-~> **NOTE:** Private zones require at least one VPC association at all times.
+Make a private zone by associating a VPC either inline:
 
 ```terraform
 resource "aws_route53_zone" "private" {
@@ -61,6 +61,19 @@ resource "aws_route53_zone" "private" {
   vpc {
     vpc_id = aws_vpc.example.id
   }
+}
+```
+
+or with a separate [Zone VPC Association](/docs/providers/aws/r/route53_zone_association.html) resource:
+
+```terraform
+resource "aws_route53_zone" "private" {
+  name = "example.com"
+}
+
+resource "aws_route53_zone_association" "private" {
+  zone_id = aws_route53_zone.private.zone_id
+  vpc_id  aws_vpc.example.id
 }
 ```
 

--- a/website/docs/r/route53_zone_association.html.markdown
+++ b/website/docs/r/route53_zone_association.html.markdown
@@ -16,6 +16,51 @@ Manages a Route53 Hosted Zone VPC association. VPC associations can only be made
 
 ## Example Usage
 
+### Cross-account authorization
+
+```terraform
+provider "aws" {
+}
+
+provider "aws" {
+  alias = "secondary"
+}
+
+resource "aws_vpc" "primary" {
+  cidr_block           = "10.6.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_vpc" "secondary" {
+  provider             = aws.secondary
+  cidr_block           = "10.7.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_route53_zone" "example" {
+  name = "example.com"
+}
+
+resource "aws_route53_zone_association" "primary" {
+  zone_id = aws_route53_zone.example.zone_id
+  vpc_id  = aws_vpc.primary.id
+}
+
+resource "aws_route53_vpc_association_authorization" "example" {
+  vpc_id  = aws_vpc.secondary.id
+  zone_id = aws_route53_zone.example.id
+}
+
+resource "aws_route53_zone_association" "secondary" {
+  provider = aws.secondary
+  zone_id  = aws_route53_zone.example.zone_id
+  vpc_id   = aws_vpc.secondary.id
+}
+```
+
+### With ignore_changes lifecycle
 ```terraform
 resource "aws_vpc" "primary" {
   cidr_block           = "10.6.0.0/16"


### PR DESCRIPTION
### Description
I was using the example code and I believe it could be a bit more clearer. 
1. Having the notes under the description and not in-line with the examples, like often the case in other docs in this repo. 
2. Making it more explicit what makes an hosted zone a _private_ hosted zone.
3. Adding an example for cross-account zone association.

I am aware this is opinionated, so feel free to disagree. Let's work together to make the best of it.

### Relations
NA

### References
NA

### Output from Acceptance Testing
NA
