### PR TITLE
b/aws_vpc_ipam_pool_cidr_allocation-read `description` and `netmask_length`

### DIFF
--- a/.changelog/38618.txt
+++ b/.changelog/38618.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_vpc_ipam_pool_cidr_allocation: Set `description` on Read
+```
+
+```release-note:bug
+resource/aws_vpc_ipam_pool_cidr_allocation: Set `netmask_length` on Read
+```

--- a/internal/service/ec2/ipam_pool_cidr_allocation.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation.go
@@ -167,6 +167,7 @@ func resourceIPAMPoolCIDRAllocationRead(ctx context.Context, d *schema.ResourceD
 	d.Set("cidr", allocation.Cidr)
 	d.Set("ipam_pool_allocation_id", allocation.IpamPoolAllocationId)
 	d.Set("ipam_pool_id", poolID)
+	d.Set(names.AttrDescription, allocation.Description)
 	d.Set(names.AttrResourceID, allocation.ResourceId)
 	d.Set(names.AttrResourceOwner, allocation.ResourceOwner)
 	d.Set(names.AttrResourceType, allocation.ResourceType)

--- a/internal/service/ec2/ipam_pool_cidr_allocation.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation.go
@@ -166,13 +166,13 @@ func resourceIPAMPoolCIDRAllocationRead(ctx context.Context, d *schema.ResourceD
 		return sdkdiag.AppendErrorf(diags, "reading IPAM Pool CIDR Allocation (%s): %s", d.Id(), err)
 	}
 
-	d.Set("cidr", allocation.Cidr)
+	cidr := aws.ToString(allocation.Cidr)
+	d.Set("cidr", cidr)
+	d.Set(names.AttrDescription, allocation.Description)
 	d.Set("ipam_pool_allocation_id", allocation.IpamPoolAllocationId)
 	d.Set("ipam_pool_id", poolID)
-	cidr := aws.ToString(allocation.Cidr)
 	d.Set("netmask_length", nil)
-	parts := strings.Split(cidr, "/")
-	if len(parts) == 2 {
+	if parts := strings.Split(cidr, "/"); len(parts) == 2 {
 		if v, err := strconv.Atoi(parts[1]); err == nil {
 			d.Set("netmask_length", v)
 		} else {
@@ -181,7 +181,7 @@ func resourceIPAMPoolCIDRAllocationRead(ctx context.Context, d *schema.ResourceD
 	} else {
 		log.Printf("[WARN] Invalid CIDR block format: %s", cidr)
 	}
-	d.Set(names.AttrDescription, allocation.Description)
+
 	d.Set(names.AttrResourceID, allocation.ResourceId)
 	d.Set(names.AttrResourceOwner, allocation.ResourceOwner)
 	d.Set(names.AttrResourceType, allocation.ResourceType)

--- a/internal/service/ec2/ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation_test.go
@@ -71,7 +71,7 @@ func TestAccIPAMPoolCIDRAllocation_ipv4Description(t *testing.T) {
 				Config: testAccIPAMPoolCIDRAllocationConfig_description(originalDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPAMPoolCIDRAllocationExists(ctx, resourceName, &allocationV1),
-					resource.TestCheckResourceAttr(resourceName, "description", originalDescription),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, originalDescription),
 				),
 			},
 			{
@@ -84,7 +84,7 @@ func TestAccIPAMPoolCIDRAllocation_ipv4Description(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPAMPoolCIDRAllocationExists(ctx, resourceName, &allocationV2),
 					testAccCheckIPAMPoolCIDRAllocationRecreated(&allocationV1, &allocationV2),
-					resource.TestCheckResourceAttr(resourceName, "description", updatedDescription),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, updatedDescription),
 				),
 			},
 		},

--- a/internal/service/ec2/ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation_test.go
@@ -42,6 +42,7 @@ func TestAccIPAMPoolCIDRAllocation_ipv4Basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, names.AttrID, regexache.MustCompile(`^ipam-pool-alloc-[0-9a-f]+_ipam-pool(-[0-9a-f]+)$`)),
 					resource.TestMatchResourceAttr(resourceName, "ipam_pool_allocation_id", regexache.MustCompile(`^ipam-pool-alloc-[0-9a-f]+$`)),
 					resource.TestCheckResourceAttrPair(resourceName, "ipam_pool_id", "aws_vpc_ipam_pool.test", names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "netmask_length", strings.Split(cidr, "/")[1]),
 				),
 			},
 			{

--- a/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
@@ -87,7 +87,7 @@ This resource supports the following arguments:
 * `description` - (Optional, Forces new resource) The description for the allocation.
 * `disallowed_cidrs` - (Optional) Exclude a particular CIDR range from being returned by the pool.
 * `ipam_pool_id` - (Required) The ID of the pool to which you want to assign a CIDR.
-* `netmask_length` - (Optional) The netmask length of the CIDR you would like to allocate to the IPAM pool. Valid Values: `0-128`.
+* `netmask_length` - (Optional, Forces new resource) The netmask length of the CIDR you would like to allocate to the IPAM pool. Valid Values: `0-128`.
 
 ## Attribute Reference
 

--- a/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
@@ -84,7 +84,7 @@ resource "aws_vpc_ipam" "example" {
 This resource supports the following arguments:
 
 * `cidr` - (Optional) The CIDR you want to assign to the pool.
-* `description` - (Optional) The description for the allocation.
+* `description` - (Optional, Forces new resource) The description for the allocation.
 * `disallowed_cidrs` - (Optional) Exclude a particular CIDR range from being returned by the pool.
 * `ipam_pool_id` - (Required) The ID of the pool to which you want to assign a CIDR.
 * `netmask_length` - (Optional) The netmask length of the CIDR you would like to allocate to the IPAM pool. Valid Values: `0-128`.

--- a/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
@@ -83,10 +83,10 @@ resource "aws_vpc_ipam" "example" {
 
 This resource supports the following arguments:
 
-* `cidr` - (Optional) The CIDR you want to assign to the pool.
+* `cidr` - (Optional, Forces new resource) The CIDR you want to assign to the pool.
 * `description` - (Optional, Forces new resource) The description for the allocation.
-* `disallowed_cidrs` - (Optional) Exclude a particular CIDR range from being returned by the pool.
-* `ipam_pool_id` - (Required) The ID of the pool to which you want to assign a CIDR.
+* `disallowed_cidrs` - (Optional, Forces new resource) Exclude a particular CIDR range from being returned by the pool.
+* `ipam_pool_id` - (Required, Forces new resource) The ID of the pool to which you want to assign a CIDR.
 * `netmask_length` - (Optional, Forces new resource) The netmask length of the CIDR you would like to allocate to the IPAM pool. Valid Values: `0-128`.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Practitioner-facing changes
- Read `description` and `netmask_length` into state. This allows the resource to be imported when those arguments are specified
- Update documentation to specify arguments as force new

Internal changes
- Test for `description` create, import, re-create
- Test for `netmask_length` import, re-create
- Test for `netmask_length` attribute when `cidr` argument is used in create

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38613
Closes #38614

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccIPAMPoolCIDRAllocation_' PKG=ec2 ACCTEST_PARALLELISM=1
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ec2/... -v -count 1 -parallel 1  -run=TestAccIPAMPoolCIDRAllocation_ -timeout 360m
=== RUN   TestAccIPAMPoolCIDRAllocation_ipv4Basic
=== PAUSE TestAccIPAMPoolCIDRAllocation_ipv4Basic
=== RUN   TestAccIPAMPoolCIDRAllocation_ipv4Description
=== PAUSE TestAccIPAMPoolCIDRAllocation_ipv4Description
=== RUN   TestAccIPAMPoolCIDRAllocation_disappears
=== PAUSE TestAccIPAMPoolCIDRAllocation_disappears
=== RUN   TestAccIPAMPoolCIDRAllocation_ipv4BasicNetmask
=== PAUSE TestAccIPAMPoolCIDRAllocation_ipv4BasicNetmask
=== RUN   TestAccIPAMPoolCIDRAllocation_ipv4DisallowedCIDR
=== PAUSE TestAccIPAMPoolCIDRAllocation_ipv4DisallowedCIDR
=== RUN   TestAccIPAMPoolCIDRAllocation_multiple
=== PAUSE TestAccIPAMPoolCIDRAllocation_multiple
=== RUN   TestAccIPAMPoolCIDRAllocation_differentRegion
=== PAUSE TestAccIPAMPoolCIDRAllocation_differentRegion
=== CONT  TestAccIPAMPoolCIDRAllocation_ipv4Basic
--- PASS: TestAccIPAMPoolCIDRAllocation_ipv4Basic (90.99s)
=== CONT  TestAccIPAMPoolCIDRAllocation_ipv4DisallowedCIDR
--- PASS: TestAccIPAMPoolCIDRAllocation_ipv4DisallowedCIDR (89.77s)
=== CONT  TestAccIPAMPoolCIDRAllocation_differentRegion
--- PASS: TestAccIPAMPoolCIDRAllocation_differentRegion (90.64s)
=== CONT  TestAccIPAMPoolCIDRAllocation_multiple
--- PASS: TestAccIPAMPoolCIDRAllocation_multiple (144.52s)
=== CONT  TestAccIPAMPoolCIDRAllocation_disappears
--- PASS: TestAccIPAMPoolCIDRAllocation_disappears (96.31s)
=== CONT  TestAccIPAMPoolCIDRAllocation_ipv4BasicNetmask
--- PASS: TestAccIPAMPoolCIDRAllocation_ipv4BasicNetmask (118.75s)
=== CONT  TestAccIPAMPoolCIDRAllocation_ipv4Description
--- PASS: TestAccIPAMPoolCIDRAllocation_ipv4Description (119.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        750.878s

...
```
