### PR TITLE
td/appstream: use `image_builder` datasource in tests

### DIFF
--- a/internal/service/appstream/fleet_test.go
+++ b/internal/service/appstream/fleet_test.go
@@ -411,23 +411,32 @@ func testAccCheckFleetDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
+const testAccFleetConfig_base = `
+data "aws_appstream_image" "test" {
+  name_regex  = "^Amazon-AppStream2-Sample-Image.*$"
+  type        = "PUBLIC"
+  most_recent = true
+}
+`
+
 func testAccFleetConfig_basic(name, instanceType string) string {
 	// "Amazon-AppStream2-Sample-Image-03-11-2023" is not available in GovCloud
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccFleetConfig_base, fmt.Sprintf(`
 resource "aws_appstream_fleet" "test" {
   name          = %[1]q
-  image_name    = "Amazon-AppStream2-Sample-Image-03-11-2023"
+  image_name    = data.aws_appstream_image.test.name
   instance_type = %[2]q
 
   compute_capacity {
     desired_instances = 1
   }
 }
-`, name, instanceType)
+`, name, instanceType))
 }
 
 func testAccFleetConfig_complete(name, description, fleetType, instanceType string) string {
 	return acctest.ConfigCompose(
+		testAccFleetConfig_base,
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
 data "aws_region" "current" {}
@@ -446,7 +455,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_appstream_fleet" "test" {
   name      = %[1]q
-  image_arn = "arn:${data.aws_partition.current.partition}:appstream:${data.aws_region.current.name}::image/Amazon-AppStream2-Sample-Image-03-11-2023"
+  image_arn = data.aws_appstream_image.test.arn
 
   compute_capacity {
     desired_instances = 1
@@ -469,6 +478,7 @@ resource "aws_appstream_fleet" "test" {
 
 func testAccFleetConfig_completeNoStopping(name, description, fleetType, instanceType, displayName string) string {
 	return acctest.ConfigCompose(
+		testAccFleetConfig_base,
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
@@ -484,7 +494,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_appstream_fleet" "test" {
   name       = %[1]q
-  image_name = "Amazon-AppStream2-Sample-Image-03-11-2023"
+  image_name = data.aws_appstream_image.test.name
 
   compute_capacity {
     desired_instances = 1
@@ -507,6 +517,7 @@ resource "aws_appstream_fleet" "test" {
 
 func testAccFleetConfig_tags(name, description, fleetType, instanceType, displayName string) string {
 	return acctest.ConfigCompose(
+		testAccFleetConfig_base,
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
@@ -522,7 +533,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_appstream_fleet" "test" {
   name       = %[1]q
-  image_name = "Amazon-AppStream2-Sample-Image-03-11-2023"
+  image_name = data.aws_appstream_image.test.name
 
   compute_capacity {
     desired_instances = 1
@@ -549,10 +560,10 @@ resource "aws_appstream_fleet" "test" {
 
 func testAccFleetConfig_emptyDomainJoin(name, instanceType, empty string) string {
 	// "Amazon-AppStream2-Sample-Image-03-11-2023" is not available in GovCloud
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccFleetConfig_base, fmt.Sprintf(`
 resource "aws_appstream_fleet" "test" {
   name          = %[1]q
-  image_name    = "Amazon-AppStream2-Sample-Image-03-11-2023"
+  image_name    = data.aws_appstream_image.test.name
   instance_type = %[2]q
 
   compute_capacity {
@@ -564,7 +575,7 @@ resource "aws_appstream_fleet" "test" {
     organizational_unit_distinguished_name = %[3]s
   }
 }
-`, name, instanceType, empty)
+`, name, instanceType, empty))
 }
 
 func testAccFleetConfig_multiSession(name, instanceType string, desiredSessions, maxSessionsPerInstance int) string {
@@ -585,9 +596,15 @@ resource "aws_subnet" "test" {
   vpc_id            = aws_vpc.test.id
 }
 
+data "aws_appstream_image" "test" {
+  name_regex  = "^AppStream-WinServer.*$"
+  type        = "PUBLIC"
+  most_recent = true
+}
+
 resource "aws_appstream_fleet" "test" {
   name      = %[1]q
-  image_arn = "arn:${data.aws_partition.current.partition}:appstream:${data.aws_region.current.name}::image/AppStream-WinServer2019-01-26-2024"
+  image_arn = data.aws_appstream_image.test.arn
 
   compute_capacity {
     desired_sessions = %[3]d

--- a/internal/service/appstream/image_builder_test.go
+++ b/internal/service/appstream/image_builder_test.go
@@ -54,7 +54,6 @@ func TestAccAppStreamImageBuilder_withIAMRole(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appstream_image_builder.test"
 	instanceType := "stream.standard.medium"
-	imageName := "AppStream-WinServer2022-06-17-2024"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -64,7 +63,7 @@ func TestAccAppStreamImageBuilder_withIAMRole(t *testing.T) {
 		CheckDestroy:             testAccCheckImageBuilderDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageBuilderConfig_withIAMRole(rName, imageName, instanceType),
+				Config: testAccImageBuilderConfig_withIAMRole(rName, instanceType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageBuilderExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -203,7 +202,6 @@ func TestAccAppStreamImageBuilder_imageARN(t *testing.T) {
 	resourceName := "aws_appstream_image_builder.test"
 	// imageName selected from the available AWS Managed AppStream 2.0 Base Images
 	// Reference: https://docs.aws.amazon.com/appstream2/latest/developerguide/base-image-version-history.html
-	imageName := "AppStream-WinServer2022-06-17-2024"
 	instanceType := "stream.standard.small"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -214,10 +212,10 @@ func TestAccAppStreamImageBuilder_imageARN(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppStreamServiceID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImageBuilderConfig_byARN(rName, imageName, instanceType),
+				Config: testAccImageBuilderConfig_byARN(rName, instanceType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageBuilderExists(ctx, resourceName),
-					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, "image_arn", "appstream", fmt.Sprintf("image/%s", imageName)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 				),
 			},
 			{
@@ -274,20 +272,28 @@ func testAccCheckImageBuilderDestroy(ctx context.Context) resource.TestCheckFunc
 	}
 }
 
+const testAccImageBuilderConfig_base = `
+data "aws_appstream_image" "test" {
+  name_regex  = "^AppStream-WinServer.*$"
+  type        = "PUBLIC"
+  most_recent = true
+}
+`
+
 func testAccImageBuilderConfig_basic(instanceType, rName string) string {
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccImageBuilderConfig_base, fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name    = "AppStream-WinServer2022-06-17-2024"
+  image_name    = data.aws_appstream_image.test.name
   instance_type = %[1]q
   name          = %[2]q
 }
-`, instanceType, rName)
+`, instanceType, rName))
 }
 
 func testAccImageBuilderConfig_complete(rName, description, instanceType string) string {
-	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccImageBuilderConfig_base, acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name                     = "AppStream-WinServer2022-06-17-2024"
+  image_name                     = data.aws_appstream_image.test.name
   name                           = %[1]q
   description                    = %[2]q
   enable_default_internet_access = false
@@ -300,9 +306,9 @@ resource "aws_appstream_image_builder" "test" {
 }
 
 func testAccImageBuilderConfig_tags1(instanceType, rName, key, value string) string {
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccImageBuilderConfig_base, fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name    = "AppStream-WinServer2022-06-17-2024"
+  image_name    = data.aws_appstream_image.test.name
   instance_type = %[1]q
   name          = %[2]q
 
@@ -310,13 +316,13 @@ resource "aws_appstream_image_builder" "test" {
     %[3]q = %[4]q
   }
 }
-`, instanceType, rName, key, value)
+`, instanceType, rName, key, value))
 }
 
 func testAccImageBuilderConfig_tags2(instanceType, rName, key1, value1, key2, value2 string) string {
-	return fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccImageBuilderConfig_base, fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
-  image_name    = "AppStream-WinServer2022-06-17-2024"
+  image_name    = data.aws_appstream_image.test.name
   instance_type = %[1]q
   name          = %[2]q
 
@@ -325,28 +331,28 @@ resource "aws_appstream_image_builder" "test" {
     %[5]q = %[6]q
   }
 }
-`, instanceType, rName, key1, value1, key2, value2)
+`, instanceType, rName, key1, value1, key2, value2))
 }
 
-func testAccImageBuilderConfig_byARN(rName, imageName, instanceType string) string {
-	return fmt.Sprintf(`
+func testAccImageBuilderConfig_byARN(rName, instanceType string) string {
+	return acctest.ConfigCompose(testAccImageBuilderConfig_base, fmt.Sprintf(`
 data "aws_partition" "current" {}
 
 resource "aws_appstream_image_builder" "test" {
-  image_arn     = "arn:${data.aws_partition.current.partition}:appstream:%[1]s::image/%[2]s"
-  instance_type = %[3]q
-  name          = %[4]q
+  image_arn     = data.aws_appstream_image.test.arn
+  instance_type = %[1]q
+  name          = %[2]q
 }
-`, acctest.Region(), imageName, instanceType, rName)
+`, instanceType, rName))
 }
 
-func testAccImageBuilderConfig_withIAMRole(rName, imageName, instanceType string) string {
-	return fmt.Sprintf(`
+func testAccImageBuilderConfig_withIAMRole(rName, instanceType string) string {
+	return acctest.ConfigCompose(testAccImageBuilderConfig_base, fmt.Sprintf(`
 resource "aws_appstream_image_builder" "test" {
   name          = %[1]q
   instance_type = %[2]q
   iam_role_arn  = aws_iam_role.test.arn
-  image_name    = %[3]q
+  image_name    = data.aws_appstream_image.test.name
 }
 
 resource "aws_iam_role" "test" {
@@ -364,5 +370,5 @@ data "aws_iam_policy_document" "test" {
     }
   }
 }
-`, rName, instanceType, imageName)
+`, rName, instanceType))
 }

--- a/internal/service/appstream/image_data_source_test.go
+++ b/internal/service/appstream/image_data_source_test.go
@@ -50,11 +50,11 @@ func TestAccAppStreamImageDataSource_basic(t *testing.T) {
 
 // name        = "AppStream-WinServer2019-06-17-2024"
 func testAccImageDataSourceConfig_basic() string {
-	return (`
+	return `
 data "aws_appstream_image" "test" {
   name_regex  = "^AppStream-WinServer.*$"
   type        = "PUBLIC"
   most_recent = true
 }
-`)
+`
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccAppStreamImageBuilder_" PKG=appstream

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/appstream/... -v -count 1 -parallel 20 -run=TestAccAppStreamImageBuilder_ -timeout 360m
--- PASS: TestAccAppStreamImageBuilder_withIAMRole (772.60s)
--- PASS: TestAccAppStreamImageBuilder_basic (777.34s)
--- PASS: TestAccAppStreamImageBuilder_imageARN (802.56s)
--- PASS: TestAccAppStreamImageBuilder_disappears (812.80s)
--- PASS: TestAccAppStreamImageBuilder_tags (821.41s)
--- PASS: TestAccAppStreamImageBuilder_complete (1684.72s)
PASS
ok   	     github.com/hashicorp/terraform-provider-aws/internal/service/appstream	1690.603s
```

```console
% make testacc TESTARGS="-run=TestAccAppStreamFleet_" PKG=appstream

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/appstream/... -v -count 1 -parallel 20  -run=TestAccAppStreamFleet_ -timeout 360m
--- PASS: TestAccAppStreamFleet_emptyDomainJoin (797.53s)
--- PASS: TestAccAppStreamFleet_disappears (800.49s)
--- PASS: TestAccAppStreamFleet_withTags (892.75s)
--- PASS: TestAccAppStreamFleet_basic (910.98s)
--- PASS: TestAccAppStreamFleet_completeWithoutStop (972.22s)
--- PASS: TestAccAppStreamFleet_multiSession (1016.64s)
--- PASS: TestAccAppStreamFleet_completeWithStop (1950.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/appstream	1956.201s
```
