### PR TITLE
[New Resource]: Image Deregistration Protection

### DIFF
--- a/internal/service/ec2/image_deregistration_protection.go
+++ b/internal/service/ec2/image_deregistration_protection.go
@@ -1,0 +1,129 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+)
+
+// @SDKDataSource("aws_ec2_image_deregistration_protection", name="Image Deregistration Protection")
+func resourceImageDeregistrationProtection() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceImageDeregistrationProtectionRequestCreate,
+		ReadWithoutTimeout:   resourceImageDeregistrationProtectionRequestRead,
+		DeleteWithoutTimeout: resourceImageDeregistrationProtectionRequestDelete,
+		UpdateWithoutTimeout: resourceImageDeregistrationProtectionRequestUpdate,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"ami_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"with_cooldown": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"deregistration_protection": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceImageDeregistrationProtectionRequestCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+
+	input := &ec2.EnableImageDeregistrationProtectionInput{
+		ImageId:      aws.String(d.Get("ami_id").(string)),
+		WithCooldown: aws.Bool(d.Get("with_cooldown").(bool)),
+	}
+	_, err := conn.EnableImageDeregistrationProtection(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "Enabling Image Deregistration Protection for AMI ID (%s): %s", d.Get("ami_id").(string), err)
+	}
+	d.SetId(d.Get("ami_id").(string))
+	return append(diags, resourceImageDeregistrationProtectionRequestRead(ctx, d, meta)...)
+}
+
+func resourceImageDeregistrationProtectionRequestRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+
+	output, err := checkEc2DeregistrationProtection(ctx, conn, &ec2.DescribeImagesInput{
+		ImageIds: []string{d.Id()},
+	})
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "Reading the ami id (%s): %s", d.Id(), err)
+	}
+
+	d.Set("ami_id", d.Id())
+	d.Set("with_cooldown", d.Get("with_cooldown").(bool))
+	d.Set("deregistration_protection", output.Images[0].DeregistrationProtection)
+
+	return diags
+}
+
+func resourceImageDeregistrationProtectionRequestUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+
+	input := &ec2.EnableImageDeregistrationProtectionInput{
+		ImageId:      aws.String(d.Id()),
+		WithCooldown: aws.Bool(d.Get("with_cooldown").(bool)),
+	}
+
+	_, err := conn.EnableImageDeregistrationProtection(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "Updating Image Deregistration Protection for AMI ID (%s): %s", d.Get("ami_id").(string), err)
+	}
+	return append(diags, resourceImageDeregistrationProtectionRequestRead(ctx, d, meta)...)
+}
+
+func resourceImageDeregistrationProtectionRequestDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+
+	input := &ec2.DisableImageDeregistrationProtectionInput{
+		ImageId: aws.String(d.Id()),
+	}
+	log.Printf("[INFO] Disabling image deregistration protection for ami id: %s", d.Id())
+
+	_, err := conn.DisableImageDeregistrationProtection(ctx, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "Disabling Image Deregistration Protection for AMI ID (%s): %s", d.Id(), err)
+	}
+	return diags
+}
+
+func checkEc2DeregistrationProtection(ctx context.Context, conn *ec2.Client, input *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+	output, err := conn.DescribeImages(ctx, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/internal/service/ec2/image_deregistration_protection_test.go
+++ b/internal/service/ec2/image_deregistration_protection_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccEc2ImageDeregistrationProtection_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ec2_image_deregistration_protection.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAMIDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEc2ImageDeregistrationProtectionBasic(rName, "t2.medium"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "with_cooldown", "false"),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValueAtPath(
+						"deregistration_protection",
+						tfjsonpath.New("deregistration_protection"),
+						knownvalue.StringRegexp(regexp.MustCompile("enabled-without-cooldown")),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccEc2ImageDeregistrationProtectionBasic(rName, instanceType string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		testAccInstanceVPCConfig(rName, false, 0),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami       = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  subnet_id = aws_subnet.test.id
+
+  instance_type = %[1]q
+
+  tags = {
+    Name = %[2]q
+  }
+}
+
+resource "aws_ami_from_instance" "test" {
+  name               = "terraform-example-ami"
+  source_instance_id = aws_instance.test.id
+}
+
+resource "aws_ec2_image_deregistration_protection" "test" {
+  ami_id = aws_ami_from_instance.test.id
+}
+
+output "deregistration_protection_output" {
+  value = aws_ec2_image_deregistration_protection.test
+}	
+`, instanceType, rName))
+}

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -725,6 +725,11 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Name:     "Image Block Public Access",
 		},
 		{
+			Factory:  resourceImageDeregistrationProtection,
+			TypeName: "aws_ec2_image_deregistration_protection",
+			Name:     "Image Deregistration Protection",
+		},
+		{
 			Factory:  resourceInstanceState,
 			TypeName: "aws_ec2_instance_state",
 			Name:     "Instance State",

--- a/website/docs/r/ec2_image_deregistration_protection.html.markdown
+++ b/website/docs/r/ec2_image_deregistration_protection.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "EC2 (Elastic Compute Cloud)"
+layout: "aws"
+page_title: "AWS: aws_ec2_image_deregistration_protection"
+description: |-
+  Terraform resource for managing an AWS EC2 (Elastic Compute Cloud) Image Deregistration Protection.
+---
+
+# Resource: aws_ec2_image_deregistration_protection
+
+Terraform resource for managing an AWS EC2 (Elastic Compute Cloud) Image Deregistration Protection. This prevents AMIs from being deleted.
+
+## Example Usuage
+
+```terraform
+resource "aws_ec2_image_deregistration_protection" "example" {
+  ami_id = "ami-odb953344c964484b"
+  with_cooldown = true
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `ami_id` - (Required) AMI ID to which image deregistration protection has to be enabled or disabled.
+
+The following arguments are optional:
+
+* `with_cooldown` - (Optional) if true, enabled image deregistration proteciton. The default value is `false`.
+
+## Attribute Reference
+
+This resource exports the following attributes to the arguments above:
+
+* `id` - AMI ID to which image deregistration protection has to be enabled or disabled.
+* `deregistration_protection` - Image deregistration protection enabled or disabled, e.g., `enabled-without-cooldown` or `enabled-with-cooldown`.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `10m`)
+- `update` - (Default `10m`)
+- `delete` - (Default `15m`)
+
+## Import
+
+You cannot import this resource.


### PR DESCRIPTION
Description: 
aws_ec2_image_deregistration_protection resource added.
Acceptance tests added for aws_ec2_image_deregistration_protection resource.
Website documentation added for aws_ec2_image_deregistration_protection resource.

Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/37081