### PR TITLE
[Bugfix] r/aws_networkmanager_core_network: Fix network-function-groups null error with base policy

### DIFF
--- a/.changelog/38642.txt
+++ b/.changelog/38642.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_networkmanager_core_network: Fix null error when creating resource with `create_base_policy` argument
+```

--- a/.changelog/38642.txt
+++ b/.changelog/38642.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_networkmanager_core_network: Fix null error when creating resource with `create_base_policy` argument
+resource/aws_networkmanager_core_network: Fix `$.network-function-groups: null found, array expected` errors when creating resource with `create_base_policy` argument
 ```

--- a/internal/service/networkmanager/core_network_policy_model.go
+++ b/internal/service/networkmanager/core_network_policy_model.go
@@ -14,7 +14,7 @@ type coreNetworkPolicyDocument struct {
 	Version                  string                                     `json:"version,omitempty"`
 	CoreNetworkConfiguration *coreNetworkPolicyCoreNetworkConfiguration `json:"core-network-configuration"`
 	Segments                 []*coreNetworkPolicySegment                `json:"segments"`
-	NetworkFunctionGroups    []*coreNetworkPolicyNetworkFunctionGroup   `json:"network-function-groups"`
+	NetworkFunctionGroups    []*coreNetworkPolicyNetworkFunctionGroup   `json:"network-function-groups,omitempty"`
 	SegmentActions           []*coreNetworkPolicySegmentAction          `json:"segment-actions,omitempty"`
 	AttachmentPolicies       []*coreNetworkPolicyAttachmentPolicy       `json:"attachment-policies,omitempty"`
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fixes the `"$.network-function-groups: null found, array expected"` error when creating a `aws_networkmanager_core_network` resource with the `create_base_policy` argument set to true. Also fixes currently failing acceptance tests for the `aws_networkmanager_core_network` resource.

### Relations
Closes #38255

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Core network policy version parameters in AWS Cloud WAN: https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policies-json.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS='TestAccNetworkManagerCoreNetwork__*' PKG=networkmanager ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/networkmanager/... -v -count 1 -parallel 3 -run='TestAccNetworkManagerCoreNetwork__*'  -timeout 360m
=== RUN   TestAccNetworkManagerCoreNetwork_basic
=== PAUSE TestAccNetworkManagerCoreNetwork_basic
=== RUN   TestAccNetworkManagerCoreNetwork_disappears
=== PAUSE TestAccNetworkManagerCoreNetwork_disappears
=== RUN   TestAccNetworkManagerCoreNetwork_tags
=== PAUSE TestAccNetworkManagerCoreNetwork_tags
=== RUN   TestAccNetworkManagerCoreNetwork_description
=== PAUSE TestAccNetworkManagerCoreNetwork_description
=== RUN   TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithoutRegion
=== PAUSE TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithoutRegion
=== RUN   TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithRegion
=== PAUSE TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithRegion
=== RUN   TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithMultiRegion
=== PAUSE TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithMultiRegion
=== RUN   TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument
=== PAUSE TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument
=== RUN   TestAccNetworkManagerCoreNetwork_withoutPolicyDocumentUpdateToCreateBasePolicyDocument
=== PAUSE TestAccNetworkManagerCoreNetwork_withoutPolicyDocumentUpdateToCreateBasePolicyDocument
=== CONT  TestAccNetworkManagerCoreNetwork_basic
=== CONT  TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithRegion
=== CONT  TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument
--- PASS: TestAccNetworkManagerCoreNetwork_basic (321.47s)
=== CONT  TestAccNetworkManagerCoreNetwork_withoutPolicyDocumentUpdateToCreateBasePolicyDocument
--- PASS: TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithRegion (551.41s)
=== CONT  TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithMultiRegion
--- PASS: TestAccNetworkManagerCoreNetwork_withoutPolicyDocumentUpdateToCreateBasePolicyDocument (515.15s)
=== CONT  TestAccNetworkManagerCoreNetwork_description
--- PASS: TestAccNetworkManagerCoreNetwork_description (329.12s)
=== CONT  TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithoutRegion
--- PASS: TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithPolicyDocument (1407.00s)
=== CONT  TestAccNetworkManagerCoreNetwork_tags
--- PASS: TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithoutRegion (488.87s)
=== CONT  TestAccNetworkManagerCoreNetwork_disappears
--- PASS: TestAccNetworkManagerCoreNetwork_tags (337.57s)
--- PASS: TestAccNetworkManagerCoreNetwork_createBasePolicyDocumentWithMultiRegion (1363.04s)
--- PASS: TestAccNetworkManagerCoreNetwork_disappears (317.75s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager     1978.705s
```
