### PR TITLE
internal/framework/flex: add field name prefix option 

### DIFF
--- a/docs/data-handling-and-conversion.md
+++ b/docs/data-handling-and-conversion.md
@@ -189,14 +189,14 @@ AutoFlex uses field names to map between the source and target structures:
 1. An exact, case-sensitive match
 1. An exact, case-insensitive match
 1. Comparing plural and singular field names
-1. Adding a field name prefix set using the AutoFlex options function `flex.NewFieldNamePrefixOptionsFunc`, e.g. Lex v2 Intents in `internal/service/lexv2models/intent.go`
+1. Adding a field name prefix set using the AutoFlex options function `flex.WithFieldNamePrefix`, e.g. Lex v2 Intents in `internal/service/lexv2models/intent.go`
 
 By default, AutoFlex ignores fields with the name `Tags`, as AWS resource tags are [handled separately](./resource-tagging.md).
 Additional fields can be ignored and the `Tags` field can be included by passing optional `flex.AutoFlexOptionsFunc`s to `Flatten` or `Expand`.
-For example, to add an additional ignored field, use the `flex.NewIgnoredFieldAppendOptionsFunc` function constructor
+For example, to add an additional ignored field, use
 
 ```go
-diags := flex.Expand(ctx, source, &target, flex.NewIgnoredFieldAppendOptionsFunc("OtherField"))
+diags := flex.Expand(ctx, source, &target, flex.WithIgnoredFieldNamesAppend("OtherField"))
 ```
 
 This will ignore both `Tags` and `OtherField`.
@@ -204,7 +204,7 @@ To override existing ignored fields, use `flex.NewIgnoredFieldOptionsFunc`.
 For example, to include `Tags`, call
 
 ```go
-diags := flex.Expand(ctx, source, &target, flex.NewIgnoredFieldOptionsFunc([]string{}))
+diags := flex.Expand(ctx, source, &target, flex.WithIgnoredFieldNames([]string{}))
 ```
 
 In some cases, flattening and expanding need conditional handling.

--- a/docs/data-handling-and-conversion.md
+++ b/docs/data-handling-and-conversion.md
@@ -200,11 +200,11 @@ diags := flex.Expand(ctx, source, &target, flex.WithIgnoredFieldNamesAppend("Oth
 ```
 
 This will ignore both `Tags` and `OtherField`.
-To override existing ignored fields, use `flex.NewIgnoredFieldOptionsFunc`.
+To empty the list of ignored fields, use `flex.WithNoIgoredFieldNames`.
 For example, to include `Tags`, call
 
 ```go
-diags := flex.Expand(ctx, source, &target, flex.WithIgnoredFieldNames([]string{}))
+diags := flex.Expand(ctx, source, &target, flex.WithNoIgnoredFieldNames())
 ```
 
 In some cases, flattening and expanding need conditional handling.

--- a/docs/data-handling-and-conversion.md
+++ b/docs/data-handling-and-conversion.md
@@ -189,26 +189,22 @@ AutoFlex uses field names to map between the source and target structures:
 1. An exact, case-sensitive match
 1. An exact, case-insensitive match
 1. Comparing plural and singular field names
-1. Adding a resource name prefix set on the `context.Context` passed to the function with the key `flex.ResourcePrefix`, e.g. Lex v2 Intents in `internal/service/lexv2models/intent.go`
+1. Adding a field name prefix set using the AutoFlex options function `flex.NewFieldNamePrefixOptionsFunc`, e.g. Lex v2 Intents in `internal/service/lexv2models/intent.go`
 
 By default, AutoFlex ignores fields with the name `Tags`, as AWS resource tags are [handled separately](./resource-tagging.md).
 Additional fields can be ignored and the `Tags` field can be included by passing optional `flex.AutoFlexOptionsFunc`s to `Flatten` or `Expand`.
-For example, to add an additional ignored field, use
+For example, to add an additional ignored field, use the `flex.NewIgnoredFieldAppendOptionsFunc` function constructor
 
 ```go
-diags := flex.Expand(ctx, source, &target, func(opts *flex.AutoFlexOptions) {
-    opts.AddIgnoredField("OtherField")
-})
+diags := flex.Expand(ctx, source, &target, flex.NewIgnoredFieldAppendOptionsFunc("OtherField"))
 ```
 
 This will ignore both `Tags` and `OtherField`.
-To override existing ignored fields, call `opts.SetIgnoredFields`.
+To override existing ignored fields, use `flex.NewIgnoredFieldOptionsFunc`.
 For example, to include `Tags`, call
 
 ```go
-diags := flex.Expand(ctx, source, &target, func(opts *flex.AutoFlexOptions) {
-    opts.SetIgnoredFields([]string{})
-})
+diags := flex.Expand(ctx, source, &target, flex.NewIgnoredFieldOptionsFunc([]string{}))
 ```
 
 In some cases, flattening and expanding need conditional handling.

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -2140,7 +2140,7 @@ func TestExpandOptions(t *testing.T) {
 			},
 		},
 		"include tags with option override": {
-			Options: []AutoFlexOptionsFunc{WithIgnoredFieldNames([]string{})},
+			Options: []AutoFlexOptionsFunc{WithNoIgnoredFieldNames()},
 			Source: &tf01{
 				Field1: types.BoolValue(true),
 				Tags: fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -434,7 +434,7 @@ func TestExpand(t *testing.T) {
 			},
 		},
 		"resource name prefix": {
-			ContextFn: func(ctx context.Context) context.Context { return context.WithValue(ctx, ResourcePrefix, "Intent") },
+			Options: []AutoFlexOptionsFunc{NewFieldNamePrefixOptionsFunc("Intent")},
 			Source: &TestFlexTF16{
 				Name: types.StringValue("Ovodoghen"),
 			},

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -434,7 +434,7 @@ func TestExpand(t *testing.T) {
 			},
 		},
 		"resource name prefix": {
-			Options: []AutoFlexOptionsFunc{NewFieldNamePrefixOptionsFunc("Intent")},
+			Options: []AutoFlexOptionsFunc{WithFieldNamePrefix("Intent")},
 			Source: &TestFlexTF16{
 				Name: types.StringValue("Ovodoghen"),
 			},
@@ -2140,7 +2140,7 @@ func TestExpandOptions(t *testing.T) {
 			},
 		},
 		"include tags with option override": {
-			Options: []AutoFlexOptionsFunc{NewIgnoredFieldOptionsFunc([]string{})},
+			Options: []AutoFlexOptionsFunc{WithIgnoredFieldNames([]string{})},
 			Source: &tf01{
 				Field1: types.BoolValue(true),
 				Tags: fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{
@@ -2164,7 +2164,7 @@ func TestExpandOptions(t *testing.T) {
 			},
 		},
 		"ignore custom field": {
-			Options: []AutoFlexOptionsFunc{NewIgnoredFieldOptionsFunc([]string{"Field1"})},
+			Options: []AutoFlexOptionsFunc{WithIgnoredFieldNames([]string{"Field1"})},
 			Source: &tf01{
 				Field1: types.BoolValue(true),
 				Tags: fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -2140,11 +2140,7 @@ func TestExpandOptions(t *testing.T) {
 			},
 		},
 		"include tags with option override": {
-			Options: []AutoFlexOptionsFunc{
-				func(opts *AutoFlexOptions) {
-					opts.SetIgnoredFields([]string{})
-				},
-			},
+			Options: []AutoFlexOptionsFunc{NewIgnoredFieldOptionsFunc([]string{})},
 			Source: &tf01{
 				Field1: types.BoolValue(true),
 				Tags: fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{
@@ -2168,11 +2164,7 @@ func TestExpandOptions(t *testing.T) {
 			},
 		},
 		"ignore custom field": {
-			Options: []AutoFlexOptionsFunc{
-				func(opts *AutoFlexOptions) {
-					opts.SetIgnoredFields([]string{"Field1"})
-				},
-			},
+			Options: []AutoFlexOptionsFunc{NewIgnoredFieldOptionsFunc([]string{"Field1"})},
 			Source: &tf01{
 				Field1: types.BoolValue(true),
 				Tags: fwtypes.NewMapValueOfMust[types.String](ctx, map[string]attr.Value{

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -677,7 +677,7 @@ func TestFlatten(t *testing.T) {
 			},
 		},
 		"resource name prefix": {
-			Options: []AutoFlexOptionsFunc{NewFieldNamePrefixOptionsFunc("Intent")},
+			Options: []AutoFlexOptionsFunc{WithFieldNamePrefix("Intent")},
 			Source: &TestFlexAWS18{
 				IntentName: aws.String("Ovodoghen"),
 			},
@@ -1900,7 +1900,7 @@ func TestFlattenOptions(t *testing.T) {
 			},
 		},
 		"include tags with option override": {
-			Options: []AutoFlexOptionsFunc{NewIgnoredFieldOptionsFunc([]string{})},
+			Options: []AutoFlexOptionsFunc{WithIgnoredFieldNames([]string{})},
 			Source: &aws01{
 				Field1: true,
 				Tags:   map[string]string{"foo": "bar"},
@@ -1923,7 +1923,7 @@ func TestFlattenOptions(t *testing.T) {
 			},
 		},
 		"ignore custom field": {
-			Options: []AutoFlexOptionsFunc{NewIgnoredFieldOptionsFunc([]string{"Field1"})},
+			Options: []AutoFlexOptionsFunc{WithIgnoredFieldNames([]string{"Field1"})},
 			Source: &aws01{
 				Field1: true,
 				Tags:   map[string]string{"foo": "bar"},

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -677,7 +677,7 @@ func TestFlatten(t *testing.T) {
 			},
 		},
 		"resource name prefix": {
-			ContextFn: func(ctx context.Context) context.Context { return context.WithValue(ctx, ResourcePrefix, "Intent") },
+			Options: []AutoFlexOptionsFunc{NewFieldNamePrefixOptionsFunc("Intent")},
 			Source: &TestFlexAWS18{
 				IntentName: aws.String("Ovodoghen"),
 			},

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -1900,7 +1900,7 @@ func TestFlattenOptions(t *testing.T) {
 			},
 		},
 		"include tags with option override": {
-			Options: []AutoFlexOptionsFunc{WithIgnoredFieldNames([]string{})},
+			Options: []AutoFlexOptionsFunc{WithNoIgnoredFieldNames()},
 			Source: &aws01{
 				Field1: true,
 				Tags:   map[string]string{"foo": "bar"},

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -1900,11 +1900,7 @@ func TestFlattenOptions(t *testing.T) {
 			},
 		},
 		"include tags with option override": {
-			Options: []AutoFlexOptionsFunc{
-				func(opts *AutoFlexOptions) {
-					opts.SetIgnoredFields([]string{})
-				},
-			},
+			Options: []AutoFlexOptionsFunc{NewIgnoredFieldOptionsFunc([]string{})},
 			Source: &aws01{
 				Field1: true,
 				Tags:   map[string]string{"foo": "bar"},
@@ -1927,11 +1923,7 @@ func TestFlattenOptions(t *testing.T) {
 			},
 		},
 		"ignore custom field": {
-			Options: []AutoFlexOptionsFunc{
-				func(opts *AutoFlexOptions) {
-					opts.SetIgnoredFields([]string{"Field1"})
-				},
-			},
+			Options: []AutoFlexOptionsFunc{NewIgnoredFieldOptionsFunc([]string{"Field1"})},
 			Source: &aws01{
 				Field1: true,
 				Tags:   map[string]string{"foo": "bar"},

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -33,45 +33,6 @@ type autoFlexer interface {
 	getOptions() AutoFlexOptions
 }
 
-// AutoFlexOptions stores configurable options for an auto-flattener or expander.
-type AutoFlexOptions struct {
-	// ignoredFieldNames stores names which expanders and flatteners will
-	// not read from or write to
-	ignoredFieldNames []string
-}
-
-// IsIgnoredField returns true if s is in the list of ignored field names
-func (o *AutoFlexOptions) IsIgnoredField(s string) bool {
-	for _, name := range o.ignoredFieldNames {
-		if s == name {
-			return true
-		}
-	}
-	return false
-}
-
-// AddIgnoredField appends s to the list of ignored field names
-func (o *AutoFlexOptions) AddIgnoredField(s string) {
-	o.ignoredFieldNames = append(o.ignoredFieldNames, s)
-}
-
-// SetIgnoredFields replaces the list of ignored field names
-//
-// To preseve existing items in the list, use the AddIgnoredField
-// method instead.
-func (o *AutoFlexOptions) SetIgnoredFields(fields []string) {
-	o.ignoredFieldNames = fields
-}
-
-var (
-	DefaultIgnoredFieldNames = []string{
-		"Tags", // Resource tags are handled separately.
-	}
-)
-
-// AutoFlexOptionsFunc is a type alias for an autoFlexer functional option.
-type AutoFlexOptionsFunc func(*AutoFlexOptions)
-
 // autoFlexValues returns the underlying `reflect.Value`s of `from` and `to`.
 func autoFlexValues(_ context.Context, from, to any) (reflect.Value, reflect.Value, diag.Diagnostics) {
 	var diags diag.Diagnostics

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -16,12 +16,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-type ResourcePrefixCtxKey string
+type AutoFlexCtxKey string
 
 const (
-	ResourcePrefix        ResourcePrefixCtxKey = "RESOURCE_PREFIX"
-	resourcePrefixRecurse ResourcePrefixCtxKey = "RESOURCE_PREFIX_RECURSE"
-	MapBlockKey                                = "MapBlockKey"
+	FieldNamePrefixRecurse AutoFlexCtxKey = "FIELD_NAME_PREFIX_RECURSE"
+
+	MapBlockKey = "MapBlockKey"
 )
 
 // Expand  = TF -->  AWS
@@ -204,11 +204,11 @@ func findFieldFuzzy(ctx context.Context, fieldNameFrom string, valTo, valFrom re
 	}
 
 	// fourth precedence is using resource prefix
-	if v, ok := ctx.Value(ResourcePrefix).(string); ok && v != "" {
+	if v := opts.fieldNamePrefix; v != "" {
 		v = strings.ReplaceAll(v, " ", "")
-		if ctx.Value(resourcePrefixRecurse) == nil {
+		if ctx.Value(FieldNamePrefixRecurse) == nil {
 			// so it will only recurse once
-			ctx = context.WithValue(ctx, resourcePrefixRecurse, true)
+			ctx = context.WithValue(ctx, FieldNamePrefixRecurse, true)
 			if strings.HasPrefix(fieldNameFrom, v) {
 				return findFieldFuzzy(ctx, strings.TrimPrefix(fieldNameFrom, v), valTo, valFrom, flexer)
 			}

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -114,7 +114,7 @@ func autoFlexConvertStruct(ctx context.Context, sourcePath path.Path, from any, 
 			continue // Skip unexported fields.
 		}
 		fieldName := field.Name
-		if opts.IsIgnoredField(fieldName) {
+		if opts.isIgnoredField(fieldName) {
 			tflog.SubsystemTrace(ctx, subsystemName, "Skipping ignored field", map[string]any{
 				logAttrKeySourceFieldname: fieldName,
 			})
@@ -179,7 +179,7 @@ func findFieldFuzzy(ctx context.Context, fieldNameFrom string, valTo, valFrom re
 			continue // Skip unexported fields.
 		}
 		fieldNameTo := field.Name
-		if opts.IsIgnoredField(fieldNameTo) {
+		if opts.isIgnoredField(fieldNameTo) {
 			continue
 		}
 		if v := valTo.FieldByName(fieldNameTo); v.IsValid() && strings.EqualFold(fieldNameFrom, fieldNameTo) && !fieldExistsInStruct(fieldNameTo, valFrom) {

--- a/internal/framework/flex/options.go
+++ b/internal/framework/flex/options.go
@@ -23,31 +23,31 @@ type AutoFlexOptions struct {
 	ignoredFieldNames []string
 }
 
-// NewFieldNamePrefixOptionsFunc specifies a prefix to be accounted for when
+// WithFieldNamePrefix specifies a prefix to be accounted for when
 // matching field names between Terraform and AWS data structures
 //
 // Use this option to improve fuzzy matching of field names during AutoFlex
 // expand/flatten operations.
-func NewFieldNamePrefixOptionsFunc(s string) AutoFlexOptionsFunc {
+func WithFieldNamePrefix(s string) AutoFlexOptionsFunc {
 	return func(o *AutoFlexOptions) {
 		o.fieldNamePrefix = s
 	}
 }
 
-// NewIgnoredFieldAppendOptionsFunc appends to the list of ignored field names
+// WithIgnoredFieldNamesAppend appends to the list of ignored field names
 //
 // Use this option to preserve preexisting items in the ignored fields list.
-func NewIgnoredFieldAppendOptionsFunc(s string) AutoFlexOptionsFunc {
+func WithIgnoredFieldNamesAppend(s string) AutoFlexOptionsFunc {
 	return func(o *AutoFlexOptions) {
 		o.ignoredFieldNames = append(o.ignoredFieldNames, s)
 	}
 }
 
-// NewIgnoredFieldOptionsFunc sets the list of ignored field names
+// WithIgnoredFieldNames sets the list of ignored field names
 //
 // Use this option to fully overwrite the ignored fields list. To preseve
-// preexisting items, use NewIgnoredFieldAppendOptionsFunc instead.
-func NewIgnoredFieldOptionsFunc(fields []string) AutoFlexOptionsFunc {
+// preexisting items, use WithIgnoredFieldNamesAppend instead.
+func WithIgnoredFieldNames(fields []string) AutoFlexOptionsFunc {
 	return func(o *AutoFlexOptions) {
 		o.ignoredFieldNames = fields
 	}

--- a/internal/framework/flex/options.go
+++ b/internal/framework/flex/options.go
@@ -14,19 +14,24 @@ type AutoFlexOptionsFunc func(*AutoFlexOptions)
 
 // AutoFlexOptions stores configurable options for an auto-flattener or expander.
 type AutoFlexOptions struct {
+	// fieldNamePrefix specifies a common prefix which may be applied to one
+	// or more fields on an AWS data structure
+	fieldNamePrefix string
+
 	// ignoredFieldNames stores names which expanders and flatteners will
 	// not read from or write to
 	ignoredFieldNames []string
 }
 
-// IsIgnoredField returns true if s is in the list of ignored field names
-func (o *AutoFlexOptions) IsIgnoredField(s string) bool {
-	for _, name := range o.ignoredFieldNames {
-		if s == name {
-			return true
-		}
+// NewFieldNamePrefixOptionsFunc specifies a prefix to be accounted for when
+// matching field names between Terraform and AWS data structures
+//
+// Use this option to improve fuzzy matching of field names during AutoFlex
+// expand/flatten operations.
+func NewFieldNamePrefixOptionsFunc(s string) AutoFlexOptionsFunc {
+	return func(o *AutoFlexOptions) {
+		o.fieldNamePrefix = s
 	}
-	return false
 }
 
 // AddIgnoredField appends s to the list of ignored field names
@@ -40,4 +45,14 @@ func (o *AutoFlexOptions) AddIgnoredField(s string) {
 // method instead.
 func (o *AutoFlexOptions) SetIgnoredFields(fields []string) {
 	o.ignoredFieldNames = fields
+}
+
+// IsIgnoredField returns true if s is in the list of ignored field names
+func (o *AutoFlexOptions) IsIgnoredField(s string) bool {
+	for _, name := range o.ignoredFieldNames {
+		if s == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/framework/flex/options.go
+++ b/internal/framework/flex/options.go
@@ -53,6 +53,13 @@ func WithIgnoredFieldNames(fields []string) AutoFlexOptionsFunc {
 	}
 }
 
+// WithNoIgnoredFieldNames empties the list of ignored field names
+func WithNoIgnoredFieldNames() AutoFlexOptionsFunc {
+	return func(o *AutoFlexOptions) {
+		o.ignoredFieldNames = []string{}
+	}
+}
+
 // isIgnoredField returns true if s is in the list of ignored field names
 func (o *AutoFlexOptions) isIgnoredField(s string) bool {
 	for _, name := range o.ignoredFieldNames {

--- a/internal/framework/flex/options.go
+++ b/internal/framework/flex/options.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package flex
+
+var (
+	DefaultIgnoredFieldNames = []string{
+		"Tags", // Resource tags are handled separately.
+	}
+)
+
+// AutoFlexOptionsFunc is a type alias for an autoFlexer functional option.
+type AutoFlexOptionsFunc func(*AutoFlexOptions)
+
+// AutoFlexOptions stores configurable options for an auto-flattener or expander.
+type AutoFlexOptions struct {
+	// ignoredFieldNames stores names which expanders and flatteners will
+	// not read from or write to
+	ignoredFieldNames []string
+}
+
+// IsIgnoredField returns true if s is in the list of ignored field names
+func (o *AutoFlexOptions) IsIgnoredField(s string) bool {
+	for _, name := range o.ignoredFieldNames {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
+// AddIgnoredField appends s to the list of ignored field names
+func (o *AutoFlexOptions) AddIgnoredField(s string) {
+	o.ignoredFieldNames = append(o.ignoredFieldNames, s)
+}
+
+// SetIgnoredFields replaces the list of ignored field names
+//
+// To preseve existing items in the list, use the AddIgnoredField
+// method instead.
+func (o *AutoFlexOptions) SetIgnoredFields(fields []string) {
+	o.ignoredFieldNames = fields
+}

--- a/internal/framework/flex/options.go
+++ b/internal/framework/flex/options.go
@@ -34,21 +34,27 @@ func NewFieldNamePrefixOptionsFunc(s string) AutoFlexOptionsFunc {
 	}
 }
 
-// AddIgnoredField appends s to the list of ignored field names
-func (o *AutoFlexOptions) AddIgnoredField(s string) {
-	o.ignoredFieldNames = append(o.ignoredFieldNames, s)
-}
-
-// SetIgnoredFields replaces the list of ignored field names
+// NewIgnoredFieldAppendOptionsFunc appends to the list of ignored field names
 //
-// To preseve existing items in the list, use the AddIgnoredField
-// method instead.
-func (o *AutoFlexOptions) SetIgnoredFields(fields []string) {
-	o.ignoredFieldNames = fields
+// Use this option to preserve preexisting items in the ignored fields list.
+func NewIgnoredFieldAppendOptionsFunc(s string) AutoFlexOptionsFunc {
+	return func(o *AutoFlexOptions) {
+		o.ignoredFieldNames = append(o.ignoredFieldNames, s)
+	}
 }
 
-// IsIgnoredField returns true if s is in the list of ignored field names
-func (o *AutoFlexOptions) IsIgnoredField(s string) bool {
+// NewIgnoredFieldOptionsFunc sets the list of ignored field names
+//
+// Use this option to fully overwrite the ignored fields list. To preseve
+// preexisting items, use NewIgnoredFieldAppendOptionsFunc instead.
+func NewIgnoredFieldOptionsFunc(fields []string) AutoFlexOptionsFunc {
+	return func(o *AutoFlexOptions) {
+		o.ignoredFieldNames = fields
+	}
+}
+
+// isIgnoredField returns true if s is in the list of ignored field names
+func (o *AutoFlexOptions) isIgnoredField(s string) bool {
 	for _, name := range o.ignoredFieldNames {
 		if s == name {
 			return true

--- a/internal/service/drs/replication_configuration_template.go
+++ b/internal/service/drs/replication_configuration_template.go
@@ -148,6 +148,8 @@ func (r *replicationConfigurationTemplateResource) Schema(ctx context.Context, r
 	}
 }
 
+var flexOpt = flex.NewFieldNamePrefixOptionsFunc(ResNameReplicationConfigurationTemplate)
+
 func (r *replicationConfigurationTemplateResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	var data replicationConfigurationTemplateResourceModel
 	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
@@ -158,7 +160,7 @@ func (r *replicationConfigurationTemplateResource) Create(ctx context.Context, r
 	conn := r.Meta().DRSClient(ctx)
 
 	input := &drs.CreateReplicationConfigurationTemplateInput{}
-	response.Diagnostics.Append(flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, ResPrefixReplicationConfigurationTemplate), data, input)...)
+	response.Diagnostics.Append(flex.Expand(ctx, data, input, flexOpt)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -180,7 +182,7 @@ func (r *replicationConfigurationTemplateResource) Create(ctx context.Context, r
 		return
 	}
 
-	response.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResPrefixReplicationConfigurationTemplate), output, &data)...)
+	response.Diagnostics.Append(flex.Flatten(ctx, output, &data, flexOpt)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -212,7 +214,7 @@ func (r *replicationConfigurationTemplateResource) Read(ctx context.Context, req
 		return
 	}
 
-	response.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResPrefixReplicationConfigurationTemplate), output, &data)...)
+	response.Diagnostics.Append(flex.Flatten(ctx, output, &data, flexOpt)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -236,7 +238,7 @@ func (r *replicationConfigurationTemplateResource) Update(ctx context.Context, r
 
 	if replicationConfigurationTemplateHasChanges(ctx, new, old) {
 		input := &drs.UpdateReplicationConfigurationTemplateInput{}
-		response.Diagnostics.Append(flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, ResPrefixReplicationConfigurationTemplate), new, input)...)
+		response.Diagnostics.Append(flex.Expand(ctx, new, input, flexOpt)...)
 		if response.Diagnostics.HasError() {
 			return
 		}
@@ -262,7 +264,7 @@ func (r *replicationConfigurationTemplateResource) Update(ctx context.Context, r
 		return
 	}
 
-	response.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResPrefixReplicationConfigurationTemplate), output, &new)...)
+	response.Diagnostics.Append(flex.Flatten(ctx, output, &new, flexOpt)...)
 	if response.Diagnostics.HasError() {
 		return
 	}

--- a/internal/service/drs/replication_configuration_template.go
+++ b/internal/service/drs/replication_configuration_template.go
@@ -148,7 +148,7 @@ func (r *replicationConfigurationTemplateResource) Schema(ctx context.Context, r
 	}
 }
 
-var flexOpt = flex.NewFieldNamePrefixOptionsFunc(ResNameReplicationConfigurationTemplate)
+var flexOpt = flex.WithFieldNamePrefix(ResNameReplicationConfigurationTemplate)
 
 func (r *replicationConfigurationTemplateResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
 	var data replicationConfigurationTemplateResourceModel

--- a/internal/service/lexv2models/exports_test.go
+++ b/internal/service/lexv2models/exports_test.go
@@ -13,4 +13,6 @@ var (
 	ResourceSlotType   = newResourceSlotType
 
 	FindSlotByID = findSlotByID
+
+	IntentFlexOpt = intentFlexOpt
 )

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -899,6 +899,8 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 	}
 }
 
+var intentFlexOpt = flex.NewFieldNamePrefixOptionsFunc(ResNameIntent)
+
 func (r *resourceIntent) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	conn := r.Meta().LexV2ModelsClient(ctx)
 
@@ -909,7 +911,7 @@ func (r *resourceIntent) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	in := &lexmodelsv2.CreateIntentInput{}
-	resp.Diagnostics.Append(flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, ResNameIntent), &data, in)...)
+	resp.Diagnostics.Append(flex.Expand(ctx, &data, in, intentFlexOpt)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -944,7 +946,7 @@ func (r *resourceIntent) Create(ctx context.Context, req resource.CreateRequest,
 
 	// get some data from the intent
 	var dataAfter ResourceIntentData
-	resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameIntent), intent, &dataAfter)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, intent, &dataAfter, intentFlexOpt)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -985,7 +987,7 @@ func (r *resourceIntent) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameIntent), out, &data)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data, intentFlexOpt)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -1053,7 +1055,7 @@ func (r *resourceIntent) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	input := &lexmodelsv2.UpdateIntentInput{}
-	resp.Diagnostics.Append(flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, ResNameIntent), &new, input)...)
+	resp.Diagnostics.Append(flex.Expand(ctx, &new, input, intentFlexOpt)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -899,7 +899,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 	}
 }
 
-var intentFlexOpt = flex.NewFieldNamePrefixOptionsFunc(ResNameIntent)
+var intentFlexOpt = flex.WithFieldNamePrefix(ResNameIntent)
 
 func (r *resourceIntent) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	conn := r.Meta().LexV2ModelsClient(ctx)

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -847,7 +847,7 @@ func TestIntentAutoFlex(t *testing.T) {
 		t.Run(fmt.Sprintf("expand %s", testCase.TestName), func(t *testing.T) {
 			t.Parallel()
 
-			diags := flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, "Intent"), testCase.TFFull, testCase.AWSEmpty)
+			diags := flex.Expand(ctx, testCase.TFFull, testCase.AWSEmpty, tflexv2models.IntentFlexOpt)
 
 			gotErr := diags != nil
 
@@ -869,7 +869,7 @@ func TestIntentAutoFlex(t *testing.T) {
 		t.Run(fmt.Sprintf("flatten %s", testCase.TestName), func(t *testing.T) {
 			t.Parallel()
 
-			diags := flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, "Intent"), testCase.AWSFull, testCase.TFEmpty)
+			diags := flex.Flatten(ctx, testCase.AWSFull, testCase.TFEmpty, tflexv2models.IntentFlexOpt)
 
 			gotErr := diags != nil
 

--- a/internal/service/lexv2models/slot.go
+++ b/internal/service/lexv2models/slot.go
@@ -531,7 +531,7 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 	}
 }
 
-var slotFlexOpt = flex.NewFieldNamePrefixOptionsFunc(ResNameSlot)
+var slotFlexOpt = flex.WithFieldNamePrefix(ResNameSlot)
 
 func (r *resourceSlot) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	conn := r.Meta().LexV2ModelsClient(ctx)

--- a/internal/service/lexv2models/slot.go
+++ b/internal/service/lexv2models/slot.go
@@ -531,6 +531,8 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 	}
 }
 
+var slotFlexOpt = flex.NewFieldNamePrefixOptionsFunc(ResNameSlot)
+
 func (r *resourceSlot) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	conn := r.Meta().LexV2ModelsClient(ctx)
 
@@ -544,7 +546,7 @@ func (r *resourceSlot) Create(ctx context.Context, req resource.CreateRequest, r
 		SlotName: aws.String(plan.Name.ValueString()),
 	}
 
-	resp.Diagnostics.Append(flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlot), &plan, in)...)
+	resp.Diagnostics.Append(flex.Expand(ctx, &plan, in, slotFlexOpt)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -583,7 +585,7 @@ func (r *resourceSlot) Create(ctx context.Context, req resource.CreateRequest, r
 
 	plan.ID = types.StringValue(id)
 
-	resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlot), out, &plan)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &plan, slotFlexOpt)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -613,7 +615,7 @@ func (r *resourceSlot) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlot), out, &state)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state, slotFlexOpt)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -634,7 +636,7 @@ func (r *resourceSlot) Update(ctx context.Context, req resource.UpdateRequest, r
 	if slotHasChanges(ctx, plan, state) {
 		input := &lexmodelsv2.UpdateSlotInput{}
 
-		resp.Diagnostics.Append(flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlot), plan, input)...)
+		resp.Diagnostics.Append(flex.Expand(ctx, plan, input, slotFlexOpt)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -655,7 +657,7 @@ func (r *resourceSlot) Update(ctx context.Context, req resource.UpdateRequest, r
 			return
 		}
 
-		resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlot), input, &plan)...)
+		resp.Diagnostics.Append(flex.Flatten(ctx, input, &plan, slotFlexOpt)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -242,6 +242,8 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 	}
 }
 
+var slotTypeFlexOpt = flex.NewFieldNamePrefixOptionsFunc(ResNameSlotType)
+
 func (r *resourceSlotType) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	conn := r.Meta().LexV2ModelsClient(ctx)
 
@@ -254,7 +256,7 @@ func (r *resourceSlotType) Create(ctx context.Context, req resource.CreateReques
 	in := &lexmodelsv2.CreateSlotTypeInput{
 		SlotTypeName: aws.String(plan.Name.ValueString()),
 	}
-	resp.Diagnostics.Append(flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlotType), &plan, in)...)
+	resp.Diagnostics.Append(flex.Expand(ctx, &plan, in, slotTypeFlexOpt)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -292,7 +294,7 @@ func (r *resourceSlotType) Create(ctx context.Context, req resource.CreateReques
 
 	plan.ID = types.StringValue(id)
 
-	resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlotType), out, &plan)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &plan, slotTypeFlexOpt)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -322,7 +324,7 @@ func (r *resourceSlotType) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlotType), out, &state)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state, slotTypeFlexOpt)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -342,7 +344,7 @@ func (r *resourceSlotType) Update(ctx context.Context, req resource.UpdateReques
 	if slotTypeHasChanges(ctx, plan, state) {
 		input := &lexmodelsv2.UpdateSlotTypeInput{}
 
-		resp.Diagnostics.Append(flex.Expand(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlotType), plan, input)...)
+		resp.Diagnostics.Append(flex.Expand(ctx, plan, input, slotTypeFlexOpt)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -363,7 +365,7 @@ func (r *resourceSlotType) Update(ctx context.Context, req resource.UpdateReques
 			return
 		}
 
-		resp.Diagnostics.Append(flex.Flatten(context.WithValue(ctx, flex.ResourcePrefix, ResNameSlotType), input, &plan)...)
+		resp.Diagnostics.Append(flex.Flatten(ctx, input, &plan, slotTypeFlexOpt)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -242,7 +242,7 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 	}
 }
 
-var slotTypeFlexOpt = flex.NewFieldNamePrefixOptionsFunc(ResNameSlotType)
+var slotTypeFlexOpt = flex.WithFieldNamePrefix(ResNameSlotType)
 
 func (r *resourceSlotType) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	conn := r.Meta().LexV2ModelsClient(ctx)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This AutoFlex option will allow a field name prefix to be passed into the `Flatten` and `Expand` functions to improve fuzzy matching between Terraform and AWS data structures. Replaces the previous method of providing the prefix via a context key.

Also adjusts the entry point of the ignored field names option from methods on the option struct to exported constructor functions. This should simplify the syntax when used in service packages.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37266


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=drs TESTS=TestAccDRSReplicationConfigurationTemplate_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/drs/... -v -count 1 -parallel 20 -run='TestAccDRSReplicationConfigurationTemplate_'  -timeout 360m
=== RUN   TestAccDRSReplicationConfigurationTemplate_serial
=== PAUSE TestAccDRSReplicationConfigurationTemplate_serial
=== CONT  TestAccDRSReplicationConfigurationTemplate_serial
=== RUN   TestAccDRSReplicationConfigurationTemplate_serial/disappears
=== RUN   TestAccDRSReplicationConfigurationTemplate_serial/basic
--- PASS: TestAccDRSReplicationConfigurationTemplate_serial (180.58s)
    --- PASS: TestAccDRSReplicationConfigurationTemplate_serial/disappears (89.44s)
    --- PASS: TestAccDRSReplicationConfigurationTemplate_serial/basic (91.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/drs        186.422s
```

```console
% make testacc PKG=lexv2models TESTS=TestAccLexV2ModelsIntent_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsIntent_'  -timeout 360m

--- PASS: TestAccLexV2ModelsIntent_disappears (45.17s)
--- PASS: TestAccLexV2ModelsIntent_basic (47.25s)
--- PASS: TestAccLexV2ModelsIntent_updateSampleUtterance (61.25s)
--- PASS: TestAccLexV2ModelsIntent_updateDialogCodeHook (61.58s)
--- PASS: TestAccLexV2ModelsIntent_updateInputContext (61.59s)
--- PASS: TestAccLexV2ModelsIntent_updateFulfillmentCodeHook (63.12s)
--- PASS: TestAccLexV2ModelsIntent_updateInitialResponseSetting (63.15s)
--- PASS: TestAccLexV2ModelsIntent_updateConfirmationSetting (65.53s)
--- PASS: TestAccLexV2ModelsIntent_updateOutputContext (66.23s)
--- PASS: TestAccLexV2ModelsIntent_updateClosingSetting (67.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        73.602s
```

```console
% make testacc PKG=lexv2models TESTS=TestAccLexV2ModelsSlot_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsSlot_'  -timeout 360m

--- PASS: TestAccLexV2ModelsSlot_ObfuscationSetting (39.61s)
--- PASS: TestAccLexV2ModelsSlot_disappears (39.66s)
--- PASS: TestAccLexV2ModelsSlot_basic (41.14s)
--- PASS: TestAccLexV2ModelsSlot_updateMultipleValuesSetting (51.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        57.688s
```

```console
% make testacc PKG=lexv2models TESTS=TestAccLexV2ModelsSlotType_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsSlotType_'  -timeout 360m

--- PASS: TestAccLexV2ModelsSlotType_disappears (38.80s)
--- PASS: TestAccLexV2ModelsSlotType_basic (40.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        46.902s
```

