### PR TITLE
[Enhancements] Unhealthy draining Internal in elbv2

### DIFF
--- a/.changelog/38654.txt
+++ b/.changelog/38654.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_alb_target_group: Add `unhealthy_draining_interval` attribute
+```

--- a/.changelog/38654.txt
+++ b/.changelog/38654.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_alb_target_group: Add `unhealthy_draining_interval` attribute
+resource/aws_alb_target_group: Add `target_health_state.unhealthy_draining_interval` argument
 ```

--- a/.changelog/38654.txt
+++ b/.changelog/38654.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_alb_target_group: Add `target_health_state.unhealthy_draining_interval` argument
+resource/aws_lb_target_group: Add `target_health_state.unhealthy_draining_interval` argument
 ```

--- a/internal/service/elbv2/const.go
+++ b/internal/service/elbv2/const.go
@@ -118,6 +118,7 @@ const (
 	targetGroupAttributePreserveClientIPEnabled                                = "preserve_client_ip.enabled"
 	targetGroupAttributeProxyProtocolV2Enabled                                 = "proxy_protocol_v2.enabled"
 	targetGroupAttributeTargetHealthStateUnhealthyConnectionTerminationEnabled = "target_health_state.unhealthy.connection_termination.enabled"
+	targetGroupAttributeTargetHealthStateUnhealthyDrainingIntervalSeconds      = "target_health_state.unhealthy.draining_interval_seconds"
 
 	// The following attributes are supported only by Gateway Load Balancers:
 	targetGroupAttributeTargetFailoverOnDeregistration = "target_failover.on_deregistration"

--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -378,6 +378,12 @@ func resourceTargetGroup() *schema.Resource {
 							Type:     schema.TypeBool,
 							Required: true,
 						},
+						"unhealthy_draining_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(0, 360000),
+						},
 					},
 				},
 			},
@@ -1321,7 +1327,12 @@ func expandTargetGroupTargetHealthStateAttributes(tfMap map[string]interface{}, 
 			awstypes.TargetGroupAttribute{
 				Key:   aws.String(targetGroupAttributeTargetHealthStateUnhealthyConnectionTerminationEnabled),
 				Value: flex.BoolValueToString(tfMap["enable_unhealthy_connection_termination"].(bool)),
-			})
+			},
+			awstypes.TargetGroupAttribute{
+				Key:   aws.String(targetGroupAttributeTargetHealthStateUnhealthyDrainingIntervalSeconds),
+				Value: flex.IntValueToString(tfMap["unhealthy_draining_interval"].(int)),
+			},
+		)
 	}
 
 	return apiObjects
@@ -1340,6 +1351,8 @@ func flattenTargetGroupTargetHealthStateAttributes(apiObjects []awstypes.TargetG
 			switch k, v := aws.ToString(apiObject.Key), apiObject.Value; k {
 			case targetGroupAttributeTargetHealthStateUnhealthyConnectionTerminationEnabled:
 				tfMap["enable_unhealthy_connection_termination"] = flex.StringToBoolValue(v)
+			case targetGroupAttributeTargetHealthStateUnhealthyDrainingIntervalSeconds:
+				tfMap["unhealthy_draining_interval"] = flex.StringToIntValue(v)
 			}
 		}
 	}

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -5024,7 +5024,7 @@ resource "aws_lb_target_group" "test" {
 
   target_health_state {
     enable_unhealthy_connection_termination = false
-	unhealthy_draining_interval = %[3]d
+	unhealthy_draining_interval 			= %[3]d
   }
 }
 

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -2555,6 +2555,42 @@ func TestAccELBV2TargetGroup_targetHealthStateUnhealthyConnectionTermination(t *
 	})
 }
 
+func TestAccELBV2TargetGroup_targetHealthStateUnhealthyDrainInterval(t *testing.T) {
+	ctx := acctest.Context(t)
+	var targetGroup awstypes.TargetGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lb_target_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTargetGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTargetGroupConfig_unhealthyDrainInterval(rName, "TCP", 3600),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTargetGroupExists(ctx, resourceName, &targetGroup),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrProtocol, "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "target_health_state.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "target_health_state.0.unhealthy_draining_interval", "3600"),
+				),
+			},
+			{
+				Config: testAccTargetGroupConfig_unhealthyDrainInterval(rName, "TLS", 3600),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckTargetGroupExists(ctx, resourceName, &targetGroup),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrProtocol, "TLS"),
+					resource.TestCheckResourceAttr(resourceName, "target_health_state.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "target_health_state.0.unhealthy_draining_interval", "3600"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccELBV2TargetGroup_targetGroupHealthState(t *testing.T) {
 	ctx := acctest.Context(t)
 	var targetGroup awstypes.TargetGroup
@@ -4976,6 +5012,30 @@ resource "aws_vpc" "test" {
   }
 }
 `, rName, protocol, enabled)
+}
+
+func testAccTargetGroupConfig_unhealthyDrainInterval(rName, protocol string, interval int) string {
+	return fmt.Sprintf(`
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 25
+  protocol = %[2]q
+  vpc_id   = aws_vpc.test.id
+
+  target_health_state {
+    enable_unhealthy_connection_termination = false
+	unhealthy_draining_interval = %[3]d
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, protocol, interval)
 }
 
 func testAccTargetGroupConfig_targetGroupHealthState(rName, targetGroupHealthCount string, targetGroupHealthPercentageEnabled string, unhealthyStateRoutingCount int, unhealthyStateRoutingPercentageEnabled string) string {

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -5024,7 +5024,7 @@ resource "aws_lb_target_group" "test" {
 
   target_health_state {
     enable_unhealthy_connection_termination = false
-	unhealthy_draining_interval 			= %[3]d
+    unhealthy_draining_interval             = %[3]d
   }
 }
 

--- a/website/docs/r/lb_target_group.html.markdown
+++ b/website/docs/r/lb_target_group.html.markdown
@@ -194,6 +194,7 @@ This resource supports the following arguments:
 ~> **NOTE:** This block is only valid for a Network Load Balancer (NLB) target group when `protocol` is `TCP` or `TLS`.
 
 * `enable_unhealthy_connection_termination` - (Optional) Indicates whether the load balancer terminates connections to unhealthy targets. Possible values are `true` or `false`. Default: `true`.
+* `unhealthy_draining_interval` - (Optional) Indicates the time to wait for in-flight requests to complete when a target becomes unhealthy. The range is `0-360000`. This value has to be set only if `enable_unhealthy_connection_termination` is set to false. Default: `0`.
 
 ### target_group_health
 


### PR DESCRIPTION
Description

Added the unhealthy draining interval in target_state_health in elbv2

Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/38393