### PR TITLE
Fix state machine update bug

### DIFF
--- a/.changelog/38657.txt
+++ b/.changelog/38657.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sfn_state_machine: Fix `state_machine_version_arn` and `revision_id` update during resource update
+```

--- a/.changelog/38657.txt
+++ b/.changelog/38657.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_sfn_state_machine: Fix `state_machine_version_arn` and `revision_id` update during resource update
+resource/aws_sfn_state_machine: Mark `revision_id` and `state_machine_version_arn` as Computed on update if `publish` is `true`
 ```

--- a/internal/service/sfn/state_machine.go
+++ b/internal/service/sfn/state_machine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -23,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -189,7 +191,10 @@ func resourceStateMachine() *schema.Resource {
 			},
 		},
 
-		CustomizeDiff: verify.SetTagsDiff,
+		CustomizeDiff: customdiff.Sequence(
+			updateComputedAttributesOnPublish,
+			verify.SetTagsDiff,
+		),
 	}
 }
 
@@ -527,4 +532,29 @@ func flattenTracingConfiguration(apiObject *awstypes.TracingConfiguration) map[s
 	}
 
 	return tfMap
+}
+
+func updateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	publish := d.Get("publish").(bool)
+	if publish && needsConfigUpdate(d) {
+		d.SetNewComputed("revision_id")
+		d.SetNewComputed("state_machine_version_arn")
+	}
+	return nil
+}
+
+func needsConfigUpdate(d sdkv2.ResourceDiffer) bool {
+	for k, attr := range resourceStateMachine().Schema {
+		if attr.ForceNew {
+			continue
+		}
+		if attr.Computed && !attr.Optional {
+			continue
+		}
+
+		if d.HasChange(k) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/service/sfn/state_machine.go
+++ b/internal/service/sfn/state_machine.go
@@ -192,7 +192,7 @@ func resourceStateMachine() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.Sequence(
-			updateComputedAttributesOnPublish,
+			stateMachineUpdateComputedAttributesOnPublish,
 			verify.SetTagsDiff,
 		),
 	}
@@ -534,16 +534,16 @@ func flattenTracingConfiguration(apiObject *awstypes.TracingConfiguration) map[s
 	return tfMap
 }
 
-func updateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func stateMachineUpdateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	publish := d.Get("publish").(bool)
-	if publish && needsConfigUpdate(d) {
+	if publish && stateMachineNeedsConfigUpdate(d) {
 		d.SetNewComputed("revision_id")
 		d.SetNewComputed("state_machine_version_arn")
 	}
 	return nil
 }
 
-func needsConfigUpdate(d sdkv2.ResourceDiffer) bool {
+func stateMachineNeedsConfigUpdate(d sdkv2.ResourceDiffer) bool {
 	for k, attr := range resourceStateMachine().Schema {
 		if attr.ForceNew {
 			continue


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
State Machine resource is currently unaware that the version_arn and revision_id attributes will be updated when the resource is updated. This result in resources that depend on the new version only getting updated on subsequent terraform runs.

Took inspiration from how Lambda and CloudFormation resources are handling the updates.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #36272
--->

Closes #36272

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=sfn

=== RUN   TestAccSFNActivityDataSource_basic
=== PAUSE TestAccSFNActivityDataSource_basic
=== RUN   TestAccSFNActivity_basic
=== PAUSE TestAccSFNActivity_basic
=== RUN   TestAccSFNActivity_disappears
=== PAUSE TestAccSFNActivity_disappears
=== RUN   TestAccSFNActivity_tags
=== PAUSE TestAccSFNActivity_tags
=== RUN   TestAccSFNActivity_encryptionConfigurationCustomerManagedKMSKey
--- PASS: TestAccSFNActivity_encryptionConfigurationCustomerManagedKMSKey (76.60s)
=== RUN   TestAccSFNActivity_encryptionConfigurationServiceOwnedKey
--- PASS: TestAccSFNActivity_encryptionConfigurationServiceOwnedKey (72.55s)
=== RUN   TestAccSFNAliasDataSource_basic
=== PAUSE TestAccSFNAliasDataSource_basic
=== RUN   TestAccSFNAlias_basic
=== PAUSE TestAccSFNAlias_basic
=== RUN   TestAccSFNAlias_disappears
=== PAUSE TestAccSFNAlias_disappears
=== RUN   TestEndpointConfiguration
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/no_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file
=== RUN   TestEndpointConfiguration/alias_name_0_endpoint_config
=== RUN   TestEndpointConfiguration/alias_name_0_endpoint_config_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar
=== RUN   TestEndpointConfiguration/service_config_file
=== RUN   TestEndpointConfiguration/service_config_file_overrides_base_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/use_fips_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar
=== RUN   TestEndpointConfiguration/alias_name_0_endpoint_config_overrides_aws_service_envvar
=== RUN   TestEndpointConfiguration/alias_name_0_endpoint_config_overrides_base_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_alias_name_0_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file
=== RUN   TestEndpointConfiguration/alias_name_0_endpoint_config_overrides_base_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config
--- PASS: TestEndpointConfiguration (0.81s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file (0.06s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/no_config (0.02s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar (0.04s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/alias_name_0_endpoint_config (0.04s)
    --- PASS: TestEndpointConfiguration/alias_name_0_endpoint_config_overrides_service_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/service_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/service_config_file_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/base_endpoint_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/use_fips_config (0.02s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config (0.04s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar (0.04s)
    --- PASS: TestEndpointConfiguration/alias_name_0_endpoint_config_overrides_aws_service_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/alias_name_0_endpoint_config_overrides_base_envvar (0.04s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_alias_name_0_config (0.04s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/alias_name_0_endpoint_config_overrides_base_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config (0.04s)
=== RUN   TestAccSFNStateMachineDataSource_basic
=== PAUSE TestAccSFNStateMachineDataSource_basic
=== RUN   TestAccSFNStateMachine_createUpdate
=== PAUSE TestAccSFNStateMachine_createUpdate
=== RUN   TestAccSFNStateMachine_expressUpdate
=== PAUSE TestAccSFNStateMachine_expressUpdate
=== RUN   TestAccSFNStateMachine_standardUpdate
=== PAUSE TestAccSFNStateMachine_standardUpdate
=== RUN   TestAccSFNStateMachine_nameGenerated
=== PAUSE TestAccSFNStateMachine_nameGenerated
=== RUN   TestAccSFNStateMachine_namePrefix
=== PAUSE TestAccSFNStateMachine_namePrefix
=== RUN   TestAccSFNStateMachine_publish
=== PAUSE TestAccSFNStateMachine_publish
=== RUN   TestAccSFNStateMachine_tags
=== PAUSE TestAccSFNStateMachine_tags
=== RUN   TestAccSFNStateMachine_tracing
=== PAUSE TestAccSFNStateMachine_tracing
=== RUN   TestAccSFNStateMachine_disappears
=== PAUSE TestAccSFNStateMachine_disappears
=== RUN   TestAccSFNStateMachine_expressLogging
=== PAUSE TestAccSFNStateMachine_expressLogging
=== RUN   TestAccSFNStateMachine_encryptionConfigurationCustomerManagedKMSKey
--- PASS: TestAccSFNStateMachine_encryptionConfigurationCustomerManagedKMSKey (137.50s)
=== RUN   TestAccSFNStateMachine_encryptionConfigurationServiceOwnedKey
--- PASS: TestAccSFNStateMachine_encryptionConfigurationServiceOwnedKey (123.27s)
=== RUN   TestAccSFNStateMachineVersionsDataSource_basic
=== PAUSE TestAccSFNStateMachineVersionsDataSource_basic
=== CONT  TestAccSFNActivityDataSource_basic
=== CONT  TestAccSFNStateMachine_standardUpdate
=== CONT  TestAccSFNStateMachine_tracing
=== CONT  TestAccSFNAlias_basic
=== CONT  TestAccSFNActivity_tags
=== CONT  TestAccSFNStateMachine_expressLogging
=== CONT  TestAccSFNStateMachine_createUpdate
=== CONT  TestAccSFNStateMachine_tags
=== CONT  TestAccSFNAliasDataSource_basic
=== CONT  TestAccSFNStateMachine_expressUpdate
=== CONT  TestAccSFNStateMachine_disappears
=== CONT  TestAccSFNActivity_basic
=== CONT  TestAccSFNAlias_disappears
=== CONT  TestAccSFNActivity_disappears
=== CONT  TestAccSFNStateMachineVersionsDataSource_basic
=== CONT  TestAccSFNStateMachine_publish
=== CONT  TestAccSFNStateMachine_namePrefix
=== CONT  TestAccSFNStateMachine_nameGenerated
=== CONT  TestAccSFNStateMachineDataSource_basic
--- PASS: TestAccSFNActivityDataSource_basic (23.20s)
--- PASS: TestAccSFNActivity_disappears (23.35s)
--- PASS: TestAccSFNActivity_basic (25.47s)
--- PASS: TestAccSFNStateMachine_disappears (51.56s)
--- PASS: TestAccSFNStateMachine_namePrefix (61.46s)
--- PASS: TestAccSFNActivity_tags (72.28s)
--- PASS: TestAccSFNStateMachine_createUpdate (91.05s)
--- PASS: TestAccSFNStateMachineDataSource_basic (103.03s)
--- PASS: TestAccSFNAliasDataSource_basic (110.08s)
--- PASS: TestAccSFNStateMachine_expressUpdate (113.50s)
--- PASS: TestAccSFNStateMachine_publish (115.52s)
--- PASS: TestAccSFNAlias_basic (130.60s)
--- PASS: TestAccSFNStateMachineVersionsDataSource_basic (131.91s)
--- PASS: TestAccSFNStateMachine_expressLogging (159.73s)
--- PASS: TestAccSFNAlias_disappears (169.92s)
--- PASS: TestAccSFNStateMachine_tags (174.63s)
--- PASS: TestAccSFNStateMachine_tracing (174.80s)
--- PASS: TestAccSFNStateMachine_standardUpdate (185.16s)
--- PASS: TestAccSFNStateMachine_nameGenerated (188.13s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sfn	603.118s

...
```
