### PR TITLE
b/smithy json type expands to any type

### DIFF
--- a/internal/framework/types/smithy_json.go
+++ b/internal/framework/types/smithy_json.go
@@ -125,7 +125,7 @@ func (v SmithyJSON[T]) ValueInterface() (T, diag.Diagnostics) {
 		return zero, diags
 	}
 
-	var data map[string]any
+	var data any
 	err := json.Unmarshal([]byte(v.ValueString()), &data)
 
 	if err != nil {

--- a/internal/framework/types/smithy_json_test.go
+++ b/internal/framework/types/smithy_json_test.go
@@ -142,6 +142,12 @@ func TestSmithyJSONValueInterface(t *testing.T) {
 				},
 			},
 		},
+		"valid SmithyJSON slice": { // lintignore:AWSAT003,AWSAT005
+			val: fwtypes.SmithyJSONValue[smithyjson.JSONStringer](`["value1","value"]`, newTestJSONDocument), // lintignore:AWSAT003,AWSAT005
+			expected: &testJSONDocument{
+				Value: []any{"value1", "value"},
+			},
+		},
 		"invalid SmithyJSON": {
 			val:         fwtypes.SmithyJSONValue[smithyjson.JSONStringer]("not ok", newTestJSONDocument), // lintignore:AWSAT003,AWSAT005
 			expectError: true,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**before**

```console
go test -count=1 ./internal/framework/types/... -run=TestSmithyJSONValueInterface -v
=== RUN   TestSmithyJSONValueInterface
=== PAUSE TestSmithyJSONValueInterface
=== CONT  TestSmithyJSONValueInterface
=== RUN   TestSmithyJSONValueInterface/valid_SmithyJSON
=== PAUSE TestSmithyJSONValueInterface/valid_SmithyJSON
=== RUN   TestSmithyJSONValueInterface/valid_SmithyJSON_slice
=== PAUSE TestSmithyJSONValueInterface/valid_SmithyJSON_slice
=== RUN   TestSmithyJSONValueInterface/invalid_SmithyJSON
=== PAUSE TestSmithyJSONValueInterface/invalid_SmithyJSON
=== RUN   TestSmithyJSONValueInterface/null_value
=== PAUSE TestSmithyJSONValueInterface/null_value
=== RUN   TestSmithyJSONValueInterface/unknown_value
=== PAUSE TestSmithyJSONValueInterface/unknown_value
=== CONT  TestSmithyJSONValueInterface/valid_SmithyJSON
=== CONT  TestSmithyJSONValueInterface/null_value
=== CONT  TestSmithyJSONValueInterface/invalid_SmithyJSON
=== CONT  TestSmithyJSONValueInterface/valid_SmithyJSON_slice
=== CONT  TestSmithyJSONValueInterface/unknown_value
=== NAME  TestSmithyJSONValueInterface/valid_SmithyJSON_slice
    smithy_json_test.go:166: gotErr = true, wantErr = false
    smithy_json_test.go:171: err = [{"An unexpected error occurred while unmarshalling a JSON string. Please report this to the provider developers.\n\nError: json: cannot unmarshal array into Go value of type map[string]interface {}" "JSON Unmarshal Error"}]
--- FAIL: TestSmithyJSONValueInterface (0.00s)
    --- PASS: TestSmithyJSONValueInterface/invalid_SmithyJSON (0.00s)
    --- PASS: TestSmithyJSONValueInterface/unknown_value (0.00s)
    --- PASS: TestSmithyJSONValueInterface/null_value (0.00s)
    --- PASS: TestSmithyJSONValueInterface/valid_SmithyJSON (0.00s)
    --- FAIL: TestSmithyJSONValueInterface/valid_SmithyJSON_slice (0.00s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/framework/types	0.625s
FAIL
````

**after**

```console
% go test -count=1 ./internal/framework/types/... -run=TestSmithyJSONValueInterface -v

=== RUN   TestSmithyJSONValueInterface
=== PAUSE TestSmithyJSONValueInterface
=== CONT  TestSmithyJSONValueInterface
=== RUN   TestSmithyJSONValueInterface/null_value
=== PAUSE TestSmithyJSONValueInterface/null_value
=== RUN   TestSmithyJSONValueInterface/unknown_value
=== PAUSE TestSmithyJSONValueInterface/unknown_value
=== RUN   TestSmithyJSONValueInterface/valid_SmithyJSON
=== PAUSE TestSmithyJSONValueInterface/valid_SmithyJSON
=== RUN   TestSmithyJSONValueInterface/valid_SmithyJSON_slice
=== PAUSE TestSmithyJSONValueInterface/valid_SmithyJSON_slice
=== RUN   TestSmithyJSONValueInterface/invalid_SmithyJSON
=== PAUSE TestSmithyJSONValueInterface/invalid_SmithyJSON
=== CONT  TestSmithyJSONValueInterface/null_value
=== CONT  TestSmithyJSONValueInterface/valid_SmithyJSON_slice
=== CONT  TestSmithyJSONValueInterface/valid_SmithyJSON
=== CONT  TestSmithyJSONValueInterface/unknown_value
=== CONT  TestSmithyJSONValueInterface/invalid_SmithyJSON
--- PASS: TestSmithyJSONValueInterface (0.00s)
    --- PASS: TestSmithyJSONValueInterface/null_value (0.00s)
    --- PASS: TestSmithyJSONValueInterface/unknown_value (0.00s)
    --- PASS: TestSmithyJSONValueInterface/valid_SmithyJSON_slice (0.00s)
    --- PASS: TestSmithyJSONValueInterface/valid_SmithyJSON (0.00s)
    --- PASS: TestSmithyJSONValueInterface/invalid_SmithyJSON (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/types	0.801s
```
