### PR TITLE
r/aws_lexmodelsv2(test): handle `PreconditionFailedException` on delete

### DIFF
--- a/.changelog/38661.txt
+++ b/.changelog/38661.txt
@@ -1,0 +1,9 @@
+```release-note:bug
+resource/aws_lexv2models_bot: Handle `PreconditionFailedException` on delete for resources deleted out-of-band
+```
+```release-note:bug
+resource/aws_lexv2models_bot_locale: Handle `PreconditionFailedException` on delete for resources deleted out-of-band
+```
+```release-note:bug
+resource/aws_lexv2models_bot_version: Handle `PreconditionFailedException` on delete for resources deleted out-of-band
+```

--- a/internal/service/lexv2models/bot_locale.go
+++ b/internal/service/lexv2models/bot_locale.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
@@ -342,8 +343,8 @@ func (r *resourceBotLocale) Delete(ctx context.Context, req resource.DeleteReque
 
 	_, err := conn.DeleteBotLocale(ctx, in)
 	if err != nil {
-		var nfe *awstypes.ResourceNotFoundException
-		if errors.As(err, &nfe) {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) ||
+			errs.IsAErrorMessageContains[*awstypes.PreconditionFailedException](err, "does not exist") {
 			return
 		}
 		resp.Diagnostics.AddError(
@@ -449,8 +450,7 @@ func FindBotLocaleByID(ctx context.Context, conn *lexmodelsv2.Client, id string)
 
 	out, err := conn.DescribeBotLocale(ctx, in)
 	if err != nil {
-		var nfe *awstypes.ResourceNotFoundException
-		if errors.As(err, &nfe) {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 			return nil, &retry.NotFoundError{
 				LastError:   err,
 				LastRequest: in,


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


Fixes `_disappears` tests for the bot, bot locale, and bot version resources which were not handling `PreconditionFailedException` errors.

Before:

```console
% make testacc PKG=lexv2models TESTS="TestAccLexV2ModelsBot_disappears|TestAccLexV2ModelsBotLocale_disappears|TestAccLexV2ModelsBotVersion_disappears"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsBot_disappears|TestAccLexV2ModelsBotLocale_disappears|TestAccLexV2ModelsBotVersion_disappears'  -timeout 360m

    bot_test.go:124: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting AWS Lex V2 Models Bot ("5FUXN7KX75"): operation error Lex Models V2: DeleteBot, https response error StatusCode: 412, RequestID: 91556c02-7ceb-4af4-81a8-c3480eede6d1, PreconditionFailedException: Failed to retrieve resource since it does not exist

        operation error Lex Models V2: DeleteBot, https response error StatusCode:
        412, RequestID: 91556c02-7ceb-4af4-81a8-c3480eede6d1,
        PreconditionFailedException: Failed to retrieve resource since it does not
        exist
--- FAIL: TestAccLexV2ModelsBot_disappears (16.42s)
=== NAME  TestAccLexV2ModelsBotLocale_disappears
    bot_locale_test.go:69: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting AWS Lex V2 Models Bot Locale ("en_US"): operation error Lex Models V2: DeleteBotLocale, https response error StatusCode: 412, RequestID: 7aca0765-3185-491b-8196-a0047c3aac3f, PreconditionFailedException: Failed to retrieve resource since it does not exist

        operation error Lex Models V2: DeleteBotLocale, https response error
        StatusCode: 412, RequestID: 7aca0765-3185-491b-8196-a0047c3aac3f,
        PreconditionFailedException: Failed to retrieve resource since it does not
        exist
--- FAIL: TestAccLexV2ModelsBotLocale_disappears (26.23s)
=== NAME  TestAccLexV2ModelsBotVersion_disappears
    bot_version_test.go:69: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting AWS Lex V2 Models Bot Version ("R8R6LBARQ7,1"): operation error Lex Models V2: DeleteBotVersion, https response error StatusCode: 412, RequestID: 2389c15b-6fa0-4793-9694-1f9553f93953, PreconditionFailedException: Failed to retrieve resource since it does not exist

        operation error Lex Models V2: DeleteBotVersion, https response error
        StatusCode: 412, RequestID: 2389c15b-6fa0-4793-9694-1f9553f93953,
        PreconditionFailedException: Failed to retrieve resource since it does not
        exist
--- FAIL: TestAccLexV2ModelsBotVersion_disappears (34.46s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        40.510s

```

After:

```console
% make testacc PKG=lexv2models TESTS="TestAccLexV2ModelsBot_disappears|TestAccLexV2ModelsBotLocale_disappears|TestAccLexV2ModelsBotVersion_disappears"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsBot_disappears|TestAccLexV2ModelsBotLocale_disappears|TestAccLexV2ModelsBotVersion_disappears'  -timeout 360m

--- PASS: TestAccLexV2ModelsBot_disappears (26.59s)
--- PASS: TestAccLexV2ModelsBotLocale_disappears (41.12s)
--- PASS: TestAccLexV2ModelsBotVersion_disappears (49.95s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        56.721s
```

