### PR TITLE
r/aws_sns_topic_subscription(test): fix auto confirming acceptance tests

### DIFF
--- a/internal/service/sns/topic_subscription_test.go
+++ b/internal/service/sns/topic_subscription_test.go
@@ -1067,7 +1067,7 @@ resource "aws_lambda_function" "lambda" {
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "main.confirm_subscription"
   source_code_hash = filebase64sha256("test-fixtures/lambda_confirm_sns.zip")
-  runtime          = "python3.7"
+  runtime          = "python3.12"
 }
 
 resource "aws_api_gateway_deployment" "test" {
@@ -1193,7 +1193,7 @@ resource "aws_lambda_function" "lambda" {
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "main.confirm_subscription"
   source_code_hash = filebase64sha256("test-fixtures/lambda_confirm_sns.zip")
-  runtime          = "python3.7"
+  runtime          = "python3.12"
 }
 
 resource "aws_api_gateway_deployment" "test" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


Before:

```console
% make testacc PKG=sns TESTS=TestAccSNSTopicSubscription_autoConfirming
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/sns/... -v -count 1 -parallel 20 -run='TestAccSNSTopicSubscription_autoConfirming'  -timeout 360m

=== NAME  TestAccSNSTopicSubscription_autoConfirmingEndpoint
    topic_subscription_test.go:536: Step 1/2 error: Error running apply: exit status 1

        Error: creating Lambda Function (tf-acc-test-913109990468982250): operation error Lambda: CreateFunction, https response error StatusCode: 400, RequestID: a7a32e51-557b-4d89-879a-77fe32ce61f3, InvalidParameterValueException: The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions.

          with aws_lambda_function.lambda,
          on terraform_plugin_test.tf line 110, in resource "aws_lambda_function" "lambda":
         110: resource "aws_lambda_function" "lambda" {

--- FAIL: TestAccSNSTopicSubscription_autoConfirmingEndpoint (16.09s)
=== NAME  TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint
    topic_subscription_test.go:567: Step 1/2 error: Error running apply: exit status 1

        Error: creating Lambda Function (tf-acc-test-7586208927784828020): operation error Lambda: CreateFunction, https response error StatusCode: 400, RequestID: 9ad28049-d2a5-4704-966a-fdab9347592c, InvalidParameterValueException: The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions.

          with aws_lambda_function.lambda,
          on terraform_plugin_test.tf line 111, in resource "aws_lambda_function" "lambda":
         111: resource "aws_lambda_function" "lambda" {

--- FAIL: TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint (46.23s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/sns        52.203s
```

After:

```console
% make testacc PKG=sns TESTS=TestAccSNSTopicSubscription_autoConfirming
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/sns/... -v -count 1 -parallel 20 -run='TestAccSNSTopicSubscription_autoConfirming'  -timeout 360m
=== RUN   TestAccSNSTopicSubscription_autoConfirmingEndpoint
=== PAUSE TestAccSNSTopicSubscription_autoConfirmingEndpoint
=== RUN   TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== PAUSE TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint
=== CONT  TestAccSNSTopicSubscription_autoConfirmingEndpoint
=== CONT  TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint
--- PASS: TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint (44.75s)
--- PASS: TestAccSNSTopicSubscription_autoConfirmingEndpoint (123.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sns        129.721s
```
