### PR TITLE
fix: Allow ROOT as a Repository Creation Template prefix

### DIFF
--- a/.changelog/38685.txt
+++ b/.changelog/38685.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_ecr_repository_creation_template: Support `ROOT` as a valid value for `prefix`
+```
+
+```release-note:bug
+data-source/aws_ecr_repository_creation_template: Support `ROOT` as a valid value for `prefix`
+```

--- a/internal/service/ecr/repository_creation_template.go
+++ b/internal/service/ecr/repository_creation_template.go
@@ -106,8 +106,8 @@ func resourceRepositoryCreationTemplate() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 30),
 					validation.StringMatch(
-						regexache.MustCompile(`(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*`),
-						"must only include alphanumeric, underscore, period, hyphen, or slash characters"),
+						regexache.MustCompile(`(?:ROOT|(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*)`),
+						"must only include alphanumeric, underscore, period, hyphen, or slash characters, or be the string `ROOT`"),
 				),
 			},
 			"registry_id": {

--- a/internal/service/ecr/repository_creation_template_data_source.go
+++ b/internal/service/ecr/repository_creation_template_data_source.go
@@ -70,8 +70,8 @@ func dataSourceRepositoryCreationTemplate() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 30),
 					validation.StringMatch(
-						regexache.MustCompile(`(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*`),
-						"must only include alphanumeric, underscore, period, hyphen, or slash characters"),
+						regexache.MustCompile(`(?:ROOT|(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*)`),
+						"must only include alphanumeric, underscore, period, hyphen, or slash characters, or be the string `ROOT`"),
 				),
 			},
 			"registry_id": {

--- a/internal/service/ecr/repository_creation_template_data_source_test.go
+++ b/internal/service/ecr/repository_creation_template_data_source_test.go
@@ -47,6 +47,25 @@ func TestAccECRRepositoryCreationTemplateDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccECRRepositoryCreationTemplateDataSource_root(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSource := "data.aws_ecr_repository_creation_template.root"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepositoryCreationTemplateDataSourceConfig_root(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSource, names.AttrPrefix, "ROOT"),
+				),
+			},
+		},
+	})
+}
+
 func testAccRepositoryCreationTemplateDataSourceConfig_basic(repositoryPrefix string) string {
 	return fmt.Sprintf(`
 resource "aws_ecr_repository_creation_template" "test" {
@@ -65,4 +84,20 @@ data "aws_ecr_repository_creation_template" "test" {
   prefix = aws_ecr_repository_creation_template.test.prefix
 }
 `, repositoryPrefix)
+}
+
+func testAccRepositoryCreationTemplateDataSourceConfig_root() string {
+	return `
+resource "aws_ecr_repository_creation_template" "root" {
+  prefix = "ROOT"
+
+  applied_for = [
+    "PULL_THROUGH_CACHE",
+  ]
+}
+
+data "aws_ecr_repository_creation_template" "root" {
+  prefix = aws_ecr_repository_creation_template.root.prefix
+}
+`
 }

--- a/internal/service/ecr/repository_creation_template_test.go
+++ b/internal/service/ecr/repository_creation_template_test.go
@@ -168,6 +168,26 @@ func TestAccECRRepositoryCreationTemplate_repository(t *testing.T) {
 	})
 }
 
+func TestAccECRRepositoryCreationTemplate_root(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ecr_repository_creation_template.root"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRepositoryCreationTemplateDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepositoryCreationTemplateConfig_root(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRepositoryCreationTemplateExists(ctx, resourceName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRepositoryCreationTemplateDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ECRClient(ctx)
@@ -393,4 +413,16 @@ resource "aws_ecr_repository_creation_template" "test" {
   })
 }
 `, repositoryPrefix)
+}
+
+func testAccRepositoryCreationTemplateConfig_root() string {
+	return `
+resource "aws_ecr_repository_creation_template" "root" {
+  prefix = "ROOT"
+
+  applied_for = [
+    "PULL_THROUGH_CACHE",
+  ]
+}
+`
 }

--- a/website/docs/r/ecr_repository_creation_template.html.markdown
+++ b/website/docs/r/ecr_repository_creation_template.html.markdown
@@ -88,7 +88,7 @@ EOT
 
 This resource supports the following arguments:
 
-* `prefix` - (Required, Forces new resource) The repository name prefix to match against.
+* `prefix` - (Required, Forces new resource) The repository name prefix to match against. Use `ROOT` to match any prefix that doesn't explicitly match another template.
 * `applied_for` - (Required) Which features this template applies to. Must contain one or more of `PULL_THROUGH_CACHE` or `REPLICATION`.
 * `custom_role_arn` - (Optional) A custom IAM role to use for repository creation. Required if using repository tags or KMS encryption.
 * `description` - (Optional) The description for this template.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This fixes the `aws_ecr_repository_creation_template` resource and data source so they accept `ROOT` as a valid value. I think this was missed as I originally copied the validator from the pull-through cache code without adding this additional special case.

Tests added, explicitly not using `ParallelTest` so the resource and data source tests don’t fight over the one template that can exist.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38650 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccECRRepositoryCreationTemplate PKG=ecr
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepositoryCreationTemplate'  -timeout 360m
=== RUN   TestAccECRRepositoryCreationTemplateDataSource_basic
=== PAUSE TestAccECRRepositoryCreationTemplateDataSource_basic
=== RUN   TestAccECRRepositoryCreationTemplateDataSource_root
--- PASS: TestAccECRRepositoryCreationTemplateDataSource_root (14.21s)
=== RUN   TestAccECRRepositoryCreationTemplate_basic
=== PAUSE TestAccECRRepositoryCreationTemplate_basic
=== RUN   TestAccECRRepositoryCreationTemplate_disappears
=== PAUSE TestAccECRRepositoryCreationTemplate_disappears
=== RUN   TestAccECRRepositoryCreationTemplate_failWhenAlreadyExists
=== PAUSE TestAccECRRepositoryCreationTemplate_failWhenAlreadyExists
=== RUN   TestAccECRRepositoryCreationTemplate_ignoreEquivalentLifecycle
=== PAUSE TestAccECRRepositoryCreationTemplate_ignoreEquivalentLifecycle
=== RUN   TestAccECRRepositoryCreationTemplate_repository
=== PAUSE TestAccECRRepositoryCreationTemplate_repository
=== RUN   TestAccECRRepositoryCreationTemplate_root
--- PASS: TestAccECRRepositoryCreationTemplate_root (13.11s)
=== CONT  TestAccECRRepositoryCreationTemplateDataSource_basic
=== CONT  TestAccECRRepositoryCreationTemplate_failWhenAlreadyExists
=== CONT  TestAccECRRepositoryCreationTemplate_repository
=== CONT  TestAccECRRepositoryCreationTemplate_disappears
=== CONT  TestAccECRRepositoryCreationTemplate_ignoreEquivalentLifecycle
=== CONT  TestAccECRRepositoryCreationTemplate_basic
--- PASS: TestAccECRRepositoryCreationTemplate_failWhenAlreadyExists (18.72s)
--- PASS: TestAccECRRepositoryCreationTemplateDataSource_basic (34.20s)
--- PASS: TestAccECRRepositoryCreationTemplate_disappears (34.66s)
--- PASS: TestAccECRRepositoryCreationTemplate_basic (39.77s)
--- PASS: TestAccECRRepositoryCreationTemplate_ignoreEquivalentLifecycle (40.89s)
--- PASS: TestAccECRRepositoryCreationTemplate_repository (49.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        77.078s
```
