### PR TITLE
b/aws_ec2_capacity_block_reservation: add `created_date` attribute

### DIFF
--- a/.changelog/38689.txt
+++ b/.changelog/38689.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_capacity_block_reservation: Fix error during apply for missing `created_date` attribute
+```

--- a/internal/service/ec2/ec2_capacity_block_reservation.go
+++ b/internal/service/ec2/ec2_capacity_block_reservation.go
@@ -250,6 +250,7 @@ type capacityBlockReservationReservationModel struct {
 	ARN                     types.String                                                     `tfsdk:"arn"`
 	AvailabilityZone        types.String                                                     `tfsdk:"availability_zone"`
 	CapacityBlockOfferingID types.String                                                     `tfsdk:"capacity_block_offering_id"`
+	CreatedDate             timetypes.RFC3339                                                `tfsdk:"created_date"`
 	EbsOptimized            types.Bool                                                       `tfsdk:"ebs_optimized"`
 	EndDate                 timetypes.RFC3339                                                `tfsdk:"end_date"`
 	EndDateType             fwtypes.StringEnum[awstypes.EndDateType]                         `tfsdk:"end_date_type"`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fix error while flattening.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #38652

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Best effort resource.

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
