### PR TITLE
internal/framework/flex: add WithFieldNameSuffix option

### DIFF
--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -449,6 +449,22 @@ func TestExpand(t *testing.T) {
 				infoConvertingWithPath("Name", reflect.TypeFor[types.String](), "IntentName", reflect.TypeFor[*string]()),
 			},
 		},
+		"resource name suffix": {
+			Options: []AutoFlexOptionsFunc{WithFieldNameSuffix("Config")},
+			Source: &TestFlexTF22{
+				Policy: types.StringValue("foo"),
+			},
+			Target: &TestFlexAWS23{},
+			WantTarget: &TestFlexAWS23{
+				PolicyConfig: aws.String("foo"),
+			},
+			expectedLogLines: []map[string]any{
+				infoExpanding(reflect.TypeFor[*TestFlexTF22](), reflect.TypeFor[*TestFlexAWS23]()),
+				infoConverting(reflect.TypeFor[TestFlexTF22](), reflect.TypeFor[TestFlexAWS23]()),
+				traceMatchedFields("Policy", reflect.TypeFor[*TestFlexTF22](), "PolicyConfig", reflect.TypeFor[*TestFlexAWS23]()),
+				infoConvertingWithPath("Policy", reflect.TypeFor[types.String](), "PolicyConfig", reflect.TypeFor[*string]()),
+			},
+		},
 		"single ARN Source and single string Target": {
 			Source:     &TestFlexTF17{Field1: fwtypes.ARNValue(testARN)},
 			Target:     &TestFlexAWS01{},

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -692,6 +692,22 @@ func TestFlatten(t *testing.T) {
 				infoConvertingWithPath("IntentName", reflect.TypeFor[*string](), "Name", reflect.TypeFor[types.String]()),
 			},
 		},
+		"resource name suffix": {
+			Options: []AutoFlexOptionsFunc{WithFieldNameSuffix("Config")},
+			Source: &TestFlexAWS23{
+				PolicyConfig: aws.String("foo"),
+			},
+			Target: &TestFlexTF22{},
+			WantTarget: &TestFlexTF22{
+				Policy: types.StringValue("foo"),
+			},
+			expectedLogLines: []map[string]any{
+				infoFlattening(reflect.TypeFor[*TestFlexAWS23](), reflect.TypeFor[*TestFlexTF22]()),
+				infoConverting(reflect.TypeFor[TestFlexAWS23](), reflect.TypeFor[TestFlexTF22]()),
+				traceMatchedFields("PolicyConfig", reflect.TypeFor[*TestFlexAWS23](), "Policy", reflect.TypeFor[*TestFlexTF22]()),
+				infoConvertingWithPath("PolicyConfig", reflect.TypeFor[*string](), "Policy", reflect.TypeFor[types.String]()),
+			},
+		},
 		"single string Source and single ARN Target": {
 			Source:     &TestFlexAWS01{Field1: testARN},
 			Target:     &TestFlexTF17{},

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -20,6 +20,7 @@ type AutoFlexCtxKey string
 
 const (
 	FieldNamePrefixRecurse AutoFlexCtxKey = "FIELD_NAME_PREFIX_RECURSE"
+	FieldNameSuffixRecurse AutoFlexCtxKey = "FIELD_NAME_SUFFIX_RECURSE"
 
 	MapBlockKey = "MapBlockKey"
 )
@@ -203,7 +204,7 @@ func findFieldFuzzy(ctx context.Context, fieldNameFrom string, valTo, valFrom re
 		}
 	}
 
-	// fourth precedence is using resource prefix
+	// fourth precedence is using field name prefix
 	if v := opts.fieldNamePrefix; v != "" {
 		v = strings.ReplaceAll(v, " ", "")
 		if ctx.Value(FieldNamePrefixRecurse) == nil {
@@ -213,6 +214,19 @@ func findFieldFuzzy(ctx context.Context, fieldNameFrom string, valTo, valFrom re
 				return findFieldFuzzy(ctx, strings.TrimPrefix(fieldNameFrom, v), valTo, valFrom, flexer)
 			}
 			return findFieldFuzzy(ctx, v+fieldNameFrom, valTo, valFrom, flexer)
+		}
+	}
+
+	// fifth precedence is using field name suffix
+	if v := opts.fieldNameSuffix; v != "" {
+		v = strings.ReplaceAll(v, " ", "")
+		if ctx.Value(FieldNameSuffixRecurse) == nil {
+			// so it will only recurse once
+			ctx = context.WithValue(ctx, FieldNameSuffixRecurse, true)
+			if strings.HasSuffix(fieldNameFrom, v) {
+				return findFieldFuzzy(ctx, strings.TrimSuffix(fieldNameFrom, v), valTo, valFrom, flexer)
+			}
+			return findFieldFuzzy(ctx, fieldNameFrom+v, valTo, valFrom, flexer)
 		}
 	}
 

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -170,6 +170,14 @@ type TestFlexAWS18 struct {
 	IntentName *string
 }
 
+type TestFlexTF22 struct {
+	Policy types.String `tfsdk:"policy"`
+}
+
+type TestFlexAWS23 struct {
+	PolicyConfig *string
+}
+
 type TestFlexTimeTF01 struct {
 	CreationDateTime timetypes.RFC3339 `tfsdk:"creation_date_time"`
 }

--- a/internal/framework/flex/options.go
+++ b/internal/framework/flex/options.go
@@ -18,6 +18,10 @@ type AutoFlexOptions struct {
 	// or more fields on an AWS data structure
 	fieldNamePrefix string
 
+	// fieldNameSuffix specifies a common suffix which may be applied to one
+	// or more fields on an AWS data structure
+	fieldNameSuffix string
+
 	// ignoredFieldNames stores names which expanders and flatteners will
 	// not read from or write to
 	ignoredFieldNames []string
@@ -31,6 +35,17 @@ type AutoFlexOptions struct {
 func WithFieldNamePrefix(s string) AutoFlexOptionsFunc {
 	return func(o *AutoFlexOptions) {
 		o.fieldNamePrefix = s
+	}
+}
+
+// WithFieldNameSuffix specifies a suffix to be accounted for when
+// matching field names between Terraform and AWS data structures
+//
+// Use this option to improve fuzzy matching of field names during AutoFlex
+// expand/flatten operations.
+func WithFieldNameSuffix(s string) AutoFlexOptionsFunc {
+	return func(o *AutoFlexOptions) {
+		o.fieldNameSuffix = s
 	}
 }
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This option will allow a suffix to be provided which can improve matching of field names between Terraform and AWS data structures. This can be useful in cases where field names differ by a consistent suffix between the Create/Update and Read AWS data structures.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38626 

