### PR TITLE
tests(s3): updated s3 test data config to use aws_service_principal data source

### DIFF
--- a/internal/service/s3/bucket_notification_test.go
+++ b/internal/service/s3/bucket_notification_test.go
@@ -362,6 +362,9 @@ resource "aws_s3_bucket_notification" "test" {
 func testAccBucketNotificationConfig_topicMultiple(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
 
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -373,7 +376,7 @@ resource "aws_sns_topic" "test" {
     {
       "Sid": "",
       "Effect": "Allow",
-      "Principal": { "Service": "s3.${data.aws_partition.current.dns_suffix}" },
+      "Principal": { "Service": "${data.aws_service_principal.current.name}" },
       "Action": "SNS:Publish",
       "Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",
       "Condition": {
@@ -527,7 +530,12 @@ resource "aws_s3_bucket_notification" "test" {
 func testAccBucketNotificationConfig_lambdaFunction(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
-
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
+data "aws_service_principal" "current_lambda" {
+  service_name = "lambda"
+}
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -538,7 +546,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "lambda.${data.aws_partition.current.dns_suffix}"
+        "Service": "${data.aws_service_principal.current_lambda.name}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -552,7 +560,7 @@ resource "aws_lambda_permission" "test" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.test.arn
-  principal     = "s3.${data.aws_partition.current.dns_suffix}"
+  principal     = "${data.aws_service_principal.current.name}"
   source_arn    = aws_s3_bucket.test.arn
 }
 
@@ -616,6 +624,12 @@ resource "aws_s3_bucket_notification" "test" {
 func testAccBucketNotificationConfig_lambdaFunctionLambdaFunctionARNAlias(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
+data "aws_service_principal" "current_lambda" {
+  service_name = "lambda"
+}
 
 resource "aws_iam_role" "test" {
   assume_role_policy = <<EOF
@@ -625,7 +639,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "lambda.${data.aws_partition.current.dns_suffix}"
+        "Service": "${data.aws_service_principal.current_lambda.name}"
       },
       "Effect": "Allow"
     }
@@ -653,7 +667,7 @@ resource "aws_lambda_alias" "test" {
 resource "aws_lambda_permission" "test" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.test.arn
-  principal     = "s3.${data.aws_partition.current.dns_suffix}"
+  principal     = "${data.aws_service_principal.current.name}"
   qualifier     = aws_lambda_alias.test.name
   source_arn    = aws_s3_bucket.test.arn
   statement_id  = "AllowExecutionFromS3Bucket"
@@ -678,6 +692,9 @@ resource "aws_s3_bucket_notification" "test" {
 func testAccBucketNotificationConfig_topic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
 
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -690,7 +707,7 @@ resource "aws_sns_topic" "test" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": "s3.${data.aws_partition.current.dns_suffix}"
+        "Service": "${data.aws_service_principal.current.name}"
       },
       "Action": "SNS:Publish",
       "Resource": "arn:${data.aws_partition.current.partition}:sns:*:*:%[1]s",

--- a/internal/service/s3/bucket_policy_data_source_test.go
+++ b/internal/service/s3/bucket_policy_data_source_test.go
@@ -73,6 +73,10 @@ func testAccCheckBucketPolicyMatch(nameFirst, keyFirst, nameSecond, keySecond st
 
 func testAccDataSourceBucketPolicyConfig_base(rName string) string {
 	return fmt.Sprintf(`
+data "aws_service_principal" "current" {
+  service_name = "lambda"
+}
+
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
 }
@@ -98,7 +102,7 @@ data "aws_iam_policy_document" "test" {
 
     principals {
       type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
+      identifiers = ["${data.aws_service_principal.current.name}"]
     }
   }
 }

--- a/internal/service/s3/bucket_policy_test.go
+++ b/internal/service/s3/bucket_policy_test.go
@@ -591,6 +591,9 @@ data "aws_iam_policy_document" "policy" {
 func testAccBucketPolicyIAMRoleOrderConfig_base(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
 
 resource "aws_iam_role" "test1" {
   name = "%[1]s-sultan"
@@ -600,7 +603,7 @@ resource "aws_iam_role" "test1" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-        Service = "s3.${data.aws_partition.current.dns_suffix}"
+        Service = "${data.aws_service_principal.current.name}"
       }
     }]
     Version = "2012-10-17"
@@ -615,7 +618,7 @@ resource "aws_iam_role" "test2" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-        Service = "s3.${data.aws_partition.current.dns_suffix}"
+        Service = "${data.aws_service_principal.current.name}"
       }
     }]
     Version = "2012-10-17"
@@ -630,7 +633,7 @@ resource "aws_iam_role" "test3" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-        Service = "s3.${data.aws_partition.current.dns_suffix}"
+        Service = "${data.aws_service_principal.current.name}"
       }
     }]
     Version = "2012-10-17"
@@ -645,7 +648,7 @@ resource "aws_iam_role" "test4" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-        Service = "s3.${data.aws_partition.current.dns_suffix}"
+        Service = "${data.aws_service_principal.current.name}"
       }
     }]
     Version = "2012-10-17"
@@ -660,7 +663,7 @@ resource "aws_iam_role" "test5" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-        Service = "s3.${data.aws_partition.current.dns_suffix}"
+        Service = "${data.aws_service_principal.current.name}"
       }
     }]
     Version = "2012-10-17"

--- a/internal/service/s3/bucket_replication_configuration_test.go
+++ b/internal/service/s3/bucket_replication_configuration_test.go
@@ -1273,6 +1273,9 @@ func testAccCheckBucketReplicationConfigurationExists(ctx context.Context, n str
 func testAccBucketReplicationConfigurationConfig_base(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1284,7 +1287,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "s3.${data.aws_partition.current.dns_suffix}"
+        "Service": "${data.aws_service_principal.current.name}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -1924,6 +1927,10 @@ resource "aws_s3_bucket_replication_configuration" "test" {
 
 func testAccBucketReplicationConfigurationConfig_schemaV2SameRegion(rName, rNameDestination string) string {
 	return fmt.Sprintf(`
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -1934,7 +1941,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "s3.amazonaws.com"
+        "Service": "${data.aws_service_principal.current.name}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -1998,6 +2005,9 @@ resource "aws_s3_bucket_replication_configuration" "test" {
 func testAccBucketReplicationConfigurationConfig_existingObject(rName, rNameDestination string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2009,7 +2019,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "s3.${data.aws_partition.current.dns_suffix}"
+        "Service": "${data.aws_service_principal.current.name}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -2296,6 +2306,9 @@ resource "aws_s3_bucket_replication_configuration" "test" {
 func testAccBucketReplicationConfigurationConfig_migrationBase(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
 
 resource "aws_iam_role" "role" {
   name = %[1]q
@@ -2307,7 +2320,7 @@ resource "aws_iam_role" "role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "s3.${data.aws_partition.current.dns_suffix}"
+        "Service": "${data.aws_service_principal.current.name}"
       },
       "Effect": "Allow",
       "Sid": ""

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -3056,6 +3056,9 @@ func testAccBucketConfig_ReplicationBase(bucketName string) string {
 		acctest.ConfigMultipleRegionProvider(2),
 		fmt.Sprintf(`
 data "aws_partition" "current" {}
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
 
 resource "aws_iam_role" "role" {
   name = %[1]q
@@ -3067,7 +3070,7 @@ resource "aws_iam_role" "role" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "s3.${data.aws_partition.current.dns_suffix}"
+        "Service": "${data.aws_service_principal.current.name}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -3580,6 +3583,10 @@ resource "aws_s3_bucket" "source" {
 
 func testAccBucketConfig_replicationV2SameRegionNoTags(rName string) string {
 	return fmt.Sprintf(`
+data "aws_service_principal" "current" {
+  service_name = "s3"
+}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
 
@@ -3590,7 +3597,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "s3.amazonaws.com"
+        "Service": "${data.aws_service_principal.current.name}"
       },
       "Effect": "Allow",
       "Sid": ""


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

With the release of the AWS Service Principal Name Data Source in [v5.60.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.60.0) this PR updates S3 test resources to use it, in order to provide more effective testing across partitions


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #38307

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
N/A

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  TF_ACC=1 go test ./internal/service/s3/ -v -run="TestAccS3BucketPolicyDataSource"

=== RUN   TestAccS3BucketPolicyDataSource_basic
=== PAUSE TestAccS3BucketPolicyDataSource_basic
=== CONT  TestAccS3BucketPolicyDataSource_basic
--- PASS: TestAccS3BucketPolicyDataSource_basic (18.81s)
PASS

% TF_ACC=1 go test ./internal/service/s3/ -v -run="TestAccS3BucketPolicy"

=== RUN   TestAccS3BucketPolicyDataSource_basic
=== PAUSE TestAccS3BucketPolicyDataSource_basic
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPolicy_disappears
=== PAUSE TestAccS3BucketPolicy_disappears
=== RUN   TestAccS3BucketPolicy_disappears_bucket
=== PAUSE TestAccS3BucketPolicy_disappears_bucket
=== RUN   TestAccS3BucketPolicy_policyUpdate
=== PAUSE TestAccS3BucketPolicy_policyUpdate
=== RUN   TestAccS3BucketPolicy_IAMRoleOrder_policyDoc
=== PAUSE TestAccS3BucketPolicy_IAMRoleOrder_policyDoc
=== RUN   TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal
=== PAUSE TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal
=== RUN   TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode
=== PAUSE TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode
=== RUN   TestAccS3BucketPolicy_migrate_noChange
=== PAUSE TestAccS3BucketPolicy_migrate_noChange
=== RUN   TestAccS3BucketPolicy_migrate_withChange
=== PAUSE TestAccS3BucketPolicy_migrate_withChange
=== RUN   TestAccS3BucketPolicy_directoryBucket
=== PAUSE TestAccS3BucketPolicy_directoryBucket
=== CONT  TestAccS3BucketPolicyDataSource_basic
=== CONT  TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal
=== CONT  TestAccS3BucketPolicy_IAMRoleOrder_policyDoc
=== CONT  TestAccS3BucketPolicy_migrate_withChange
=== CONT  TestAccS3BucketPolicy_directoryBucket
=== CONT  TestAccS3BucketPolicy_disappears
=== CONT  TestAccS3BucketPolicy_migrate_noChange
=== CONT  TestAccS3BucketPolicy_policyUpdate
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3BucketPolicy_disappears_bucket
--- PASS: TestAccS3BucketPolicy_directoryBucket (25.59s)
=== CONT  TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode
--- PASS: TestAccS3BucketPolicy_disappears_bucket (25.67s)
--- PASS: TestAccS3BucketPolicyDataSource_basic (26.59s)
--- PASS: TestAccS3BucketPolicy_disappears (27.59s)
--- PASS: TestAccS3BucketPolicy_basic (30.34s)
--- PASS: TestAccS3BucketPolicy_migrate_withChange (41.06s)
--- PASS: TestAccS3BucketPolicy_migrate_noChange (42.28s)
--- PASS: TestAccS3BucketPolicy_policyUpdate (45.18s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDoc (49.67s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_policyDocNotPrincipal (56.67s)
--- PASS: TestAccS3BucketPolicy_IAMRoleOrder_jsonEncode (84.02s)
PASS

.....
```
