### PR TITLE
internal/provider(test): remove DMS from unusual endpoint tests

### DIFF
--- a/internal/provider/provider_acc_test.go
+++ b/internal/provider/provider_acc_test.go
@@ -217,8 +217,7 @@ func TestAccProvider_unusualEndpoints(t *testing.T) {
 	ctx := acctest.Context(t)
 	var provider *schema.Provider
 	unusual1 := unusualEndpoint{"es", "elasticsearch", "http://notarealendpoint"}
-	unusual2 := unusualEndpoint{"databasemigration", "dms", "http://alsonotarealendpoint"}
-	unusual3 := unusualEndpoint{"lexmodelbuildingservice", "lexmodels", "http://kingofspain"}
+	unusual2 := unusualEndpoint{"lexmodelbuildingservice", "lexmodels", "http://kingofspain"}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -227,11 +226,10 @@ func TestAccProvider_unusualEndpoints(t *testing.T) {
 		CheckDestroy:             nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProviderConfig_unusualEndpoints(unusual1, unusual2, unusual3),
+				Config: testAccProviderConfig_unusualEndpoints(unusual1, unusual2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUnusualEndpoints(ctx, &provider, unusual1),
 					testAccCheckUnusualEndpoints(ctx, &provider, unusual2),
-					testAccCheckUnusualEndpoints(ctx, &provider, unusual3),
 				),
 			},
 		},
@@ -1056,7 +1054,7 @@ resource "aws_s3_bucket" "test" {
 `, endpoint, rName))
 }
 
-func testAccProviderConfig_unusualEndpoints(unusual1, unusual2, unusual3 unusualEndpoint) string {
+func testAccProviderConfig_unusualEndpoints(unusual1, unusual2 unusualEndpoint) string {
 	//lintignore:AT004
 	return acctest.ConfigCompose(testAccProviderConfig_base, fmt.Sprintf(`
 provider "aws" {
@@ -1067,10 +1065,9 @@ provider "aws" {
   endpoints {
     %[1]s = %[2]q
     %[3]s = %[4]q
-    %[5]s = %[6]q
   }
 }
-`, unusual1.fieldName, unusual1.url, unusual2.fieldName, unusual2.url, unusual3.fieldName, unusual3.url))
+`, unusual1.fieldName, unusual1.url, unusual2.fieldName, unusual2.url))
 }
 
 func testAccProviderConfig_useFipsEndpointFlag(rName string) string {


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
DMS has been migrated to AWS SDK for Go V2, and thus the corresponding `DMSConn` method to create a V1 client no longer exists. The generic `TestAccProvider_endpoints` test effectively ignores services which use V2 AWS SDK clients with the following conditional in the test check function (`serviceConn` will always return a method name ending in `Conn`):

```go
			methodName := serviceConn(serviceKey)
			method := reflect.ValueOf(providerClient).MethodByName(methodName)
			if !method.IsValid() {
				continue
			}
```

Because this generic test check ignores V2 clients, the DMS case for the unusual endpoints tests has been removed entirely rather than including new conditional logic which would effectively just skip the case before executing any real checks.

### Relations

Relates #37780

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TF_ACC=1 go test -count=1 ./internal/provider/... -run="TestAccProvider_unusualEndpoints"
?       github.com/hashicorp/terraform-provider-aws/internal/provider/fwprovider        [no test files]
ok      github.com/hashicorp/terraform-provider-aws/internal/provider   23.263s
```