### PR TITLE
f/add slot type attribute

### DIFF
--- a/.changelog/38698.txt
+++ b/.changelog/38698.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lexv2models_slot: Add `sub_slot_setting` attribute
+```

--- a/internal/service/lexv2models/slot.go
+++ b/internal/service/lexv2models/slot.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -460,10 +461,16 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 		},
 	}
 
-	slotSpecificationsLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[SlotSpecificationsData](ctx),
+	slotSpecificationsLNB := schema.SetNestedBlock{
+		Validators: []validator.Set{
+			setvalidator.SizeAtMost(6),
+		},
+		CustomType: fwtypes.NewSetNestedObjectTypeOf[SlotSpecificationsData](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
+				"map_block_key": schema.StringAttribute{
+					Required: true,
+				},
 				"slot_type_id": schema.StringAttribute{
 					Required: true,
 				},
@@ -555,6 +562,7 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 			},
 			"slot_type_id": schema.StringAttribute{
 				Optional: true,
+				Computed: true,
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -792,13 +800,14 @@ type resourceSlotData struct {
 }
 
 type SubSlotSettingData struct {
-	Expression        types.String                                            `tfsdk:"expression"`
-	SlotSpecification fwtypes.ListNestedObjectValueOf[SlotSpecificationsData] `tfsdk:"slot_specification"`
+	Expression         types.String                                           `tfsdk:"expression"`
+	SlotSpecifications fwtypes.SetNestedObjectValueOf[SlotSpecificationsData] `tfsdk:"slot_specifications"`
 }
 
 type SlotSpecificationsData struct {
 	SlotTypeID              types.String                                                        `tfsdk:"slot_type_id"`
 	ValueElicitationSetting fwtypes.ListNestedObjectValueOf[SubSlotValueElicitationSettingData] `tfsdk:"value_elicitation_setting"`
+	MapBlockKey             types.String                                                        `tfsdk:"map_block_key"`
 }
 
 type SubSlotValueElicitationSettingData struct {

--- a/internal/service/lexv2models/slot.go
+++ b/internal/service/lexv2models/slot.go
@@ -485,7 +485,7 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 		CustomType: fwtypes.NewListNestedObjectTypeOf[SubSlotSettingData](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
-				"expression": schema.StringAttribute{
+				names.AttrExpression: schema.StringAttribute{
 					Optional: true,
 				},
 			},

--- a/internal/service/lexv2models/slot.go
+++ b/internal/service/lexv2models/slot.go
@@ -448,6 +448,17 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 		},
 	}
 
+	subSlotSettingLNB := schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[SubSlotSettingData](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"expression": schema.StringAttribute{
+					Optional: true,
+				},
+			},
+		},
+	}
+
 	valueElicitationSettingLNB := schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[ValueElicitationSettingData](ctx),
 		Validators: []validator.List{
@@ -521,7 +532,7 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"multiple_values_setting":   multValueSettingsLNB,
 			"obfuscation_setting":       obfuscationSettingLNB,
 			"value_elicitation_setting": valueElicitationSettingLNB,
-			//sub_slot_setting
+			"sub_slot_setting":          subSlotSettingLNB,
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,

--- a/internal/service/lexv2models/slot.go
+++ b/internal/service/lexv2models/slot.go
@@ -448,6 +448,32 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 		},
 	}
 
+	subSlotValueElicitationSettingLNB := schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[SubSlotValueElicitationSettingData](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Blocks: map[string]schema.Block{
+				"prompt_specification":            promptSpecificationLNB,
+				"default_value_specification":     defaultValueSpecificationLNB,
+				"sample_utterance":                sampleUtteranceLNB,
+				"wait_and_continue_specification": waitAndContinueSpecificationLNB,
+			},
+		},
+	}
+
+	slotSpecificationsLNB := schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[SlotSpecificationsData](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"slot_type_id": schema.StringAttribute{
+					Required: true,
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"value_elicitation_setting": subSlotValueElicitationSettingLNB,
+			},
+		},
+	}
+
 	subSlotSettingLNB := schema.ListNestedBlock{
 		CustomType: fwtypes.NewListNestedObjectTypeOf[SubSlotSettingData](ctx),
 		NestedObject: schema.NestedBlockObject{
@@ -455,6 +481,9 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 				"expression": schema.StringAttribute{
 					Optional: true,
 				},
+			},
+			Blocks: map[string]schema.Block{
+				"slot_specifications": slotSpecificationsLNB,
 			},
 		},
 	}
@@ -759,6 +788,24 @@ type resourceSlotData struct {
 	Timeouts                timeouts.Value                                               `tfsdk:"timeouts"`
 	SlotTypeID              types.String                                                 `tfsdk:"slot_type_id"`
 	ValueElicitationSetting fwtypes.ListNestedObjectValueOf[ValueElicitationSettingData] `tfsdk:"value_elicitation_setting"`
+	SubSlotSetting          fwtypes.ListNestedObjectValueOf[SubSlotSettingData]          `tfsdk:"sub_slot_setting"`
+}
+
+type SubSlotSettingData struct {
+	Expression        types.String                                            `tfsdk:"expression"`
+	SlotSpecification fwtypes.ListNestedObjectValueOf[SlotSpecificationsData] `tfsdk:"slot_specification"`
+}
+
+type SlotSpecificationsData struct {
+	SlotTypeID              types.String                                                        `tfsdk:"slot_type_id"`
+	ValueElicitationSetting fwtypes.ListNestedObjectValueOf[SubSlotValueElicitationSettingData] `tfsdk:"value_elicitation_setting"`
+}
+
+type SubSlotValueElicitationSettingData struct {
+	PromptSpecification          fwtypes.ListNestedObjectValueOf[PromptSpecification]              `tfsdk:"prompt_specification"`
+	DefaultValueSpecification    fwtypes.ListNestedObjectValueOf[DefaultValueSpecificationData]    `tfsdk:"default_value_specification"`
+	SampleUtterance              fwtypes.ListNestedObjectValueOf[SampleUtterance]                  `tfsdk:"sample_utterance"`
+	WaitAndContinueSpecification fwtypes.ListNestedObjectValueOf[WaitAndContinueSpecificationData] `tfsdk:"wait_and_continue_specification"`
 }
 
 type MultipleValuesSettingData struct {

--- a/internal/service/lexv2models/slot.go
+++ b/internal/service/lexv2models/slot.go
@@ -453,8 +453,8 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 		CustomType: fwtypes.NewListNestedObjectTypeOf[SubSlotValueElicitationSettingData](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Blocks: map[string]schema.Block{
-				"prompt_specification":            promptSpecificationLNB,
 				"default_value_specification":     defaultValueSpecificationLNB,
+				"prompt_specification":            promptSpecificationLNB,
 				"sample_utterance":                sampleUtteranceLNB,
 				"wait_and_continue_specification": waitAndContinueSpecificationLNB,
 			},
@@ -490,7 +490,7 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 				},
 			},
 			Blocks: map[string]schema.Block{
-				"slot_specifications": slotSpecificationsLNB,
+				"slot_specification": slotSpecificationsLNB,
 			},
 		},
 	}
@@ -561,8 +561,8 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Required: true,
 			},
 			"slot_type_id": schema.StringAttribute{
-				Optional: true,
 				Computed: true,
+				Optional: true,
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -800,8 +800,8 @@ type resourceSlotData struct {
 }
 
 type SubSlotSettingData struct {
-	Expression         types.String                                           `tfsdk:"expression"`
-	SlotSpecifications fwtypes.SetNestedObjectValueOf[SlotSpecificationsData] `tfsdk:"slot_specifications"`
+	Expression        types.String                                           `tfsdk:"expression"`
+	SlotSpecification fwtypes.SetNestedObjectValueOf[SlotSpecificationsData] `tfsdk:"slot_specification"`
 }
 
 type SlotSpecificationsData struct {

--- a/internal/service/lexv2models/slot_test.go
+++ b/internal/service/lexv2models/slot_test.go
@@ -108,7 +108,7 @@ func TestAccLexV2ModelsSlot_updateMultipleValuesSetting(t *testing.T) {
 	})
 }
 
-func TestAccLexV2ModelsSlot_ObfuscationSetting(t *testing.T) {
+func TestAccLexV2ModelsSlot_obfuscationSetting(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var slot lexmodelsv2.DescribeSlotOutput
@@ -143,7 +143,7 @@ func TestAccLexV2ModelsSlot_ObfuscationSetting(t *testing.T) {
 	})
 }
 
-func TestAccLexV2ModelsSlot_SubSlotSetting(t *testing.T) {
+func TestAccLexV2ModelsSlot_subSlotSetting(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var slot lexmodelsv2.DescribeSlotOutput
@@ -171,7 +171,7 @@ func TestAccLexV2ModelsSlot_SubSlotSetting(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
 					resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.0.expression", "string"),
-					resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.0.slot_specifications.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.0.slot_specification.#", acctest.Ct1),
 				),
 			},
 		},
@@ -431,7 +431,7 @@ resource "aws_lexv2models_slot" "test" {
 
   sub_slot_setting {
     expression = "string"
-    slot_specifications {
+    slot_specification {
       map_block_key = "Initial"
       slot_type_id  = aws_lexv2models_slot_type.test.slot_type_id
       value_elicitation_setting {

--- a/internal/service/lexv2models/slot_test.go
+++ b/internal/service/lexv2models/slot_test.go
@@ -169,9 +169,9 @@ func TestAccLexV2ModelsSlot_SubSlotSetting(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
 					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
-					resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.#", acctest.Ct2),
-					// resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.0.expression", "string"),
-					// resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.0.slot_specifications.#", "7"),
+					resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.0.expression", "string"),
+					resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.0.slot_specifications.#", acctest.Ct1),
 				),
 			},
 		},
@@ -432,7 +432,8 @@ resource "aws_lexv2models_slot" "test" {
   sub_slot_setting {
     expression = "string"
     slot_specifications {
-      slot_type_id = aws_lexv2models_slot_type.test.id
+      map_block_key = "Initial"
+      slot_type_id = aws_lexv2models_slot_type.test.slot_type_id
       value_elicitation_setting {
         prompt_specification {
           allow_interrupt            = true
@@ -445,17 +446,65 @@ resource "aws_lexv2models_slot" "test" {
               }
             }
           }
-        }
-        default_value_specification {
-          default_value_list {
-            default_value = "default"
+          prompt_attempts_specification {
+            allow_interrupt = true
+            map_block_key   = "Initial"
+
+            allowed_input_types {
+              allow_audio_input = true
+              allow_dtmf_input  = true
+            }
+
+            audio_and_dtmf_input_specification {
+              start_timeout_ms = 4000
+
+              audio_specification {
+                end_timeout_ms = 640
+                max_length_ms  = 15000
+              }
+
+              dtmf_specification {
+                deletion_character = "*"
+                end_character      = "#"
+                end_timeout_ms     = 5000
+                max_length         = 513
+              }
+            }
+
+            text_input_specification {
+              start_timeout_ms = 30000
+            }
           }
-        }
-        sample_utterance {
-		  utterance = "blue"
-        }
-        wait_and_continue_specification {
-          active = true
+
+          prompt_attempts_specification {
+            allow_interrupt = true
+            map_block_key   = "Retry1"
+
+            allowed_input_types {
+              allow_audio_input = true
+              allow_dtmf_input  = true
+            }
+
+            audio_and_dtmf_input_specification {
+              start_timeout_ms = 4000
+
+            audio_specification {
+              end_timeout_ms = 640
+              max_length_ms  = 15000
+            }
+
+            dtmf_specification {
+              deletion_character = "*"
+              end_character      = "#"
+              end_timeout_ms     = 5000
+              max_length         = 513
+            }
+          }
+
+          text_input_specification {
+            start_timeout_ms = 30000
+          }
+		}
         }
       }
     }

--- a/internal/service/lexv2models/slot_test.go
+++ b/internal/service/lexv2models/slot_test.go
@@ -433,7 +433,7 @@ resource "aws_lexv2models_slot" "test" {
     expression = "string"
     slot_specifications {
       map_block_key = "Initial"
-      slot_type_id = aws_lexv2models_slot_type.test.slot_type_id
+      slot_type_id  = aws_lexv2models_slot_type.test.slot_type_id
       value_elicitation_setting {
         prompt_specification {
           allow_interrupt            = true
@@ -488,23 +488,23 @@ resource "aws_lexv2models_slot" "test" {
             audio_and_dtmf_input_specification {
               start_timeout_ms = 4000
 
-            audio_specification {
-              end_timeout_ms = 640
-              max_length_ms  = 15000
+              audio_specification {
+                end_timeout_ms = 640
+                max_length_ms  = 15000
+              }
+
+              dtmf_specification {
+                deletion_character = "*"
+                end_character      = "#"
+                end_timeout_ms     = 5000
+                max_length         = 513
+              }
             }
 
-            dtmf_specification {
-              deletion_character = "*"
-              end_character      = "#"
-              end_timeout_ms     = 5000
-              max_length         = 513
+            text_input_specification {
+             start_timeout_ms = 30000
             }
           }
-
-          text_input_specification {
-            start_timeout_ms = 30000
-          }
-		}
         }
       }
     }

--- a/internal/service/lexv2models/slot_test.go
+++ b/internal/service/lexv2models/slot_test.go
@@ -502,7 +502,7 @@ resource "aws_lexv2models_slot" "test" {
             }
 
             text_input_specification {
-             start_timeout_ms = 30000
+              start_timeout_ms = 30000
             }
           }
         }

--- a/internal/service/lexv2models/slot_test.go
+++ b/internal/service/lexv2models/slot_test.go
@@ -143,6 +143,41 @@ func TestAccLexV2ModelsSlot_ObfuscationSetting(t *testing.T) {
 	})
 }
 
+func TestAccLexV2ModelsSlot_SubSlotSetting(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var slot lexmodelsv2.DescribeSlotOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_slot.test"
+	botLocaleName := "aws_lexv2models_bot_locale.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSlotDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSlotConfig_subSlotSetting(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSlotExists(ctx, resourceName, &slot),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_id", botLocaleName, "bot_id"),
+					resource.TestCheckResourceAttrPair(resourceName, "bot_version", botLocaleName, "bot_version"),
+					resource.TestCheckResourceAttrPair(resourceName, "locale_id", botLocaleName, "locale_id"),
+					resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.#", acctest.Ct2),
+					// resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.0.expression", "string"),
+					// resource.TestCheckResourceAttr(resourceName, "sub_slot_setting.0.slot_specifications.#", "7"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLexV2ModelsSlot_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -358,4 +393,73 @@ resource "aws_lexv2models_slot" "test" {
   }
 }
 `, rName, settingType))
+}
+
+func testAccSlotConfig_subSlotSetting(rName string, allow bool) string {
+	return acctest.ConfigCompose(
+		testAccSlotConfig_base(rName, 60, true),
+		fmt.Sprintf(`
+resource "aws_lexv2models_slot_type" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  value_selection_setting {
+    resolution_strategy = "OriginalValue"
+  }
+}
+resource "aws_lexv2models_slot" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  intent_id   = aws_lexv2models_intent.test.intent_id
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  value_elicitation_setting {
+    slot_constraint = "Optional"
+    default_value_specification {
+      default_value_list {
+        default_value = "default"
+      }
+    }
+  }
+
+  multiple_values_setting {
+    allow_multiple_values = %[2]t
+  }
+
+  sub_slot_setting {
+    expression = "string"
+    slot_specifications {
+      slot_type_id = aws_lexv2models_slot_type.test.id
+      value_elicitation_setting {
+        prompt_specification {
+          allow_interrupt            = true
+          max_retries                = 1
+          message_selection_strategy = "Ordered"
+          message_group {
+            message {
+              plain_text_message {
+                value = "test"
+              }
+            }
+          }
+        }
+        default_value_specification {
+          default_value_list {
+            default_value = "default"
+          }
+        }
+        sample_utterance {
+		  utterance = "blue"
+        }
+        wait_and_continue_specification {
+          active = true
+        }
+      }
+    }
+  }
+}
+`, rName, allow))
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add `sub_slot_type` to `slot` resource

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35514

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTARGS='-run=TestAccLexV2ModelsSlot_' PKG=lexv2models
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/lexv2models/... -v -count 1 -parallel 20  -run=TestAccLexV2ModelsSlot_ -timeout 360m
=== RUN   TestAccLexV2ModelsSlot_basic
=== PAUSE TestAccLexV2ModelsSlot_basic
=== RUN   TestAccLexV2ModelsSlot_updateMultipleValuesSetting
=== PAUSE TestAccLexV2ModelsSlot_updateMultipleValuesSetting
=== RUN   TestAccLexV2ModelsSlot_obfuscationSetting
=== PAUSE TestAccLexV2ModelsSlot_obfuscationSetting
=== RUN   TestAccLexV2ModelsSlot_subSlotSetting
=== PAUSE TestAccLexV2ModelsSlot_subSlotSetting
=== RUN   TestAccLexV2ModelsSlot_disappears
=== PAUSE TestAccLexV2ModelsSlot_disappears
=== CONT  TestAccLexV2ModelsSlot_basic
=== CONT  TestAccLexV2ModelsSlot_obfuscationSetting
=== CONT  TestAccLexV2ModelsSlot_subSlotSetting
=== CONT  TestAccLexV2ModelsSlot_disappears
=== CONT  TestAccLexV2ModelsSlot_updateMultipleValuesSetting
--- PASS: TestAccLexV2ModelsSlot_obfuscationSetting (40.74s)
--- PASS: TestAccLexV2ModelsSlot_disappears (42.43s)
--- PASS: TestAccLexV2ModelsSlot_basic (44.72s)
--- PASS: TestAccLexV2ModelsSlot_subSlotSetting (47.11s)
--- PASS: TestAccLexV2ModelsSlot_updateMultipleValuesSetting (54.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        59.860s

...
```
