### PR TITLE
Fix issue with `filter.and.object*` size fields not being set when a zero value is specified

### DIFF
--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -711,11 +711,11 @@ func expandLifecycleRuleFilterMemberAnd(ctx context.Context, m map[string]interf
 		Value: types.LifecycleRuleAndOperator{},
 	}
 
-	if v, null, _ := nullable.Int(m["object_size_greater_than"].(string)).ValueInt64(); !null {
+	if v, null, _ := nullable.Int(m["object_size_greater_than"].(string)).ValueInt64(); !null && v >= 0 {
 		result.Value.ObjectSizeGreaterThan = aws.Int64(v)
 	}
 
-	if v, null, _ := nullable.Int(m["object_size_less_than"].(string)).ValueInt64(); !null {
+	if v, null, _ := nullable.Int(m["object_size_less_than"].(string)).ValueInt64(); !null && v > 0 {
 		result.Value.ObjectSizeLessThan = aws.Int64(v)
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- makes the `filter.and.object_size_greater_than` and `filter.and.object_size_less_than` fields more consistent in type as well as flatten/expand behavior to the `filter.object_size_greater_than` and `filter.object_size_less_than` fields
- avoids bug where if you set `filter.and.object_size_greater_than` to zero it doesn't get expanded in `expandLifecycleRuleFilterMemberAnd`


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38551 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix PKG=s3

=== RUN   TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
=== CONT  TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (174.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	179.504s

```
