### PR TITLE
docs: move attribute to correct location in example code

### DIFF
--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -65,8 +65,6 @@ resource "aws_wafv2_web_acl" "example" {
       }
     }
 
-    token_domains = ["mywebsite.com", "myotherwebsite.com"]
-
     visibility_config {
       cloudwatch_metrics_enabled = false
       metric_name                = "friendly-rule-metric-name"
@@ -78,6 +76,8 @@ resource "aws_wafv2_web_acl" "example" {
     Tag1 = "Value1"
     Tag2 = "Value2"
   }
+
+  token_domains = ["mywebsite.com", "myotherwebsite.com"]
 
   visibility_config {
     cloudwatch_metrics_enabled = false


### PR DESCRIPTION
### Description

The [example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#managed-rule) provided in the documentation does not pass a `terraform validate` run.

Reason: `token_domains` is in the wrong place. In the example it is part of a `rule` inside , but it needs to be provided on resource level.  Under references I provided a link to the relevant source code section.

### Relations

Closes #38703 


### References

- [Source code reference](https://github.com/hashicorp/terraform-provider-aws/blob/0a8bbd706b6e776e343dde4409c27ad41ca5636a/internal/service/wafv2/web_acl.go#L171)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.