### PR TITLE
sweepers: Separates `Register` functions for AWS SDK versions

### DIFF
--- a/internal/service/appautoscaling/sweep.go
+++ b/internal/service/appautoscaling/sweep.go
@@ -24,9 +24,9 @@ const (
 )
 
 func RegisterSweepers() {
-	sweep.Register("aws_appautoscaling_policy", sweepPolicy)
+	awsv2.Register("aws_appautoscaling_policy", sweepPolicy)
 
-	sweep.Register("aws_appautoscaling_target", sweepTarget,
+	awsv2.Register("aws_appautoscaling_target", sweepTarget,
 		"aws_appautoscaling_policy",
 	)
 }
@@ -46,12 +46,6 @@ func sweepPolicy(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepabl
 		pages := applicationautoscaling.NewDescribeScalingPoliciesPaginator(conn, &input)
 		for pages.HasMorePages() {
 			page, err := pages.NextPage(ctx)
-			if awsv2.SkipSweepError(err) {
-				tflog.Warn(ctx, "Skipping sweeper", map[string]any{
-					"error": err.Error(),
-				})
-				return nil, nil
-			}
 			if errs.IsAErrorMessageContains[*awstypes.ValidationException](err, "at 'serviceNamespace' failed to satisfy constraint") {
 				tflog.Info(ctx, "Skipping service namespace", map[string]any{
 					"error": err.Error(),
@@ -93,12 +87,6 @@ func sweepTarget(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepabl
 		pages := applicationautoscaling.NewDescribeScalableTargetsPaginator(conn, &input)
 		for pages.HasMorePages() {
 			page, err := pages.NextPage(ctx)
-			if awsv2.SkipSweepError(err) {
-				tflog.Warn(ctx, "Skipping sweeper", map[string]any{
-					"error": err.Error(),
-				})
-				return nil, nil
-			}
 			if errs.IsAErrorMessageContains[*awstypes.ValidationException](err, "at 'serviceNamespace' failed to satisfy constraint") {
 				tflog.Info(ctx, "Skipping service namespace", map[string]any{
 					"error": err.Error(),

--- a/internal/service/appflow/sweep.go
+++ b/internal/service/appflow/sweep.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/appflow"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
@@ -17,7 +16,7 @@ import (
 )
 
 func RegisterSweepers() {
-	sweep.Register("aws_appflow_flow", sweepInstanceProfile)
+	awsv2.Register("aws_appflow_flow", sweepInstanceProfile)
 }
 
 func sweepInstanceProfile(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
@@ -29,12 +28,6 @@ func sweepInstanceProfile(ctx context.Context, client *conns.AWSClient) ([]sweep
 	pages := appflow.NewListFlowsPaginator(conn, &appflow.ListFlowsInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
-			tflog.Warn(ctx, "Skipping sweeper", map[string]any{
-				"error": err.Error(),
-			})
-			return nil, nil
-		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/sdk"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -41,7 +42,7 @@ func RegisterSweepers() {
 		"aws_iam_role",
 	)
 
-	sweep.Register("aws_iam_openid_connect_provider", sweepOpenIDConnectProvider)
+	awsv1.Register("aws_iam_openid_connect_provider", sweepOpenIDConnectProvider)
 
 	resource.AddTestSweepers("aws_iam_policy", &resource.Sweeper{
 		Name: "aws_iam_policy",
@@ -86,11 +87,11 @@ func RegisterSweepers() {
 		F: sweepRoles,
 	})
 
-	sweep.Register("aws_iam_saml_provider", sweepSAMLProvider)
+	awsv1.Register("aws_iam_saml_provider", sweepSAMLProvider)
 
-	sweep.Register("aws_iam_service_specific_credential", sweepServiceSpecificCredentials)
+	awsv1.Register("aws_iam_service_specific_credential", sweepServiceSpecificCredentials)
 
-	sweep.Register("aws_iam_signing_certificate", sweepSigningCertificates)
+	awsv1.Register("aws_iam_signing_certificate", sweepSigningCertificates)
 
 	resource.AddTestSweepers("aws_iam_server_certificate", &resource.Sweeper{
 		Name: "aws_iam_server_certificate",

--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -37,7 +37,7 @@ func RegisterSweepers() {
 		},
 	})
 
-	sweep.Register("aws_iam_instance_profile", sweepInstanceProfile,
+	awsv2.Register("aws_iam_instance_profile", sweepInstanceProfile,
 		"aws_iam_role",
 	)
 
@@ -97,7 +97,7 @@ func RegisterSweepers() {
 		F:    sweepServerCertificates,
 	})
 
-	sweep.Register("aws_iam_service_linked_role", sweepServiceLinkedRoles)
+	awsv2.Register("aws_iam_service_linked_role", sweepServiceLinkedRoles)
 
 	resource.AddTestSweepers("aws_iam_user", &resource.Sweeper{
 		Name: "aws_iam_user",
@@ -110,7 +110,7 @@ func RegisterSweepers() {
 		},
 	})
 
-	sweep.Register("aws_iam_virtual_mfa_device", sweepVirtualMFADevice)
+	awsv2.Register("aws_iam_virtual_mfa_device", sweepVirtualMFADevice)
 }
 
 func sweepGroups(region string) error {
@@ -234,9 +234,8 @@ func sweepInstanceProfile(ctx context.Context, client *conns.AWSClient) ([]sweep
 	pages := iam.NewListInstanceProfilesPaginator(conn, &iam.ListInstanceProfilesInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping IAM Instance Profile sweep: %s", err)
-			return sweepResources, nil
+		if err != nil {
+			return nil, err
 		}
 
 		for _, instanceProfile := range page.InstanceProfiles {
@@ -556,11 +555,6 @@ func sweepServiceLinkedRoles(ctx context.Context, client *conns.AWSClient) ([]sw
 	pages := iam.NewListRolesPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping IAM Service Linked Role sweep: %s", err)
-			return sweepResources, nil
-		}
-
 		if err != nil {
 			return sweepResources, err
 		}
@@ -720,11 +714,6 @@ func sweepVirtualMFADevice(ctx context.Context, client *conns.AWSClient) ([]swee
 	pages := iam.NewListVirtualMFADevicesPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping IAM Virtual MFA Device sweep: %s", err)
-			return sweepResources, nil
-		}
-
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/lakeformation/sweep.go
+++ b/internal/service/lakeformation/sweep.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lakeformation"
 	"github.com/aws/aws-sdk-go-v2/service/lakeformation/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
@@ -17,9 +16,9 @@ import (
 )
 
 func RegisterSweepers() {
-	sweep.Register("aws_lakeformation_permissions", sweepPermissions)
+	awsv2.Register("aws_lakeformation_permissions", sweepPermissions)
 
-	sweep.Register("aws_lakeformation_resource", sweepResource)
+	awsv2.Register("aws_lakeformation_resource", sweepResource)
 }
 
 func sweepPermissions(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
@@ -31,13 +30,6 @@ func sweepPermissions(ctx context.Context, client *conns.AWSClient) ([]sweep.Swe
 	pages := lakeformation.NewListPermissionsPaginator(conn, &lakeformation.ListPermissionsInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			tflog.Warn(ctx, "Skipping sweeper", map[string]any{
-				"error": err.Error(),
-			})
-			return nil, nil
-		}
 		if err != nil {
 			return nil, err
 		}
@@ -95,13 +87,6 @@ func sweepResource(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepa
 	pages := lakeformation.NewListResourcesPaginator(conn, &lakeformation.ListResourcesInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			tflog.Warn(ctx, "Skipping sweeper", map[string]any{
-				"error": err.Error(),
-			})
-			return nil, nil
-		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/m2/sweep.go
+++ b/internal/service/m2/sweep.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/m2"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
@@ -17,9 +16,9 @@ import (
 )
 
 func RegisterSweepers() {
-	sweep.Register("aws_m2_application", sweepApplications)
+	awsv2.Register("aws_m2_application", sweepApplications)
 
-	sweep.Register("aws_m2_environment", sweepEnvironments)
+	awsv2.Register("aws_m2_environment", sweepEnvironments)
 }
 
 func sweepApplications(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
@@ -30,12 +29,6 @@ func sweepApplications(ctx context.Context, client *conns.AWSClient) ([]sweep.Sw
 	pages := m2.NewListApplicationsPaginator(conn, &m2.ListApplicationsInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
-			tflog.Warn(ctx, "Skipping sweeper", map[string]any{
-				"error": err.Error(),
-			})
-			return nil, nil
-		}
 		if err != nil {
 			return nil, err
 		}
@@ -57,12 +50,6 @@ func sweepEnvironments(ctx context.Context, client *conns.AWSClient) ([]sweep.Sw
 	pages := m2.NewListEnvironmentsPaginator(conn, &m2.ListEnvironmentsInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if awsv2.SkipSweepError(err) {
-			tflog.Warn(ctx, "Skipping sweeper", map[string]any{
-				"error": err.Error(),
-			})
-			return nil, nil
-		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/sqs/sweep.go
+++ b/internal/service/sqs/sweep.go
@@ -9,10 +9,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
 )
 
 func RegisterSweepers() {
-	sweep.Register("aws_sqs_queue", sweepQueues,
+	awsv1.Register("aws_sqs_queue", sweepQueues,
 		"aws_autoscaling_group",
 		"aws_cloudwatch_event_rule",
 		"aws_elastic_beanstalk_environment",

--- a/internal/service/xray/sweep.go
+++ b/internal/service/xray/sweep.go
@@ -16,9 +16,9 @@ import (
 )
 
 func RegisterSweepers() {
-	sweep.Register("aws_xray_group", sweepGroups)
+	awsv2.Register("aws_xray_group", sweepGroups)
 
-	sweep.Register("aws_xray_sampling_rule", sweepSamplingRules)
+	awsv2.Register("aws_xray_sampling_rule", sweepSamplingRules)
 }
 
 func sweepGroups(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
@@ -30,13 +30,6 @@ func sweepGroups(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepabl
 	pages := xray.NewGetGroupsPaginator(conn, &xray.GetGroupsInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			tflog.Warn(ctx, "Skipping sweeper", map[string]any{
-				"error": err.Error(),
-			})
-			return nil, nil
-		}
 		if err != nil {
 			return nil, err
 		}
@@ -68,13 +61,6 @@ func sweepSamplingRules(ctx context.Context, client *conns.AWSClient) ([]sweep.S
 	pages := xray.NewGetSamplingRulesPaginator(conn, &xray.GetSamplingRulesInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			tflog.Warn(ctx, "Skipping sweeper", map[string]any{
-				"error": err.Error(),
-			})
-			return nil, nil
-		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/sweep/awsv1/register.go
+++ b/internal/sweep/awsv1/register.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package awsv1
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/internal/log"
+)
+
+func Register(name string, f sweep.SweeperFn, dependencies ...string) {
+	resource.AddTestSweepers(name, &resource.Sweeper{
+		Name: name,
+		F: func(region string) error {
+			ctx := sweep.Context(region)
+			ctx = log.WithResourceType(ctx, name)
+
+			client, err := sweep.SharedRegionalSweepClient(ctx, region)
+			if err != nil {
+				return fmt.Errorf("getting client: %w", err)
+			}
+			tflog.Info(ctx, "listing resources")
+			sweepResources, err := f(ctx, client)
+
+			if SkipSweepError(err) {
+				tflog.Warn(ctx, "Skipping sweeper", map[string]any{
+					"error": err.Error(),
+				})
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("listing %q (%s): %w", name, region, err)
+			}
+
+			err = sweep.SweepOrchestrator(ctx, sweepResources)
+			if err != nil {
+				return fmt.Errorf("sweeping %q (%s): %w", name, region, err)
+			}
+
+			return nil
+		},
+	})
+}

--- a/internal/sweep/awsv2/register.go
+++ b/internal/sweep/awsv2/register.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package awsv2
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/internal/log"
+)
+
+func Register(name string, f sweep.SweeperFn, dependencies ...string) {
+	resource.AddTestSweepers(name, &resource.Sweeper{
+		Name: name,
+		F: func(region string) error {
+			ctx := sweep.Context(region)
+			ctx = log.WithResourceType(ctx, name)
+
+			client, err := sweep.SharedRegionalSweepClient(ctx, region)
+			if err != nil {
+				return fmt.Errorf("getting client: %w", err)
+			}
+			tflog.Info(ctx, "listing resources")
+			sweepResources, err := f(ctx, client)
+
+			if SkipSweepError(err) {
+				tflog.Warn(ctx, "Skipping sweeper", map[string]any{
+					"error": err.Error(),
+				})
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("listing %q (%s): %w", name, region, err)
+			}
+
+			err = sweep.SweepOrchestrator(ctx, sweepResources)
+			if err != nil {
+				return fmt.Errorf("sweeping %q (%s): %w", name, region, err)
+			}
+
+			return nil
+		},
+	})
+}

--- a/internal/sweep/context.go
+++ b/internal/sweep/context.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/internal/log"
 )
 
 func Context(region string) context.Context {
@@ -14,7 +15,7 @@ func Context(region string) context.Context {
 
 	ctx = tfsdklog.RegisterStdlogSink(ctx)
 
-	ctx = logger(ctx, "sweeper", region)
+	ctx = log.Logger(ctx, "sweeper", region)
 
 	return ctx
 }

--- a/internal/sweep/internal/log/log.go
+++ b/internal/sweep/internal/log/log.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package sweep
+package log
 
 import (
 	"context"
@@ -20,7 +20,7 @@ const (
 	loggingKeyResourceType = "tf_resource_type"
 )
 
-func logger(ctx context.Context, loggerName, region string) context.Context {
+func Logger(ctx context.Context, loggerName, region string) context.Context {
 	ctx = tfsdklog.NewRootProviderLogger(ctx,
 		tfsdklog.WithLevel(hclog.Debug),
 		tfsdklog.WithLogName(loggerName),
@@ -31,6 +31,6 @@ func logger(ctx context.Context, loggerName, region string) context.Context {
 	return ctx
 }
 
-func logWithResourceType(ctx context.Context, resourceType string) context.Context {
+func WithResourceType(ctx context.Context, resourceType string) context.Context {
 	return tflog.SetField(ctx, loggingKeyResourceType, resourceType)
 }

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -12,11 +12,8 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
-	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
-	"github.com/hashicorp/terraform-provider-aws/internal/sweep/internal/log"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -123,9 +120,6 @@ func SweepOrchestrator(ctx context.Context, sweepables []Sweepable, optFns ...tf
 	return g.Wait().ErrorOrNil()
 }
 
-// Deprecated: Use awsv1.SkipSweepError
-var SkipSweepError = awsv1.SkipSweepError
-
 func Partition(region string) string {
 	return names.PartitionForRegion(region)
 }
@@ -135,37 +129,3 @@ func PartitionDNSSuffix(region string) string {
 }
 
 type SweeperFn func(ctx context.Context, client *conns.AWSClient) ([]Sweepable, error)
-
-func Register(name string, f SweeperFn, dependencies ...string) {
-	resource.AddTestSweepers(name, &resource.Sweeper{
-		Name: name,
-		F: func(region string) error {
-			ctx := Context(region)
-			ctx = log.WithResourceType(ctx, name)
-
-			client, err := SharedRegionalSweepClient(ctx, region)
-			if err != nil {
-				return fmt.Errorf("getting client: %w", err)
-			}
-			tflog.Info(ctx, "listing resources")
-			sweepResources, err := f(ctx, client)
-
-			if SkipSweepError(err) {
-				tflog.Warn(ctx, "Skipping sweeper", map[string]any{
-					"error": err.Error(),
-				})
-				return nil
-			}
-			if err != nil {
-				return fmt.Errorf("listing %q (%s): %w", name, region, err)
-			}
-
-			err = SweepOrchestrator(ctx, sweepResources)
-			if err != nil {
-				return fmt.Errorf("sweeping %q (%s): %w", name, region, err)
-			}
-
-			return nil
-		},
-	})
-}

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/envvar"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/internal/log"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -140,7 +141,7 @@ func Register(name string, f SweeperFn, dependencies ...string) {
 		Name: name,
 		F: func(region string) error {
 			ctx := Context(region)
-			ctx = logWithResourceType(ctx, name)
+			ctx = log.WithResourceType(ctx, name)
 
 			client, err := SharedRegionalSweepClient(ctx, region)
 			if err != nil {


### PR DESCRIPTION
### Description

Adds `awsv2.Register` to transparently handle AWS SDK for Go v2 errors

Moves `sweep.Register` to `awsv1` to clarify that it's for AWS SDK for Go v1
