### PR TITLE
[BUG] `aws_batch_job_definition`: add extra nil checks

### DIFF
--- a/.changelog/38716.txt
+++ b/.changelog/38716.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_batch_job_definition: Fix panic when checking `eks_properties` for job updates
+```

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -516,7 +516,7 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {
 		}
 
 		var oeks, neks *batch.EksPodProperties
-		if len(o.([]interface{})) > 0 && 0.([]interface{})[0] != nil {
+		if len(o.([]interface{})) > 0 && o.([]interface{})[0] != nil {
 			oProps := o.([]interface{})[0].(map[string]interface{})
 			if opodProps, ok := oProps["pod_properties"].([]interface{}); ok && len(opodProps) > 0 {
 				oeks = expandEKSPodProperties(opodProps[0].(map[string]interface{}))

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -516,14 +516,14 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {
 		}
 
 		var oeks, neks *batch.EksPodProperties
-		if len(o.([]interface{})) > 0 {
+		if len(o.([]interface{})) > 0 && 0.([]interface{})[0] != nil {
 			oProps := o.([]interface{})[0].(map[string]interface{})
 			if opodProps, ok := oProps["pod_properties"].([]interface{}); ok && len(opodProps) > 0 {
 				oeks = expandEKSPodProperties(opodProps[0].(map[string]interface{}))
 			}
 		}
 
-		if len(n.([]interface{})) > 0 {
+		if len(n.([]interface{})) > 0 && n.([]interface{})[0] != nil {
 			nProps := n.([]interface{})[0].(map[string]interface{})
 			if npodProps, ok := nProps["pod_properties"].([]interface{}); ok && len(npodProps) > 0 {
 				neks = expandEKSPodProperties(npodProps[0].(map[string]interface{}))
@@ -540,12 +540,12 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {
 		}
 
 		var ors, nrs *batch.RetryStrategy
-		if len(o.([]interface{})) > 0 {
+		if len(o.([]interface{})) > 0 && o.([]interface{})[0] != nil {
 			oProps := o.([]interface{})[0].(map[string]interface{})
 			ors = expandRetryStrategy(oProps)
 		}
 
-		if len(n.([]interface{})) > 0 {
+		if len(n.([]interface{})) > 0 && n.([]interface{})[0] != nil {
 			nProps := n.([]interface{})[0].(map[string]interface{})
 			nrs = expandRetryStrategy(nProps)
 		}
@@ -560,12 +560,12 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {
 		}
 
 		var ors, nrs *batch.JobTimeout
-		if len(o.([]interface{})) > 0 {
+		if len(o.([]interface{})) > 0 && o.([]interface{})[0] != nil {
 			oProps := o.([]interface{})[0].(map[string]interface{})
 			ors = expandJobTimeout(oProps)
 		}
 
-		if len(n.([]interface{})) > 0 {
+		if len(n.([]interface{})) > 0 && n.([]interface{})[0] != nil {
 			nProps := n.([]interface{})[0].(map[string]interface{})
 			nrs = expandJobTimeout(nProps)
 		}
@@ -616,7 +616,7 @@ func resourceJobDefinitionCreate(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 
-		if v, ok := d.GetOk("eks_properties"); ok && len(v.([]interface{})) > 0 {
+		if v, ok := d.GetOk("eks_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			eksProps := v.([]interface{})[0].(map[string]interface{})
 			if podProps, ok := eksProps["pod_properties"].([]interface{}); ok && len(podProps) > 0 {
 				if aws.StringValue(input.Type) == batch.JobDefinitionTypeContainer {


### PR DESCRIPTION
### Description
Extra nil check in the `aws_batch_job_definition` resource

### Relations
Closes #38710
Closes #38684 

### References

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=batch

...
```
