### PR TITLE
sweeper/aws_directory_service_directory:Addresses API rate limiting when sweeping many directories

### DIFF
--- a/internal/service/ds/directory.go
+++ b/internal/service/ds/directory.go
@@ -727,10 +727,12 @@ func waitDirectoryCreated(ctx context.Context, conn *directoryservice.Client, id
 
 func waitDirectoryDeleted(ctx context.Context, conn *directoryservice.Client, id string, timeout time.Duration) (*awstypes.DirectoryDescription, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.DirectoryStageActive, awstypes.DirectoryStageDeleting),
-		Target:  []string{},
-		Refresh: statusDirectoryStage(ctx, conn, id),
-		Timeout: timeout,
+		Pending:    enum.Slice(awstypes.DirectoryStageActive, awstypes.DirectoryStageDeleting),
+		Target:     []string{},
+		Refresh:    statusDirectoryStage(ctx, conn, id),
+		Timeout:    timeout,
+		Delay:      1 * time.Minute,
+		MinTimeout: 10 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/ds/sweep.go
+++ b/internal/service/ds/sweep.go
@@ -6,6 +6,7 @@ package ds
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
 func RegisterSweepers() {
@@ -70,7 +72,7 @@ func sweepDirectories(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
+	err = sweep.SweepOrchestrator(ctx, sweepResources, tfresource.WithMinPollInterval(10*time.Second)) // Brute-force approach to add some delay due to rate limiting
 
 	if err != nil {
 		return fmt.Errorf("error sweeping Directory Service Directories (%s): %w", region, err)


### PR DESCRIPTION
### Description

Sweeping a large number of directories, e.g. 20 would hit rate limits that prevented any directories from being swept. Adds some delay, which addresses the rate limit to some extent.
