### PR TITLE
Migrate `Pinpoint` resources to AWS SDK V2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -289,6 +289,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.32.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.4 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.12.3 h1:9oQMCF4oLvWS
 github.com/aws/aws-sdk-go-v2/service/paymentcryptography v1.12.3/go.mod h1:NNyvgUO7XweCVxGTSnllS6XdsD/9Il6Kc63D/stKgiM=
 github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.7.3 h1:xKVSPlN0K1r9VBe6MaKHgUi3EvJotLE9s4etstJq0jw=
 github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.7.3/go.mod h1:4Lk91jzPQQKOzml7LHOR/zAE5FF4+mL0CPrArI8vnCY=
+github.com/aws/aws-sdk-go-v2/service/pinpoint v1.32.3 h1:uBukpBpEOhnT/iWfhiunEjbPTWXgurgLUr5NJlk7yJk=
+github.com/aws/aws-sdk-go-v2/service/pinpoint v1.32.3/go.mod h1:yv43WVYryFKJFbThuv8mHV3zGt4RfnzB/+Om7iwRyxs=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.14.3 h1:fYZlFa1OvrgaFODrdf0KVDp4qCRHMZNr8S/F3aGNuno=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.14.3/go.mod h1:S0g2KF8IpU6Ptn46eSywrS+w1PMUwrf/xWF8szcTZ2Q=
 github.com/aws/aws-sdk-go-v2/service/polly v1.42.3 h1:MuoVKFJr/TUimLdT6nvio+OehAPM7kILgNLF3rYcaP0=

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/inspector2"
 	inspector2types "github.com/aws/aws-sdk-go-v2/service/inspector2/types"
 	organizationstypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 	ssoadmintypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 	"github.com/aws/aws-sdk-go-v2/service/wafv2"
@@ -43,7 +44,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/outposts"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -1199,11 +1199,11 @@ func PreCheckOrganizationMemberAccountWithProvider(ctx context.Context, t *testi
 }
 
 func PreCheckPinpointApp(ctx context.Context, t *testing.T) {
-	conn := Provider.Meta().(*conns.AWSClient).PinpointConn(ctx)
+	conn := Provider.Meta().(*conns.AWSClient).PinpointClient(ctx)
 
 	input := &pinpoint.GetAppsInput{}
 
-	_, err := conn.GetAppsWithContext(ctx, input)
+	_, err := conn.GetApps(ctx, input)
 
 	if PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -156,6 +156,7 @@ import (
 	osis_sdkv2 "github.com/aws/aws-sdk-go-v2/service/osis"
 	paymentcryptography_sdkv2 "github.com/aws/aws-sdk-go-v2/service/paymentcryptography"
 	pcaconnectorad_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pcaconnectorad"
+	pinpoint_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pinpoint"
 	pipes_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pipes"
 	polly_sdkv2 "github.com/aws/aws-sdk-go-v2/service/polly"
 	pricing_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pricing"
@@ -236,7 +237,6 @@ import (
 	opensearchservice_sdkv1 "github.com/aws/aws-sdk-go/service/opensearchservice"
 	opsworks_sdkv1 "github.com/aws/aws-sdk-go/service/opsworks"
 	outposts_sdkv1 "github.com/aws/aws-sdk-go/service/outposts"
-	pinpoint_sdkv1 "github.com/aws/aws-sdk-go/service/pinpoint"
 	quicksight_sdkv1 "github.com/aws/aws-sdk-go/service/quicksight"
 	rds_sdkv1 "github.com/aws/aws-sdk-go/service/rds"
 	redshift_sdkv1 "github.com/aws/aws-sdk-go/service/redshift"
@@ -933,8 +933,8 @@ func (c *AWSClient) PaymentCryptographyClient(ctx context.Context) *paymentcrypt
 	return errs.Must(client[*paymentcryptography_sdkv2.Client](ctx, c, names.PaymentCryptography, make(map[string]any)))
 }
 
-func (c *AWSClient) PinpointConn(ctx context.Context) *pinpoint_sdkv1.Pinpoint {
-	return errs.Must(conn[*pinpoint_sdkv1.Pinpoint](ctx, c, names.Pinpoint, make(map[string]any)))
+func (c *AWSClient) PinpointClient(ctx context.Context) *pinpoint_sdkv2.Client {
+	return errs.Must(client[*pinpoint_sdkv2.Client](ctx, c, names.Pinpoint, make(map[string]any)))
 }
 
 func (c *AWSClient) PipesClient(ctx context.Context) *pipes_sdkv2.Client {

--- a/internal/service/pinpoint/adm_channel_test.go
+++ b/internal/service/pinpoint/adm_channel_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfpinpoint "github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -50,7 +50,7 @@ func testAccADMChannelConfigurationFromEnv(t *testing.T) *testAccADMChannelConfi
 
 func TestAccPinpointADMChannel_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var channel pinpoint.ADMChannelResponse
+	var channel awstypes.ADMChannelResponse
 	resourceName := "aws_pinpoint_adm_channel.channel"
 
 	config := testAccADMChannelConfigurationFromEnv(t)
@@ -85,7 +85,7 @@ func TestAccPinpointADMChannel_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckADMChannelExists(ctx context.Context, n string, channel *pinpoint.ADMChannelResponse) resource.TestCheckFunc {
+func testAccCheckADMChannelExists(ctx context.Context, n string, channel *awstypes.ADMChannelResponse) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -96,19 +96,41 @@ func testAccCheckADMChannelExists(ctx context.Context, n string, channel *pinpoi
 			return fmt.Errorf("No Pinpoint ADM channel with that Application ID exists")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointClient(ctx)
 
-		// Check if the ADM Channel exists
-		params := &pinpoint.GetAdmChannelInput{
-			ApplicationId: aws.String(rs.Primary.ID),
-		}
-		output, err := conn.GetAdmChannelWithContext(ctx, params)
+		output, err := tfpinpoint.FindADMChannelByApplicationId(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		*channel = *output.ADMChannelResponse
+		*channel = *output
+
+		return nil
+	}
+}
+
+func testAccCheckADMChannelDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_pinpoint_adm_channel" {
+				continue
+			}
+
+			_, err := tfpinpoint.FindADMChannelByApplicationId(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Pinpoint ADM Channel %s still exists", rs.Primary.ID)
+		}
 
 		return nil
 	}
@@ -126,31 +148,4 @@ resource "aws_pinpoint_adm_channel" "channel" {
   enabled       = false
 }
 `, conf.ClientID, conf.ClientSecret)
-}
-
-func testAccCheckADMChannelDestroy(ctx context.Context) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointConn(ctx)
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_pinpoint_adm_channel" {
-				continue
-			}
-
-			// Check if the ADM channel exists by fetching its attributes
-			params := &pinpoint.GetAdmChannelInput{
-				ApplicationId: aws.String(rs.Primary.ID),
-			}
-			_, err := conn.GetAdmChannelWithContext(ctx, params)
-			if err != nil {
-				if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-					continue
-				}
-				return err
-			}
-			return fmt.Errorf("ADM Channel exists when it should be destroyed!")
-		}
-
-		return nil
-	}
 }

--- a/internal/service/pinpoint/apns_channel.go
+++ b/internal/service/pinpoint/apns_channel.go
@@ -7,18 +7,21 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_pinpoint_apns_channel")
-func ResourceAPNSChannel() *schema.Resource {
+// @SDKResource("aws_pinpoint_apns_channel", name="APNS Channel")
+func resourceAPNSChannel() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAPNSChannelUpsert,
 		ReadWithoutTimeout:   resourceAPNSChannelRead,
@@ -91,11 +94,11 @@ func resourceAPNSChannelUpsert(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "At least one set of credentials is required; either [certificate, private_key] or [bundle_id, team_id, token_key, token_key_id]")
 	}
 
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	applicationId := d.Get(names.AttrApplicationID).(string)
 
-	params := &pinpoint.APNSChannelRequest{}
+	params := &awstypes.APNSChannelRequest{}
 
 	params.DefaultAuthenticationMethod = aws.String(d.Get("default_authentication_method").(string))
 	params.Enabled = aws.Bool(d.Get(names.AttrEnabled).(bool))
@@ -113,7 +116,7 @@ func resourceAPNSChannelUpsert(ctx context.Context, d *schema.ResourceData, meta
 		APNSChannelRequest: params,
 	}
 
-	_, err := conn.UpdateApnsChannelWithContext(ctx, &req)
+	_, err := conn.UpdateApnsChannel(ctx, &req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Pinpoint APNs Channel for Application %s: %s", applicationId, err)
 	}
@@ -125,26 +128,21 @@ func resourceAPNSChannelUpsert(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceAPNSChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[INFO] Reading Pinpoint APNs Channel for Application %s", d.Id())
 
-	output, err := conn.GetApnsChannelWithContext(ctx, &pinpoint.GetApnsChannelInput{
-		ApplicationId: aws.String(d.Id()),
-	})
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-			log.Printf("[WARN] Pinpoint APNs Channel for application %s not found, removing from state", d.Id())
-			d.SetId("")
-			return diags
-		}
+	output, err := findAPNSChannelByApplicationId(ctx, conn, d.Id())
 
-		return sdkdiag.AppendErrorf(diags, "getting Pinpoint APNs Channel for application %s: %s", d.Id(), err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Pinpoint APNS Channel (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
 	}
 
-	d.Set(names.AttrApplicationID, output.APNSChannelResponse.ApplicationId)
-	d.Set("default_authentication_method", output.APNSChannelResponse.DefaultAuthenticationMethod)
-	d.Set(names.AttrEnabled, output.APNSChannelResponse.Enabled)
+	d.Set(names.AttrApplicationID, output.ApplicationId)
+	d.Set("default_authentication_method", output.DefaultAuthenticationMethod)
+	d.Set(names.AttrEnabled, output.Enabled)
 	// Sensitive params are not returned
 
 	return diags
@@ -152,14 +150,14 @@ func resourceAPNSChannelRead(ctx context.Context, d *schema.ResourceData, meta i
 
 func resourceAPNSChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Pinpoint APNs Channel: %s", d.Id())
-	_, err := conn.DeleteApnsChannelWithContext(ctx, &pinpoint.DeleteApnsChannelInput{
+	_, err := conn.DeleteApnsChannel(ctx, &pinpoint.DeleteApnsChannelInput{
 		ApplicationId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags
 	}
 
@@ -167,4 +165,27 @@ func resourceAPNSChannelDelete(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint APNs Channel for Application %s: %s", d.Id(), err)
 	}
 	return diags
+}
+
+func findAPNSChannelByApplicationId(ctx context.Context, conn *pinpoint.Client, applicationId string) (*awstypes.APNSChannelResponse, error) {
+	input := &pinpoint.GetApnsChannelInput{
+		ApplicationId: aws.String(applicationId),
+	}
+
+	output, err := conn.GetApnsChannel(ctx, input)
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.APNSChannelResponse == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.APNSChannelResponse, nil
 }

--- a/internal/service/pinpoint/apns_channel.go
+++ b/internal/service/pinpoint/apns_channel.go
@@ -140,6 +140,10 @@ func resourceAPNSChannelRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diags
 	}
 
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Pinpoint APNS Channel (%s): %s", d.Id(), err)
+	}
+
 	d.Set(names.AttrApplicationID, output.ApplicationId)
 	d.Set("default_authentication_method", output.DefaultAuthenticationMethod)
 	d.Set(names.AttrEnabled, output.Enabled)

--- a/internal/service/pinpoint/apns_sandbox_channel.go
+++ b/internal/service/pinpoint/apns_sandbox_channel.go
@@ -140,6 +140,10 @@ func resourceAPNSSandboxChannelRead(ctx context.Context, d *schema.ResourceData,
 		return diags
 	}
 
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Pinpoint APNS Sandbox Channel (%s): %s", d.Id(), err)
+	}
+
 	d.Set(names.AttrApplicationID, output.ApplicationId)
 	d.Set("default_authentication_method", output.DefaultAuthenticationMethod)
 	d.Set(names.AttrEnabled, output.Enabled)

--- a/internal/service/pinpoint/apns_sandbox_channel.go
+++ b/internal/service/pinpoint/apns_sandbox_channel.go
@@ -7,18 +7,21 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_pinpoint_apns_sandbox_channel")
-func ResourceAPNSSandboxChannel() *schema.Resource {
+// @SDKResource("aws_pinpoint_apns_sandbox_channel", name="APNS Sandbox Channel")
+func resourceAPNSSandboxChannel() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAPNSSandboxChannelUpsert,
 		ReadWithoutTimeout:   resourceAPNSSandboxChannelRead,
@@ -91,11 +94,11 @@ func resourceAPNSSandboxChannelUpsert(ctx context.Context, d *schema.ResourceDat
 		return sdkdiag.AppendErrorf(diags, "At least one set of credentials is required; either [certificate, private_key] or [bundle_id, team_id, token_key, token_key_id]")
 	}
 
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	applicationId := d.Get(names.AttrApplicationID).(string)
 
-	params := &pinpoint.APNSSandboxChannelRequest{}
+	params := &awstypes.APNSSandboxChannelRequest{}
 
 	params.DefaultAuthenticationMethod = aws.String(d.Get("default_authentication_method").(string))
 	params.Enabled = aws.Bool(d.Get(names.AttrEnabled).(bool))
@@ -113,7 +116,7 @@ func resourceAPNSSandboxChannelUpsert(ctx context.Context, d *schema.ResourceDat
 		APNSSandboxChannelRequest: params,
 	}
 
-	_, err := conn.UpdateApnsSandboxChannelWithContext(ctx, &req)
+	_, err := conn.UpdateApnsSandboxChannel(ctx, &req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Pinpoint APNs Sandbox Channel for Application %s: %s", applicationId, err)
 	}
@@ -125,26 +128,21 @@ func resourceAPNSSandboxChannelUpsert(ctx context.Context, d *schema.ResourceDat
 
 func resourceAPNSSandboxChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[INFO] Reading Pinpoint APNs Channel for Application %s", d.Id())
 
-	output, err := conn.GetApnsSandboxChannelWithContext(ctx, &pinpoint.GetApnsSandboxChannelInput{
-		ApplicationId: aws.String(d.Id()),
-	})
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-			log.Printf("[WARN] Pinpoint APNs Sandbox Channel for application %s not found, removing from state", d.Id())
-			d.SetId("")
-			return diags
-		}
+	output, err := findAPNSSandboxChannelByApplicationId(ctx, conn, d.Id())
 
-		return sdkdiag.AppendErrorf(diags, "getting Pinpoint APNs Sandbox Channel for application %s: %s", d.Id(), err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Pinpoint APNS Sandbox Channel (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
 	}
 
-	d.Set(names.AttrApplicationID, output.APNSSandboxChannelResponse.ApplicationId)
-	d.Set("default_authentication_method", output.APNSSandboxChannelResponse.DefaultAuthenticationMethod)
-	d.Set(names.AttrEnabled, output.APNSSandboxChannelResponse.Enabled)
+	d.Set(names.AttrApplicationID, output.ApplicationId)
+	d.Set("default_authentication_method", output.DefaultAuthenticationMethod)
+	d.Set(names.AttrEnabled, output.Enabled)
 	// Sensitive params are not returned
 
 	return diags
@@ -152,14 +150,14 @@ func resourceAPNSSandboxChannelRead(ctx context.Context, d *schema.ResourceData,
 
 func resourceAPNSSandboxChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Pinpoint APNs Sandbox Channel: %s", d.Id())
-	_, err := conn.DeleteApnsSandboxChannelWithContext(ctx, &pinpoint.DeleteApnsSandboxChannelInput{
+	_, err := conn.DeleteApnsSandboxChannel(ctx, &pinpoint.DeleteApnsSandboxChannelInput{
 		ApplicationId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags
 	}
 
@@ -167,4 +165,27 @@ func resourceAPNSSandboxChannelDelete(ctx context.Context, d *schema.ResourceDat
 		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint APNs Sandbox Channel for Application %s: %s", d.Id(), err)
 	}
 	return diags
+}
+
+func findAPNSSandboxChannelByApplicationId(ctx context.Context, conn *pinpoint.Client, applicationId string) (*awstypes.APNSSandboxChannelResponse, error) {
+	input := &pinpoint.GetApnsSandboxChannelInput{
+		ApplicationId: aws.String(applicationId),
+	}
+
+	output, err := conn.GetApnsSandboxChannel(ctx, input)
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.APNSSandboxChannelResponse == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.APNSSandboxChannelResponse, nil
 }

--- a/internal/service/pinpoint/apns_voip_channel.go
+++ b/internal/service/pinpoint/apns_voip_channel.go
@@ -140,6 +140,10 @@ func resourceAPNSVoIPChannelRead(ctx context.Context, d *schema.ResourceData, me
 		return diags
 	}
 
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Pinpoint APNS VoIP Channel (%s): %s", d.Id(), err)
+	}
+
 	d.Set(names.AttrApplicationID, output.ApplicationId)
 	d.Set("default_authentication_method", output.DefaultAuthenticationMethod)
 	d.Set(names.AttrEnabled, output.Enabled)

--- a/internal/service/pinpoint/apns_voip_channel.go
+++ b/internal/service/pinpoint/apns_voip_channel.go
@@ -7,18 +7,21 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_pinpoint_apns_voip_channel")
-func ResourceAPNSVoIPChannel() *schema.Resource {
+// @SDKResource("aws_pinpoint_apns_voip_channel", name="APNS VoIP Channel")
+func resourceAPNSVoIPChannel() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAPNSVoIPChannelUpsert,
 		ReadWithoutTimeout:   resourceAPNSVoIPChannelRead,
@@ -91,11 +94,11 @@ func resourceAPNSVoIPChannelUpsert(ctx context.Context, d *schema.ResourceData, 
 		return sdkdiag.AppendErrorf(diags, "At least one set of credentials is required; either [certificate, private_key] or [bundle_id, team_id, token_key, token_key_id]")
 	}
 
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	applicationId := d.Get(names.AttrApplicationID).(string)
 
-	params := &pinpoint.APNSVoipChannelRequest{}
+	params := &awstypes.APNSVoipChannelRequest{}
 
 	params.DefaultAuthenticationMethod = aws.String(d.Get("default_authentication_method").(string))
 	params.Enabled = aws.Bool(d.Get(names.AttrEnabled).(bool))
@@ -113,9 +116,9 @@ func resourceAPNSVoIPChannelUpsert(ctx context.Context, d *schema.ResourceData, 
 		APNSVoipChannelRequest: params,
 	}
 
-	_, err := conn.UpdateApnsVoipChannelWithContext(ctx, &req)
+	_, err := conn.UpdateApnsVoipChannel(ctx, &req)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating Pinpoint APNs Voip Channel for Application %s: %s", applicationId, err)
+		return sdkdiag.AppendErrorf(diags, "updating Pinpoint APNs VoIP Channel for Application %s: %s", applicationId, err)
 	}
 
 	d.SetId(applicationId)
@@ -125,26 +128,21 @@ func resourceAPNSVoIPChannelUpsert(ctx context.Context, d *schema.ResourceData, 
 
 func resourceAPNSVoIPChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
-	log.Printf("[INFO] Reading Pinpoint APNs Voip Channel for Application %s", d.Id())
+	log.Printf("[INFO] Reading Pinpoint APNs VoIP Channel for Application %s", d.Id())
 
-	output, err := conn.GetApnsVoipChannelWithContext(ctx, &pinpoint.GetApnsVoipChannelInput{
-		ApplicationId: aws.String(d.Id()),
-	})
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-			log.Printf("[WARN] Pinpoint APNs Voip Channel for application %s not found, removing from state", d.Id())
-			d.SetId("")
-			return diags
-		}
+	output, err := findAPNSVoIPChannelByApplicationId(ctx, conn, d.Id())
 
-		return sdkdiag.AppendErrorf(diags, "getting Pinpoint APNs Voip Channel for application %s: %s", d.Id(), err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Pinpoint APNS VoIP Channel (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
 	}
 
-	d.Set(names.AttrApplicationID, output.APNSVoipChannelResponse.ApplicationId)
-	d.Set("default_authentication_method", output.APNSVoipChannelResponse.DefaultAuthenticationMethod)
-	d.Set(names.AttrEnabled, output.APNSVoipChannelResponse.Enabled)
+	d.Set(names.AttrApplicationID, output.ApplicationId)
+	d.Set("default_authentication_method", output.DefaultAuthenticationMethod)
+	d.Set(names.AttrEnabled, output.Enabled)
 	// Sensitive params are not returned
 
 	return diags
@@ -152,19 +150,42 @@ func resourceAPNSVoIPChannelRead(ctx context.Context, d *schema.ResourceData, me
 
 func resourceAPNSVoIPChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
-	log.Printf("[DEBUG] Deleting Pinpoint APNs Voip Channel: %s", d.Id())
-	_, err := conn.DeleteApnsVoipChannelWithContext(ctx, &pinpoint.DeleteApnsVoipChannelInput{
+	log.Printf("[DEBUG] Deleting Pinpoint APNs VoIP Channel: %s", d.Id())
+	_, err := conn.DeleteApnsVoipChannel(ctx, &pinpoint.DeleteApnsVoipChannelInput{
 		ApplicationId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint APNs Voip Channel for Application %s: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint APNs VoIP Channel for Application %s: %s", d.Id(), err)
 	}
 	return diags
+}
+
+func findAPNSVoIPChannelByApplicationId(ctx context.Context, conn *pinpoint.Client, applicationId string) (*awstypes.APNSVoipChannelResponse, error) {
+	input := &pinpoint.GetApnsVoipChannelInput{
+		ApplicationId: aws.String(applicationId),
+	}
+
+	output, err := conn.GetApnsVoipChannel(ctx, input)
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.APNSVoipChannelResponse == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.APNSVoipChannelResponse, nil
 }

--- a/internal/service/pinpoint/apns_voip_channel_test.go
+++ b/internal/service/pinpoint/apns_voip_channel_test.go
@@ -11,13 +11,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfpinpoint "github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -97,7 +97,7 @@ func testAccAPNSVoIPChannelTokenConfigurationFromEnv(t *testing.T) *testAccAPNSV
 
 func TestAccPinpointAPNSVoIPChannel_basicCertificate(t *testing.T) {
 	ctx := acctest.Context(t)
-	var channel pinpoint.APNSVoipChannelResponse
+	var channel awstypes.APNSVoipChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_channel.test_channel"
 
 	configuration := testAccAPNSVoIPChannelCertConfigurationFromEnv(t)
@@ -132,7 +132,7 @@ func TestAccPinpointAPNSVoIPChannel_basicCertificate(t *testing.T) {
 
 func TestAccPinpointAPNSVoIPChannel_basicToken(t *testing.T) {
 	ctx := acctest.Context(t)
-	var channel pinpoint.APNSVoipChannelResponse
+	var channel awstypes.APNSVoipChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_channel.test_channel"
 
 	configuration := testAccAPNSVoIPChannelTokenConfigurationFromEnv(t)
@@ -165,7 +165,7 @@ func TestAccPinpointAPNSVoIPChannel_basicToken(t *testing.T) {
 	})
 }
 
-func testAccCheckAPNSVoIPChannelExists(ctx context.Context, n string, channel *pinpoint.APNSVoipChannelResponse) resource.TestCheckFunc {
+func testAccCheckAPNSVoIPChannelExists(ctx context.Context, n string, channel *awstypes.APNSVoipChannelResponse) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -173,22 +173,44 @@ func testAccCheckAPNSVoIPChannelExists(ctx context.Context, n string, channel *p
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Pinpoint APNs Voip Channel with that Application ID exists")
+			return fmt.Errorf("No Pinpoint APNs VoIP Channel with that Application ID exists")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointClient(ctx)
 
-		// Check if the app exists
-		params := &pinpoint.GetApnsVoipChannelInput{
-			ApplicationId: aws.String(rs.Primary.ID),
-		}
-		output, err := conn.GetApnsVoipChannelWithContext(ctx, params)
+		output, err := tfpinpoint.FindAPNSVoIPChannelByApplicationId(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		*channel = *output.APNSVoipChannelResponse
+		*channel = *output
+
+		return nil
+	}
+}
+
+func testAccCheckAPNSVoIPChannelDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_pinpoint_apns_voip_channel" {
+				continue
+			}
+
+			_, err := tfpinpoint.FindAPNSVoIPChannelByApplicationId(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Pinpoint APNS VoIP Channel %s still exists", rs.Primary.ID)
+		}
 
 		return nil
 	}
@@ -224,31 +246,4 @@ resource "aws_pinpoint_apns_voip_channel" "test_channel" {
   token_key_id = %s
 }
 `, conf.BundleId, conf.TeamId, conf.TokenKey, conf.TokenKeyId)
-}
-
-func testAccCheckAPNSVoIPChannelDestroy(ctx context.Context) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointConn(ctx)
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_pinpoint_apns_voip_channel" {
-				continue
-			}
-
-			// Check if the channel exists
-			params := &pinpoint.GetApnsVoipChannelInput{
-				ApplicationId: aws.String(rs.Primary.ID),
-			}
-			_, err := conn.GetApnsVoipChannelWithContext(ctx, params)
-			if err != nil {
-				if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-					continue
-				}
-				return err
-			}
-			return fmt.Errorf("APNs Voip Channel exists when it should be destroyed!")
-		}
-
-		return nil
-	}
 }

--- a/internal/service/pinpoint/apns_voip_sandbox_channel.go
+++ b/internal/service/pinpoint/apns_voip_sandbox_channel.go
@@ -140,6 +140,10 @@ func resourceAPNSVoIPSandboxChannelRead(ctx context.Context, d *schema.ResourceD
 		return diags
 	}
 
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Pinpoint APNS VoIP Sandbox Channel (%s): %s", d.Id(), err)
+	}
+
 	d.Set(names.AttrApplicationID, output.ApplicationId)
 	d.Set("default_authentication_method", output.DefaultAuthenticationMethod)
 	d.Set(names.AttrEnabled, output.Enabled)

--- a/internal/service/pinpoint/apns_voip_sandbox_channel.go
+++ b/internal/service/pinpoint/apns_voip_sandbox_channel.go
@@ -7,18 +7,21 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_pinpoint_apns_voip_sandbox_channel")
-func ResourceAPNSVoIPSandboxChannel() *schema.Resource {
+// @SDKResource("aws_pinpoint_apns_voip_sandbox_channel", name="APNS VoIP Sandbox Channel")
+func resourceAPNSVoIPSandboxChannel() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAPNSVoIPSandboxChannelUpsert,
 		ReadWithoutTimeout:   resourceAPNSVoIPSandboxChannelRead,
@@ -91,11 +94,11 @@ func resourceAPNSVoIPSandboxChannelUpsert(ctx context.Context, d *schema.Resourc
 		return sdkdiag.AppendErrorf(diags, "At least one set of credentials is required; either [certificate, private_key] or [bundle_id, team_id, token_key, token_key_id]")
 	}
 
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	applicationId := d.Get(names.AttrApplicationID).(string)
 
-	params := &pinpoint.APNSVoipSandboxChannelRequest{}
+	params := &awstypes.APNSVoipSandboxChannelRequest{}
 
 	params.DefaultAuthenticationMethod = aws.String(d.Get("default_authentication_method").(string))
 	params.Enabled = aws.Bool(d.Get(names.AttrEnabled).(bool))
@@ -113,9 +116,9 @@ func resourceAPNSVoIPSandboxChannelUpsert(ctx context.Context, d *schema.Resourc
 		APNSVoipSandboxChannelRequest: params,
 	}
 
-	_, err := conn.UpdateApnsVoipSandboxChannelWithContext(ctx, &req)
+	_, err := conn.UpdateApnsVoipSandboxChannel(ctx, &req)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating Pinpoint APNs Voip Sandbox Channel for Application %s: %s", applicationId, err)
+		return sdkdiag.AppendErrorf(diags, "updating Pinpoint APNS VoIP Sandbox Channel for Application %s: %s", applicationId, err)
 	}
 
 	d.SetId(applicationId)
@@ -125,26 +128,21 @@ func resourceAPNSVoIPSandboxChannelUpsert(ctx context.Context, d *schema.Resourc
 
 func resourceAPNSVoIPSandboxChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
-	log.Printf("[INFO] Reading Pinpoint APNs Voip Sandbox Channel for Application %s", d.Id())
+	log.Printf("[INFO] Reading Pinpoint APNS VoIP Sandbox Channel for Application %s", d.Id())
 
-	output, err := conn.GetApnsVoipSandboxChannelWithContext(ctx, &pinpoint.GetApnsVoipSandboxChannelInput{
-		ApplicationId: aws.String(d.Id()),
-	})
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-			log.Printf("[WARN] Pinpoint APNs Voip Sandbox Channel for application %s not found, removing from state", d.Id())
-			d.SetId("")
-			return diags
-		}
+	output, err := findAPNSVoIPSandboxChannelByApplicationId(ctx, conn, d.Id())
 
-		return sdkdiag.AppendErrorf(diags, "getting Pinpoint APNs Voip Sandbox Channel for application %s: %s", d.Id(), err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Pinpoint APNS VoIP Sandbox Channel (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
 	}
 
-	d.Set(names.AttrApplicationID, output.APNSVoipSandboxChannelResponse.ApplicationId)
-	d.Set("default_authentication_method", output.APNSVoipSandboxChannelResponse.DefaultAuthenticationMethod)
-	d.Set(names.AttrEnabled, output.APNSVoipSandboxChannelResponse.Enabled)
+	d.Set(names.AttrApplicationID, output.ApplicationId)
+	d.Set("default_authentication_method", output.DefaultAuthenticationMethod)
+	d.Set(names.AttrEnabled, output.Enabled)
 	// Sensitive params are not returned
 
 	return diags
@@ -152,19 +150,42 @@ func resourceAPNSVoIPSandboxChannelRead(ctx context.Context, d *schema.ResourceD
 
 func resourceAPNSVoIPSandboxChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
-	log.Printf("[DEBUG] Deleting Pinpoint APNs Voip Sandbox Channel: %s", d.Id())
-	_, err := conn.DeleteApnsVoipSandboxChannelWithContext(ctx, &pinpoint.DeleteApnsVoipSandboxChannelInput{
+	log.Printf("[DEBUG] Deleting Pinpoint APNS VoIP Sandbox Channel: %s", d.Id())
+	_, err := conn.DeleteApnsVoipSandboxChannel(ctx, &pinpoint.DeleteApnsVoipSandboxChannelInput{
 		ApplicationId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint APNs Voip Sandbox Channel for Application %s: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint APNS VoIP Sandbox Channel for Application %s: %s", d.Id(), err)
 	}
 	return diags
+}
+
+func findAPNSVoIPSandboxChannelByApplicationId(ctx context.Context, conn *pinpoint.Client, applicationId string) (*awstypes.APNSVoipSandboxChannelResponse, error) {
+	input := &pinpoint.GetApnsVoipSandboxChannelInput{
+		ApplicationId: aws.String(applicationId),
+	}
+
+	output, err := conn.GetApnsVoipSandboxChannel(ctx, input)
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.APNSVoipSandboxChannelResponse == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.APNSVoipSandboxChannelResponse, nil
 }

--- a/internal/service/pinpoint/apns_voip_sandbox_channel_test.go
+++ b/internal/service/pinpoint/apns_voip_sandbox_channel_test.go
@@ -11,13 +11,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfpinpoint "github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -97,7 +97,7 @@ func testAccAPNSVoIPSandboxChannelTokenConfigurationFromEnv(t *testing.T) *testA
 
 func TestAccPinpointAPNSVoIPSandboxChannel_basicCertificate(t *testing.T) {
 	ctx := acctest.Context(t)
-	var channel pinpoint.APNSVoipSandboxChannelResponse
+	var channel awstypes.APNSVoipSandboxChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_sandbox_channel.test_channel"
 
 	configuration := testAccAPNSVoIPSandboxChannelCertConfigurationFromEnv(t)
@@ -132,7 +132,7 @@ func TestAccPinpointAPNSVoIPSandboxChannel_basicCertificate(t *testing.T) {
 
 func TestAccPinpointAPNSVoIPSandboxChannel_basicToken(t *testing.T) {
 	ctx := acctest.Context(t)
-	var channel pinpoint.APNSVoipSandboxChannelResponse
+	var channel awstypes.APNSVoipSandboxChannelResponse
 	resourceName := "aws_pinpoint_apns_voip_sandbox_channel.test_channel"
 
 	configuration := testAccAPNSVoIPSandboxChannelTokenConfigurationFromEnv(t)
@@ -165,7 +165,7 @@ func TestAccPinpointAPNSVoIPSandboxChannel_basicToken(t *testing.T) {
 	})
 }
 
-func testAccCheckAPNSVoIPSandboxChannelExists(ctx context.Context, n string, channel *pinpoint.APNSVoipSandboxChannelResponse) resource.TestCheckFunc {
+func testAccCheckAPNSVoIPSandboxChannelExists(ctx context.Context, n string, channel *awstypes.APNSVoipSandboxChannelResponse) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -173,22 +173,44 @@ func testAccCheckAPNSVoIPSandboxChannelExists(ctx context.Context, n string, cha
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Pinpoint APNs Voip Sandbox Channel with that Application ID exists")
+			return fmt.Errorf("No Pinpoint APNS VoIP Sandbox Channel with that Application ID exists")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointClient(ctx)
 
-		// Check if the app exists
-		params := &pinpoint.GetApnsVoipSandboxChannelInput{
-			ApplicationId: aws.String(rs.Primary.ID),
-		}
-		output, err := conn.GetApnsVoipSandboxChannelWithContext(ctx, params)
+		output, err := tfpinpoint.FindAPNSVoIPSandboxChannelByApplicationId(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		*channel = *output.APNSVoipSandboxChannelResponse
+		*channel = *output
+
+		return nil
+	}
+}
+
+func testAccCheckAPNSVoIPSandboxChannelDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_pinpoint_apns_voip_sandbox_channel" {
+				continue
+			}
+
+			_, err := tfpinpoint.FindAPNSVoIPSandboxChannelByApplicationId(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Pinpoint APNS VoIP Sandbox Channel %s still exists", rs.Primary.ID)
+		}
 
 		return nil
 	}
@@ -224,31 +246,4 @@ resource "aws_pinpoint_apns_voip_sandbox_channel" "test_channel" {
   token_key_id = %s
 }
 `, conf.BundleId, conf.TeamId, conf.TokenKey, conf.TokenKeyId)
-}
-
-func testAccCheckAPNSVoIPSandboxChannelDestroy(ctx context.Context) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointConn(ctx)
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_pinpoint_apns_voip_sandbox_channel" {
-				continue
-			}
-
-			// Check if the channel exists
-			params := &pinpoint.GetApnsVoipSandboxChannelInput{
-				ApplicationId: aws.String(rs.Primary.ID),
-			}
-			_, err := conn.GetApnsVoipSandboxChannelWithContext(ctx, params)
-			if err != nil {
-				if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-					continue
-				}
-				return err
-			}
-			return fmt.Errorf("APNs Voip Sandbox Channel exists when it should be destroyed!")
-		}
-
-		return nil
-	}
 }

--- a/internal/service/pinpoint/app_test.go
+++ b/internal/service/pinpoint/app_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/pinpoint"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -25,7 +25,7 @@ import (
 
 func TestAccPinpointApp_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_pinpoint_app.test"
 
@@ -81,7 +81,7 @@ func TestAccPinpointApp_basic(t *testing.T) {
 
 func TestAccPinpointApp_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_pinpoint_app.test"
 
@@ -105,7 +105,7 @@ func TestAccPinpointApp_disappears(t *testing.T) {
 
 func TestAccPinpointApp_nameGenerated(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -128,7 +128,7 @@ func TestAccPinpointApp_nameGenerated(t *testing.T) {
 
 func TestAccPinpointApp_namePrefix(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	resourceName := "aws_pinpoint_app.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -151,7 +151,7 @@ func TestAccPinpointApp_namePrefix(t *testing.T) {
 
 func TestAccPinpointApp_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_pinpoint_app.test"
 
@@ -197,7 +197,7 @@ func TestAccPinpointApp_tags(t *testing.T) {
 
 func TestAccPinpointApp_campaignHookLambda(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_pinpoint_app.test"
 
@@ -217,7 +217,7 @@ func TestAccPinpointApp_campaignHookLambda(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("campaign_hook"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"lambda_function_name": knownvalue.NotNull(), // Should be a Pair function, waiting on https://github.com/hashicorp/terraform-plugin-testing/pull/330
-							names.AttrMode:         knownvalue.StringExact(pinpoint.ModeDelivery),
+							names.AttrMode:         knownvalue.StringExact(string(awstypes.ModeDelivery)),
 							"web_url":              knownvalue.StringExact(""),
 						}),
 					})),
@@ -234,7 +234,7 @@ func TestAccPinpointApp_campaignHookLambda(t *testing.T) {
 
 func TestAccPinpointApp_campaignHookEmpty(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_pinpoint_app.test"
 
@@ -270,7 +270,7 @@ func TestAccPinpointApp_campaignHookEmpty(t *testing.T) {
 
 func TestAccPinpointApp_limits(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_pinpoint_app.test"
 
@@ -307,7 +307,7 @@ func TestAccPinpointApp_limits(t *testing.T) {
 
 func TestAccPinpointApp_limitsEmpty(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_pinpoint_app.test"
 
@@ -344,7 +344,7 @@ func TestAccPinpointApp_limitsEmpty(t *testing.T) {
 
 func TestAccPinpointApp_quietTime(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_pinpoint_app.test"
 
@@ -379,7 +379,7 @@ func TestAccPinpointApp_quietTime(t *testing.T) {
 
 func TestAccPinpointApp_quietTimeEmpty(t *testing.T) {
 	ctx := acctest.Context(t)
-	var application pinpoint.ApplicationResponse
+	var application awstypes.ApplicationResponse
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_pinpoint_app.test"
 
@@ -419,7 +419,7 @@ func testAccPreCheckApp(ctx context.Context, t *testing.T) {
 
 func testAccCheckAppDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_pinpoint_app" {
@@ -443,14 +443,14 @@ func testAccCheckAppDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckAppExists(ctx context.Context, n string, v *pinpoint.ApplicationResponse) resource.TestCheckFunc {
+func testAccCheckAppExists(ctx context.Context, n string, v *awstypes.ApplicationResponse) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).PinpointClient(ctx)
 
 		output, err := tfpinpoint.FindAppByID(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/pinpoint/baidu_channel.go
+++ b/internal/service/pinpoint/baidu_channel.go
@@ -97,6 +97,10 @@ func resourceBaiduChannelRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diags
 	}
 
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Pinpoint Baidu Channel (%s): %s", d.Id(), err)
+	}
+
 	d.Set(names.AttrApplicationID, output.ApplicationId)
 	d.Set(names.AttrEnabled, output.Enabled)
 	// ApiKey and SecretKey are never returned

--- a/internal/service/pinpoint/baidu_channel.go
+++ b/internal/service/pinpoint/baidu_channel.go
@@ -7,18 +7,21 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_pinpoint_baidu_channel")
-func ResourceBaiduChannel() *schema.Resource {
+// @SDKResource("aws_pinpoint_baidu_channel", name="Baidu Channel")
+func resourceBaiduChannel() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBaiduChannelUpsert,
 		ReadWithoutTimeout:   resourceBaiduChannelRead,
@@ -55,11 +58,11 @@ func ResourceBaiduChannel() *schema.Resource {
 
 func resourceBaiduChannelUpsert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	applicationId := d.Get(names.AttrApplicationID).(string)
 
-	params := &pinpoint.BaiduChannelRequest{}
+	params := &awstypes.BaiduChannelRequest{}
 
 	params.Enabled = aws.Bool(d.Get(names.AttrEnabled).(bool))
 	params.ApiKey = aws.String(d.Get("api_key").(string))
@@ -70,7 +73,7 @@ func resourceBaiduChannelUpsert(ctx context.Context, d *schema.ResourceData, met
 		BaiduChannelRequest: params,
 	}
 
-	_, err := conn.UpdateBaiduChannelWithContext(ctx, &req)
+	_, err := conn.UpdateBaiduChannel(ctx, &req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Pinpoint Baidu Channel for application %s: %s", applicationId, err)
 	}
@@ -82,25 +85,20 @@ func resourceBaiduChannelUpsert(ctx context.Context, d *schema.ResourceData, met
 
 func resourceBaiduChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[INFO] Reading Pinpoint Baidu Channel for application %s", d.Id())
 
-	output, err := conn.GetBaiduChannelWithContext(ctx, &pinpoint.GetBaiduChannelInput{
-		ApplicationId: aws.String(d.Id()),
-	})
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-			log.Printf("[WARN] Pinpoint Baidu Channel for application %s not found, removing from state", d.Id())
-			d.SetId("")
-			return diags
-		}
+	output, err := findBaiduChannelByApplicationId(ctx, conn, d.Id())
 
-		return sdkdiag.AppendErrorf(diags, "getting Pinpoint Baidu Channel for application %s: %s", d.Id(), err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Pinpoint Baidu Channel (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
 	}
 
-	d.Set(names.AttrApplicationID, output.BaiduChannelResponse.ApplicationId)
-	d.Set(names.AttrEnabled, output.BaiduChannelResponse.Enabled)
+	d.Set(names.AttrApplicationID, output.ApplicationId)
+	d.Set(names.AttrEnabled, output.Enabled)
 	// ApiKey and SecretKey are never returned
 
 	return diags
@@ -108,14 +106,14 @@ func resourceBaiduChannelRead(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceBaiduChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Pinpoint Baidu Channel for application %s", d.Id())
-	_, err := conn.DeleteBaiduChannelWithContext(ctx, &pinpoint.DeleteBaiduChannelInput{
+	_, err := conn.DeleteBaiduChannel(ctx, &pinpoint.DeleteBaiduChannelInput{
 		ApplicationId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags
 	}
 
@@ -123,4 +121,27 @@ func resourceBaiduChannelDelete(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint Baidu Channel for application %s: %s", d.Id(), err)
 	}
 	return diags
+}
+
+func findBaiduChannelByApplicationId(ctx context.Context, conn *pinpoint.Client, applicationId string) (*awstypes.BaiduChannelResponse, error) {
+	input := &pinpoint.GetBaiduChannelInput{
+		ApplicationId: aws.String(applicationId),
+	}
+
+	output, err := conn.GetBaiduChannel(ctx, input)
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.BaiduChannelResponse == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.BaiduChannelResponse, nil
 }

--- a/internal/service/pinpoint/email_channel.go
+++ b/internal/service/pinpoint/email_channel.go
@@ -7,19 +7,22 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_pinpoint_email_channel")
-func ResourceEmailChannel() *schema.Resource {
+// @SDKResource("aws_pinpoint_email_channel", name="Email Channel")
+func resourceEmailChannel() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEmailChannelUpsert,
 		ReadWithoutTimeout:   resourceEmailChannelRead,
@@ -68,11 +71,11 @@ func ResourceEmailChannel() *schema.Resource {
 
 func resourceEmailChannelUpsert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	applicationId := d.Get(names.AttrApplicationID).(string)
 
-	params := &pinpoint.EmailChannelRequest{}
+	params := &awstypes.EmailChannelRequest{}
 
 	params.Enabled = aws.Bool(d.Get(names.AttrEnabled).(bool))
 	params.FromAddress = aws.String(d.Get("from_address").(string))
@@ -91,7 +94,7 @@ func resourceEmailChannelUpsert(ctx context.Context, d *schema.ResourceData, met
 		EmailChannelRequest: params,
 	}
 
-	_, err := conn.UpdateEmailChannelWithContext(ctx, &req)
+	_, err := conn.UpdateEmailChannel(ctx, &req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Pinpoint Email Channel for application %s: %s", applicationId, err)
 	}
@@ -103,45 +106,39 @@ func resourceEmailChannelUpsert(ctx context.Context, d *schema.ResourceData, met
 
 func resourceEmailChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[INFO] Reading Pinpoint Email Channel for application %s", d.Id())
 
-	output, err := conn.GetEmailChannelWithContext(ctx, &pinpoint.GetEmailChannelInput{
-		ApplicationId: aws.String(d.Id()),
-	})
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-			log.Printf("[WARN] Pinpoint Email Channel for application %s not found, removing from state", d.Id())
-			d.SetId("")
-			return diags
-		}
+	output, err := findEmailChannelByApplicationId(ctx, conn, d.Id())
 
-		return sdkdiag.AppendErrorf(diags, "getting Pinpoint Email Channel for application %s: %s", d.Id(), err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Pinpoint Email Channel (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
 	}
 
-	res := output.EmailChannelResponse
-	d.Set(names.AttrApplicationID, res.ApplicationId)
-	d.Set(names.AttrEnabled, res.Enabled)
-	d.Set("from_address", res.FromAddress)
-	d.Set("identity", res.Identity)
-	d.Set(names.AttrRoleARN, res.RoleArn)
-	d.Set("configuration_set", res.ConfigurationSet)
-	d.Set("messages_per_second", res.MessagesPerSecond)
+	d.Set(names.AttrApplicationID, output.ApplicationId)
+	d.Set(names.AttrEnabled, output.Enabled)
+	d.Set("from_address", output.FromAddress)
+	d.Set("identity", output.Identity)
+	d.Set(names.AttrRoleARN, output.RoleArn)
+	d.Set("configuration_set", output.ConfigurationSet)
+	d.Set("messages_per_second", output.MessagesPerSecond)
 
 	return diags
 }
 
 func resourceEmailChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Pinpoint Email Channel for application %s", d.Id())
-	_, err := conn.DeleteEmailChannelWithContext(ctx, &pinpoint.DeleteEmailChannelInput{
+	_, err := conn.DeleteEmailChannel(ctx, &pinpoint.DeleteEmailChannelInput{
 		ApplicationId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags
 	}
 
@@ -149,4 +146,27 @@ func resourceEmailChannelDelete(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint Email Channel for application %s: %s", d.Id(), err)
 	}
 	return diags
+}
+
+func findEmailChannelByApplicationId(ctx context.Context, conn *pinpoint.Client, applicationId string) (*awstypes.EmailChannelResponse, error) {
+	input := &pinpoint.GetEmailChannelInput{
+		ApplicationId: aws.String(applicationId),
+	}
+
+	output, err := conn.GetEmailChannel(ctx, input)
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.EmailChannelResponse == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.EmailChannelResponse, nil
 }

--- a/internal/service/pinpoint/email_channel.go
+++ b/internal/service/pinpoint/email_channel.go
@@ -118,6 +118,10 @@ func resourceEmailChannelRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diags
 	}
 
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Pinpoint Email Channel (%s): %s", d.Id(), err)
+	}
+
 	d.Set(names.AttrApplicationID, output.ApplicationId)
 	d.Set(names.AttrEnabled, output.Enabled)
 	d.Set("from_address", output.FromAddress)

--- a/internal/service/pinpoint/email_channel_test.go
+++ b/internal/service/pinpoint/email_channel_test.go
@@ -41,7 +41,6 @@ func TestAccPinpointEmailChannel_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "from_address", address1),
 					resource.TestCheckResourceAttrSet(resourceName, "messages_per_second"),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, "aws_iam_role.test", names.AttrARN),
 					resource.TestCheckResourceAttrPair(resourceName, "identity", "aws_ses_domain_identity.test", names.AttrARN),
 				),
 			},
@@ -211,7 +210,6 @@ resource "aws_pinpoint_email_channel" "test" {
   enabled        = "false"
   from_address   = %[2]q
   identity       = aws_ses_domain_identity.test.arn
-  role_arn       = aws_iam_role.test.arn
 }
 
 resource "aws_ses_domain_identity" "test" {
@@ -272,7 +270,6 @@ resource "aws_pinpoint_email_channel" "test" {
   enabled           = "false"
   from_address      = %[2]q
   identity          = aws_ses_domain_identity.test.arn
-  role_arn          = aws_iam_role.test.arn
   configuration_set = aws_ses_configuration_set.test.name
 }
 

--- a/internal/service/pinpoint/event_stream.go
+++ b/internal/service/pinpoint/event_stream.go
@@ -100,6 +100,10 @@ func resourceEventStreamRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diags
 	}
 
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Pinpoint Event Stream (%s): %s", d.Id(), err)
+	}
+
 	d.Set(names.AttrApplicationID, output.ApplicationId)
 	d.Set("destination_stream_arn", output.DestinationStreamArn)
 	d.Set(names.AttrRoleARN, output.RoleArn)

--- a/internal/service/pinpoint/event_stream.go
+++ b/internal/service/pinpoint/event_stream.go
@@ -73,7 +73,7 @@ func resourceEventStreamUpsert(ctx context.Context, d *schema.ResourceData, meta
 		return conn.PutEventStream(ctx, &req)
 	}, "make sure the IAM Role is configured correctly")
 
-	if tfresource.TimedOut(err) {
+	if tfresource.TimedOut(err) { // nosemgrep:ci.helper-schema-TimeoutError-check-doesnt-return-output
 		_, err = conn.PutEventStream(ctx, &req)
 	}
 

--- a/internal/service/pinpoint/event_stream.go
+++ b/internal/service/pinpoint/event_stream.go
@@ -7,21 +7,22 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_pinpoint_event_stream")
-func ResourceEventStream() *schema.Resource {
+// @SDKResource("aws_pinpoint_event_stream", name="Event Stream")
+func resourceEventStream() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEventStreamUpsert,
 		ReadWithoutTimeout:   resourceEventStreamRead,
@@ -53,11 +54,11 @@ func ResourceEventStream() *schema.Resource {
 
 func resourceEventStreamUpsert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	applicationId := d.Get(names.AttrApplicationID).(string)
 
-	params := &pinpoint.WriteEventStream{
+	params := &awstypes.WriteEventStream{
 		DestinationStreamArn: aws.String(d.Get("destination_stream_arn").(string)),
 		RoleArn:              aws.String(d.Get(names.AttrRoleARN).(string)),
 	}
@@ -68,22 +69,12 @@ func resourceEventStreamUpsert(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	// Retry for IAM eventual consistency
-	err := retry.RetryContext(ctx, propagationTimeout, func() *retry.RetryError {
-		_, err := conn.PutEventStreamWithContext(ctx, &req)
-
-		if tfawserr.ErrMessageContains(err, pinpoint.ErrCodeBadRequestException, "make sure the IAM Role is configured correctly") {
-			return retry.RetryableError(err)
-		}
-
-		if err != nil {
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
-	})
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.BadRequestException](ctx, propagationTimeout, func() (interface{}, error) {
+		return conn.PutEventStream(ctx, &req)
+	}, "make sure the IAM Role is configured correctly")
 
 	if tfresource.TimedOut(err) {
-		_, err = conn.PutEventStreamWithContext(ctx, &req)
+		_, err = conn.PutEventStream(ctx, &req)
 	}
 
 	if err != nil {
@@ -97,41 +88,35 @@ func resourceEventStreamUpsert(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceEventStreamRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[INFO] Reading Pinpoint Event Stream for application %s", d.Id())
 
-	output, err := conn.GetEventStreamWithContext(ctx, &pinpoint.GetEventStreamInput{
-		ApplicationId: aws.String(d.Id()),
-	})
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-			log.Printf("[WARN] Pinpoint Event Stream for application %s not found, removing from state", d.Id())
-			d.SetId("")
-			return diags
-		}
+	output, err := findEventStreamByApplicationId(ctx, conn, d.Id())
 
-		return sdkdiag.AppendErrorf(diags, "getting Pinpoint Event Stream for application %s: %s", d.Id(), err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Pinpoint Event Stream (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
 	}
 
-	res := output.EventStream
-	d.Set(names.AttrApplicationID, res.ApplicationId)
-	d.Set("destination_stream_arn", res.DestinationStreamArn)
-	d.Set(names.AttrRoleARN, res.RoleArn)
+	d.Set(names.AttrApplicationID, output.ApplicationId)
+	d.Set("destination_stream_arn", output.DestinationStreamArn)
+	d.Set(names.AttrRoleARN, output.RoleArn)
 
 	return diags
 }
 
 func resourceEventStreamDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[DEBUG] Pinpoint Delete Event Stream: %s", d.Id())
-	_, err := conn.DeleteEventStreamWithContext(ctx, &pinpoint.DeleteEventStreamInput{
+	_, err := conn.DeleteEventStream(ctx, &pinpoint.DeleteEventStreamInput{
 		ApplicationId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags
 	}
 
@@ -139,4 +124,27 @@ func resourceEventStreamDelete(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint Event Stream for application %s: %s", d.Id(), err)
 	}
 	return diags
+}
+
+func findEventStreamByApplicationId(ctx context.Context, conn *pinpoint.Client, applicationId string) (*awstypes.EventStream, error) {
+	input := &pinpoint.GetEventStreamInput{
+		ApplicationId: aws.String(applicationId),
+	}
+
+	output, err := conn.GetEventStream(ctx, input)
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.EventStream == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.EventStream, nil
 }

--- a/internal/service/pinpoint/exports_test.go
+++ b/internal/service/pinpoint/exports_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package pinpoint
+
+// Exports for use in tests only.
+var (
+	ResourceApp          = resourceApp
+	ResourceEmailChannel = resourceEmailChannel
+	ResourceEventStream  = resourceEventStream
+	ResourceSMSChannel   = resourceSMSChannel
+
+	FindADMChannelByApplicationId             = findADMChannelByApplicationId
+	FindAPNSChannelByApplicationId            = findAPNSChannelByApplicationId
+	FindAPNSSandboxChannelByApplicationId     = findAPNSSandboxChannelByApplicationId
+	FindAPNSVoIPChannelByApplicationId        = findAPNSVoIPChannelByApplicationId
+	FindAPNSVoIPSandboxChannelByApplicationId = findAPNSVoIPSandboxChannelByApplicationId
+	FindAppByID                               = findAppByID
+	FindBaiduChannelByApplicationId           = findBaiduChannelByApplicationId
+	FindEmailChannelByApplicationId           = findEmailChannelByApplicationId
+	FindEventStreamByApplicationId            = findEventStreamByApplicationId
+	FindGCMChannelByApplicationId             = findGCMChannelByApplicationId
+	FindSMSChannelByApplicationId             = findSMSChannelByApplicationId
+)

--- a/internal/service/pinpoint/gcm_channel.go
+++ b/internal/service/pinpoint/gcm_channel.go
@@ -7,18 +7,21 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_pinpoint_gcm_channel")
-func ResourceGCMChannel() *schema.Resource {
+// @SDKResource("aws_pinpoint_gcm_channel", name="GCM Channel")
+func resourceGCMChannel() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceGCMChannelUpsert,
 		ReadWithoutTimeout:   resourceGCMChannelRead,
@@ -50,11 +53,11 @@ func ResourceGCMChannel() *schema.Resource {
 
 func resourceGCMChannelUpsert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	applicationId := d.Get(names.AttrApplicationID).(string)
 
-	params := &pinpoint.GCMChannelRequest{}
+	params := &awstypes.GCMChannelRequest{}
 
 	params.ApiKey = aws.String(d.Get("api_key").(string))
 	params.Enabled = aws.Bool(d.Get(names.AttrEnabled).(bool))
@@ -64,7 +67,7 @@ func resourceGCMChannelUpsert(ctx context.Context, d *schema.ResourceData, meta 
 		GCMChannelRequest: params,
 	}
 
-	_, err := conn.UpdateGcmChannelWithContext(ctx, &req)
+	_, err := conn.UpdateGcmChannel(ctx, &req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "putting Pinpoint GCM Channel for application %s: %s", applicationId, err)
 	}
@@ -76,25 +79,20 @@ func resourceGCMChannelUpsert(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceGCMChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[INFO] Reading Pinpoint GCM Channel for application %s", d.Id())
 
-	output, err := conn.GetGcmChannelWithContext(ctx, &pinpoint.GetGcmChannelInput{
-		ApplicationId: aws.String(d.Id()),
-	})
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-			log.Printf("[WARN] Pinpoint GCM Channel for application %s not found, removing from state", d.Id())
-			d.SetId("")
-			return diags
-		}
+	output, err := findGCMChannelByApplicationId(ctx, conn, d.Id())
 
-		return sdkdiag.AppendErrorf(diags, "getting Pinpoint GCM Channel for application %s: %s", d.Id(), err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Pinpoint GCM Channel (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
 	}
 
-	d.Set(names.AttrApplicationID, output.GCMChannelResponse.ApplicationId)
-	d.Set(names.AttrEnabled, output.GCMChannelResponse.Enabled)
+	d.Set(names.AttrApplicationID, output.ApplicationId)
+	d.Set(names.AttrEnabled, output.Enabled)
 	// api_key is never returned
 
 	return diags
@@ -102,14 +100,14 @@ func resourceGCMChannelRead(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceGCMChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Pinpoint GCM Channel for application %s", d.Id())
-	_, err := conn.DeleteGcmChannelWithContext(ctx, &pinpoint.DeleteGcmChannelInput{
+	_, err := conn.DeleteGcmChannel(ctx, &pinpoint.DeleteGcmChannelInput{
 		ApplicationId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags
 	}
 
@@ -117,4 +115,27 @@ func resourceGCMChannelDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint GCM Channel for application %s: %s", d.Id(), err)
 	}
 	return diags
+}
+
+func findGCMChannelByApplicationId(ctx context.Context, conn *pinpoint.Client, applicationId string) (*awstypes.GCMChannelResponse, error) {
+	input := &pinpoint.GetGcmChannelInput{
+		ApplicationId: aws.String(applicationId),
+	}
+
+	output, err := conn.GetGcmChannel(ctx, input)
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.GCMChannelResponse == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.GCMChannelResponse, nil
 }

--- a/internal/service/pinpoint/gcm_channel.go
+++ b/internal/service/pinpoint/gcm_channel.go
@@ -91,6 +91,10 @@ func resourceGCMChannelRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diags
 	}
 
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Pinpoint GCM Channel (%s): %s", d.Id(), err)
+	}
+
 	d.Set(names.AttrApplicationID, output.ApplicationId)
 	d.Set(names.AttrEnabled, output.Enabled)
 	// api_key is never returned

--- a/internal/service/pinpoint/generate.go
+++ b/internal/service/pinpoint/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOutTagsElem=TagsModel.Tags -ServiceTagsMap "-TagInCustomVal=&pinpoint.TagsModel{Tags: Tags(updatedTags.IgnoreAWS())}" -TagInTagsElem=TagsModel -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ListTagsOutTagsElem=TagsModel.Tags -ServiceTagsMap "-TagInCustomVal=&awstypes.TagsModel{Tags: Tags(updatedTags.IgnoreAWS())}" -TagInTagsElem=TagsModel -UpdateTags -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/pinpoint/service_endpoint_resolver_gen.go
+++ b/internal/service/pinpoint/service_endpoint_resolver_gen.go
@@ -6,65 +6,63 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 
-	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	pinpoint_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	smithyendpoints "github.com/aws/smithy-go/endpoints"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 )
 
-var _ endpoints_sdkv1.Resolver = resolverSDKv1{}
+var _ pinpoint_sdkv2.EndpointResolverV2 = resolverSDKv2{}
 
-type resolverSDKv1 struct {
-	ctx context.Context
+type resolverSDKv2 struct {
+	defaultResolver pinpoint_sdkv2.EndpointResolverV2
 }
 
-func newEndpointResolverSDKv1(ctx context.Context) resolverSDKv1 {
-	return resolverSDKv1{
-		ctx: ctx,
+func newEndpointResolverSDKv2() resolverSDKv2 {
+	return resolverSDKv2{
+		defaultResolver: pinpoint_sdkv2.NewDefaultEndpointResolverV2(),
 	}
 }
 
-func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoints_sdkv1.Options)) (endpoint endpoints_sdkv1.ResolvedEndpoint, err error) {
-	ctx := r.ctx
+func (r resolverSDKv2) ResolveEndpoint(ctx context.Context, params pinpoint_sdkv2.EndpointParameters) (endpoint smithyendpoints.Endpoint, err error) {
+	params = params.WithDefaults()
+	useFIPS := aws_sdkv2.ToBool(params.UseFIPS)
 
-	var opt endpoints_sdkv1.Options
-	opt.Set(opts...)
+	if eps := params.Endpoint; aws_sdkv2.ToString(eps) != "" {
+		tflog.Debug(ctx, "setting endpoint", map[string]any{
+			"tf_aws.endpoint": endpoint,
+		})
 
-	useFIPS := opt.UseFIPSEndpoint == endpoints_sdkv1.FIPSEndpointStateEnabled
+		if useFIPS {
+			tflog.Debug(ctx, "endpoint set, ignoring UseFIPSEndpoint setting")
+			params.UseFIPS = aws_sdkv2.Bool(false)
+		}
 
-	defaultResolver := endpoints_sdkv1.DefaultResolver()
-
-	if useFIPS {
+		return r.defaultResolver.ResolveEndpoint(ctx, params)
+	} else if useFIPS {
 		ctx = tflog.SetField(ctx, "tf_aws.use_fips", useFIPS)
 
-		endpoint, err = defaultResolver.EndpointFor(service, region, opts...)
+		endpoint, err = r.defaultResolver.ResolveEndpoint(ctx, params)
 		if err != nil {
 			return endpoint, err
 		}
 
 		tflog.Debug(ctx, "endpoint resolved", map[string]any{
-			"tf_aws.endpoint": endpoint.URL,
+			"tf_aws.endpoint": endpoint.URI.String(),
 		})
 
-		var endpointURL *url.URL
-		endpointURL, err = url.Parse(endpoint.URL)
-		if err != nil {
-			return endpoint, err
-		}
-
-		hostname := endpointURL.Hostname()
+		hostname := endpoint.URI.Hostname()
 		_, err = net.LookupHost(hostname)
 		if err != nil {
 			if dnsErr, ok := errs.As[*net.DNSError](err); ok && dnsErr.IsNotFound {
 				tflog.Debug(ctx, "default endpoint host not found, disabling FIPS", map[string]any{
 					"tf_aws.hostname": hostname,
 				})
-				opts = append(opts, func(o *endpoints_sdkv1.Options) {
-					o.UseFIPSEndpoint = endpoints_sdkv1.FIPSEndpointStateDisabled
-				})
+				params.UseFIPS = aws_sdkv2.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up accessanalyzer endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up pinpoint endpoint %q: %s", hostname, err)
 				return
 			}
 		} else {
@@ -72,5 +70,13 @@ func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoin
 		}
 	}
 
-	return defaultResolver.EndpointFor(service, region, opts...)
+	return r.defaultResolver.ResolveEndpoint(ctx, params)
+}
+
+func withBaseEndpoint(endpoint string) func(*pinpoint_sdkv2.Options) {
+	return func(o *pinpoint_sdkv2.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}
 }

--- a/internal/service/pinpoint/service_endpoints_gen_test.go
+++ b/internal/service/pinpoint/service_endpoints_gen_test.go
@@ -4,18 +4,22 @@ package pinpoint_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	pinpoint_sdkv1 "github.com/aws/aws-sdk-go/service/pinpoint"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	pinpoint_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -240,54 +244,63 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 }
 
 func defaultEndpoint(region string) (url.URL, error) {
-	r := endpoints.DefaultResolver()
+	r := pinpoint_sdkv2.NewDefaultEndpointResolverV2()
 
-	ep, err := r.EndpointFor(pinpoint_sdkv1.EndpointsID, region)
-	if err != nil {
-		return url.URL{}, err
-	}
-
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
-	}
-
-	return *url, nil
-}
-
-func defaultFIPSEndpoint(region string) (url.URL, error) {
-	r := endpoints.DefaultResolver()
-
-	ep, err := r.EndpointFor(pinpoint_sdkv1.EndpointsID, region, func(opt *endpoints.Options) {
-		opt.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	ep, err := r.ResolveEndpoint(context.Background(), pinpoint_sdkv2.EndpointParameters{
+		Region: aws_sdkv2.String(region),
 	})
 	if err != nil {
 		return url.URL{}, err
 	}
 
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
 	}
 
-	return *url, nil
+	return ep.URI, nil
+}
+
+func defaultFIPSEndpoint(region string) (url.URL, error) {
+	r := pinpoint_sdkv2.NewDefaultEndpointResolverV2()
+
+	ep, err := r.ResolveEndpoint(context.Background(), pinpoint_sdkv2.EndpointParameters{
+		Region:  aws_sdkv2.String(region),
+		UseFIPS: aws_sdkv2.Bool(true),
+	})
+	if err != nil {
+		return url.URL{}, err
+	}
+
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
+	}
+
+	return ep.URI, nil
 }
 
 func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCallParams {
 	t.Helper()
 
-	client := meta.PinpointConn(ctx)
+	client := meta.PinpointClient(ctx)
 
-	req, _ := client.GetAppsRequest(&pinpoint_sdkv1.GetAppsInput{})
+	var result apiCallParams
 
-	req.HTTPRequest.URL.Path = "/"
-
-	return apiCallParams{
-		endpoint: req.HTTPRequest.URL.String(),
-		region:   aws_sdkv1.StringValue(client.Config.Region),
+	_, err := client.GetApps(ctx, &pinpoint_sdkv2.GetAppsInput{},
+		func(opts *pinpoint_sdkv2.Options) {
+			opts.APIOptions = append(opts.APIOptions,
+				addRetrieveEndpointURLMiddleware(t, &result.endpoint),
+				addRetrieveRegionMiddleware(&result.region),
+				addCancelRequestMiddleware(),
+			)
+		},
+	)
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	} else if !errors.Is(err, errCancelOperation) {
+		t.Fatalf("Unexpected error: %s", err)
 	}
+
+	return result
 }
 
 func withNoConfig(_ *caseSetup) {
@@ -464,6 +477,89 @@ func testEndpointCase(t *testing.T, region string, testcase endpointTestCase, ca
 	if e, a := testcase.expected.region, callParams.region; e != a {
 		t.Errorf("expected region %q, got %q", e, a)
 	}
+}
+
+func addRetrieveEndpointURLMiddleware(t *testing.T, endpoint *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			retrieveEndpointURLMiddleware(t, endpoint),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveEndpointURLMiddleware(t *testing.T, endpoint *string) middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Retrieve Endpoint",
+		func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			t.Helper()
+
+			request, ok := in.Request.(*smithyhttp.Request)
+			if !ok {
+				t.Fatalf("Expected *github.com/aws/smithy-go/transport/http.Request, got %s", fullTypeName(in.Request))
+			}
+
+			url := request.URL
+			url.RawQuery = ""
+			url.Path = "/"
+
+			*endpoint = url.String()
+
+			return next.HandleFinalize(ctx, in)
+		})
+}
+
+func addRetrieveRegionMiddleware(region *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Serialize.Add(
+			retrieveRegionMiddleware(region),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
+	return middleware.SerializeMiddlewareFunc(
+		"Test: Retrieve Region",
+		func(ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler) (middleware.SerializeOutput, middleware.Metadata, error) {
+			*region = awsmiddleware.GetRegion(ctx)
+
+			return next.HandleSerialize(ctx, in)
+		},
+	)
+}
+
+var errCancelOperation = fmt.Errorf("Test: Canceling request")
+
+func addCancelRequestMiddleware() func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			cancelRequestMiddleware(),
+			middleware.After,
+		)
+	}
+}
+
+// cancelRequestMiddleware creates a Smithy middleware that intercepts the request before sending and cancels it
+func cancelRequestMiddleware() middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Cancel Requests",
+		func(_ context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, errCancelOperation
+		})
+}
+
+func fullTypeName(i interface{}) string {
+	return fullValueTypeName(reflect.ValueOf(i))
+}
+
+func fullValueTypeName(v reflect.Value) string {
+	if v.Kind() == reflect.Ptr {
+		return "*" + fullValueTypeName(reflect.Indirect(v))
+	}
+
+	requestType := v.Type()
+	return fmt.Sprintf("%s.%s", requestType.PkgPath(), requestType.Name())
 }
 
 func generateSharedConfigFile(config configFile) string {

--- a/internal/service/pinpoint/service_package_gen.go
+++ b/internal/service/pinpoint/service_package_gen.go
@@ -5,10 +5,8 @@ package pinpoint
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	pinpoint_sdkv1 "github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	pinpoint_sdkv2 "github.com/aws/aws-sdk-go-v2/service/pinpoint"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -31,27 +29,32 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceADMChannel,
+			Factory:  resourceADMChannel,
 			TypeName: "aws_pinpoint_adm_channel",
+			Name:     "ADM Channel",
 		},
 		{
-			Factory:  ResourceAPNSChannel,
+			Factory:  resourceAPNSChannel,
 			TypeName: "aws_pinpoint_apns_channel",
+			Name:     "APNS Channel",
 		},
 		{
-			Factory:  ResourceAPNSSandboxChannel,
+			Factory:  resourceAPNSSandboxChannel,
 			TypeName: "aws_pinpoint_apns_sandbox_channel",
+			Name:     "APNS Sandbox Channel",
 		},
 		{
-			Factory:  ResourceAPNSVoIPChannel,
+			Factory:  resourceAPNSVoIPChannel,
 			TypeName: "aws_pinpoint_apns_voip_channel",
+			Name:     "APNS VoIP Channel",
 		},
 		{
-			Factory:  ResourceAPNSVoIPSandboxChannel,
+			Factory:  resourceAPNSVoIPSandboxChannel,
 			TypeName: "aws_pinpoint_apns_voip_sandbox_channel",
+			Name:     "APNS VoIP Sandbox Channel",
 		},
 		{
-			Factory:  ResourceApp,
+			Factory:  resourceApp,
 			TypeName: "aws_pinpoint_app",
 			Name:     "App",
 			Tags: &types.ServicePackageResourceTags{
@@ -59,24 +62,29 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceBaiduChannel,
+			Factory:  resourceBaiduChannel,
 			TypeName: "aws_pinpoint_baidu_channel",
+			Name:     "Baidu Channel",
 		},
 		{
-			Factory:  ResourceEmailChannel,
+			Factory:  resourceEmailChannel,
 			TypeName: "aws_pinpoint_email_channel",
+			Name:     "Email Channel",
 		},
 		{
-			Factory:  ResourceEventStream,
+			Factory:  resourceEventStream,
 			TypeName: "aws_pinpoint_event_stream",
+			Name:     "Event Stream",
 		},
 		{
-			Factory:  ResourceGCMChannel,
+			Factory:  resourceGCMChannel,
 			TypeName: "aws_pinpoint_gcm_channel",
+			Name:     "GCM Channel",
 		},
 		{
-			Factory:  ResourceSMSChannel,
+			Factory:  resourceSMSChannel,
 			TypeName: "aws_pinpoint_sms_channel",
+			Name:     "SMS Channel",
 		},
 	}
 }
@@ -85,22 +93,14 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.Pinpoint
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*pinpoint_sdkv1.Pinpoint, error) {
-	sess := config[names.AttrSession].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*pinpoint_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	cfg := aws_sdkv1.Config{}
-
-	if endpoint := config[names.AttrEndpoint].(string); endpoint != "" {
-		tflog.Debug(ctx, "setting endpoint", map[string]any{
-			"tf_aws.endpoint": endpoint,
-		})
-		cfg.Endpoint = aws_sdkv1.String(endpoint)
-	} else {
-		cfg.EndpointResolver = newEndpointResolverSDKv1(ctx)
-	}
-
-	return pinpoint_sdkv1.New(sess.Copy(&cfg)), nil
+	return pinpoint_sdkv2.NewFromConfig(cfg,
+		pinpoint_sdkv2.WithEndpointResolverV2(newEndpointResolverSDKv2()),
+		withBaseEndpoint(config[names.AttrEndpoint].(string)),
+	), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/pinpoint/sms_channel.go
+++ b/internal/service/pinpoint/sms_channel.go
@@ -109,6 +109,10 @@ func resourceSMSChannelRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diags
 	}
 
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Pinpoint SMS Channel (%s): %s", d.Id(), err)
+	}
+
 	d.Set(names.AttrApplicationID, output.ApplicationId)
 	d.Set(names.AttrEnabled, output.Enabled)
 	d.Set("sender_id", output.SenderId)

--- a/internal/service/pinpoint/sms_channel.go
+++ b/internal/service/pinpoint/sms_channel.go
@@ -7,18 +7,21 @@ import (
 	"context"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/pinpoint/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_pinpoint_sms_channel")
-func ResourceSMSChannel() *schema.Resource {
+// @SDKResource("aws_pinpoint_sms_channel", name="SMS Channel")
+func resourceSMSChannel() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSMSChannelUpsert,
 		ReadWithoutTimeout:   resourceSMSChannelRead,
@@ -61,11 +64,11 @@ func ResourceSMSChannel() *schema.Resource {
 
 func resourceSMSChannelUpsert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	applicationId := d.Get(names.AttrApplicationID).(string)
 
-	params := &pinpoint.SMSChannelRequest{
+	params := &awstypes.SMSChannelRequest{
 		Enabled: aws.Bool(d.Get(names.AttrEnabled).(bool)),
 	}
 
@@ -82,7 +85,7 @@ func resourceSMSChannelUpsert(ctx context.Context, d *schema.ResourceData, meta 
 		SMSChannelRequest: params,
 	}
 
-	_, err := conn.UpdateSmsChannelWithContext(ctx, &req)
+	_, err := conn.UpdateSmsChannel(ctx, &req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "putting Pinpoint SMS Channel for application %s: %s", applicationId, err)
 	}
@@ -94,43 +97,37 @@ func resourceSMSChannelUpsert(ctx context.Context, d *schema.ResourceData, meta 
 
 func resourceSMSChannelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[INFO] Reading Pinpoint SMS Channel  for application %s", d.Id())
 
-	output, err := conn.GetSmsChannelWithContext(ctx, &pinpoint.GetSmsChannelInput{
-		ApplicationId: aws.String(d.Id()),
-	})
-	if err != nil {
-		if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
-			log.Printf("[WARN] Pinpoint SMS Channel for application %s not found, removing from state", d.Id())
-			d.SetId("")
-			return diags
-		}
+	output, err := findSMSChannelByApplicationId(ctx, conn, d.Id())
 
-		return sdkdiag.AppendErrorf(diags, "getting Pinpoint SMS Channel for application %s: %s", d.Id(), err)
+	if !d.IsNewResource() && tfresource.NotFound(err) {
+		log.Printf("[WARN] Pinpoint SMS Channel (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return diags
 	}
 
-	res := output.SMSChannelResponse
-	d.Set(names.AttrApplicationID, res.ApplicationId)
-	d.Set(names.AttrEnabled, res.Enabled)
-	d.Set("sender_id", res.SenderId)
-	d.Set("short_code", res.ShortCode)
-	d.Set("promotional_messages_per_second", res.PromotionalMessagesPerSecond)
-	d.Set("transactional_messages_per_second", res.TransactionalMessagesPerSecond)
+	d.Set(names.AttrApplicationID, output.ApplicationId)
+	d.Set(names.AttrEnabled, output.Enabled)
+	d.Set("sender_id", output.SenderId)
+	d.Set("short_code", output.ShortCode)
+	d.Set("promotional_messages_per_second", output.PromotionalMessagesPerSecond)
+	d.Set("transactional_messages_per_second", output.TransactionalMessagesPerSecond)
 	return diags
 }
 
 func resourceSMSChannelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).PinpointConn(ctx)
+	conn := meta.(*conns.AWSClient).PinpointClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Pinpoint SMS Channel for application %s", d.Id())
-	_, err := conn.DeleteSmsChannelWithContext(ctx, &pinpoint.DeleteSmsChannelInput{
+	_, err := conn.DeleteSmsChannel(ctx, &pinpoint.DeleteSmsChannelInput{
 		ApplicationId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, pinpoint.ErrCodeNotFoundException) {
+	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags
 	}
 
@@ -138,4 +135,27 @@ func resourceSMSChannelDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "deleting Pinpoint SMS Channel for application %s: %s", d.Id(), err)
 	}
 	return diags
+}
+
+func findSMSChannelByApplicationId(ctx context.Context, conn *pinpoint.Client, applicationId string) (*awstypes.SMSChannelResponse, error) {
+	input := &pinpoint.GetSmsChannelInput{
+		ApplicationId: aws.String(applicationId),
+	}
+
+	output, err := conn.GetSmsChannel(ctx, input)
+	if errs.IsA[*awstypes.NotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.SMSChannelResponse == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.SMSChannelResponse, nil
 }

--- a/internal/service/pinpoint/sweep.go
+++ b/internal/service/pinpoint/sweep.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/pinpoint"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
-	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv1"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func RegisterSweepers() {
@@ -27,14 +27,14 @@ func sweepApps(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
-	conn := client.PinpointConn(ctx)
+	conn := client.PinpointClient(ctx)
 
 	input := &pinpoint.GetAppsInput{}
 
 	for {
-		output, err := conn.GetAppsWithContext(ctx, input)
+		output, err := conn.GetApps(ctx, input)
 		if err != nil {
-			if awsv1.SkipSweepError(err) {
+			if awsv2.SkipSweepError(err) {
 				log.Printf("[WARN] Skipping Pinpoint app sweep for %s: %s", region, err)
 				return nil
 			}
@@ -47,10 +47,10 @@ func sweepApps(region string) error {
 		}
 
 		for _, item := range output.ApplicationsResponse.Item {
-			name := aws.StringValue(item.Name)
+			name := aws.ToString(item.Name)
 
 			log.Printf("[INFO] Deleting Pinpoint app %s", name)
-			_, err := conn.DeleteAppWithContext(ctx, &pinpoint.DeleteAppInput{
+			_, err := conn.DeleteApp(ctx, &pinpoint.DeleteAppInput{
 				ApplicationId: item.Id,
 			})
 			if err != nil {

--- a/names/data/names_data.hcl
+++ b/names/data/names_data.hcl
@@ -6936,7 +6936,7 @@ service "pinpoint" {
 
   sdk {
     id             = "Pinpoint"
-    client_version = [1]
+    client_version = [2]
   }
 
   names {

--- a/website/docs/r/pinpoint_email_channel.html.markdown
+++ b/website/docs/r/pinpoint_email_channel.html.markdown
@@ -71,7 +71,7 @@ This resource supports the following arguments:
 * `configuration_set` - (Optional) The ARN of the Amazon SES configuration set that you want to apply to messages that you send through the channel.
 * `from_address` - (Required) The email address used to send emails from. You can use email only (`user@example.com`) or friendly address (`User <user@example.com>`). This field comply with [RFC 5322](https://www.ietf.org/rfc/rfc5322.txt).
 * `identity` - (Required) The ARN of an identity verified with SES.
-* `role_arn` - (Optional) The ARN of an IAM Role used to submit events to Mobile Analytics' event ingestion service.
+* `role_arn` - (Optional) *Deprecated* This attribute is no longer supported in SDKv2. The ARN of an IAM Role used to submit events to Mobile Analytics' event ingestion service.
 
 ## Attribute Reference
 

--- a/website/docs/r/pinpoint_email_channel.html.markdown
+++ b/website/docs/r/pinpoint_email_channel.html.markdown
@@ -71,7 +71,7 @@ This resource supports the following arguments:
 * `configuration_set` - (Optional) The ARN of the Amazon SES configuration set that you want to apply to messages that you send through the channel.
 * `from_address` - (Required) The email address used to send emails from. You can use email only (`user@example.com`) or friendly address (`User <user@example.com>`). This field comply with [RFC 5322](https://www.ietf.org/rfc/rfc5322.txt).
 * `identity` - (Required) The ARN of an identity verified with SES.
-* `role_arn` - (Optional) *Deprecated* This attribute is no longer supported in SDKv2. The ARN of an IAM Role used to submit events to Mobile Analytics' event ingestion service.
+* `role_arn` - (Optional) *Deprecated* The ARN of an IAM Role used to submit events to Mobile Analytics' event ingestion service.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR migrates the `Pinpoint` resources to AWS SDKv2.

Test failures are pre-migration failures and are happening because the `GetEmailChannel` action doesn't seem to return `roleARN` in it's response body.

I will do a bit more research on where this exactly goes wrong and file if needed a support case with AWS.
For now this shouldn't block the migration.

**Update**: AWS support was able to reproduce this behaviour and will be consulting internally on how to proceed. I will create a seperate issue for visibility purposes and as to not block the progress here. Filed under https://github.com/hashicorp/terraform-provider-aws/issues/38772

**UpdateEmailChannel**

```
2024-08-07T21:47:06.964+0200 [DEBUG] aws: HTTP Request Sent: tf_aws.sdk=aws-sdk-go-v2 rpc.method=UpdateEmailChannel http.request.header.x_amz_date=20240807T194706Z http.url=https://pinpoint.us-west-2.amazonaws.com/v1/apps/5b81d750ea1748eba0c4ca78a7a9a37c/channels/email rpc.system=aws-api aws.region=us-west-2 tf_req_id=dfe6148f-6856-6f06-cca1-97af6f81819e tf_resource_type=aws_pinpoint_email_channel http.request.header.amz_sdk_invocation_id=2e470a55-de19-4cdf-b518-fca24e293d13 http.request_content_length=230 http.request.header.content_type=application/json http.request.header.authorization="AWS4-HMAC-SHA256 Credential=AKIA************LQDY/20240807/us-west-2/mobiletargeting/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;content-length;content-type;host;x-amz-date, Signature=*****" rpc.service=Pinpoint http.request.header.amz_sdk_request="attempt=1; max=25"
  http.request.body=
  | {"Enabled":false,"FromAddress":"tf-acc-test-7788522522147484357@bptw3i72.test","Identity":"arn:aws:ses:us-west-2:170689858638:identity/bptw3i72.test","RoleArn":"arn:aws:iam::012345678910:role/terraform-20240807194706056100000002"}
```

**GetEmailChannel**

```
2024-08-07T21:47:07.363+0200 [DEBUG] aws: HTTP Response Received: rpc.service=Pinpoint http.duration=209 http.response.header.x_amzn_requestid=6256168e-90a0-4b15-b6b4-926ebd6ad628 tf_provider_addr=registry.terraform.io/hashicorp/aws tf_resource_type=aws_pinpoint_email_channel tf_aws.sdk=aws-sdk-go-v2 rpc.method=GetEmailChannel http.response.header.content_type=application/json http.response.header.via="1.1 37bca31d9c7de06b67b2363770e065b4.cloudfront.net (CloudFront)" http.status_code=200 rpc.system=aws-api http.response.header.x_amzn_trace_id=Root=1-66b3cf3b-1a9174c53c20a3755f1a5d76 http.response.header.x_amz_cf_pop=AMS1-P1 http.response.header.access_control_allow_origin="*" http.response_content_length=374 http.response.header.x_amz_apigw_id=cJ1RTE7RPHcEG9w= http.response.header.x_amz_cf_id=XQkgGG-qld-hhOoKI82X0fGPZNDqigv4d7P5fJC-mjgF9qxyhnzy_w== http.response.header.date="Wed, 07 Aug 2024 19:47:07 GMT" tf_mux_provider="*schema.GRPCProviderServer" http.response.header.cache_control=no-store tf_req_id=dfe6148f-6856-6f06-cca1-97af6f81819e tf_rpc=ApplyResourceChange tf_aws.signing_region="" http.response.header.x_cache="Miss from cloudfront"
  http.response.body=
  | {"ApplicationId":"5b81d750ea1748eba0c4ca78a7a9a37c","IsArchived":false,"Version":1,"CreationDate":"2024-08-07T19:47:07.087Z","LastModifiedDate":"2024-08-07T19:47:07.087Z","Id":"email","Enabled":false,"Identity":"arn:aws:ses:us-west-2:012345678910:identity/bptw3i72.test","FromAddress":"tf-acc-test-7788522522147484357@bptw3i72.test","Platform":"EMAIL","MessagesPerSecond":1}
   aws.region=us-west-2
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/36197
Relates https://github.com/hashicorp/terraform-provider-aws/issues/32976

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAcc' PKG=pinpoint
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/pinpoint/... -v -count 1 -parallel 20  -run=TestAcc -timeout 360m
=== RUN   TestAccPinpointADMChannel_basic
    adm_channel_test.go:36: ADM_CLIENT_ID ENV is missing
--- SKIP: TestAccPinpointADMChannel_basic (0.00s)
=== RUN   TestAccPinpointAPNSChannel_basicCertificate
    apns_channel_test.go:65: Pinpoint certificate credentials envs are missing, skipping test
--- SKIP: TestAccPinpointAPNSChannel_basicCertificate (0.00s)
=== RUN   TestAccPinpointAPNSChannel_basicToken
    apns_channel_test.go:73: APNS_BUNDLE_ID env is missing, skipping test
--- SKIP: TestAccPinpointAPNSChannel_basicToken (0.00s)
=== RUN   TestAccPinpointAPNSSandboxChannel_basicCertificate
    apns_sandbox_channel_test.go:65: Pinpoint certificate credentials envs are missing, skipping test
--- SKIP: TestAccPinpointAPNSSandboxChannel_basicCertificate (0.00s)
=== RUN   TestAccPinpointAPNSSandboxChannel_basicToken
    apns_sandbox_channel_test.go:73: APNS_SANDBOX_BUNDLE_ID env is missing, skipping test
--- SKIP: TestAccPinpointAPNSSandboxChannel_basicToken (0.00s)
=== RUN   TestAccPinpointAPNSVoIPChannel_basicCertificate
    apns_voip_channel_test.go:65: Pinpoint certificate credentials envs are missing, skipping test
--- SKIP: TestAccPinpointAPNSVoIPChannel_basicCertificate (0.00s)
=== RUN   TestAccPinpointAPNSVoIPChannel_basicToken
    apns_voip_channel_test.go:73: APNS_VOIP_BUNDLE_ID env is missing, skipping test
--- SKIP: TestAccPinpointAPNSVoIPChannel_basicToken (0.00s)
=== RUN   TestAccPinpointAPNSVoIPSandboxChannel_basicCertificate
    apns_voip_sandbox_channel_test.go:65: Pinpoint certificate credentials envs are missing, skipping test
--- SKIP: TestAccPinpointAPNSVoIPSandboxChannel_basicCertificate (0.00s)
=== RUN   TestAccPinpointAPNSVoIPSandboxChannel_basicToken
    apns_voip_sandbox_channel_test.go:73: APNS_VOIP_BUNDLE_ID env is missing, skipping test
--- SKIP: TestAccPinpointAPNSVoIPSandboxChannel_basicToken (0.00s)
=== RUN   TestAccPinpointGCMChannel_basic
    gcm_channel_test.go:34: GCM_API_KEY env missing, skip test
--- SKIP: TestAccPinpointGCMChannel_basic (0.00s)
=== NAME  TestAccPinpointEmailChannel_set
    email_channel_test.go:75: Step 1/2 error: After applying this test step, the non-refresh plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_pinpoint_email_channel.test will be updated in-place
          ~ resource "aws_pinpoint_email_channel" "test" {
                id                  = "549c1ac444df4a9d9905e2e442f2cdd2"
              + role_arn            = "arn:aws:iam::012345678910:role/terraform-2024080719365897590000000a"
                # (6 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- PASS: TestAccPinpointApp_nameGenerated (28.16s)
--- FAIL: TestAccPinpointEmailChannel_set (32.17s)
--- PASS: TestAccPinpointApp_namePrefix (35.44s)
--- PASS: TestAccPinpointApp_disappears (35.44s)
--- PASS: TestAccPinpointSMSChannel_disappears (36.70s)
--- PASS: TestAccPinpointEmailChannel_disappears (36.99s)
=== NAME  TestAccPinpointEmailChannel_basic
    email_channel_test.go:31: Step 1/3 error: Check failed: Check 5/6 error: aws_pinpoint_email_channel.test: Attribute 'role_arn' expected "arn:aws:iam::012345678910:role/terraform-2024080719372352960000000f", got ""
--- PASS: TestAccPinpointEmailChannel_noRole (40.87s)
--- PASS: TestAccPinpointApp_quietTimeEmpty (41.41s)
--- PASS: TestAccPinpointApp_basic (41.41s)
--- PASS: TestAccPinpointApp_campaignHookEmpty (41.54s)
--- PASS: TestAccPinpointApp_limitsEmpty (41.57s)
--- PASS: TestAccPinpointApp_quietTime (41.60s)
--- PASS: TestAccPinpointApp_limits (41.82s)
--- FAIL: TestAccPinpointEmailChannel_basic (15.60s)
--- PASS: TestAccPinpointSMSChannel_basic (50.14s)
--- PASS: TestAccPinpointBaiduChannel_basic (51.96s)
--- PASS: TestAccPinpointSMSChannel_full (52.75s)
--- PASS: TestAccPinpointApp_campaignHookLambda (52.84s)
--- PASS: TestAccPinpointApp_tags (60.67s)
--- PASS: TestAccPinpointEventStream_disappears (64.08s)
--- PASS: TestAccPinpointEventStream_basic (116.44s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint	121.082s
FAIL
...
```
