### PR TITLE
r/aws_quicksight_account_subscription: fix panic reading nil account info

### DIFF
--- a/.changelog/38752.txt
+++ b/.changelog/38752.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_account_subscription: Fix panic when read returns nil account info
+```

--- a/internal/service/quicksight/account_subscription.go
+++ b/internal/service/quicksight/account_subscription.go
@@ -228,12 +228,13 @@ func resourceAccountSubscriptionRead(ctx context.Context, d *schema.ResourceData
 
 	out, err := FindAccountSubscriptionByID(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	var ere *tfresource.EmptyResultError
+	if !d.IsNewResource() && (tfresource.NotFound(err) || errors.As(err, &ere)) {
 		log.Printf("[WARN] QuickSight AccountSubscription (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
-	// Ressource is logically deleted with UNSUBSCRIBED status
+	// Resource is logically deleted with UNSUBSCRIBED status
 	if !d.IsNewResource() && aws.StringValue(out.AccountSubscriptionStatus) == statusUnsuscribed {
 		log.Printf("[WARN] QuickSight AccountSubscription (%s) unsuscribed, removing from state", d.Id())
 		d.SetId("")
@@ -352,7 +353,7 @@ func FindAccountSubscriptionByID(ctx context.Context, conn *quicksight.QuickSigh
 		return nil, err
 	}
 
-	if out == nil || out.AccountInfo.AccountName == nil {
+	if out == nil || out.AccountInfo == nil {
 		return nil, tfresource.NewEmptyResultError(in)
 	}
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Previously the read operation did not handle an `EmptyResultError` prior to attempting to reference fields from the output. The additional handling added in this change will prevent dereferencing of a nil output.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38637

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=quicksight TESTS="TestAccQuickSight_serial/AccountSubscription"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.5 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSight_serial/AccountSubscription'  -timeout 360m
?       github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  [no test files]

--- PASS: TestAccQuickSight_serial (329.40s)
    --- PASS: TestAccQuickSight_serial/AccountSubscription (329.40s)
        --- PASS: TestAccQuickSight_serial/AccountSubscription/disappears (163.87s)
        --- PASS: TestAccQuickSight_serial/AccountSubscription/basic (165.53s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 335.228s
```
