### PR TITLE
r/aws_elbv2_trust_store_revocation: fix to properly return create errors

### DIFF
--- a/.changelog/38756.txt
+++ b/.changelog/38756.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elbv2_trust_store_revocation: Fix to properly return errors during resource creation
+```

--- a/internal/service/elbv2/trust_store_revocation.go
+++ b/internal/service/elbv2/trust_store_revocation.go
@@ -98,7 +98,7 @@ func resourceTrustStoreRevocationCreate(ctx context.Context, d *schema.ResourceD
 	output, err := conn.AddTrustStoreRevocations(ctx, input)
 
 	if err != nil {
-		sdkdiag.AppendErrorf(diags, "creating ELBv2 Trust Store (%s) Revocation (s3://%s/%s): %s", trustStoreARN, s3Bucket, s3Key, err)
+		return sdkdiag.AppendErrorf(diags, "creating ELBv2 Trust Store (%s) Revocation (s3://%s/%s): %s", trustStoreARN, s3Bucket, s3Key, err)
 	}
 
 	revocationID := aws.ToInt64(output.TrustStoreRevocations[0].RevocationId)


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously the error was appended to the existing diagnostics but not returned, allowing the create operation to proceed and eventually attempt dereferencing a nil pointer to the create API response.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38353 



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elbv2 TESTS=TestAccELBV2TrustStoreRevocation_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TrustStoreRevocation_'  -timeout 360m

--- PASS: TestAccELBV2TrustStoreRevocation_basic (53.44s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      59.341s
```
