### PR TITLE
[Docs]: Correct exampe for data.aws_cloudfront_origin_access_control

### DIFF
--- a/website/docs/d/cloudfront_origin_access_control.html.markdown
+++ b/website/docs/d/cloudfront_origin_access_control.html.markdown
@@ -15,7 +15,7 @@ Use this data source to retrieve information for an Amazon CloudFront origin acc
 The below example retrieves a CloudFront origin access control config.
 
 ```terraform
-data "aws_cloudfront_origin_access_identity" "example" {
+data "aws_cloudfront_origin_access_control" "example" {
   id = "E2T5VTFBZJ3BJB"
 }
 ```


### PR DESCRIPTION
### Description
Example used `aws_cloudfront_origin_access_identity`, which is a separate data source for a legacy feature with similar functionality. This PR corrects the example to use `aws_cloudfront_origin_access_control`.

### Relations
Closes #38754 

### References
#38754 
