### PR TITLE
docs: improve role description details

### DIFF
--- a/website/docs/r/guardduty_malware_protection_plan.html.markdown
+++ b/website/docs/r/guardduty_malware_protection_plan.html.markdown
@@ -41,7 +41,7 @@ This resource supports the following arguments:
 
 * `actions` - (Optional) Information about whether the tags will be added to the S3 object after scanning. See [`actions`](#actions-argument-reference) below.
 * `protected_resource` - (Required) Information about the protected resource that is associated with the created Malware Protection plan. Presently, S3Bucket is the only supported protected resource. See [`protected_resource`](#protected_resource-argument-reference) below.
-* `role` - (Required) The IAM role that includes the permissions required to scan and add tags to the associated protected resource.
+* `role` - (Required) ARN of IAM role that includes the permissions required to scan and add tags to the associated protected resource.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### `actions` argument reference


### PR DESCRIPTION
### Description

Update the description for the argument `role` for resource `aws_guardduty_malware_protection_plan`. 
The existing documentation was not providing details on exact input (i.e. role name or ARN)

### Relations

Closes #38719 

### References

- [Source code reference](https://github.com/hashicorp/terraform-provider-aws/blob/30ff9c056572127506da56f67ed69be0b99799b4/internal/service/guardduty/malware_protection_plan.go#L83)


### Output from Acceptance Testing

Not applicable. Only documentation is updated.