### PR TITLE
r/aws_emr_cluster: fix panic reading instance fleet

### DIFF
--- a/.changelog/38773.txt
+++ b/.changelog/38773.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_emr_cluster: Fix panic when reading an instance fleet with an empty `launch_specifications` argument
+```

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -2132,7 +2132,7 @@ func readInstanceFleetConfig(data map[string]interface{}, InstanceFleetType stri
 		config.InstanceTypeConfigs = expandInstanceTypeConfigs(v.List())
 	}
 
-	if v, ok := data["launch_specifications"].([]interface{}); ok && len(v) == 1 {
+	if v, ok := data["launch_specifications"].([]interface{}); ok && len(v) == 1 && v[0] != nil {
 		config.LaunchSpecifications = expandLaunchSpecification(v[0].(map[string]interface{}))
 	}
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes a panic when reading an instance fleet with an empty `launch_specifications` argument.




### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38276


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=emr TESTS=TestAccEMRCluster_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/emr/... -v -count 1 -parallel 20 -run='TestAccEMRCluster_'  -timeout 360m

--- PASS: TestAccEMRCluster_basic (434.89s)
=== CONT  TestAccEMRCluster_autoTerminationPolicy
--- PASS: TestAccEMRCluster_Step_basic (458.24s)
=== CONT  TestAccEMRCluster_MasterInstanceGroup_instanceCount
--- PASS: TestAccEMRCluster_sJSON (463.57s)
=== CONT  TestAccEMRCluster_security
--- PASS: TestAccEMRCluster_additionalInfo (478.89s)
=== CONT  TestAccEMRCluster_MasterInstanceGroup_name
--- PASS: TestAccEMRCluster_disappears (497.97s)
=== CONT  TestAccEMRCluster_MasterInstanceGroup_instanceType
--- PASS: TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy (588.15s)
=== CONT  TestAccEMRCluster_Kerberos_clusterDedicatedKdc
--- PASS: TestAccEMRCluster_InstanceFleetMaster_only (670.75s)
=== CONT  TestAccEMRCluster_MasterInstanceGroup_bidPrice                                                                                                                                                        --- PASS: TestAccEMRCluster_StepConcurrency_level (724.43s)
=== CONT  TestAccEMRCluster_terminationProtected
--- PASS: TestAccEMRCluster_s3LogEncryption (759.72s)
=== CONT  TestAccEMRCluster_s3Logging
--- PASS: TestAccEMRCluster_unhealthyNodeReplacement (792.17s)
=== CONT  TestAccEMRCluster_Bootstrap_ordering
--- PASS: TestAccEMRCluster_tags (793.52s)
=== CONT  TestAccEMRCluster_visibleToAllUsers
--- PASS: TestAccEMRCluster_Step_mode (837.79s)
=== CONT  TestAccEMRCluster_PlacementGroupConfigs
--- PASS: TestAccEMRCluster_CoreInstanceGroup_instanceType (864.33s)                                                                                                                                            === CONT  TestAccEMRCluster_keepJob
--- PASS: TestAccEMRCluster_RootVolume_size (896.28s)
=== CONT  TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups
--- PASS: TestAccEMRCluster_security (464.92s)
=== CONT  TestAccEMRCluster_Step_multiple_listStates
--- PASS: TestAccEMRCluster_CoreInstanceGroup_bidPrice (1007.29s)
=== CONT  TestAccEMRCluster_Step_multiple
--- PASS: TestAccEMRCluster_terminationProtected (389.17s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_instanceType (678.07s)
--- PASS: TestAccEMRCluster_Kerberos_clusterDedicatedKdc (614.73s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_name (737.79s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_name (1229.11s)
--- PASS: TestAccEMRCluster_keepJob (401.33s)
--- PASS: TestAccEMRCluster_Step_multiple_listStates (417.17s)
--- PASS: TestAccEMRCluster_autoTerminationPolicy (925.32s)
=== NAME  TestAccEMRCluster_visibleToAllUsers
    cluster_test.go:1296: Step 3/4 error: Check failed: Check 2/2 error: aws_emr_cluster.test: Attribute 'visible_to_all_users' expected "false", got "true"
--- PASS: TestAccEMRCluster_s3Logging (633.74s)
--- PASS: TestAccEMRCluster_Step_multiple (395.48s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_instanceCount (961.03s)
--- PASS: TestAccEMRCluster_PlacementGroupConfigs (628.98s)
--- FAIL: TestAccEMRCluster_visibleToAllUsers (712.97s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_bidPrice (847.10s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_instanceCount (1612.28s)
--- PASS: TestAccEMRCluster_Bootstrap_ordering (1107.51s)
--- PASS: TestAccEMRCluster_InstanceFleet_basic (2024.62s)
--- PASS: TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups (1842.94s)
=== NAME  TestAccEMRCluster_ebs
    cluster_test.go:1539: Step 1/2 error: Error running apply: exit status 1

        Error: waiting for EMR Cluster (j-33UEO2SNMV9LX) to create: unexpected state 'TERMINATING', wanted target 'RUNNING, WAITING'. last error: INTERNAL_ERROR: Failed to start the job flow due to an internal error

          with aws_emr_cluster.test,
          on terraform_plugin_test.tf line 194, in resource "aws_emr_cluster" "test":
         194: resource "aws_emr_cluster" "test" {

--- FAIL: TestAccEMRCluster_ebs (2950.94s)
=== NAME  TestAccEMRCluster_CustomAMI_id
    cluster_test.go:1573: Step 1/2 error: Error running apply: exit status 1

        Error: waiting for EMR Cluster (j-4KYO8528ZP33) to create: unexpected state 'TERMINATING', wanted target 'RUNNING, WAITING'. last error: INTERNAL_ERROR: Failed to start the job flow due to an internal error

          with aws_emr_cluster.test,
          on terraform_plugin_test.tf line 305, in resource "aws_emr_cluster" "test":
         305: resource "aws_emr_cluster" "test" {

--- FAIL: TestAccEMRCluster_CustomAMI_id (2995.13s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/emr        3001.300s
```

Test failures are pre-existing and not related to this change.
