### PR TITLE
r/aws_grafana_workspace: fix expander panics

### DIFF
--- a/.changelog/38775.txt
+++ b/.changelog/38775.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_grafana_workspace: Fix crash when empty `network_access_control` block is configured
+```
+```release-note:bug
+resource/aws_grafana_workspace: Fix crash when empty `vpc_configuration` block is configured
+```

--- a/internal/service/grafana/workspace.go
+++ b/internal/service/grafana/workspace.go
@@ -550,7 +550,7 @@ func waitWorkspaceDeleted(ctx context.Context, conn *grafana.Client, id string, 
 }
 
 func expandVPCConfiguration(tfList []interface{}) *awstypes.VpcConfiguration {
-	if len(tfList) < 1 {
+	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
@@ -581,7 +581,7 @@ func flattenVPCConfiguration(apiObject *awstypes.VpcConfiguration) []interface{}
 }
 
 func expandNetworkAccessControl(tfList []interface{}) *awstypes.NetworkAccessConfiguration {
-	if len(tfList) < 1 {
+	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The expanders for the `network_access_control` and `vpc_configuration` arguments did not check for a list of one nil item, resulting in a failed type assertion and panic when a single, empty configuration is provided.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38264


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc PKG=grafana TESTS=TestAccGrafana_serial/Workspace
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/grafana/... -v -count 1 -parallel 20 -run='TestAccGrafana_serial/Workspace'  -timeout 360m

--- PASS: TestAccGrafana_serial (6114.72s)
    --- PASS: TestAccGrafana_serial/Workspace (6114.72s)
        --- PASS: TestAccGrafana_serial/Workspace/saml (350.87s)
        --- PASS: TestAccGrafana_serial/Workspace/permissionType (402.51s)
        --- PASS: TestAccGrafana_serial/Workspace/tags (371.33s)
        --- PASS: TestAccGrafana_serial/Workspace/configuration (675.03s)
        --- PASS: TestAccGrafana_serial/Workspace/networkAccess (709.10s)
        --- SKIP: TestAccGrafana_serial/Workspace/sso (0.57s)
        --- PASS: TestAccGrafana_serial/Workspace/disappears (416.76s)
        --- SKIP: TestAccGrafana_serial/Workspace/organization (0.89s)
        --- PASS: TestAccGrafana_serial/Workspace/dataSources (347.22s)
        --- PASS: TestAccGrafana_serial/Workspace/notificationDestinations (397.44s)
        --- PASS: TestAccGrafana_serial/Workspace/vpc (1222.79s)
        --- PASS: TestAccGrafana_serial/Workspace/version (1220.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/grafana    6120.565s
```

