### PR TITLE
r/aws_iot_thing_group: fix crash with empty `attribute_payload` block

### DIFF
--- a/.changelog/38776.txt
+++ b/.changelog/38776.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iot_thing_group: Fix crash when empty `attribute_payload` block is configured
+```

--- a/internal/service/iot/thing_group.go
+++ b/internal/service/iot/thing_group.go
@@ -291,7 +291,7 @@ func expandThingGroupProperties(tfMap map[string]interface{}) *awstypes.ThingGro
 
 	apiObject := &awstypes.ThingGroupProperties{}
 
-	if v, ok := tfMap["attribute_payload"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["attribute_payload"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.AttributePayload = expandAttributePayload(v[0].(map[string]interface{}))
 	}
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Setting the `attribute_payload` argument to an empty block resulted the in the associated expander attempting to assert the lists single nil item into a map. This change adds a check for nil items to prevent this.




### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38093


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=iot TESTS=TestAccIoTThingGroup_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTThingGroup_'  -timeout 360m

--- PASS: TestAccIoTThingGroup_disappears (12.93s)
--- PASS: TestAccIoTThingGroup_basic (15.24s)
--- PASS: TestAccIoTThingGroup_parentGroup (19.73s)
--- PASS: TestAccIoTThingGroup_properties (22.78s)
--- PASS: TestAccIoTThingGroup_tags (30.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        36.178s
```
