### PR TITLE
Draft: f/aws_ecr_image - add image_tag_prefix option

### DIFF
--- a/.changelog/38774.txt
+++ b/.changelog/38774.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+datasource/aws_ecr_image: Add image_tag_prefix argument for most_recent flow
+```

--- a/internal/service/ecr/image_data_source.go
+++ b/internal/service/ecr/image_data_source.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
@@ -18,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -56,6 +58,11 @@ func dataSourceImage() *schema.Resource {
 			"image_uri": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"image_tag_prefix": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"image_digest", "image_tag"},
 			},
 			names.AttrMostRecent: {
 				Type:          schema.TypeBool,
@@ -109,7 +116,11 @@ func dataSourceImageRead(ctx context.Context, d *schema.ResourceData, meta inter
 		input.RegistryId = aws.String(v.(string))
 	}
 
-	imageDetails, err := findImageDetails(ctx, conn, input)
+	var imageTagPrefix = ""
+	if v, ok := d.GetOk("image_tag_prefix"); ok {
+		imageTagPrefix = v.(string)
+	}
+	imageDetails, err := findImageDetails(ctx, conn, input, imageTagPrefix)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading ECR Images: %s", err)
@@ -161,7 +172,7 @@ func dataSourceImageRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func findImageDetails(ctx context.Context, conn *ecr.Client, input *ecr.DescribeImagesInput) ([]types.ImageDetail, error) {
+func findImageDetails(ctx context.Context, conn *ecr.Client, input *ecr.DescribeImagesInput, imageTagPrefix string) ([]types.ImageDetail, error) {
 	var output []types.ImageDetail
 
 	pages := ecr.NewDescribeImagesPaginator(conn, input)
@@ -179,7 +190,16 @@ func findImageDetails(ctx context.Context, conn *ecr.Client, input *ecr.Describe
 			return nil, err
 		}
 
-		output = append(output, page.ImageDetails...)
+		var imageDetails = page.ImageDetails
+		if imageTagPrefix != "" {
+			imageDetails = tfslices.Filter(page.ImageDetails, func(v types.ImageDetail) bool {
+				return tfslices.Any(v.ImageTags, func(t string) bool {
+					return strings.HasPrefix(t, imageTagPrefix)
+				})
+			})
+		}
+
+		output = append(output, imageDetails...)
 	}
 
 	return output, nil

--- a/internal/service/ecr/image_data_source_test.go
+++ b/internal/service/ecr/image_data_source_test.go
@@ -18,6 +18,7 @@ func TestAccECRImageDataSource_basic(t *testing.T) {
 	resourceByTag := "data.aws_ecr_image.by_tag"
 	resourceByDigest := "data.aws_ecr_image.by_digest"
 	resourceByMostRecent := "data.aws_ecr_image.by_most_recent"
+	resourceByMostRecentWithPrefix := "data.aws_ecr_image.by_most_recent_with_prefix"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -38,6 +39,9 @@ func TestAccECRImageDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceByDigest, "image_uri"),
 					resource.TestCheckResourceAttrSet(resourceByMostRecent, "image_pushed_at"),
 					resource.TestCheckResourceAttrSet(resourceByMostRecent, "image_size_in_bytes"),
+					resource.TestCheckResourceAttrSet(resourceByMostRecentWithPrefix, "image_pushed_at"),
+					resource.TestCheckResourceAttrSet(resourceByMostRecentWithPrefix, "image_size_in_bytes"),
+					resource.TestCheckTypeSetElemAttr(resourceByMostRecentWithPrefix, "image_tags.*", "2022"),
 				),
 			},
 		},
@@ -62,6 +66,13 @@ data "aws_ecr_image" "by_most_recent" {
   registry_id     = data.aws_ecr_image.by_tag.registry_id
   repository_name = data.aws_ecr_image.by_tag.repository_name
   most_recent     = true
+}
+
+data "aws_ecr_image" "by_most_recent_with_prefix" {
+  registry_id      = data.aws_ecr_image.by_tag.registry_id
+  repository_name  = data.aws_ecr_image.by_tag.repository_name
+  most_recent      = true
+  image_tag_prefix = "2022"
 }
 `, reg, repo, tag)
 }

--- a/internal/service/ecr/repository_data_source.go
+++ b/internal/service/ecr/repository_data_source.go
@@ -120,7 +120,7 @@ func dataSourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta 
 	imageDetails, err := findImageDetails(ctx, conn, &ecr.DescribeImagesInput{
 		RepositoryName: repository.RepositoryName,
 		RegistryId:     repository.RegistryId,
-	})
+	}, "")
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading images for ECR Repository (%s): %s", d.Id(), err)

--- a/website/docs/d/ecr_image.html.markdown
+++ b/website/docs/d/ecr_image.html.markdown
@@ -28,6 +28,7 @@ This data source supports the following arguments:
 * `image_digest` - (Optional) Sha256 digest of the image manifest. At least one of `image_digest`, `image_tag`, or `most_recent` must be specified.
 * `image_tag` - (Optional) Tag associated with this image. At least one of `image_digest`, `image_tag`, or `most_recent` must be specified.
 * `most_recent` - (Optional) Return the most recently pushed image. At least one of `image_digest`, `image_tag`, or `most_recent` must be specified.
+* `image_tag_prefix` - (Optional) Return only images with the given prefix. Only applicable when using `most_recent`. At least one of `image_digest`, `image_tag`, or `most_recent` must be specified.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
Add `image_tag_prefix` option to `aws_ecr_image` for the purposes of filtering the list of images in a repository before choosing the latest. The idea is that you might have images tagged `develop-(commit hash)` or `(branch)-(commit hash)` or `v1.2.0` all in one repository, and it is sometimes convenient to be able to choose the latest image with a given prefix. I didn't see an option in the AWS APIs that covers it.

I'd be interested in doing a regex/pattern match of some kind instead but didn't spot any prior art in this package. I could take a swing at it with some guidance.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccECRImageDataSource_basic PKG=ecr
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRImageDataSource_basic'  -timeout 360m
=== RUN   TestAccECRImageDataSource_basic
=== PAUSE TestAccECRImageDataSource_basic
=== CONT  TestAccECRImageDataSource_basic
--- PASS: TestAccECRImageDataSource_basic (13.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        13.387s
```
