### PR TITLE
r/aws_elasticache_replication_group: fix crash setting `replicas_per_node_group`

### DIFF
--- a/.changelog/38797.txt
+++ b/.changelog/38797.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Fix crash when setting `replicas_per_node_group` if node groups are empty
+```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -682,7 +682,9 @@ func resourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	d.Set("num_node_groups", len(rgp.NodeGroups))
-	d.Set("replicas_per_node_group", len(rgp.NodeGroups[0].NodeGroupMembers)-1)
+	if len(rgp.NodeGroups) > 0 {
+		d.Set("replicas_per_node_group", len(rgp.NodeGroups[0].NodeGroupMembers)-1)
+	}
 
 	d.Set("cluster_enabled", rgp.ClusterEnabled)
 	d.Set("cluster_mode", rgp.ClusterMode)


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

In cases where the `NodeGroups` list in the read ouput is empty, the provider would crash attempting to read the `NodeGroupMembers` count from the first item in the list.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37771


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc PKG=elasticache TESTS="TestAccElastiCacheReplicationGroup_basic|TestAccElastiCacheReplicationGroup_ClusterMode_basic"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_basic|TestAccElastiCacheReplicationGroup_ClusterMode_basic'  -timeout 360m

--- PASS: TestAccElastiCacheReplicationGroup_basic_v5 (775.08s)
--- PASS: TestAccElastiCacheReplicationGroup_basic (775.23s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (915.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        921.685s
```
