### PR TITLE
r/aws_networkmanager_connect_peer: return all BGP configurations

### DIFF
--- a/.changelog/38798.txt
+++ b/.changelog/38798.txt
@@ -1,4 +1,4 @@
 ```release-note:bug
-resource/aws_networkmanager_connect_peer: Return all BGP configurations
+resource/aws_networkmanager_connect_peer: Set all `configuration.bgp_configurations` on Read
 ```
 

--- a/.changelog/38798.txt
+++ b/.changelog/38798.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+resource/aws_networkmanager_connect_peer: Return all BGP configurations
+```
+

--- a/internal/service/networkmanager/connect_peer.go
+++ b/internal/service/networkmanager/connect_peer.go
@@ -383,22 +383,26 @@ func flattenPeerConfiguration(apiObject *networkmanager.ConnectPeerConfiguration
 
 	confMap := map[string]interface{}{}
 
-	if v := apiObject.BgpConfigurations; v != nil {
+	for _, v := range apiObject.BgpConfigurations {
 		bgpConfMap := map[string]interface{}{}
 
-		if a := v[0].CoreNetworkAddress; a != nil {
+		if a := v.CoreNetworkAddress; a != nil {
 			bgpConfMap["core_network_address"] = aws.StringValue(a)
 		}
-		if a := v[0].CoreNetworkAsn; a != nil {
+		if a := v.CoreNetworkAsn; a != nil {
 			bgpConfMap["core_network_asn"] = aws.Int64Value(a)
 		}
-		if a := v[0].PeerAddress; a != nil {
+		if a := v.PeerAddress; a != nil {
 			bgpConfMap["peer_address"] = aws.StringValue(a)
 		}
-		if a := v[0].PeerAsn; a != nil {
+		if a := v.PeerAsn; a != nil {
 			bgpConfMap["peer_asn"] = aws.Int64Value(a)
 		}
-		confMap["bgp_configurations"] = []interface{}{bgpConfMap}
+		var existing []interface{}
+		if c, ok := confMap["bgp_configurations"]; ok {
+			existing = c.([]interface{})
+		}
+		confMap["bgp_configurations"] = append(existing, bgpConfMap)
 	}
 	if v := apiObject.CoreNetworkAddress; v != nil {
 		confMap["core_network_address"] = aws.StringValue(v)

--- a/internal/service/networkmanager/connect_peer_test.go
+++ b/internal/service/networkmanager/connect_peer_test.go
@@ -46,7 +46,7 @@ func TestAccNetworkManagerConnectPeer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.inside_cidr_blocks.0", insideCidrBlocksv4),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.peer_address", peerAddress),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.protocol", "GRE"),
-					resource.TestCheckResourceAttr(resourceName, "configuration.0.bgp_configurations.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.bgp_configurations.#", acctest.Ct2),
 					resource.TestCheckResourceAttrSet(resourceName, "connect_attachment_id"),
 					resource.TestCheckResourceAttr(resourceName, "inside_cidr_blocks.0", insideCidrBlocksv4),
 					resource.TestCheckResourceAttr(resourceName, "peer_address", peerAddress),
@@ -91,7 +91,7 @@ func TestAccNetworkManagerConnectPeer_noDependsOn(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.inside_cidr_blocks.0", insideCidrBlocksv4),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.peer_address", peerAddress),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.protocol", "GRE"),
-					resource.TestCheckResourceAttr(resourceName, "configuration.0.bgp_configurations.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.bgp_configurations.#", acctest.Ct2),
 					resource.TestCheckResourceAttrSet(resourceName, "connect_attachment_id"),
 					resource.TestCheckResourceAttr(resourceName, "inside_cidr_blocks.0", insideCidrBlocksv4),
 					resource.TestCheckResourceAttr(resourceName, "peer_address", peerAddress),
@@ -116,7 +116,7 @@ func TestAccNetworkManagerConnectPeer_subnetARN(t *testing.T) {
 	resourceName := "aws_networkmanager_connect_peer.test"
 	subnetResourceName := "aws_subnet.test2"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	peerAddress := "1.1.1.1"
+	peerAddress := "10.0.2.100" // Must be an address inside the subnet CIDR range.
 	protocol := "NO_ENCAP"
 	asn := "65501"
 
@@ -134,7 +134,7 @@ func TestAccNetworkManagerConnectPeer_subnetARN(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.peer_address", peerAddress),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.protocol", "NO_ENCAP"),
-					resource.TestCheckResourceAttr(resourceName, "configuration.0.bgp_configurations.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "configuration.0.bgp_configurations.#", acctest.Ct2),
 					resource.TestCheckResourceAttrSet(resourceName, "connect_attachment_id"),
 					resource.TestCheckResourceAttr(resourceName, "peer_address", peerAddress),
 					resource.TestCheckResourceAttr(resourceName, "edge_location", acctest.Region()),


### PR DESCRIPTION
### Description

When you create a connect peer in AWS Network Manager, AWS sets up two BGP endpoints. However, the code for the `aws_networkmanager_connect_peer` resource only returns the first entry in the list. This commit updates the resource to loop over all BGP configurations returned by the API.

### Relations

Closes #29680

### References


### Output from Acceptance Testing
```console
% make testacc TESTS='TestAccNetworkManagerConnectPeer_.*' PKG=networkmanager
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/networkmanager/... -v -count 1 -parallel 20 -run='TestAccNetworkManagerConnectPeer_.*'  -timeout 360m
=== RUN   TestAccNetworkManagerConnectPeer_basic
=== PAUSE TestAccNetworkManagerConnectPeer_basic
=== RUN   TestAccNetworkManagerConnectPeer_noDependsOn
=== PAUSE TestAccNetworkManagerConnectPeer_noDependsOn
=== RUN   TestAccNetworkManagerConnectPeer_subnetARN
=== PAUSE TestAccNetworkManagerConnectPeer_subnetARN
=== RUN   TestAccNetworkManagerConnectPeer_tags
=== PAUSE TestAccNetworkManagerConnectPeer_tags
=== CONT  TestAccNetworkManagerConnectPeer_basic
=== CONT  TestAccNetworkManagerConnectPeer_subnetARN
=== CONT  TestAccNetworkManagerConnectPeer_tags
=== CONT  TestAccNetworkManagerConnectPeer_noDependsOn
--- PASS: TestAccNetworkManagerConnectPeer_noDependsOn (1627.02s)
--- PASS: TestAccNetworkManagerConnectPeer_basic (1647.69s)
--- PASS: TestAccNetworkManagerConnectPeer_tags (1663.89s)
--- PASS: TestAccNetworkManagerConnectPeer_subnetARN (1903.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/networkmanager	1903.337s
```
