### PR TITLE
Prepare agent after knowledge base association

### DIFF
--- a/.changelog/38799.txt
+++ b/.changelog/38799.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_bedrockagent_agent_knowledge_base_association: Prepare agent when associating a knowledge base so it can be used.
+resource/aws_bedrockagent_agent_knowledge_base_association: Prepare agent when associating a knowledge base so it can be used
 ```

--- a/.changelog/38799.txt
+++ b/.changelog/38799.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagent_agent_knowledge_base_association: Prepare agent when associating a knowledge base so it can be used.
+```

--- a/internal/service/bedrockagent/agent_knowledge_base_association.go
+++ b/internal/service/bedrockagent/agent_knowledge_base_association.go
@@ -37,7 +37,6 @@ func newAgentKnowledgeBaseAssociationResource(context.Context) (resource.Resourc
 
 	r.SetDefaultCreateTimeout(5 * time.Minute)
 	r.SetDefaultUpdateTimeout(5 * time.Minute)
-	r.SetDefaultDeleteTimeout(5 * time.Minute)
 
 	return r, nil
 }
@@ -94,7 +93,6 @@ func (r *agentKnowledgeBaseAssociationResource) Schema(ctx context.Context, requ
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
-				Delete: true,
 			}),
 		},
 	}

--- a/internal/service/bedrockagent/agent_knowledge_base_association.go
+++ b/internal/service/bedrockagent/agent_knowledge_base_association.go
@@ -6,10 +6,12 @@ package bedrockagent
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagent"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagent/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -33,12 +35,17 @@ import (
 func newAgentKnowledgeBaseAssociationResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &agentKnowledgeBaseAssociationResource{}
 
+	r.SetDefaultCreateTimeout(5 * time.Minute)
+	r.SetDefaultUpdateTimeout(5 * time.Minute)
+	r.SetDefaultDeleteTimeout(5 * time.Minute)
+
 	return r, nil
 }
 
 type agentKnowledgeBaseAssociationResource struct {
 	framework.ResourceWithConfigure
 	framework.WithImportByID
+	framework.WithTimeouts
 }
 
 func (*agentKnowledgeBaseAssociationResource) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
@@ -83,6 +90,13 @@ func (r *agentKnowledgeBaseAssociationResource) Schema(ctx context.Context, requ
 				CustomType: fwtypes.StringEnumType[awstypes.KnowledgeBaseState](),
 			},
 		},
+		Blocks: map[string]schema.Block{
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
 	}
 }
 
@@ -110,6 +124,13 @@ func (r *agentKnowledgeBaseAssociationResource) Create(ctx context.Context, requ
 
 	// Set values for unknowns.
 	data.setID()
+
+	_, err = prepareAgent(ctx, conn, data.AgentID.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
+	if err != nil {
+		response.Diagnostics.AddError("preparing Agent", err.Error())
+
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
@@ -178,6 +199,12 @@ func (r *agentKnowledgeBaseAssociationResource) Update(ctx context.Context, requ
 
 		return
 	}
+	_, err = prepareAgent(ctx, conn, new.AgentID.ValueString(), r.CreateTimeout(ctx, new.Timeouts))
+	if err != nil {
+		response.Diagnostics.AddError("preparing Agent", err.Error())
+
+		return
+	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
 }
@@ -242,6 +269,7 @@ type agentKnowledgeBaseAssociationResourceModel struct {
 	ID                 types.String                                    `tfsdk:"id"`
 	KnowledgeBaseID    types.String                                    `tfsdk:"knowledge_base_id"`
 	KnowledgeBaseState fwtypes.StringEnum[awstypes.KnowledgeBaseState] `tfsdk:"knowledge_base_state"`
+	Timeouts           timeouts.Value                                  `tfsdk:"timeouts"`
 }
 
 const (

--- a/internal/service/bedrockagent/agent_knowledge_base_association.go
+++ b/internal/service/bedrockagent/agent_knowledge_base_association.go
@@ -199,7 +199,7 @@ func (r *agentKnowledgeBaseAssociationResource) Update(ctx context.Context, requ
 
 		return
 	}
-	_, err = prepareAgent(ctx, conn, new.AgentID.ValueString(), r.CreateTimeout(ctx, new.Timeouts))
+	_, err = prepareAgent(ctx, conn, new.AgentID.ValueString(), r.UpdateTimeout(ctx, new.Timeouts))
 	if err != nil {
 		response.Diagnostics.AddError("preparing Agent", err.Error())
 

--- a/website/docs/r/bedrockagent_agent_knowledge_base_association.html.markdown
+++ b/website/docs/r/bedrockagent_agent_knowledge_base_association.html.markdown
@@ -41,6 +41,15 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `id` - Agent ID, agent version, and knowledge base ID separated by `,`.
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `5m`)
+* `update` - (Default `5m`)
+* `delete` - (Default `5m`)
+
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Agents for Amazon Bedrock Agent Knowledge Base Association using the agent ID, the agent version, and the knowledge base ID separated by `,`. For example:

--- a/website/docs/r/bedrockagent_agent_knowledge_base_association.html.markdown
+++ b/website/docs/r/bedrockagent_agent_knowledge_base_association.html.markdown
@@ -49,7 +49,6 @@ This resource exports the following attributes in addition to the arguments abov
 * `update` - (Default `5m`)
 * `delete` - (Default `5m`)
 
-
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Agents for Amazon Bedrock Agent Knowledge Base Association using the agent ID, the agent version, and the knowledge base ID separated by `,`. For example:

--- a/website/docs/r/bedrockagent_agent_knowledge_base_association.html.markdown
+++ b/website/docs/r/bedrockagent_agent_knowledge_base_association.html.markdown
@@ -47,7 +47,6 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `create` - (Default `5m`)
 * `update` - (Default `5m`)
-* `delete` - (Default `5m`)
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
After associating a knowledge base we need to prepare the agent again before we can use it.

### Relations

Closes #38660

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccBedrockAgentAgentKnowledgeBaseAssociation_ PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentAgentKnowledgeBaseAssociation_'  -timeout 360m
=== RUN   TestAccBedrockAgentAgentKnowledgeBaseAssociation_basic
=== PAUSE TestAccBedrockAgentAgentKnowledgeBaseAssociation_basic
=== RUN   TestAccBedrockAgentAgentKnowledgeBaseAssociation_update
=== PAUSE TestAccBedrockAgentAgentKnowledgeBaseAssociation_update
=== RUN   TestAccBedrockAgentAgentKnowledgeBaseAssociation_disappears
=== PAUSE TestAccBedrockAgentAgentKnowledgeBaseAssociation_disappears
=== CONT  TestAccBedrockAgentAgentKnowledgeBaseAssociation_basic
=== CONT  TestAccBedrockAgentAgentKnowledgeBaseAssociation_disappears
=== CONT  TestAccBedrockAgentAgentKnowledgeBaseAssociation_update
--- PASS: TestAccBedrockAgentAgentKnowledgeBaseAssociation_basic (1521.07s)
--- PASS: TestAccBedrockAgentAgentKnowledgeBaseAssociation_disappears (1580.96s)
--- PASS: TestAccBedrockAgentAgentKnowledgeBaseAssociation_update (1642.55s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       1647.296s

```
