### PR TITLE
r/aws_cloudwatch_event_connection: fix expander assertions

### DIFF
--- a/.changelog/38800.txt
+++ b/.changelog/38800.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_event_connection: Fix various expander type assertions to prevent crashes
+```

--- a/internal/service/events/connection.go
+++ b/internal/service/events/connection.go
@@ -478,7 +478,12 @@ func waitConnectionDeleted(ctx context.Context, conn *eventbridge.Client, name s
 
 func expandCreateConnectionAuthRequestParameters(config []interface{}) *types.CreateConnectionAuthRequestParameters {
 	authParameters := &types.CreateConnectionAuthRequestParameters{}
+
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param["api_key"].([]interface{}); ok && len(v) > 0 {
 			authParameters.ApiKeyAuthParameters = expandCreateConnectionAPIKeyAuthRequestParameters(v)
@@ -501,8 +506,13 @@ func expandCreateConnectionAPIKeyAuthRequestParameters(config []interface{}) *ty
 	if len(config) == 0 {
 		return nil
 	}
+
 	apiKeyAuthParameters := &types.CreateConnectionApiKeyAuthRequestParameters{}
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param[names.AttrKey].(string); ok && v != "" {
 			apiKeyAuthParameters.ApiKeyName = aws.String(v)
@@ -511,6 +521,7 @@ func expandCreateConnectionAPIKeyAuthRequestParameters(config []interface{}) *ty
 			apiKeyAuthParameters.ApiKeyValue = aws.String(v)
 		}
 	}
+
 	return apiKeyAuthParameters
 }
 
@@ -518,8 +529,13 @@ func expandCreateConnectionBasicAuthRequestParameters(config []interface{}) *typ
 	if len(config) == 0 {
 		return nil
 	}
+
 	basicAuthParameters := &types.CreateConnectionBasicAuthRequestParameters{}
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param[names.AttrUsername].(string); ok && v != "" {
 			basicAuthParameters.Username = aws.String(v)
@@ -528,6 +544,7 @@ func expandCreateConnectionBasicAuthRequestParameters(config []interface{}) *typ
 			basicAuthParameters.Password = aws.String(v)
 		}
 	}
+
 	return basicAuthParameters
 }
 
@@ -535,8 +552,13 @@ func expandCreateConnectionOAuthAuthRequestParameters(config []interface{}) *typ
 	if len(config) == 0 {
 		return nil
 	}
+
 	oAuthParameters := &types.CreateConnectionOAuthRequestParameters{}
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param["authorization_endpoint"].(string); ok && v != "" {
 			oAuthParameters.AuthorizationEndpoint = aws.String(v)
@@ -551,12 +573,18 @@ func expandCreateConnectionOAuthAuthRequestParameters(config []interface{}) *typ
 			oAuthParameters.ClientParameters = expandCreateConnectionOAuthClientRequestParameters(v)
 		}
 	}
+
 	return oAuthParameters
 }
 
 func expandCreateConnectionOAuthClientRequestParameters(config []interface{}) *types.CreateConnectionOAuthClientRequestParameters {
 	oAuthClientRequestParameters := &types.CreateConnectionOAuthClientRequestParameters{}
+
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param[names.AttrClientID].(string); ok && v != "" {
 			oAuthClientRequestParameters.ClientID = aws.String(v)
@@ -565,6 +593,7 @@ func expandCreateConnectionOAuthClientRequestParameters(config []interface{}) *t
 			oAuthClientRequestParameters.ClientSecret = aws.String(v)
 		}
 	}
+
 	return oAuthClientRequestParameters
 }
 
@@ -572,8 +601,13 @@ func expandConnectionHTTPParameters(config []interface{}) *types.ConnectionHttpP
 	if len(config) == 0 {
 		return nil
 	}
+
 	httpParameters := &types.ConnectionHttpParameters{}
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param["body"].([]interface{}); ok && len(v) > 0 {
 			httpParameters.BodyParameters = expandConnectionHTTPParametersBody(v)
@@ -585,6 +619,7 @@ func expandConnectionHTTPParameters(config []interface{}) *types.ConnectionHttpP
 			httpParameters.QueryStringParameters = expandConnectionHTTPParametersQueryString(v)
 		}
 	}
+
 	return httpParameters
 }
 
@@ -592,10 +627,14 @@ func expandConnectionHTTPParametersBody(config []interface{}) []types.Connection
 	if len(config) == 0 {
 		return nil
 	}
+
 	var parameters []types.ConnectionBodyParameter
 	for _, c := range config {
-		parameter := types.ConnectionBodyParameter{}
+		if c == nil {
+			continue
+		}
 
+		parameter := types.ConnectionBodyParameter{}
 		input := c.(map[string]interface{})
 		if v, ok := input[names.AttrKey].(string); ok && v != "" {
 			parameter.Key = aws.String(v)
@@ -608,6 +647,7 @@ func expandConnectionHTTPParametersBody(config []interface{}) []types.Connection
 		}
 		parameters = append(parameters, parameter)
 	}
+
 	return parameters
 }
 
@@ -615,10 +655,14 @@ func expandConnectionHTTPParametersHeader(config []interface{}) []types.Connecti
 	if len(config) == 0 {
 		return nil
 	}
+
 	var parameters []types.ConnectionHeaderParameter
 	for _, c := range config {
-		parameter := types.ConnectionHeaderParameter{}
+		if c == nil {
+			continue
+		}
 
+		parameter := types.ConnectionHeaderParameter{}
 		input := c.(map[string]interface{})
 		if v, ok := input[names.AttrKey].(string); ok && v != "" {
 			parameter.Key = aws.String(v)
@@ -631,6 +675,7 @@ func expandConnectionHTTPParametersHeader(config []interface{}) []types.Connecti
 		}
 		parameters = append(parameters, parameter)
 	}
+
 	return parameters
 }
 
@@ -638,10 +683,14 @@ func expandConnectionHTTPParametersQueryString(config []interface{}) []types.Con
 	if len(config) == 0 {
 		return nil
 	}
+
 	var parameters []types.ConnectionQueryStringParameter
 	for _, c := range config {
-		parameter := types.ConnectionQueryStringParameter{}
+		if c == nil {
+			continue
+		}
 
+		parameter := types.ConnectionQueryStringParameter{}
 		input := c.(map[string]interface{})
 		if v, ok := input[names.AttrKey].(string); ok && v != "" {
 			parameter.Key = aws.String(v)
@@ -654,6 +703,7 @@ func expandConnectionHTTPParametersQueryString(config []interface{}) []types.Con
 		}
 		parameters = append(parameters, parameter)
 	}
+
 	return parameters
 }
 
@@ -809,7 +859,12 @@ func flattenConnectionHTTPParameters(httpParameters *types.ConnectionHttpParamet
 
 func expandUpdateConnectionAuthRequestParameters(config []interface{}) *types.UpdateConnectionAuthRequestParameters {
 	authParameters := &types.UpdateConnectionAuthRequestParameters{}
+
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param["api_key"].([]interface{}); ok && len(v) > 0 {
 			authParameters.ApiKeyAuthParameters = expandUpdateConnectionAPIKeyAuthRequestParameters(v)
@@ -835,6 +890,10 @@ func expandUpdateConnectionAPIKeyAuthRequestParameters(config []interface{}) *ty
 
 	apiKeyAuthParameters := &types.UpdateConnectionApiKeyAuthRequestParameters{}
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param[names.AttrKey].(string); ok && v != "" {
 			apiKeyAuthParameters.ApiKeyName = aws.String(v)
@@ -843,6 +902,7 @@ func expandUpdateConnectionAPIKeyAuthRequestParameters(config []interface{}) *ty
 			apiKeyAuthParameters.ApiKeyValue = aws.String(v)
 		}
 	}
+
 	return apiKeyAuthParameters
 }
 
@@ -853,6 +913,10 @@ func expandUpdateConnectionBasicAuthRequestParameters(config []interface{}) *typ
 
 	basicAuthParameters := &types.UpdateConnectionBasicAuthRequestParameters{}
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param[names.AttrUsername].(string); ok && v != "" {
 			basicAuthParameters.Username = aws.String(v)
@@ -861,6 +925,7 @@ func expandUpdateConnectionBasicAuthRequestParameters(config []interface{}) *typ
 			basicAuthParameters.Password = aws.String(v)
 		}
 	}
+
 	return basicAuthParameters
 }
 
@@ -871,6 +936,10 @@ func expandUpdateConnectionOAuthAuthRequestParameters(config []interface{}) *typ
 
 	oAuthParameters := &types.UpdateConnectionOAuthRequestParameters{}
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param["authorization_endpoint"].(string); ok && v != "" {
 			oAuthParameters.AuthorizationEndpoint = aws.String(v)
@@ -885,12 +954,18 @@ func expandUpdateConnectionOAuthAuthRequestParameters(config []interface{}) *typ
 			oAuthParameters.ClientParameters = expandUpdateConnectionOAuthClientRequestParameters(v)
 		}
 	}
+
 	return oAuthParameters
 }
 
 func expandUpdateConnectionOAuthClientRequestParameters(config []interface{}) *types.UpdateConnectionOAuthClientRequestParameters {
 	oAuthClientRequestParameters := &types.UpdateConnectionOAuthClientRequestParameters{}
+
 	for _, c := range config {
+		if c == nil {
+			continue
+		}
+
 		param := c.(map[string]interface{})
 		if v, ok := param[names.AttrClientID].(string); ok && v != "" {
 			oAuthClientRequestParameters.ClientID = aws.String(v)
@@ -899,5 +974,6 @@ func expandUpdateConnectionOAuthClientRequestParameters(config []interface{}) *t
 			oAuthClientRequestParameters.ClientSecret = aws.String(v)
 		}
 	}
+
 	return oAuthClientRequestParameters
 }

--- a/internal/service/events/connection.go
+++ b/internal/service/events/connection.go
@@ -476,376 +476,372 @@ func waitConnectionDeleted(ctx context.Context, conn *eventbridge.Client, name s
 	return nil, err
 }
 
-func expandCreateConnectionAuthRequestParameters(config []interface{}) *types.CreateConnectionAuthRequestParameters {
-	authParameters := &types.CreateConnectionAuthRequestParameters{}
+func expandCreateConnectionAuthRequestParameters(tfList []interface{}) *types.CreateConnectionAuthRequestParameters {
+	apiObject := &types.CreateConnectionAuthRequestParameters{}
 
-	for _, c := range config {
-		if c == nil {
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param["api_key"].([]interface{}); ok && len(v) > 0 {
-			authParameters.ApiKeyAuthParameters = expandCreateConnectionAPIKeyAuthRequestParameters(v)
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap["api_key"].([]interface{}); ok && len(v) > 0 {
+			apiObject.ApiKeyAuthParameters = expandCreateConnectionAPIKeyAuthRequestParameters(v)
 		}
-		if v, ok := param["basic"].([]interface{}); ok && len(v) > 0 {
-			authParameters.BasicAuthParameters = expandCreateConnectionBasicAuthRequestParameters(v)
+		if v, ok := tfMap["basic"].([]interface{}); ok && len(v) > 0 {
+			apiObject.BasicAuthParameters = expandCreateConnectionBasicAuthRequestParameters(v)
 		}
-		if v, ok := param["oauth"].([]interface{}); ok && len(v) > 0 {
-			authParameters.OAuthParameters = expandCreateConnectionOAuthAuthRequestParameters(v)
+		if v, ok := tfMap["oauth"].([]interface{}); ok && len(v) > 0 {
+			apiObject.OAuthParameters = expandCreateConnectionOAuthAuthRequestParameters(v)
 		}
-		if v, ok := param["invocation_http_parameters"].([]interface{}); ok && len(v) > 0 {
-			authParameters.InvocationHttpParameters = expandConnectionHTTPParameters(v)
+		if v, ok := tfMap["invocation_http_parameters"].([]interface{}); ok && len(v) > 0 {
+			apiObject.InvocationHttpParameters = expandConnectionHTTPParameters(v)
 		}
 	}
 
-	return authParameters
+	return apiObject
 }
 
-func expandCreateConnectionAPIKeyAuthRequestParameters(config []interface{}) *types.CreateConnectionApiKeyAuthRequestParameters {
-	if len(config) == 0 {
+func expandCreateConnectionAPIKeyAuthRequestParameters(tfList []interface{}) *types.CreateConnectionApiKeyAuthRequestParameters {
+	if len(tfList) == 0 {
 		return nil
 	}
 
-	apiKeyAuthParameters := &types.CreateConnectionApiKeyAuthRequestParameters{}
-	for _, c := range config {
-		if c == nil {
+	apiObject := &types.CreateConnectionApiKeyAuthRequestParameters{}
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param[names.AttrKey].(string); ok && v != "" {
-			apiKeyAuthParameters.ApiKeyName = aws.String(v)
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap[names.AttrKey].(string); ok && v != "" {
+			apiObject.ApiKeyName = aws.String(v)
 		}
-		if v, ok := param[names.AttrValue].(string); ok && v != "" {
-			apiKeyAuthParameters.ApiKeyValue = aws.String(v)
+		if v, ok := tfMap[names.AttrValue].(string); ok && v != "" {
+			apiObject.ApiKeyValue = aws.String(v)
 		}
 	}
 
-	return apiKeyAuthParameters
+	return apiObject
 }
 
-func expandCreateConnectionBasicAuthRequestParameters(config []interface{}) *types.CreateConnectionBasicAuthRequestParameters {
-	if len(config) == 0 {
+func expandCreateConnectionBasicAuthRequestParameters(tfList []interface{}) *types.CreateConnectionBasicAuthRequestParameters {
+	if len(tfList) == 0 {
 		return nil
 	}
 
-	basicAuthParameters := &types.CreateConnectionBasicAuthRequestParameters{}
-	for _, c := range config {
-		if c == nil {
+	apiObject := &types.CreateConnectionBasicAuthRequestParameters{}
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param[names.AttrUsername].(string); ok && v != "" {
-			basicAuthParameters.Username = aws.String(v)
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap[names.AttrUsername].(string); ok && v != "" {
+			apiObject.Username = aws.String(v)
 		}
-		if v, ok := param[names.AttrPassword].(string); ok && v != "" {
-			basicAuthParameters.Password = aws.String(v)
+		if v, ok := tfMap[names.AttrPassword].(string); ok && v != "" {
+			apiObject.Password = aws.String(v)
 		}
 	}
 
-	return basicAuthParameters
+	return apiObject
 }
 
-func expandCreateConnectionOAuthAuthRequestParameters(config []interface{}) *types.CreateConnectionOAuthRequestParameters {
-	if len(config) == 0 {
+func expandCreateConnectionOAuthAuthRequestParameters(tfList []interface{}) *types.CreateConnectionOAuthRequestParameters {
+	if len(tfList) == 0 {
 		return nil
 	}
 
-	oAuthParameters := &types.CreateConnectionOAuthRequestParameters{}
-	for _, c := range config {
-		if c == nil {
+	apiObject := &types.CreateConnectionOAuthRequestParameters{}
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param["authorization_endpoint"].(string); ok && v != "" {
-			oAuthParameters.AuthorizationEndpoint = aws.String(v)
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap["authorization_endpoint"].(string); ok && v != "" {
+			apiObject.AuthorizationEndpoint = aws.String(v)
 		}
-		if v, ok := param["http_method"].(string); ok && v != "" {
-			oAuthParameters.HttpMethod = types.ConnectionOAuthHttpMethod(v)
+		if v, ok := tfMap["http_method"].(string); ok && v != "" {
+			apiObject.HttpMethod = types.ConnectionOAuthHttpMethod(v)
 		}
-		if v, ok := param["oauth_http_parameters"].([]interface{}); ok && len(v) > 0 {
-			oAuthParameters.OAuthHttpParameters = expandConnectionHTTPParameters(v)
+		if v, ok := tfMap["oauth_http_parameters"].([]interface{}); ok && len(v) > 0 {
+			apiObject.OAuthHttpParameters = expandConnectionHTTPParameters(v)
 		}
-		if v, ok := param["client_parameters"].([]interface{}); ok && len(v) > 0 {
-			oAuthParameters.ClientParameters = expandCreateConnectionOAuthClientRequestParameters(v)
+		if v, ok := tfMap["client_parameters"].([]interface{}); ok && len(v) > 0 {
+			apiObject.ClientParameters = expandCreateConnectionOAuthClientRequestParameters(v)
 		}
 	}
 
-	return oAuthParameters
+	return apiObject
 }
 
-func expandCreateConnectionOAuthClientRequestParameters(config []interface{}) *types.CreateConnectionOAuthClientRequestParameters {
-	oAuthClientRequestParameters := &types.CreateConnectionOAuthClientRequestParameters{}
+func expandCreateConnectionOAuthClientRequestParameters(tfList []interface{}) *types.CreateConnectionOAuthClientRequestParameters {
+	apiObject := &types.CreateConnectionOAuthClientRequestParameters{}
 
-	for _, c := range config {
-		if c == nil {
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param[names.AttrClientID].(string); ok && v != "" {
-			oAuthClientRequestParameters.ClientID = aws.String(v)
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap[names.AttrClientID].(string); ok && v != "" {
+			apiObject.ClientID = aws.String(v)
 		}
-		if v, ok := param[names.AttrClientSecret].(string); ok && v != "" {
-			oAuthClientRequestParameters.ClientSecret = aws.String(v)
+		if v, ok := tfMap[names.AttrClientSecret].(string); ok && v != "" {
+			apiObject.ClientSecret = aws.String(v)
 		}
 	}
 
-	return oAuthClientRequestParameters
+	return apiObject
 }
 
-func expandConnectionHTTPParameters(config []interface{}) *types.ConnectionHttpParameters {
-	if len(config) == 0 {
+func expandConnectionHTTPParameters(tfList []interface{}) *types.ConnectionHttpParameters {
+	if len(tfList) == 0 {
 		return nil
 	}
 
-	httpParameters := &types.ConnectionHttpParameters{}
-	for _, c := range config {
-		if c == nil {
+	apiObject := &types.ConnectionHttpParameters{}
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param["body"].([]interface{}); ok && len(v) > 0 {
-			httpParameters.BodyParameters = expandConnectionHTTPParametersBody(v)
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap["body"].([]interface{}); ok && len(v) > 0 {
+			apiObject.BodyParameters = expandConnectionHTTPParametersBody(v)
 		}
-		if v, ok := param[names.AttrHeader].([]interface{}); ok && len(v) > 0 {
-			httpParameters.HeaderParameters = expandConnectionHTTPParametersHeader(v)
+		if v, ok := tfMap[names.AttrHeader].([]interface{}); ok && len(v) > 0 {
+			apiObject.HeaderParameters = expandConnectionHTTPParametersHeader(v)
 		}
-		if v, ok := param["query_string"].([]interface{}); ok && len(v) > 0 {
-			httpParameters.QueryStringParameters = expandConnectionHTTPParametersQueryString(v)
+		if v, ok := tfMap["query_string"].([]interface{}); ok && len(v) > 0 {
+			apiObject.QueryStringParameters = expandConnectionHTTPParametersQueryString(v)
 		}
 	}
 
-	return httpParameters
+	return apiObject
 }
 
-func expandConnectionHTTPParametersBody(config []interface{}) []types.ConnectionBodyParameter {
-	if len(config) == 0 {
+func expandConnectionHTTPParametersBody(tfList []interface{}) []types.ConnectionBodyParameter {
+	if len(tfList) == 0 {
 		return nil
 	}
 
-	var parameters []types.ConnectionBodyParameter
-	for _, c := range config {
-		if c == nil {
+	var apiObjects []types.ConnectionBodyParameter
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		parameter := types.ConnectionBodyParameter{}
-		input := c.(map[string]interface{})
-		if v, ok := input[names.AttrKey].(string); ok && v != "" {
-			parameter.Key = aws.String(v)
+		apiObject := types.ConnectionBodyParameter{}
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap[names.AttrKey].(string); ok && v != "" {
+			apiObject.Key = aws.String(v)
 		}
-		if v, ok := input[names.AttrValue].(string); ok && v != "" {
-			parameter.Value = aws.String(v)
+		if v, ok := tfMap[names.AttrValue].(string); ok && v != "" {
+			apiObject.Value = aws.String(v)
 		}
-		if v, ok := input["is_value_secret"].(bool); ok {
-			parameter.IsValueSecret = v
+		if v, ok := tfMap["is_value_secret"].(bool); ok {
+			apiObject.IsValueSecret = v
 		}
-		parameters = append(parameters, parameter)
+		apiObjects = append(apiObjects, apiObject)
 	}
 
-	return parameters
+	return apiObjects
 }
 
-func expandConnectionHTTPParametersHeader(config []interface{}) []types.ConnectionHeaderParameter {
-	if len(config) == 0 {
+func expandConnectionHTTPParametersHeader(tfList []interface{}) []types.ConnectionHeaderParameter {
+	if len(tfList) == 0 {
 		return nil
 	}
 
-	var parameters []types.ConnectionHeaderParameter
-	for _, c := range config {
-		if c == nil {
+	var apiObjects []types.ConnectionHeaderParameter
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		parameter := types.ConnectionHeaderParameter{}
-		input := c.(map[string]interface{})
-		if v, ok := input[names.AttrKey].(string); ok && v != "" {
-			parameter.Key = aws.String(v)
+		apiObject := types.ConnectionHeaderParameter{}
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap[names.AttrKey].(string); ok && v != "" {
+			apiObject.Key = aws.String(v)
 		}
-		if v, ok := input[names.AttrValue].(string); ok && v != "" {
-			parameter.Value = aws.String(v)
+		if v, ok := tfMap[names.AttrValue].(string); ok && v != "" {
+			apiObject.Value = aws.String(v)
 		}
-		if v, ok := input["is_value_secret"].(bool); ok {
-			parameter.IsValueSecret = v
+		if v, ok := tfMap["is_value_secret"].(bool); ok {
+			apiObject.IsValueSecret = v
 		}
-		parameters = append(parameters, parameter)
+		apiObjects = append(apiObjects, apiObject)
 	}
 
-	return parameters
+	return apiObjects
 }
 
-func expandConnectionHTTPParametersQueryString(config []interface{}) []types.ConnectionQueryStringParameter {
-	if len(config) == 0 {
+func expandConnectionHTTPParametersQueryString(tfList []interface{}) []types.ConnectionQueryStringParameter {
+	if len(tfList) == 0 {
 		return nil
 	}
 
-	var parameters []types.ConnectionQueryStringParameter
-	for _, c := range config {
-		if c == nil {
+	var apiObjects []types.ConnectionQueryStringParameter
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		parameter := types.ConnectionQueryStringParameter{}
-		input := c.(map[string]interface{})
-		if v, ok := input[names.AttrKey].(string); ok && v != "" {
-			parameter.Key = aws.String(v)
+		apiObject := types.ConnectionQueryStringParameter{}
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap[names.AttrKey].(string); ok && v != "" {
+			apiObject.Key = aws.String(v)
 		}
-		if v, ok := input[names.AttrValue].(string); ok && v != "" {
-			parameter.Value = aws.String(v)
+		if v, ok := tfMap[names.AttrValue].(string); ok && v != "" {
+			apiObject.Value = aws.String(v)
 		}
-		if v, ok := input["is_value_secret"].(bool); ok {
-			parameter.IsValueSecret = v
+		if v, ok := tfMap["is_value_secret"].(bool); ok {
+			apiObject.IsValueSecret = v
 		}
-		parameters = append(parameters, parameter)
+		apiObjects = append(apiObjects, apiObject)
 	}
 
-	return parameters
+	return apiObjects
 }
 
-func flattenConnectionAuthParameters(authParameters *types.ConnectionAuthResponseParameters, d *schema.ResourceData) []map[string]interface{} {
-	config := make(map[string]interface{})
+func flattenConnectionAuthParameters(apiObject *types.ConnectionAuthResponseParameters, d *schema.ResourceData) []map[string]interface{} {
+	tfMap := make(map[string]interface{})
 
-	if authParameters.ApiKeyAuthParameters != nil {
-		config["api_key"] = flattenConnectionAPIKeyAuthParameters(authParameters.ApiKeyAuthParameters, d)
+	if apiObject.ApiKeyAuthParameters != nil {
+		tfMap["api_key"] = flattenConnectionAPIKeyAuthParameters(apiObject.ApiKeyAuthParameters, d)
 	}
 
-	if authParameters.BasicAuthParameters != nil {
-		config["basic"] = flattenConnectionBasicAuthParameters(authParameters.BasicAuthParameters, d)
+	if apiObject.BasicAuthParameters != nil {
+		tfMap["basic"] = flattenConnectionBasicAuthParameters(apiObject.BasicAuthParameters, d)
 	}
 
-	if authParameters.OAuthParameters != nil {
-		config["oauth"] = flattenConnectionOAuthParameters(authParameters.OAuthParameters, d)
+	if apiObject.OAuthParameters != nil {
+		tfMap["oauth"] = flattenConnectionOAuthParameters(apiObject.OAuthParameters, d)
 	}
 
-	if authParameters.InvocationHttpParameters != nil {
-		config["invocation_http_parameters"] = flattenConnectionHTTPParameters(authParameters.InvocationHttpParameters, d, "auth_parameters.0.invocation_http_parameters")
+	if apiObject.InvocationHttpParameters != nil {
+		tfMap["invocation_http_parameters"] = flattenConnectionHTTPParameters(apiObject.InvocationHttpParameters, d, "auth_parameters.0.invocation_http_parameters")
 	}
 
-	result := []map[string]interface{}{config}
-	return result
+	return []map[string]interface{}{tfMap}
 }
 
-func flattenConnectionAPIKeyAuthParameters(apiKeyAuthParameters *types.ConnectionApiKeyAuthResponseParameters, d *schema.ResourceData) []map[string]interface{} {
-	if apiKeyAuthParameters == nil {
+func flattenConnectionAPIKeyAuthParameters(apiObject *types.ConnectionApiKeyAuthResponseParameters, d *schema.ResourceData) []map[string]interface{} {
+	if apiObject == nil {
 		return nil
 	}
 
-	config := make(map[string]interface{})
-	if apiKeyAuthParameters.ApiKeyName != nil {
-		config[names.AttrKey] = aws.ToString(apiKeyAuthParameters.ApiKeyName)
+	tfMap := make(map[string]interface{})
+	if apiObject.ApiKeyName != nil {
+		tfMap[names.AttrKey] = aws.ToString(apiObject.ApiKeyName)
 	}
 
 	if v, ok := d.GetOk("auth_parameters.0.api_key.0.value"); ok {
-		config[names.AttrValue] = v.(string)
+		tfMap[names.AttrValue] = v.(string)
 	}
 
-	result := []map[string]interface{}{config}
-	return result
+	return []map[string]interface{}{tfMap}
 }
 
-func flattenConnectionBasicAuthParameters(basicAuthParameters *types.ConnectionBasicAuthResponseParameters, d *schema.ResourceData) []map[string]interface{} {
-	if basicAuthParameters == nil {
+func flattenConnectionBasicAuthParameters(apiObject *types.ConnectionBasicAuthResponseParameters, d *schema.ResourceData) []map[string]interface{} {
+	if apiObject == nil {
 		return nil
 	}
 
-	config := make(map[string]interface{})
-	if basicAuthParameters.Username != nil {
-		config[names.AttrUsername] = aws.ToString(basicAuthParameters.Username)
+	tfMap := make(map[string]interface{})
+	if apiObject.Username != nil {
+		tfMap[names.AttrUsername] = aws.ToString(apiObject.Username)
 	}
 
 	if v, ok := d.GetOk("auth_parameters.0.basic.0.password"); ok {
-		config[names.AttrPassword] = v.(string)
+		tfMap[names.AttrPassword] = v.(string)
 	}
 
-	result := []map[string]interface{}{config}
-	return result
+	return []map[string]interface{}{tfMap}
 }
 
-func flattenConnectionOAuthParameters(oAuthParameters *types.ConnectionOAuthResponseParameters, d *schema.ResourceData) []map[string]interface{} {
-	if oAuthParameters == nil {
+func flattenConnectionOAuthParameters(apiObject *types.ConnectionOAuthResponseParameters, d *schema.ResourceData) []map[string]interface{} {
+	if apiObject == nil {
 		return nil
 	}
 
-	config := make(map[string]interface{})
-	if oAuthParameters.AuthorizationEndpoint != nil {
-		config["authorization_endpoint"] = aws.ToString(oAuthParameters.AuthorizationEndpoint)
+	tfMap := make(map[string]interface{})
+	if apiObject.AuthorizationEndpoint != nil {
+		tfMap["authorization_endpoint"] = aws.ToString(apiObject.AuthorizationEndpoint)
 	}
-	config["http_method"] = oAuthParameters.HttpMethod
-	config["oauth_http_parameters"] = flattenConnectionHTTPParameters(oAuthParameters.OAuthHttpParameters, d, "auth_parameters.0.oauth.0.oauth_http_parameters")
-	config["client_parameters"] = flattenConnectionOAuthClientResponseParameters(oAuthParameters.ClientParameters, d)
+	tfMap["http_method"] = apiObject.HttpMethod
+	tfMap["oauth_http_parameters"] = flattenConnectionHTTPParameters(apiObject.OAuthHttpParameters, d, "auth_parameters.0.oauth.0.oauth_http_parameters")
+	tfMap["client_parameters"] = flattenConnectionOAuthClientResponseParameters(apiObject.ClientParameters, d)
 
-	result := []map[string]interface{}{config}
-	return result
+	return []map[string]interface{}{tfMap}
 }
 
-func flattenConnectionOAuthClientResponseParameters(oAuthClientRequestParameters *types.ConnectionOAuthClientResponseParameters, d *schema.ResourceData) []map[string]interface{} {
-	if oAuthClientRequestParameters == nil {
+func flattenConnectionOAuthClientResponseParameters(apiObject *types.ConnectionOAuthClientResponseParameters, d *schema.ResourceData) []map[string]interface{} {
+	if apiObject == nil {
 		return nil
 	}
 
-	config := make(map[string]interface{})
-	if oAuthClientRequestParameters.ClientID != nil {
-		config[names.AttrClientID] = aws.ToString(oAuthClientRequestParameters.ClientID)
+	tfMap := make(map[string]interface{})
+	if apiObject.ClientID != nil {
+		tfMap[names.AttrClientID] = aws.ToString(apiObject.ClientID)
 	}
 
 	if v, ok := d.GetOk("auth_parameters.0.oauth.0.client_parameters.0.client_secret"); ok {
-		config[names.AttrClientSecret] = v.(string)
+		tfMap[names.AttrClientSecret] = v.(string)
 	}
 
-	result := []map[string]interface{}{config}
-	return result
+	return []map[string]interface{}{tfMap}
 }
 
-func flattenConnectionHTTPParameters(httpParameters *types.ConnectionHttpParameters, d *schema.ResourceData, path string) []map[string]interface{} {
-	if httpParameters == nil {
+func flattenConnectionHTTPParameters(apiObject *types.ConnectionHttpParameters, d *schema.ResourceData, path string) []map[string]interface{} {
+	if apiObject == nil {
 		return nil
 	}
 
 	var bodyParameters []map[string]interface{}
-	for i, param := range httpParameters.BodyParameters {
-		config := make(map[string]interface{})
-		config["is_value_secret"] = param.IsValueSecret
-		config[names.AttrKey] = aws.ToString(param.Key)
+	for i, param := range apiObject.BodyParameters {
+		tfMap := make(map[string]interface{})
+		tfMap["is_value_secret"] = param.IsValueSecret
+		tfMap[names.AttrKey] = aws.ToString(param.Key)
 
 		if param.Value != nil {
-			config[names.AttrValue] = aws.ToString(param.Value)
+			tfMap[names.AttrValue] = aws.ToString(param.Value)
 		} else if v, ok := d.GetOk(fmt.Sprintf("%s.0.body.%d.value", path, i)); ok {
-			config[names.AttrValue] = v.(string)
+			tfMap[names.AttrValue] = v.(string)
 		}
-		bodyParameters = append(bodyParameters, config)
+
+		bodyParameters = append(bodyParameters, tfMap)
 	}
 
 	var headerParameters []map[string]interface{}
-	for i, param := range httpParameters.HeaderParameters {
-		config := make(map[string]interface{})
-		config["is_value_secret"] = param.IsValueSecret
-		config[names.AttrKey] = aws.ToString(param.Key)
+	for i, param := range apiObject.HeaderParameters {
+		tfMap := make(map[string]interface{})
+		tfMap["is_value_secret"] = param.IsValueSecret
+		tfMap[names.AttrKey] = aws.ToString(param.Key)
 
 		if param.Value != nil {
-			config[names.AttrValue] = aws.ToString(param.Value)
+			tfMap[names.AttrValue] = aws.ToString(param.Value)
 		} else if v, ok := d.GetOk(fmt.Sprintf("%s.0.header.%d.value", path, i)); ok {
-			config[names.AttrValue] = v.(string)
+			tfMap[names.AttrValue] = v.(string)
 		}
-		headerParameters = append(headerParameters, config)
+		headerParameters = append(headerParameters, tfMap)
 	}
 
 	var queryStringParameters []map[string]interface{}
-	for i, param := range httpParameters.QueryStringParameters {
-		config := make(map[string]interface{})
-		config["is_value_secret"] = param.IsValueSecret
-		config[names.AttrKey] = aws.ToString(param.Key)
+	for i, param := range apiObject.QueryStringParameters {
+		tfMap := make(map[string]interface{})
+		tfMap["is_value_secret"] = param.IsValueSecret
+		tfMap[names.AttrKey] = aws.ToString(param.Key)
 
 		if param.Value != nil {
-			config[names.AttrValue] = aws.ToString(param.Value)
+			tfMap[names.AttrValue] = aws.ToString(param.Value)
 		} else if v, ok := d.GetOk(fmt.Sprintf("%s.0.query_string.%d.value", path, i)); ok {
-			config[names.AttrValue] = v.(string)
+			tfMap[names.AttrValue] = v.(string)
 		}
-		queryStringParameters = append(queryStringParameters, config)
+		queryStringParameters = append(queryStringParameters, tfMap)
 	}
 
 	parameters := make(map[string]interface{})
@@ -853,127 +849,126 @@ func flattenConnectionHTTPParameters(httpParameters *types.ConnectionHttpParamet
 	parameters[names.AttrHeader] = headerParameters
 	parameters["query_string"] = queryStringParameters
 
-	result := []map[string]interface{}{parameters}
-	return result
+	return []map[string]interface{}{parameters}
 }
 
-func expandUpdateConnectionAuthRequestParameters(config []interface{}) *types.UpdateConnectionAuthRequestParameters {
-	authParameters := &types.UpdateConnectionAuthRequestParameters{}
+func expandUpdateConnectionAuthRequestParameters(tfList []interface{}) *types.UpdateConnectionAuthRequestParameters {
+	apiObject := &types.UpdateConnectionAuthRequestParameters{}
 
-	for _, c := range config {
-		if c == nil {
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param["api_key"].([]interface{}); ok && len(v) > 0 {
-			authParameters.ApiKeyAuthParameters = expandUpdateConnectionAPIKeyAuthRequestParameters(v)
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap["api_key"].([]interface{}); ok && len(v) > 0 {
+			apiObject.ApiKeyAuthParameters = expandUpdateConnectionAPIKeyAuthRequestParameters(v)
 		}
-		if v, ok := param["basic"].([]interface{}); ok && len(v) > 0 {
-			authParameters.BasicAuthParameters = expandUpdateConnectionBasicAuthRequestParameters(v)
+		if v, ok := tfMap["basic"].([]interface{}); ok && len(v) > 0 {
+			apiObject.BasicAuthParameters = expandUpdateConnectionBasicAuthRequestParameters(v)
 		}
-		if v, ok := param["oauth"].([]interface{}); ok && len(v) > 0 {
-			authParameters.OAuthParameters = expandUpdateConnectionOAuthAuthRequestParameters(v)
+		if v, ok := tfMap["oauth"].([]interface{}); ok && len(v) > 0 {
+			apiObject.OAuthParameters = expandUpdateConnectionOAuthAuthRequestParameters(v)
 		}
-		if v, ok := param["invocation_http_parameters"].([]interface{}); ok && len(v) > 0 {
-			authParameters.InvocationHttpParameters = expandConnectionHTTPParameters(v)
+		if v, ok := tfMap["invocation_http_parameters"].([]interface{}); ok && len(v) > 0 {
+			apiObject.InvocationHttpParameters = expandConnectionHTTPParameters(v)
 		}
 	}
 
-	return authParameters
+	return apiObject
 }
 
-func expandUpdateConnectionAPIKeyAuthRequestParameters(config []interface{}) *types.UpdateConnectionApiKeyAuthRequestParameters {
-	if len(config) == 0 {
+func expandUpdateConnectionAPIKeyAuthRequestParameters(tfList []interface{}) *types.UpdateConnectionApiKeyAuthRequestParameters {
+	if len(tfList) == 0 {
 		return nil
 	}
 
-	apiKeyAuthParameters := &types.UpdateConnectionApiKeyAuthRequestParameters{}
-	for _, c := range config {
-		if c == nil {
+	apiObject := &types.UpdateConnectionApiKeyAuthRequestParameters{}
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param[names.AttrKey].(string); ok && v != "" {
-			apiKeyAuthParameters.ApiKeyName = aws.String(v)
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap[names.AttrKey].(string); ok && v != "" {
+			apiObject.ApiKeyName = aws.String(v)
 		}
-		if v, ok := param[names.AttrValue].(string); ok && v != "" {
-			apiKeyAuthParameters.ApiKeyValue = aws.String(v)
+		if v, ok := tfMap[names.AttrValue].(string); ok && v != "" {
+			apiObject.ApiKeyValue = aws.String(v)
 		}
 	}
 
-	return apiKeyAuthParameters
+	return apiObject
 }
 
-func expandUpdateConnectionBasicAuthRequestParameters(config []interface{}) *types.UpdateConnectionBasicAuthRequestParameters {
-	if len(config) == 0 {
+func expandUpdateConnectionBasicAuthRequestParameters(tfList []interface{}) *types.UpdateConnectionBasicAuthRequestParameters {
+	if len(tfList) == 0 {
 		return nil
 	}
 
-	basicAuthParameters := &types.UpdateConnectionBasicAuthRequestParameters{}
-	for _, c := range config {
+	apiObject := &types.UpdateConnectionBasicAuthRequestParameters{}
+	for _, c := range tfList {
 		if c == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param[names.AttrUsername].(string); ok && v != "" {
-			basicAuthParameters.Username = aws.String(v)
+		tfMap := c.(map[string]interface{})
+		if v, ok := tfMap[names.AttrUsername].(string); ok && v != "" {
+			apiObject.Username = aws.String(v)
 		}
-		if v, ok := param[names.AttrPassword].(string); ok && v != "" {
-			basicAuthParameters.Password = aws.String(v)
+		if v, ok := tfMap[names.AttrPassword].(string); ok && v != "" {
+			apiObject.Password = aws.String(v)
 		}
 	}
 
-	return basicAuthParameters
+	return apiObject
 }
 
-func expandUpdateConnectionOAuthAuthRequestParameters(config []interface{}) *types.UpdateConnectionOAuthRequestParameters {
-	if len(config) == 0 {
+func expandUpdateConnectionOAuthAuthRequestParameters(tfList []interface{}) *types.UpdateConnectionOAuthRequestParameters {
+	if len(tfList) == 0 {
 		return nil
 	}
 
-	oAuthParameters := &types.UpdateConnectionOAuthRequestParameters{}
-	for _, c := range config {
+	apiObject := &types.UpdateConnectionOAuthRequestParameters{}
+	for _, c := range tfList {
 		if c == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param["authorization_endpoint"].(string); ok && v != "" {
-			oAuthParameters.AuthorizationEndpoint = aws.String(v)
+		tfMap := c.(map[string]interface{})
+		if v, ok := tfMap["authorization_endpoint"].(string); ok && v != "" {
+			apiObject.AuthorizationEndpoint = aws.String(v)
 		}
-		if v, ok := param["http_method"].(string); ok && v != "" {
-			oAuthParameters.HttpMethod = types.ConnectionOAuthHttpMethod(v)
+		if v, ok := tfMap["http_method"].(string); ok && v != "" {
+			apiObject.HttpMethod = types.ConnectionOAuthHttpMethod(v)
 		}
-		if v, ok := param["oauth_http_parameters"].([]interface{}); ok && len(v) > 0 {
-			oAuthParameters.OAuthHttpParameters = expandConnectionHTTPParameters(v)
+		if v, ok := tfMap["oauth_http_parameters"].([]interface{}); ok && len(v) > 0 {
+			apiObject.OAuthHttpParameters = expandConnectionHTTPParameters(v)
 		}
-		if v, ok := param["client_parameters"].([]interface{}); ok && len(v) > 0 {
-			oAuthParameters.ClientParameters = expandUpdateConnectionOAuthClientRequestParameters(v)
+		if v, ok := tfMap["client_parameters"].([]interface{}); ok && len(v) > 0 {
+			apiObject.ClientParameters = expandUpdateConnectionOAuthClientRequestParameters(v)
 		}
 	}
 
-	return oAuthParameters
+	return apiObject
 }
 
-func expandUpdateConnectionOAuthClientRequestParameters(config []interface{}) *types.UpdateConnectionOAuthClientRequestParameters {
-	oAuthClientRequestParameters := &types.UpdateConnectionOAuthClientRequestParameters{}
+func expandUpdateConnectionOAuthClientRequestParameters(tfList []interface{}) *types.UpdateConnectionOAuthClientRequestParameters {
+	apiObject := &types.UpdateConnectionOAuthClientRequestParameters{}
 
-	for _, c := range config {
-		if c == nil {
+	for _, item := range tfList {
+		if item == nil {
 			continue
 		}
 
-		param := c.(map[string]interface{})
-		if v, ok := param[names.AttrClientID].(string); ok && v != "" {
-			oAuthClientRequestParameters.ClientID = aws.String(v)
+		tfMap := item.(map[string]interface{})
+		if v, ok := tfMap[names.AttrClientID].(string); ok && v != "" {
+			apiObject.ClientID = aws.String(v)
 		}
-		if v, ok := param[names.AttrClientSecret].(string); ok && v != "" {
-			oAuthClientRequestParameters.ClientSecret = aws.String(v)
+		if v, ok := tfMap[names.AttrClientSecret].(string); ok && v != "" {
+			apiObject.ClientSecret = aws.String(v)
 		}
 	}
 
-	return oAuthClientRequestParameters
+	return apiObject
 }

--- a/internal/service/events/connection.go
+++ b/internal/service/events/connection.go
@@ -480,17 +480,17 @@ func expandCreateConnectionAuthRequestParameters(config []interface{}) *types.Cr
 	authParameters := &types.CreateConnectionAuthRequestParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param["api_key"]; ok {
-			authParameters.ApiKeyAuthParameters = expandCreateConnectionAPIKeyAuthRequestParameters(val.([]interface{}))
+		if v, ok := param["api_key"].([]interface{}); ok && len(v) > 0 {
+			authParameters.ApiKeyAuthParameters = expandCreateConnectionAPIKeyAuthRequestParameters(v)
 		}
-		if val, ok := param["basic"]; ok {
-			authParameters.BasicAuthParameters = expandCreateConnectionBasicAuthRequestParameters(val.([]interface{}))
+		if v, ok := param["basic"].([]interface{}); ok && len(v) > 0 {
+			authParameters.BasicAuthParameters = expandCreateConnectionBasicAuthRequestParameters(v)
 		}
-		if val, ok := param["oauth"]; ok {
-			authParameters.OAuthParameters = expandCreateConnectionOAuthAuthRequestParameters(val.([]interface{}))
+		if v, ok := param["oauth"].([]interface{}); ok && len(v) > 0 {
+			authParameters.OAuthParameters = expandCreateConnectionOAuthAuthRequestParameters(v)
 		}
-		if val, ok := param["invocation_http_parameters"]; ok {
-			authParameters.InvocationHttpParameters = expandConnectionHTTPParameters(val.([]interface{}))
+		if v, ok := param["invocation_http_parameters"].([]interface{}); ok && len(v) > 0 {
+			authParameters.InvocationHttpParameters = expandConnectionHTTPParameters(v)
 		}
 	}
 
@@ -504,11 +504,11 @@ func expandCreateConnectionAPIKeyAuthRequestParameters(config []interface{}) *ty
 	apiKeyAuthParameters := &types.CreateConnectionApiKeyAuthRequestParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param[names.AttrKey].(string); ok && val != "" {
-			apiKeyAuthParameters.ApiKeyName = aws.String(val)
+		if v, ok := param[names.AttrKey].(string); ok && v != "" {
+			apiKeyAuthParameters.ApiKeyName = aws.String(v)
 		}
-		if val, ok := param[names.AttrValue].(string); ok && val != "" {
-			apiKeyAuthParameters.ApiKeyValue = aws.String(val)
+		if v, ok := param[names.AttrValue].(string); ok && v != "" {
+			apiKeyAuthParameters.ApiKeyValue = aws.String(v)
 		}
 	}
 	return apiKeyAuthParameters
@@ -521,11 +521,11 @@ func expandCreateConnectionBasicAuthRequestParameters(config []interface{}) *typ
 	basicAuthParameters := &types.CreateConnectionBasicAuthRequestParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param[names.AttrUsername].(string); ok && val != "" {
-			basicAuthParameters.Username = aws.String(val)
+		if v, ok := param[names.AttrUsername].(string); ok && v != "" {
+			basicAuthParameters.Username = aws.String(v)
 		}
-		if val, ok := param[names.AttrPassword].(string); ok && val != "" {
-			basicAuthParameters.Password = aws.String(val)
+		if v, ok := param[names.AttrPassword].(string); ok && v != "" {
+			basicAuthParameters.Password = aws.String(v)
 		}
 	}
 	return basicAuthParameters
@@ -538,17 +538,17 @@ func expandCreateConnectionOAuthAuthRequestParameters(config []interface{}) *typ
 	oAuthParameters := &types.CreateConnectionOAuthRequestParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param["authorization_endpoint"].(string); ok && val != "" {
-			oAuthParameters.AuthorizationEndpoint = aws.String(val)
+		if v, ok := param["authorization_endpoint"].(string); ok && v != "" {
+			oAuthParameters.AuthorizationEndpoint = aws.String(v)
 		}
-		if val, ok := param["http_method"].(string); ok && val != "" {
-			oAuthParameters.HttpMethod = types.ConnectionOAuthHttpMethod(val)
+		if v, ok := param["http_method"].(string); ok && v != "" {
+			oAuthParameters.HttpMethod = types.ConnectionOAuthHttpMethod(v)
 		}
-		if val, ok := param["oauth_http_parameters"]; ok {
-			oAuthParameters.OAuthHttpParameters = expandConnectionHTTPParameters(val.([]interface{}))
+		if v, ok := param["oauth_http_parameters"].([]interface{}); ok && len(v) > 0 {
+			oAuthParameters.OAuthHttpParameters = expandConnectionHTTPParameters(v)
 		}
-		if val, ok := param["client_parameters"]; ok {
-			oAuthParameters.ClientParameters = expandCreateConnectionOAuthClientRequestParameters(val.([]interface{}))
+		if v, ok := param["client_parameters"].([]interface{}); ok && len(v) > 0 {
+			oAuthParameters.ClientParameters = expandCreateConnectionOAuthClientRequestParameters(v)
 		}
 	}
 	return oAuthParameters
@@ -558,11 +558,11 @@ func expandCreateConnectionOAuthClientRequestParameters(config []interface{}) *t
 	oAuthClientRequestParameters := &types.CreateConnectionOAuthClientRequestParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param[names.AttrClientID].(string); ok && val != "" {
-			oAuthClientRequestParameters.ClientID = aws.String(val)
+		if v, ok := param[names.AttrClientID].(string); ok && v != "" {
+			oAuthClientRequestParameters.ClientID = aws.String(v)
 		}
-		if val, ok := param[names.AttrClientSecret].(string); ok && val != "" {
-			oAuthClientRequestParameters.ClientSecret = aws.String(val)
+		if v, ok := param[names.AttrClientSecret].(string); ok && v != "" {
+			oAuthClientRequestParameters.ClientSecret = aws.String(v)
 		}
 	}
 	return oAuthClientRequestParameters
@@ -575,14 +575,14 @@ func expandConnectionHTTPParameters(config []interface{}) *types.ConnectionHttpP
 	httpParameters := &types.ConnectionHttpParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param["body"]; ok {
-			httpParameters.BodyParameters = expandConnectionHTTPParametersBody(val.([]interface{}))
+		if v, ok := param["body"].([]interface{}); ok && len(v) > 0 {
+			httpParameters.BodyParameters = expandConnectionHTTPParametersBody(v)
 		}
-		if val, ok := param[names.AttrHeader]; ok {
-			httpParameters.HeaderParameters = expandConnectionHTTPParametersHeader(val.([]interface{}))
+		if v, ok := param[names.AttrHeader].([]interface{}); ok && len(v) > 0 {
+			httpParameters.HeaderParameters = expandConnectionHTTPParametersHeader(v)
 		}
-		if val, ok := param["query_string"]; ok {
-			httpParameters.QueryStringParameters = expandConnectionHTTPParametersQueryString(val.([]interface{}))
+		if v, ok := param["query_string"].([]interface{}); ok && len(v) > 0 {
+			httpParameters.QueryStringParameters = expandConnectionHTTPParametersQueryString(v)
 		}
 	}
 	return httpParameters
@@ -597,14 +597,14 @@ func expandConnectionHTTPParametersBody(config []interface{}) []types.Connection
 		parameter := types.ConnectionBodyParameter{}
 
 		input := c.(map[string]interface{})
-		if val, ok := input[names.AttrKey].(string); ok && val != "" {
-			parameter.Key = aws.String(val)
+		if v, ok := input[names.AttrKey].(string); ok && v != "" {
+			parameter.Key = aws.String(v)
 		}
-		if val, ok := input[names.AttrValue].(string); ok && val != "" {
-			parameter.Value = aws.String(val)
+		if v, ok := input[names.AttrValue].(string); ok && v != "" {
+			parameter.Value = aws.String(v)
 		}
-		if val, ok := input["is_value_secret"].(bool); ok {
-			parameter.IsValueSecret = val
+		if v, ok := input["is_value_secret"].(bool); ok {
+			parameter.IsValueSecret = v
 		}
 		parameters = append(parameters, parameter)
 	}
@@ -620,14 +620,14 @@ func expandConnectionHTTPParametersHeader(config []interface{}) []types.Connecti
 		parameter := types.ConnectionHeaderParameter{}
 
 		input := c.(map[string]interface{})
-		if val, ok := input[names.AttrKey].(string); ok && val != "" {
-			parameter.Key = aws.String(val)
+		if v, ok := input[names.AttrKey].(string); ok && v != "" {
+			parameter.Key = aws.String(v)
 		}
-		if val, ok := input[names.AttrValue].(string); ok && val != "" {
-			parameter.Value = aws.String(val)
+		if v, ok := input[names.AttrValue].(string); ok && v != "" {
+			parameter.Value = aws.String(v)
 		}
-		if val, ok := input["is_value_secret"].(bool); ok {
-			parameter.IsValueSecret = val
+		if v, ok := input["is_value_secret"].(bool); ok {
+			parameter.IsValueSecret = v
 		}
 		parameters = append(parameters, parameter)
 	}
@@ -643,14 +643,14 @@ func expandConnectionHTTPParametersQueryString(config []interface{}) []types.Con
 		parameter := types.ConnectionQueryStringParameter{}
 
 		input := c.(map[string]interface{})
-		if val, ok := input[names.AttrKey].(string); ok && val != "" {
-			parameter.Key = aws.String(val)
+		if v, ok := input[names.AttrKey].(string); ok && v != "" {
+			parameter.Key = aws.String(v)
 		}
-		if val, ok := input[names.AttrValue].(string); ok && val != "" {
-			parameter.Value = aws.String(val)
+		if v, ok := input[names.AttrValue].(string); ok && v != "" {
+			parameter.Value = aws.String(v)
 		}
-		if val, ok := input["is_value_secret"].(bool); ok {
-			parameter.IsValueSecret = val
+		if v, ok := input["is_value_secret"].(bool); ok {
+			parameter.IsValueSecret = v
 		}
 		parameters = append(parameters, parameter)
 	}
@@ -811,17 +811,17 @@ func expandUpdateConnectionAuthRequestParameters(config []interface{}) *types.Up
 	authParameters := &types.UpdateConnectionAuthRequestParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param["api_key"]; ok {
-			authParameters.ApiKeyAuthParameters = expandUpdateConnectionAPIKeyAuthRequestParameters(val.([]interface{}))
+		if v, ok := param["api_key"].([]interface{}); ok && len(v) > 0 {
+			authParameters.ApiKeyAuthParameters = expandUpdateConnectionAPIKeyAuthRequestParameters(v)
 		}
-		if val, ok := param["basic"]; ok {
-			authParameters.BasicAuthParameters = expandUpdateConnectionBasicAuthRequestParameters(val.([]interface{}))
+		if v, ok := param["basic"].([]interface{}); ok && len(v) > 0 {
+			authParameters.BasicAuthParameters = expandUpdateConnectionBasicAuthRequestParameters(v)
 		}
-		if val, ok := param["oauth"]; ok {
-			authParameters.OAuthParameters = expandUpdateConnectionOAuthAuthRequestParameters(val.([]interface{}))
+		if v, ok := param["oauth"].([]interface{}); ok && len(v) > 0 {
+			authParameters.OAuthParameters = expandUpdateConnectionOAuthAuthRequestParameters(v)
 		}
-		if val, ok := param["invocation_http_parameters"]; ok {
-			authParameters.InvocationHttpParameters = expandConnectionHTTPParameters(val.([]interface{}))
+		if v, ok := param["invocation_http_parameters"].([]interface{}); ok && len(v) > 0 {
+			authParameters.InvocationHttpParameters = expandConnectionHTTPParameters(v)
 		}
 	}
 
@@ -832,14 +832,15 @@ func expandUpdateConnectionAPIKeyAuthRequestParameters(config []interface{}) *ty
 	if len(config) == 0 {
 		return nil
 	}
+
 	apiKeyAuthParameters := &types.UpdateConnectionApiKeyAuthRequestParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param[names.AttrKey].(string); ok && val != "" {
-			apiKeyAuthParameters.ApiKeyName = aws.String(val)
+		if v, ok := param[names.AttrKey].(string); ok && v != "" {
+			apiKeyAuthParameters.ApiKeyName = aws.String(v)
 		}
-		if val, ok := param[names.AttrValue].(string); ok && val != "" {
-			apiKeyAuthParameters.ApiKeyValue = aws.String(val)
+		if v, ok := param[names.AttrValue].(string); ok && v != "" {
+			apiKeyAuthParameters.ApiKeyValue = aws.String(v)
 		}
 	}
 	return apiKeyAuthParameters
@@ -849,14 +850,15 @@ func expandUpdateConnectionBasicAuthRequestParameters(config []interface{}) *typ
 	if len(config) == 0 {
 		return nil
 	}
+
 	basicAuthParameters := &types.UpdateConnectionBasicAuthRequestParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param[names.AttrUsername].(string); ok && val != "" {
-			basicAuthParameters.Username = aws.String(val)
+		if v, ok := param[names.AttrUsername].(string); ok && v != "" {
+			basicAuthParameters.Username = aws.String(v)
 		}
-		if val, ok := param[names.AttrPassword].(string); ok && val != "" {
-			basicAuthParameters.Password = aws.String(val)
+		if v, ok := param[names.AttrPassword].(string); ok && v != "" {
+			basicAuthParameters.Password = aws.String(v)
 		}
 	}
 	return basicAuthParameters
@@ -866,20 +868,21 @@ func expandUpdateConnectionOAuthAuthRequestParameters(config []interface{}) *typ
 	if len(config) == 0 {
 		return nil
 	}
+
 	oAuthParameters := &types.UpdateConnectionOAuthRequestParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param["authorization_endpoint"].(string); ok && val != "" {
-			oAuthParameters.AuthorizationEndpoint = aws.String(val)
+		if v, ok := param["authorization_endpoint"].(string); ok && v != "" {
+			oAuthParameters.AuthorizationEndpoint = aws.String(v)
 		}
-		if val, ok := param["http_method"].(string); ok && val != "" {
-			oAuthParameters.HttpMethod = types.ConnectionOAuthHttpMethod(val)
+		if v, ok := param["http_method"].(string); ok && v != "" {
+			oAuthParameters.HttpMethod = types.ConnectionOAuthHttpMethod(v)
 		}
-		if val, ok := param["oauth_http_parameters"]; ok {
-			oAuthParameters.OAuthHttpParameters = expandConnectionHTTPParameters(val.([]interface{}))
+		if v, ok := param["oauth_http_parameters"].([]interface{}); ok && len(v) > 0 {
+			oAuthParameters.OAuthHttpParameters = expandConnectionHTTPParameters(v)
 		}
-		if val, ok := param["client_parameters"]; ok {
-			oAuthParameters.ClientParameters = expandUpdateConnectionOAuthClientRequestParameters(val.([]interface{}))
+		if v, ok := param["client_parameters"].([]interface{}); ok && len(v) > 0 {
+			oAuthParameters.ClientParameters = expandUpdateConnectionOAuthClientRequestParameters(v)
 		}
 	}
 	return oAuthParameters
@@ -889,11 +892,11 @@ func expandUpdateConnectionOAuthClientRequestParameters(config []interface{}) *t
 	oAuthClientRequestParameters := &types.UpdateConnectionOAuthClientRequestParameters{}
 	for _, c := range config {
 		param := c.(map[string]interface{})
-		if val, ok := param[names.AttrClientID].(string); ok && val != "" {
-			oAuthClientRequestParameters.ClientID = aws.String(val)
+		if v, ok := param[names.AttrClientID].(string); ok && v != "" {
+			oAuthClientRequestParameters.ClientID = aws.String(v)
 		}
-		if val, ok := param[names.AttrClientSecret].(string); ok && val != "" {
-			oAuthClientRequestParameters.ClientSecret = aws.String(val)
+		if v, ok := param[names.AttrClientSecret].(string); ok && v != "" {
+			oAuthClientRequestParameters.ClientSecret = aws.String(v)
 		}
 	}
 	return oAuthClientRequestParameters


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Changes the location of the type assertion to `[]interface{}` on all expanders to prevent nil values from triggering a crash. Adjusts all expanders to check for nil items in an `[]interface{}` before asserting to `map[string]interface{}`.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35326
Closes #31671 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=events TESTS=TestAccEventsConnection_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsConnection_'  -timeout 360m

--- PASS: TestAccEventsConnection_disappears (14.70s)
--- PASS: TestAccEventsConnection_invocationHTTPParameters (31.96s)
--- PASS: TestAccEventsConnection_apiKey (33.89s)
--- PASS: TestAccEventsConnection_basic (33.99s)
--- PASS: TestAccEventsConnection_oAuth (72.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     77.993s
```

