### PR TITLE
Map Block Key fields should have meaningful names

### DIFF
--- a/.ci/semgrep/framework/map_block_key.go
+++ b/.ci/semgrep/framework/map_block_key.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+)
+
+func test1() {
+	// ruleid: map_block_key-meaningful-names
+	attributes := map[string]schema.Attribute{
+		"map_block_key": schema.StringAttribute{
+			Required: true,
+		},
+	}
+}
+
+func test2() {
+	// ok: map_block_key-meaningful-names
+	attributes := map[string]schema.Attribute{
+		"day_of_week": schema.StringAttribute{
+			Required: true,
+		},
+	}
+}

--- a/.ci/semgrep/framework/map_block_key.yml
+++ b/.ci/semgrep/framework/map_block_key.yml
@@ -1,0 +1,12 @@
+rules:
+  - id: map_block_key-meaningful-names
+    languages: [go]
+    message: Map Block Keys should have meaningful names
+    patterns:
+      - pattern: |
+          map[string]schema.Attribute{
+            ... ,
+            "map_block_key": schema.StringAttribute{ ... },
+            ... ,
+          }
+    severity: WARNING

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -59,7 +59,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - run: |
           semgrep $SEMGREP_ARGS \
-          --exclude .ci/semgrep/**/*.go \
           --config .ci/.semgrep.yml \
           --config .ci/.semgrep-constants.yml \
           --config .ci/.semgrep-test-constants.yml \

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -27,3 +27,6 @@ tests/
 
 # Semgrep-action log folder
 .semgrep_logs/
+
+# Our Semgrep rules folder
+.ci/semgrep/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -462,7 +462,6 @@ semgrep-all: semgrep-test semgrep-validate ## Run semgrep on all files
 	@echo "make: Running Semgrep checks locally (must have semgrep installed)..."
 	@semgrep $(SEMGREP_ARGS) \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
-		--exclude .ci/semgrep/**/*.go \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-constants.yml \
 		--config .ci/.semgrep-test-constants.yml \
@@ -485,7 +484,6 @@ semgrep-code-quality: semgrep-test semgrep-validate ## [CI] Semgrep Checks / Cod
 	@echo "make: Running Semgrep checks locally (must have semgrep installed)"
 	@semgrep $(SEMGREP_ARGS) \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
-		--exclude .ci/semgrep/**/*.go \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-constants.yml \
 		--config .ci/.semgrep-test-constants.yml \
@@ -514,7 +512,6 @@ semgrep-fix: semgrep-validate ## Fix Semgrep issues that have fixes
 	@echo "make: WARNING: This will not fix rules that don't have autofixes"
 	@semgrep $(SEMGREP_ARGS) --autofix \
 		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
-		--exclude .ci/semgrep/**/*.go \
 		--config .ci/.semgrep.yml \
 		--config .ci/.semgrep-constants.yml \
 		--config .ci/.semgrep-test-constants.yml \

--- a/internal/service/bedrockagent/agent_action_group.go
+++ b/internal/service/bedrockagent/agent_action_group.go
@@ -190,7 +190,7 @@ func (r *agentActionGroupResource) Schema(ctx context.Context, request resource.
 												names.AttrParameters: schema.SetNestedBlock{
 													CustomType: fwtypes.NewSetNestedObjectTypeOf[parameterDetailModel](ctx),
 													NestedObject: schema.NestedBlockObject{
-														Attributes: map[string]schema.Attribute{
+														Attributes: map[string]schema.Attribute{ // nosemgrep:ci.semgrep.framework.map_block_key-meaningful-names
 															names.AttrDescription: schema.StringAttribute{
 																Optional: true,
 																Validators: []validator.String{

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -257,7 +257,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 	slotValueOverrideLNB := schema.SetNestedBlock{
 		CustomType: fwtypes.NewSetNestedObjectTypeOf[SlotValueOverride](ctx),
 		NestedObject: schema.NestedBlockObject{
-			Attributes: map[string]schema.Attribute{
+			Attributes: map[string]schema.Attribute{ // nosemgrep:ci.semgrep.framework.map_block_key-meaningful-names
 				"map_block_key": schema.StringAttribute{
 					Required: true,
 				},
@@ -577,7 +577,7 @@ func (r *resourceIntent) Schema(ctx context.Context, req resource.SchemaRequest,
 		},
 		CustomType: fwtypes.NewSetNestedObjectTypeOf[PromptAttemptsSpecification](ctx),
 		NestedObject: schema.NestedBlockObject{
-			Attributes: map[string]schema.Attribute{
+			Attributes: map[string]schema.Attribute{ // nosemgrep:ci.semgrep.framework.map_block_key-meaningful-names
 				"map_block_key": schema.StringAttribute{
 					Required:   true,
 					CustomType: fwtypes.StringEnumType[PromptAttemptsType](),

--- a/internal/service/lexv2models/slot.go
+++ b/internal/service/lexv2models/slot.go
@@ -332,7 +332,7 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 	promptAttemptsSpecificationLNB := schema.SetNestedBlock{
 		CustomType: fwtypes.NewSetNestedObjectTypeOf[PromptAttemptsSpecification](ctx),
 		NestedObject: schema.NestedBlockObject{
-			Attributes: map[string]schema.Attribute{
+			Attributes: map[string]schema.Attribute{ // nosemgrep:ci.semgrep.framework.map_block_key-meaningful-names
 				"map_block_key": schema.StringAttribute{
 					Required:   true,
 					CustomType: fwtypes.StringEnumType[PromptAttemptsType](),
@@ -467,7 +467,7 @@ func (r *resourceSlot) Schema(ctx context.Context, req resource.SchemaRequest, r
 		},
 		CustomType: fwtypes.NewSetNestedObjectTypeOf[SlotSpecificationsData](ctx),
 		NestedObject: schema.NestedBlockObject{
-			Attributes: map[string]schema.Attribute{
+			Attributes: map[string]schema.Attribute{ // nosemgrep:ci.semgrep.framework.map_block_key-meaningful-names
 				"map_block_key": schema.StringAttribute{
 					Required: true,
 				},

--- a/internal/service/ssmcontacts/rotation.go
+++ b/internal/service/ssmcontacts/rotation.go
@@ -113,7 +113,7 @@ func (r *resourceRotation) Schema(ctx context.Context, request resource.SchemaRe
 								listplanmodifier.UseStateForUnknown(),
 							},
 							NestedObject: schema.NestedBlockObject{
-								Attributes: map[string]schema.Attribute{
+								Attributes: map[string]schema.Attribute{ // nosemgrep:ci.semgrep.framework.map_block_key-meaningful-names
 									"map_block_key": schema.StringAttribute{
 										CustomType: fwtypes.StringEnumType[awstypes.DayOfWeek](),
 										Required:   true,


### PR DESCRIPTION
### Description

While AutoFlex currently requires the struct field name of a Map Block Key to be `MapBlockKey`, the attribute name in the schema should be something meaningful rather than `map_block_key`. Adds a Semgrep rule to catch this and allows existing `map_block_key` attributes to ignore the rule.
