### PR TITLE
docs: set explicit ssl_policy in network load balancer example

### DIFF
--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -46,6 +46,7 @@ resource "aws_lb_listener" "front_end" {
   load_balancer_arn = aws_lb.front_end.arn
   port              = "443"
   protocol          = "TLS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
   certificate_arn   = "arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"
   alpn_policy       = "HTTP2Preferred"
 
@@ -262,7 +263,7 @@ The following arguments are optional:
 * `mutual_authentication` - (Optional) The mutual authentication configuration information. Detailed below.
 * `port` - (Optional) Port on which the load balancer is listening. Not valid for Gateway Load Balancers.
 * `protocol` - (Optional) Protocol for connections from clients to the load balancer. For Application Load Balancers, valid values are `HTTP` and `HTTPS`, with a default of `HTTP`. For Network Load Balancers, valid values are `TCP`, `TLS`, `UDP`, and `TCP_UDP`. Not valid to use `UDP` or `TCP_UDP` if dual-stack mode is enabled. Not valid for Gateway Load Balancers.
-* `ssl_policy` - (Optional) Name of the SSL Policy for the listener. Required if `protocol` is `HTTPS` or `TLS`.
+* `ssl_policy` - (Optional) Name of the SSL Policy for the listener. Used in combination with `HTTPS` or `TLS` value for `protocol`. Default is `ELBSecurityPolicy-2016-08`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ~> **NOTE::** Please note that listeners that are attached to Application Load Balancers must use either `HTTP` or `HTTPS` protocols while listeners that are attached to Network Load Balancers must use the `TCP` protocol.

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -263,7 +263,7 @@ The following arguments are optional:
 * `mutual_authentication` - (Optional) The mutual authentication configuration information. Detailed below.
 * `port` - (Optional) Port on which the load balancer is listening. Not valid for Gateway Load Balancers.
 * `protocol` - (Optional) Protocol for connections from clients to the load balancer. For Application Load Balancers, valid values are `HTTP` and `HTTPS`, with a default of `HTTP`. For Network Load Balancers, valid values are `TCP`, `TLS`, `UDP`, and `TCP_UDP`. Not valid to use `UDP` or `TCP_UDP` if dual-stack mode is enabled. Not valid for Gateway Load Balancers.
-* `ssl_policy` - (Optional) Name of the SSL Policy for the listener. Used in combination with `HTTPS` or `TLS` value for `protocol`. Default is `ELBSecurityPolicy-2016-08`.
+* `ssl_policy` - (Optional) Name of the SSL Policy for the listener. Required if `protocol` is `HTTPS` or `TLS`. Default is `ELBSecurityPolicy-2016-08`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ~> **NOTE::** Please note that listeners that are attached to Application Load Balancers must use either `HTTP` or `HTTPS` protocols while listeners that are attached to Network Load Balancers must use the `TCP` protocol.


### PR DESCRIPTION
### Description

- Make explicit use of `ssl_policy` in the NLB example available [here](https://registry.terraform.io/providers/hashicorp/aws/5.62.0/docs/resources/lb_listener#forward-action).

- In addition, the description for `ssl_policy` changes slightly. In the original version below statement can be found

  > Required if protocol is HTTPS or TLS.

  Actually one does not need to specify an SSL policy when using `TLS`/`HTTPS` protocol. Whenever it is missing, the default SSL policy will be used. Details on this can found [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#describe-ssl-policies).
  
  To test this behaviour this code snippet can be used

  ```hcl
  resource "aws_lb" "front_end" {
    name               = "test"
    internal           = true
    load_balancer_type = "network"
    subnets = ["subnet-<redacted>", "subnet-<redacted>"]
  }

  resource "aws_lb_target_group" "front_end" {
    port     = 443
    protocol = "TLS"
    vpc_id   = "vpc-<redacted>"
  }

  resource "aws_lb_listener" "front_end" {
    load_balancer_arn = aws_lb.front_end.arn
    port              = "443"
    protocol          = "TLS"
    certificate_arn   = "arn:aws:acm:eu-central-1:<redacted>:certificate/<redacted>"
    alpn_policy       = "HTTP2Preferred"
    # ssl_policy = "ELBSecurityPolicy-TLS13-1-2-2021-06"
    default_action {
      type             = "forward"
      target_group_arn = aws_lb_target_group.front_end.arn
    }
  }
  ```

### Relations

Closes #38715 

### References

- [Create TLS Listener](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html)

### Output from Acceptance Testing

Not applicable. Only documentation was updated.