### PR TITLE
Migrate `S3 on Outposts` resources to AWS SDK v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -296,6 +296,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.26.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.4 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -416,6 +416,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.58.3 h1:hT8ZAZRIfqBqHbzKTII+CIiY8G2oC
 github.com/aws/aws-sdk-go-v2/service/s3 v1.58.3/go.mod h1:Lcxzg5rojyVPU/0eFwLtcyTaek/6Mtic5B1gJo7e/zE=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.46.3 h1:3De8/YQpup0mLNKh0G9JHWJLEkWNdghd5z84vw4v+yw=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.46.3/go.mod h1:sUA7DOI2fdRHQQUpvRVfYKTo9P0+UAsWYBHvyqFHcC0=
+github.com/aws/aws-sdk-go-v2/service/s3outposts v1.26.3 h1:Hg1FVxD9pelFS8j3ilHJDUe6J/Q/VVwzWaNtN8vyNUQ=
+github.com/aws/aws-sdk-go-v2/service/s3outposts v1.26.3/go.mod h1:GVq0lM4BUD3GyiLzlNWXUq9U/H5t+2eytsEDirQSAn4=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.10.3 h1:gmpU7E0ntMzXr+yQQIXbiiueOewf/1BQ9WgeaXo6BcQ=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.10.3/go.mod h1:jnQp5kPPvEgPmVPm0h/XZPmlx7DQ0pqUiISRO4s6U3s=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.26.3 h1:ZJW2OQNpkR8P7URtISmF8twpvz2V0tUN/OgMenlxkao=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -185,6 +185,7 @@ import (
 	rum_sdkv2 "github.com/aws/aws-sdk-go-v2/service/rum"
 	s3_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	s3control_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3control"
+	s3outposts_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3outposts"
 	scheduler_sdkv2 "github.com/aws/aws-sdk-go-v2/service/scheduler"
 	schemas_sdkv2 "github.com/aws/aws-sdk-go-v2/service/schemas"
 	secretsmanager_sdkv2 "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
@@ -245,7 +246,6 @@ import (
 	redshiftserverless_sdkv1 "github.com/aws/aws-sdk-go/service/redshiftserverless"
 	route53recoverycontrolconfig_sdkv1 "github.com/aws/aws-sdk-go/service/route53recoverycontrolconfig"
 	route53resolver_sdkv1 "github.com/aws/aws-sdk-go/service/route53resolver"
-	s3outposts_sdkv1 "github.com/aws/aws-sdk-go/service/s3outposts"
 	sagemaker_sdkv1 "github.com/aws/aws-sdk-go/service/sagemaker"
 	simpledb_sdkv1 "github.com/aws/aws-sdk-go/service/simpledb"
 	worklink_sdkv1 "github.com/aws/aws-sdk-go/service/worklink"
@@ -1057,8 +1057,8 @@ func (c *AWSClient) S3ControlClient(ctx context.Context) *s3control_sdkv2.Client
 	return errs.Must(client[*s3control_sdkv2.Client](ctx, c, names.S3Control, make(map[string]any)))
 }
 
-func (c *AWSClient) S3OutpostsConn(ctx context.Context) *s3outposts_sdkv1.S3Outposts {
-	return errs.Must(conn[*s3outposts_sdkv1.S3Outposts](ctx, c, names.S3Outposts, make(map[string]any)))
+func (c *AWSClient) S3OutpostsClient(ctx context.Context) *s3outposts_sdkv2.Client {
+	return errs.Must(client[*s3outposts_sdkv2.Client](ctx, c, names.S3Outposts, make(map[string]any)))
 }
 
 func (c *AWSClient) SESClient(ctx context.Context) *ses_sdkv2.Client {

--- a/internal/service/s3outposts/endpoint.go
+++ b/internal/service/s3outposts/endpoint.go
@@ -10,21 +10,24 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/service/s3outposts"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/s3outposts"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/s3outposts/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3outposts_endpoint")
-func ResourceEndpoint() *schema.Resource {
+// @SDKResource("aws_s3outposts_endpoint", name="Endpoint")
+func resourceEndpoint() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEndpointCreate,
 		ReadWithoutTimeout:   resourceEndpointRead,
@@ -36,11 +39,11 @@ func ResourceEndpoint() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"access_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(s3outposts.EndpointAccessType_Values(), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.EndpointAccessType](),
 			},
 			names.AttrARN: {
 				Type:     schema.TypeString,
@@ -96,7 +99,7 @@ func ResourceEndpoint() *schema.Resource {
 
 func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3OutpostsConn(ctx)
+	conn := meta.(*conns.AWSClient).S3OutpostsClient(ctx)
 
 	input := &s3outposts.CreateEndpointInput{
 		OutpostId:       aws.String(d.Get("outpost_id").(string)),
@@ -105,20 +108,20 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("access_type"); ok {
-		input.AccessType = aws.String(v.(string))
+		input.AccessType = awstypes.EndpointAccessType(v.(string))
 	}
 
 	if v, ok := d.GetOk("customer_owned_ipv4_pool"); ok {
 		input.CustomerOwnedIpv4Pool = aws.String(v.(string))
 	}
 
-	output, err := conn.CreateEndpointWithContext(ctx, input)
+	output, err := conn.CreateEndpoint(ctx, input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating S3 Outposts Endpoint: %s", err)
 	}
 
-	d.SetId(aws.StringValue(output.EndpointArn))
+	d.SetId(aws.ToString(output.EndpointArn))
 
 	if _, err := waitEndpointStatusCreated(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for S3 Outposts Endpoint (%s) create: %s", d.Id(), err)
@@ -129,9 +132,9 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3OutpostsConn(ctx)
+	conn := meta.(*conns.AWSClient).S3OutpostsClient(ctx)
 
-	endpoint, err := FindEndpointByARN(ctx, conn, d.Id())
+	endpoint, err := findEndpointByARN(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] S3 Outposts Endpoint %s not found, removing from state", d.Id())
@@ -147,7 +150,7 @@ func resourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set(names.AttrARN, endpoint.EndpointArn)
 	d.Set(names.AttrCIDRBlock, endpoint.CidrBlock)
 	if endpoint.CreationTime != nil {
-		d.Set(names.AttrCreationTime, aws.TimeValue(endpoint.CreationTime).Format(time.RFC3339))
+		d.Set(names.AttrCreationTime, aws.ToTime(endpoint.CreationTime).Format(time.RFC3339))
 	}
 	d.Set("customer_owned_ipv4_pool", endpoint.CustomerOwnedIpv4Pool)
 	if err := d.Set("network_interfaces", flattenNetworkInterfaces(endpoint.NetworkInterfaces)); err != nil {
@@ -160,7 +163,7 @@ func resourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3OutpostsConn(ctx)
+	conn := meta.(*conns.AWSClient).S3OutpostsClient(ctx)
 
 	parsedArn, err := arn.Parse(d.Id())
 
@@ -176,7 +179,7 @@ func resourceEndpointDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[DEBUG] Deleting S3 Outposts Endpoint: %s", d.Id())
-	_, err = conn.DeleteEndpointWithContext(ctx, &s3outposts.DeleteEndpointInput{
+	_, err = conn.DeleteEndpoint(ctx, &s3outposts.DeleteEndpointInput{
 		EndpointId: aws.String(arnResourceParts[3]),
 		OutpostId:  aws.String(arnResourceParts[1]),
 	})
@@ -206,7 +209,7 @@ func resourceEndpointImportState(ctx context.Context, d *schema.ResourceData, me
 	return []*schema.ResourceData{d}, nil
 }
 
-func FindEndpointByARN(ctx context.Context, conn *s3outposts.S3Outposts, arn string) (*s3outposts.Endpoint, error) {
+func findEndpointByARN(ctx context.Context, conn *s3outposts.Client, arn string) (*awstypes.Endpoint, error) {
 	input := &s3outposts.ListEndpointsInput{}
 
 	output, err := findEndpoints(ctx, conn, input)
@@ -216,41 +219,41 @@ func FindEndpointByARN(ctx context.Context, conn *s3outposts.S3Outposts, arn str
 	}
 
 	for _, v := range output {
-		if aws.StringValue(v.EndpointArn) == arn && aws.StringValue(v.Status) != s3outposts.EndpointStatusDeleting && aws.StringValue(v.Status) != s3outposts.EndpointStatusDeleteFailed {
-			return v, nil
+		if aws.ToString(v.EndpointArn) == arn && v.Status != awstypes.EndpointStatusDeleting && v.Status != awstypes.EndpointStatusDeleteFailed {
+			return &v, nil
 		}
 	}
 
-	return nil, &retry.NotFoundError{}
+	return nil, tfresource.NewEmptyResultError(input)
 }
 
-func findEndpoints(ctx context.Context, conn *s3outposts.S3Outposts, input *s3outposts.ListEndpointsInput) ([]*s3outposts.Endpoint, error) {
-	var output []*s3outposts.Endpoint
+func findEndpoints(ctx context.Context, conn *s3outposts.Client, input *s3outposts.ListEndpointsInput) ([]awstypes.Endpoint, error) {
+	var output []awstypes.Endpoint
 
-	err := conn.ListEndpointsPagesWithContext(ctx, input, func(page *s3outposts.ListEndpointsOutput, lastPage bool) bool {
-		if page == nil {
-			return !lastPage
-		}
+	pages := s3outposts.NewListEndpointsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
 
-		for _, v := range page.Endpoints {
-			if v != nil {
-				output = append(output, v)
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: input,
 			}
 		}
 
-		return !lastPage
-	})
+		if err != nil {
+			return nil, err
+		}
 
-	if err != nil {
-		return nil, err
+		output = append(output, page.Endpoints...)
 	}
 
 	return output, nil
 }
 
-func statusEndpoint(ctx context.Context, conn *s3outposts.S3Outposts, arn string) retry.StateRefreshFunc {
+func statusEndpoint(ctx context.Context, conn *s3outposts.Client, arn string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		output, err := FindEndpointByARN(ctx, conn, arn)
+		output, err := findEndpointByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil
@@ -260,26 +263,26 @@ func statusEndpoint(ctx context.Context, conn *s3outposts.S3Outposts, arn string
 			return nil, "", err
 		}
 
-		return output, aws.StringValue(output.Status), nil
+		return output, string(output.Status), nil
 	}
 }
 
-func waitEndpointStatusCreated(ctx context.Context, conn *s3outposts.S3Outposts, arn string) (*s3outposts.Endpoint, error) {
+func waitEndpointStatusCreated(ctx context.Context, conn *s3outposts.Client, arn string) (*awstypes.Endpoint, error) {
 	const (
 		timeout = 20 * time.Minute
 	)
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{s3outposts.EndpointStatusPending},
-		Target:  []string{s3outposts.EndpointStatusAvailable},
+		Pending: enum.Slice(awstypes.EndpointStatusPending),
+		Target:  enum.Slice(awstypes.EndpointStatusAvailable),
 		Refresh: statusEndpoint(ctx, conn, arn),
 		Timeout: timeout,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	if output, ok := outputRaw.(*s3outposts.Endpoint); ok {
+	if output, ok := outputRaw.(*awstypes.Endpoint); ok {
 		if failedReason := output.FailedReason; failedReason != nil {
-			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.StringValue(failedReason.ErrorCode), aws.StringValue(failedReason.Message)))
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.ToString(failedReason.ErrorCode), aws.ToString(failedReason.Message)))
 		}
 
 		return output, err
@@ -288,29 +291,21 @@ func waitEndpointStatusCreated(ctx context.Context, conn *s3outposts.S3Outposts,
 	return nil, err
 }
 
-func flattenNetworkInterfaces(apiObjects []*s3outposts.NetworkInterface) []interface{} {
+func flattenNetworkInterfaces(apiObjects []awstypes.NetworkInterface) []interface{} {
 	var tfList []interface{}
 
 	for _, apiObject := range apiObjects {
-		if apiObject == nil {
-			continue
-		}
-
 		tfList = append(tfList, flattenNetworkInterface(apiObject))
 	}
 
 	return tfList
 }
 
-func flattenNetworkInterface(apiObject *s3outposts.NetworkInterface) map[string]interface{} {
-	if apiObject == nil {
-		return nil
-	}
-
+func flattenNetworkInterface(apiObject awstypes.NetworkInterface) map[string]interface{} {
 	tfMap := map[string]interface{}{}
 
 	if v := apiObject.NetworkInterfaceId; v != nil {
-		tfMap[names.AttrNetworkInterfaceID] = aws.StringValue(v)
+		tfMap[names.AttrNetworkInterfaceID] = aws.ToString(v)
 	}
 
 	return tfMap

--- a/internal/service/s3outposts/endpoint_test.go
+++ b/internal/service/s3outposts/endpoint_test.go
@@ -154,7 +154,7 @@ func TestAccS3OutpostsEndpoint_disappears(t *testing.T) {
 
 func testAccCheckEndpointDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).S3OutpostsConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3OutpostsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_s3outposts_endpoint" {
@@ -188,7 +188,7 @@ func testAccCheckEndpointExists(ctx context.Context, n string) resource.TestChec
 			return fmt.Errorf("No S3 Outposts Endpoint ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).S3OutpostsConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3OutpostsClient(ctx)
 
 		_, err := tfs3outposts.FindEndpointByARN(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/s3outposts/exports_test.go
+++ b/internal/service/s3outposts/exports_test.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package s3outposts
+
+// Exports for use in tests only.
+var (
+	FindEndpointByARN = findEndpointByARN
+
+	ResourceEndpoint = resourceEndpoint
+)

--- a/internal/service/s3outposts/service_endpoint_resolver_gen.go
+++ b/internal/service/s3outposts/service_endpoint_resolver_gen.go
@@ -6,65 +6,63 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 
-	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	s3outposts_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3outposts"
+	smithyendpoints "github.com/aws/smithy-go/endpoints"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 )
 
-var _ endpoints_sdkv1.Resolver = resolverSDKv1{}
+var _ s3outposts_sdkv2.EndpointResolverV2 = resolverSDKv2{}
 
-type resolverSDKv1 struct {
-	ctx context.Context
+type resolverSDKv2 struct {
+	defaultResolver s3outposts_sdkv2.EndpointResolverV2
 }
 
-func newEndpointResolverSDKv1(ctx context.Context) resolverSDKv1 {
-	return resolverSDKv1{
-		ctx: ctx,
+func newEndpointResolverSDKv2() resolverSDKv2 {
+	return resolverSDKv2{
+		defaultResolver: s3outposts_sdkv2.NewDefaultEndpointResolverV2(),
 	}
 }
 
-func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoints_sdkv1.Options)) (endpoint endpoints_sdkv1.ResolvedEndpoint, err error) {
-	ctx := r.ctx
+func (r resolverSDKv2) ResolveEndpoint(ctx context.Context, params s3outposts_sdkv2.EndpointParameters) (endpoint smithyendpoints.Endpoint, err error) {
+	params = params.WithDefaults()
+	useFIPS := aws_sdkv2.ToBool(params.UseFIPS)
 
-	var opt endpoints_sdkv1.Options
-	opt.Set(opts...)
+	if eps := params.Endpoint; aws_sdkv2.ToString(eps) != "" {
+		tflog.Debug(ctx, "setting endpoint", map[string]any{
+			"tf_aws.endpoint": endpoint,
+		})
 
-	useFIPS := opt.UseFIPSEndpoint == endpoints_sdkv1.FIPSEndpointStateEnabled
+		if useFIPS {
+			tflog.Debug(ctx, "endpoint set, ignoring UseFIPSEndpoint setting")
+			params.UseFIPS = aws_sdkv2.Bool(false)
+		}
 
-	defaultResolver := endpoints_sdkv1.DefaultResolver()
-
-	if useFIPS {
+		return r.defaultResolver.ResolveEndpoint(ctx, params)
+	} else if useFIPS {
 		ctx = tflog.SetField(ctx, "tf_aws.use_fips", useFIPS)
 
-		endpoint, err = defaultResolver.EndpointFor(service, region, opts...)
+		endpoint, err = r.defaultResolver.ResolveEndpoint(ctx, params)
 		if err != nil {
 			return endpoint, err
 		}
 
 		tflog.Debug(ctx, "endpoint resolved", map[string]any{
-			"tf_aws.endpoint": endpoint.URL,
+			"tf_aws.endpoint": endpoint.URI.String(),
 		})
 
-		var endpointURL *url.URL
-		endpointURL, err = url.Parse(endpoint.URL)
-		if err != nil {
-			return endpoint, err
-		}
-
-		hostname := endpointURL.Hostname()
+		hostname := endpoint.URI.Hostname()
 		_, err = net.LookupHost(hostname)
 		if err != nil {
 			if dnsErr, ok := errs.As[*net.DNSError](err); ok && dnsErr.IsNotFound {
 				tflog.Debug(ctx, "default endpoint host not found, disabling FIPS", map[string]any{
 					"tf_aws.hostname": hostname,
 				})
-				opts = append(opts, func(o *endpoints_sdkv1.Options) {
-					o.UseFIPSEndpoint = endpoints_sdkv1.FIPSEndpointStateDisabled
-				})
+				params.UseFIPS = aws_sdkv2.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up accessanalyzer endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up s3outposts endpoint %q: %s", hostname, err)
 				return
 			}
 		} else {
@@ -72,5 +70,13 @@ func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoin
 		}
 	}
 
-	return defaultResolver.EndpointFor(service, region, opts...)
+	return r.defaultResolver.ResolveEndpoint(ctx, params)
+}
+
+func withBaseEndpoint(endpoint string) func(*s3outposts_sdkv2.Options) {
+	return func(o *s3outposts_sdkv2.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}
 }

--- a/internal/service/s3outposts/service_endpoints_gen_test.go
+++ b/internal/service/s3outposts/service_endpoints_gen_test.go
@@ -4,18 +4,22 @@ package s3outposts_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	s3outposts_sdkv1 "github.com/aws/aws-sdk-go/service/s3outposts"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	s3outposts_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3outposts"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -240,54 +244,63 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 }
 
 func defaultEndpoint(region string) (url.URL, error) {
-	r := endpoints.DefaultResolver()
+	r := s3outposts_sdkv2.NewDefaultEndpointResolverV2()
 
-	ep, err := r.EndpointFor(s3outposts_sdkv1.EndpointsID, region)
-	if err != nil {
-		return url.URL{}, err
-	}
-
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
-	}
-
-	return *url, nil
-}
-
-func defaultFIPSEndpoint(region string) (url.URL, error) {
-	r := endpoints.DefaultResolver()
-
-	ep, err := r.EndpointFor(s3outposts_sdkv1.EndpointsID, region, func(opt *endpoints.Options) {
-		opt.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	ep, err := r.ResolveEndpoint(context.Background(), s3outposts_sdkv2.EndpointParameters{
+		Region: aws_sdkv2.String(region),
 	})
 	if err != nil {
 		return url.URL{}, err
 	}
 
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
 	}
 
-	return *url, nil
+	return ep.URI, nil
+}
+
+func defaultFIPSEndpoint(region string) (url.URL, error) {
+	r := s3outposts_sdkv2.NewDefaultEndpointResolverV2()
+
+	ep, err := r.ResolveEndpoint(context.Background(), s3outposts_sdkv2.EndpointParameters{
+		Region:  aws_sdkv2.String(region),
+		UseFIPS: aws_sdkv2.Bool(true),
+	})
+	if err != nil {
+		return url.URL{}, err
+	}
+
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
+	}
+
+	return ep.URI, nil
 }
 
 func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCallParams {
 	t.Helper()
 
-	client := meta.S3OutpostsConn(ctx)
+	client := meta.S3OutpostsClient(ctx)
 
-	req, _ := client.ListEndpointsRequest(&s3outposts_sdkv1.ListEndpointsInput{})
+	var result apiCallParams
 
-	req.HTTPRequest.URL.Path = "/"
-
-	return apiCallParams{
-		endpoint: req.HTTPRequest.URL.String(),
-		region:   aws_sdkv1.StringValue(client.Config.Region),
+	_, err := client.ListEndpoints(ctx, &s3outposts_sdkv2.ListEndpointsInput{},
+		func(opts *s3outposts_sdkv2.Options) {
+			opts.APIOptions = append(opts.APIOptions,
+				addRetrieveEndpointURLMiddleware(t, &result.endpoint),
+				addRetrieveRegionMiddleware(&result.region),
+				addCancelRequestMiddleware(),
+			)
+		},
+	)
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	} else if !errors.Is(err, errCancelOperation) {
+		t.Fatalf("Unexpected error: %s", err)
 	}
+
+	return result
 }
 
 func withNoConfig(_ *caseSetup) {
@@ -464,6 +477,89 @@ func testEndpointCase(t *testing.T, region string, testcase endpointTestCase, ca
 	if e, a := testcase.expected.region, callParams.region; e != a {
 		t.Errorf("expected region %q, got %q", e, a)
 	}
+}
+
+func addRetrieveEndpointURLMiddleware(t *testing.T, endpoint *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			retrieveEndpointURLMiddleware(t, endpoint),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveEndpointURLMiddleware(t *testing.T, endpoint *string) middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Retrieve Endpoint",
+		func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			t.Helper()
+
+			request, ok := in.Request.(*smithyhttp.Request)
+			if !ok {
+				t.Fatalf("Expected *github.com/aws/smithy-go/transport/http.Request, got %s", fullTypeName(in.Request))
+			}
+
+			url := request.URL
+			url.RawQuery = ""
+			url.Path = "/"
+
+			*endpoint = url.String()
+
+			return next.HandleFinalize(ctx, in)
+		})
+}
+
+func addRetrieveRegionMiddleware(region *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Serialize.Add(
+			retrieveRegionMiddleware(region),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
+	return middleware.SerializeMiddlewareFunc(
+		"Test: Retrieve Region",
+		func(ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler) (middleware.SerializeOutput, middleware.Metadata, error) {
+			*region = awsmiddleware.GetRegion(ctx)
+
+			return next.HandleSerialize(ctx, in)
+		},
+	)
+}
+
+var errCancelOperation = fmt.Errorf("Test: Canceling request")
+
+func addCancelRequestMiddleware() func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			cancelRequestMiddleware(),
+			middleware.After,
+		)
+	}
+}
+
+// cancelRequestMiddleware creates a Smithy middleware that intercepts the request before sending and cancels it
+func cancelRequestMiddleware() middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Cancel Requests",
+		func(_ context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, errCancelOperation
+		})
+}
+
+func fullTypeName(i interface{}) string {
+	return fullValueTypeName(reflect.ValueOf(i))
+}
+
+func fullValueTypeName(v reflect.Value) string {
+	if v.Kind() == reflect.Ptr {
+		return "*" + fullValueTypeName(reflect.Indirect(v))
+	}
+
+	requestType := v.Type()
+	return fmt.Sprintf("%s.%s", requestType.PkgPath(), requestType.Name())
 }
 
 func generateSharedConfigFile(config configFile) string {

--- a/internal/service/s3outposts/service_package_gen.go
+++ b/internal/service/s3outposts/service_package_gen.go
@@ -5,10 +5,8 @@ package s3outposts
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	s3outposts_sdkv1 "github.com/aws/aws-sdk-go/service/s3outposts"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	s3outposts_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3outposts"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -31,8 +29,9 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceEndpoint,
+			Factory:  resourceEndpoint,
 			TypeName: "aws_s3outposts_endpoint",
+			Name:     "Endpoint",
 		},
 	}
 }
@@ -41,22 +40,14 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.S3Outposts
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*s3outposts_sdkv1.S3Outposts, error) {
-	sess := config[names.AttrSession].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*s3outposts_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	cfg := aws_sdkv1.Config{}
-
-	if endpoint := config[names.AttrEndpoint].(string); endpoint != "" {
-		tflog.Debug(ctx, "setting endpoint", map[string]any{
-			"tf_aws.endpoint": endpoint,
-		})
-		cfg.Endpoint = aws_sdkv1.String(endpoint)
-	} else {
-		cfg.EndpointResolver = newEndpointResolverSDKv1(ctx)
-	}
-
-	return s3outposts_sdkv1.New(sess.Copy(&cfg)), nil
+	return s3outposts_sdkv2.NewFromConfig(cfg,
+		s3outposts_sdkv2.WithEndpointResolverV2(newEndpointResolverSDKv2()),
+		withBaseEndpoint(config[names.AttrEndpoint].(string)),
+	), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/names/data/names_data.hcl
+++ b/names/data/names_data.hcl
@@ -7985,7 +7985,7 @@ service "s3outposts" {
 
   sdk {
     id             = "S3Outposts"
-    client_version = [1]
+    client_version = [2]
   }
 
   names {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR migrates the `S3 on Outposts` resource to AWS SDKv2.

Unfortunately I am not able to test this as I don't have an Outpost instance, most likely going to need the same as in PR https://github.com/hashicorp/terraform-provider-aws/pull/38075

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/36207
Relates https://github.com/hashicorp/terraform-provider-aws/issues/32976

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAcc' PKG=s3outposts
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/s3outposts/... -v -count 1 -parallel 20  -run=TestAcc -timeout 360m
=== RUN   TestAccS3OutpostsEndpoint_basic
=== PAUSE TestAccS3OutpostsEndpoint_basic
=== RUN   TestAccS3OutpostsEndpoint_private
=== PAUSE TestAccS3OutpostsEndpoint_private
=== RUN   TestAccS3OutpostsEndpoint_customerOwnedIPv4Pool
=== PAUSE TestAccS3OutpostsEndpoint_customerOwnedIPv4Pool
=== RUN   TestAccS3OutpostsEndpoint_disappears
=== PAUSE TestAccS3OutpostsEndpoint_disappears
=== CONT  TestAccS3OutpostsEndpoint_basic
=== CONT  TestAccS3OutpostsEndpoint_customerOwnedIPv4Pool
=== CONT  TestAccS3OutpostsEndpoint_disappears
=== CONT  TestAccS3OutpostsEndpoint_private
=== NAME  TestAccS3OutpostsEndpoint_customerOwnedIPv4Pool
    endpoint_test.go:101: skipping since no Outposts found
--- SKIP: TestAccS3OutpostsEndpoint_customerOwnedIPv4Pool (1.31s)
=== NAME  TestAccS3OutpostsEndpoint_disappears
    endpoint_test.go:138: skipping since no Outposts found
--- SKIP: TestAccS3OutpostsEndpoint_disappears (1.31s)
=== NAME  TestAccS3OutpostsEndpoint_basic
    endpoint_test.go:29: skipping since no Outposts found
--- SKIP: TestAccS3OutpostsEndpoint_basic (1.36s)
=== NAME  TestAccS3OutpostsEndpoint_private
    endpoint_test.go:65: skipping since no Outposts found
--- SKIP: TestAccS3OutpostsEndpoint_private (1.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3outposts 6.120s
```
