### PR TITLE
r/aws_redshift_cluster: set encrypted value on restore

### DIFF
--- a/.changelog/38828.txt
+++ b/.changelog/38828.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshift_cluster: Set `encrypted` on snapshot restore, when enabled
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -488,6 +488,11 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		inputC.ElasticIp = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk(names.AttrEncrypted); ok {
+		inputC.Encrypted = aws.Bool(v.(bool))
+		inputR.Encrypted = aws.Bool(v.(bool))
+	}
+
 	if v, ok := d.GetOk("enhanced_vpc_routing"); ok {
 		inputR.EnhancedVpcRouting = aws.Bool(v.(bool))
 		inputC.EnhancedVpcRouting = aws.Bool(v.(bool))
@@ -580,10 +585,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if _, ok := d.GetOk("master_username"); !ok {
 			return sdkdiag.AppendErrorf(diags, `provider.aws: aws_redshift_cluster: %s: "master_username": required field is not set`, d.Get(names.AttrClusterIdentifier).(string))
-		}
-
-		if v, ok := d.GetOk(names.AttrEncrypted); ok {
-			inputC.Encrypted = aws.Bool(v.(bool))
 		}
 
 		if v := d.Get("number_of_nodes").(int); v > 1 {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #38827

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccRedshiftCluster_restoreFromSnapshot\|TestAccRedshiftCluster_basic\|TestAccRedshiftCluster_disappears" PKG=redshift

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/redshift/... -v -count 1 -parallel 20  -run=TestAccRedshiftCluster_restoreFromSnapshot\|TestAccRedshiftCluster_basic\|TestAccRedshiftCluster_disappears -timeout 360m
--- PASS: TestAccRedshiftCluster_basic (160.04s)
--- PASS: TestAccRedshiftCluster_disappears (165.32s)
--- PASS: TestAccRedshiftCluster_restoreFromSnapshotARN (490.19s)
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot (628.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	634.998s
```

```console
% make testacc TESTARGS="-run=TestAccRedshiftCluster_changeEncryption1\|TestAccRedshiftCluster_changeEncryption2" PKG=redshift

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/redshift/... -v -count 1 -parallel 20  -run=TestAccRedshiftCluster_changeEncryption1\|TestAccRedshiftCluster_changeEncryption2 -timeout 360m
--- PASS: TestAccRedshiftCluster_changeEncryption1 (764.45s)
--- PASS: TestAccRedshiftCluster_changeEncryption2 (890.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	896.214s
```
