### PR TITLE
AutoFlex: No longer log error when flattening `nil` primitive

### DIFF
--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -83,13 +83,13 @@ func autoFlattenConvert(ctx context.Context, from, to any, flexer autoFlexer) di
 	ctx = tflog.SubsystemSetField(ctx, subsystemName, logAttrKeySourcePath, sourcePath.String())
 	ctx = tflog.SubsystemSetField(ctx, subsystemName, logAttrKeyTargetPath, targetPath.String())
 
+	ctx = tflog.SubsystemSetField(ctx, subsystemName, logAttrKeySourceType, fullTypeName(reflect.TypeOf(from)))
+	ctx = tflog.SubsystemSetField(ctx, subsystemName, logAttrKeyTargetType, fullTypeName(reflect.TypeOf(to)))
+
 	if _, ok := to.(attr.Value); !ok {
 		vf := reflect.ValueOf(from)
 		if vf.Kind() == reflect.Invalid || vf.Kind() == reflect.Pointer && vf.IsNil() {
-			tflog.SubsystemError(ctx, subsystemName, "Source is nil", map[string]any{
-				logAttrKeySourceType: fullTypeName(reflect.TypeOf(from)),
-				logAttrKeyTargetType: fullTypeName(reflect.TypeOf(to)),
-			})
+			tflog.SubsystemError(ctx, subsystemName, "Source is nil")
 			diags.Append(diagFlatteningSourceIsNil(reflect.TypeOf(from)))
 			return diags
 		}

--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -86,18 +86,21 @@ func autoFlexConvertStruct(ctx context.Context, sourcePath path.Path, from any, 
 		return diags
 	}
 
+	// TODO: this only applies when Expanding
 	if fromExpander, ok := valFrom.Interface().(Expander); ok {
 		tflog.SubsystemInfo(ctx, subsystemName, "Source implements flex.Expander")
 		diags.Append(expandExpander(ctx, fromExpander, valTo)...)
 		return diags
 	}
 
+	// TODO: this only applies when Expanding
 	if fromTypedExpander, ok := valFrom.Interface().(TypedExpander); ok {
 		tflog.SubsystemInfo(ctx, subsystemName, "Source implements flex.TypedExpander")
 		diags.Append(expandTypedExpander(ctx, fromTypedExpander, valTo)...)
 		return diags
 	}
 
+	// TODO: this only applies when Expanding
 	if valTo.Kind() == reflect.Interface {
 		tflog.SubsystemError(ctx, subsystemName, "AutoFlex Expand; incompatible types", map[string]any{
 			"from": valFrom.Type(),
@@ -106,6 +109,7 @@ func autoFlexConvertStruct(ctx context.Context, sourcePath path.Path, from any, 
 		return diags
 	}
 
+	// TODO: this only applies when Flattening
 	if toFlattener, ok := to.(Flattener); ok {
 		tflog.SubsystemInfo(ctx, subsystemName, "Source implements flex.Flattener")
 		diags.Append(flattenFlattener(ctx, valFrom, toFlattener)...)


### PR DESCRIPTION
### Description

Fixes error when flattening `nil` primitive values

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38830
