### PR TITLE
f: add enable_private_gua argument to aws_vpc_ipam resource

### DIFF
--- a/.changelog/38838.txt
+++ b/.changelog/38838.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_vpc_ipam: Added `enable_private_gua` argument on aws_vpc_ipam resource.
+```

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.11.3
 	github.com/aws/aws-sdk-go-v2/service/drs v1.28.3
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.34.4
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.174.0
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.175.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.25.3
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.44.3

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/aws/aws-sdk-go-v2/service/dynamodb v1.34.4 h1:utG3S4T+X7nONPIpRoi1tVc
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.34.4/go.mod h1:q9vzW3Xr1KEXa8n4waHiFt1PrppNDlMymlYP+xpsFbY=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.174.0 h1:xY25etxTt0mYfWVWv8DjIUcJQyX2cwBeInpIvg6Sbsw=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.174.0/go.mod h1:o6QDjdVKpP5EF0dp/VlvqckzuSDATr1rLdHt3A5m0YY=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.175.0 h1:t8ACYzijrk828orkkmk0GT+RQnB1sQ7tXBIFq58yG0M=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.175.0/go.mod h1:o6QDjdVKpP5EF0dp/VlvqckzuSDATr1rLdHt3A5m0YY=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.32.0 h1:lZoKOTEQUf5Oi9qVaZM/Hb0Z6SHIwwpDjbLFOVgB2t8=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.32.0/go.mod h1:RhaP7Wil0+uuuhiE4FzOOEFZwkmFAk1ZflXzK+O3ptU=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.25.3 h1:n2eqzO9VabUkd77b88Hos6OEtbGohB/TRrtXLTZi38Y=
@@ -408,10 +410,10 @@ github.com/aws/aws-sdk-go-v2/service/route53domains v1.25.3 h1:VGLIgiClxmwxBpGzH
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.25.3/go.mod h1:Kgq5O7ZaDk0mTZmX6YCL+ZtZ1YcJHtGsVubp0OT77MA=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.2.3 h1:N4f5sliNiWcp3abC+8YpcaVjXuaNJIlz/dBd+saimm0=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.2.3/go.mod h1:r2B4BvTn3zSMK+BFHGl0q63B/nJMOk9/NukLZzqO8sY=
-github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.19.3 h1:M6D+IRT6YdeL+qLIdy4u4zEoMOqq3lJnNUGt0cxEI04=
-github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.19.3/go.mod h1:y4m7VlTWV77mBzMdAZWjudnobe0E77tKy5Z9+IQIku0=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.23.3 h1:apYav6exfbLJ+kRGPa27GTrUuCS4ctI0mJEeiDxSeDE=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.23.3/go.mod h1:citOcziml/EM6I2ycb7XHuBw0whC8jVD2y+vU7wQD4k=
+github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.19.3 h1:M6D+IRT6YdeL+qLIdy4u4zEoMOqq3lJnNUGt0cxEI04=
+github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.19.3/go.mod h1:y4m7VlTWV77mBzMdAZWjudnobe0E77tKy5Z9+IQIku0=
 github.com/aws/aws-sdk-go-v2/service/rum v1.19.3 h1:DR+GYJRPL7eEZknnGdwm+lH686LmUBB/X2YVQDHLNY4=
 github.com/aws/aws-sdk-go-v2/service/rum v1.19.3/go.mod h1:5jFxbuc05P/+BbJvVbBspMbzDR2IFU0LegQG3iUvj8g=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.58.3 h1:hT8ZAZRIfqBqHbzKTII+CIiY8G2oC9OpLedkZ51DWl8=

--- a/internal/service/ec2/ipam_.go
+++ b/internal/service/ec2/ipam_.go
@@ -63,6 +63,10 @@ func resourceIPAM() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"enable_private_gua": {
+				Type: 		schema.TypeBool,
+				Optional: true,
+			},
 			names.AttrDescription: {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -141,6 +145,10 @@ func resourceIPAMCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		input.Tier = awstypes.IpamTier(v.(string))
 	}
 
+	if v, ok := d.GetOk("enable_private_gua"); ok {
+		input.EnablePrivateGua = aws.Bool(v.(bool))
+	}
+
 	output, err := conn.CreateIpam(ctx, input)
 
 	if err != nil {
@@ -183,6 +191,7 @@ func resourceIPAMRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("private_default_scope_id", ipam.PrivateDefaultScopeId)
 	d.Set("scope_count", ipam.ScopeCount)
 	d.Set("tier", ipam.Tier)
+	d.Set("enable_private_gua", ipam.EnablePrivateGua)
 
 	setTagsOut(ctx, ipam.Tags)
 
@@ -227,6 +236,10 @@ func resourceIPAMUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 
 		if d.HasChange("tier") {
 			input.Tier = awstypes.IpamTier(d.Get("tier").(string))
+		}
+
+		if d.HasChange("enable_private_gua") {
+			input.EnablePrivateGua = aws.Bool(d.Get("enable_private_gua").(bool))
 		}
 
 		_, err := conn.ModifyIpam(ctx, input)

--- a/website/docs/r/vpc_ipam.html.markdown
+++ b/website/docs/r/vpc_ipam.html.markdown
@@ -61,8 +61,9 @@ This resource supports the following arguments:
 
 * `cascade` - (Optional) Enables you to quickly delete an IPAM, private scopes, pools in private scopes, and any allocations in the pools in private scopes.
 * `description` - (Optional) A description for the IPAM.
+* `enable_private_ipam` - (Optional) Enables the IPAM the ability to provision private IPv6 GUA space for its IPAM pools. 
 * `operating_regions` - (Required) Determines which locales can be chosen when you create pools. Locale is the Region where you want to make an IPAM pool available for allocations. You can only create pools with locales that match the operating Regions of the IPAM. You can only create VPCs from a pool whose locale matches the VPC's Region. You specify a region using the [region_name](#operating_regions) parameter. You **must** set your provider block region as an operating_region.
-* `tier` - (Optional) specifies the IPAM tier. Valid options include `free` and `advanced`. Default is `advanced`.
+* `tier` - (Optional) Specifies the IPAM tier. Valid options include `free` and `advanced`. Default is `advanced`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### operating_regions


### PR DESCRIPTION

### Description
Add tier argument to aws_vpc_ipam resource

### Relations

### References

### Output from Acceptance Testing
```
go test -timeout 100s -run ^TestAccIPAM_enablePrivateGua$ github.com/hashicorp/terraform-provider-aws/internal/service/ec2
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2  44.929s
```