### PR TITLE
td/ebs_default_kms_key: run as serial test

### DIFF
--- a/internal/service/ec2/ebs_default_kms_key_data_source_test.go
+++ b/internal/service/ec2/ebs_default_kms_key_data_source_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccEC2EBSDefaultKMSKeyDataSource_basic(t *testing.T) {
+func testAccEBSDefaultKMSKeyDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/ec2/ebs_default_kms_key_test.go
+++ b/internal/service/ec2/ebs_default_kms_key_test.go
@@ -19,12 +19,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccEC2EBSDefaultKMSKey_basic(t *testing.T) {
+func testAccEBSDefaultKMSKey_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ebs_default_kms_key.test"
 	resourceNameKey := "aws_kms_key.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/ec2/ebs_test.go
+++ b/internal/service/ec2/ebs_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+)
+
+func TestAccEC2EBSDefaultKMSKey_serial(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]map[string]func(t *testing.T){
+		"Resource": {
+			acctest.CtBasic: testAccEBSDefaultKMSKey_basic,
+		},
+		"DataSource": {
+			acctest.CtBasic: testAccEBSDefaultKMSKeyDataSource_basic,
+		},
+	}
+
+	acctest.RunSerialTests2Levels(t, testCases, 0)
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

tests for `aws_ebs_default_kms_key` fail intermittently when run in parallel.

```console
% make testacc TESTARGS='-run=TestAccEC2EBSDefaultKMSKey_basic\|TestAccEC2EBSDefaultKMSKeyDataSource_basic' PKG=ec2

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2EBSDefaultKMSKey_basic\|TestAccEC2EBSDefaultKMSKeyDataSource_basic -timeout 360m
=== RUN   TestAccEC2EBSDefaultKMSKeyDataSource_basic
=== PAUSE TestAccEC2EBSDefaultKMSKeyDataSource_basic
=== RUN   TestAccEC2EBSDefaultKMSKey_basic
=== PAUSE TestAccEC2EBSDefaultKMSKey_basic
=== CONT  TestAccEC2EBSDefaultKMSKeyDataSource_basic
=== CONT  TestAccEC2EBSDefaultKMSKey_basic
    ebs_default_kms_key_test.go:27: Step 1/2 error: After applying this test step, the refresh plan was not empty.
        stdout


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement

        Terraform will perform the following actions:

          # aws_ebs_default_kms_key.test must be replaced
        -/+ resource "aws_ebs_default_kms_key" "test" {
              ~ id      = "arn:aws:kms:us-east-1:************:key/22184582-1bd3-4fbd-9a0d-40f9c3eacdfc" -> (known after apply)
              ~ key_arn = "arn:aws:kms:us-east-1:************:key/ad4d4835-c1cc-42ac-92d2-de287610c524" -> "arn:aws:kms:us-east-1:************:key/22184582-1bd3-4fbd-9a0d-40f9c3eacdfc" # forces replacement
            }

        Plan: 1 to add, 0 to change, 1 to destroy.
--- PASS: TestAccEC2EBSDefaultKMSKeyDataSource_basic (12.82s)
--- FAIL: TestAccEC2EBSDefaultKMSKey_basic (14.10s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	20.287s
FAIL
make: *** [testacc] Error 1
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccEC2EBSDefaultKMSKey_serial' PKG=ec2

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2EBSDefaultKMSKey_serial -timeout 360m
=== RUN   TestAccEC2EBSDefaultKMSKey_serial
=== PAUSE TestAccEC2EBSDefaultKMSKey_serial
=== CONT  TestAccEC2EBSDefaultKMSKey_serial
=== RUN   TestAccEC2EBSDefaultKMSKey_serial/Resource
=== RUN   TestAccEC2EBSDefaultKMSKey_serial/Resource/basic
=== RUN   TestAccEC2EBSDefaultKMSKey_serial/DataSource
=== RUN   TestAccEC2EBSDefaultKMSKey_serial/DataSource/basic
--- PASS: TestAccEC2EBSDefaultKMSKey_serial (31.12s)
    --- PASS: TestAccEC2EBSDefaultKMSKey_serial/Resource (19.78s)
        --- PASS: TestAccEC2EBSDefaultKMSKey_serial/Resource/basic (19.78s)
    --- PASS: TestAccEC2EBSDefaultKMSKey_serial/DataSource (11.34s)
        --- PASS: TestAccEC2EBSDefaultKMSKey_serial/DataSource/basic (11.34s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	37.403s
```
