### PR TITLE
resource/aws_appfabric_app_authorization: Convert `credentialModel` to `fwflex.Expander`

### DIFF
--- a/.teamcity/components/generated/services_all.kt
+++ b/.teamcity/components/generated/services_all.kt
@@ -11,7 +11,7 @@ val services = mapOf(
     "apigatewayv2" to ServiceSpec("API Gateway V2", vpcLock = true),
     "appautoscaling" to ServiceSpec("Application Auto Scaling", vpcLock = true),
     "appconfig" to ServiceSpec("AppConfig"),
-    "appfabric" to ServiceSpec("AppFabric"),
+    "appfabric" to ServiceSpec("AppFabric", regionOverride = "us-east-1"),
     "appflow" to ServiceSpec("AppFlow"),
     "appintegrations" to ServiceSpec("AppIntegrations"),
     "applicationinsights" to ServiceSpec("CloudWatch Application Insights"),

--- a/internal/generate/teamcity/acctest_services.hcl
+++ b/internal/generate/teamcity/acctest_services.hcl
@@ -6,15 +6,15 @@ service "amp" {
   parallelism = 10
 }
 
-service "appautoscaling" {
-  vpc_lock = true
-}
-
 service "apigateway" {
   vpc_lock = true
 }
 
 service "apigatewayv2" {
+  vpc_lock = true
+}
+
+service "appautoscaling" {
   vpc_lock = true
 }
 

--- a/internal/generate/teamcity/acctest_services.hcl
+++ b/internal/generate/teamcity/acctest_services.hcl
@@ -18,6 +18,10 @@ service "apigatewayv2" {
   vpc_lock = true
 }
 
+service "appfabric" {
+  region = "us-east-1"
+}
+
 service "appstream" {
   vpc_lock    = true
   parallelism = 10

--- a/internal/service/appfabric/app_authorization.go
+++ b/internal/service/appfabric/app_authorization.go
@@ -207,9 +207,6 @@ func (r *appAuthorizationResource) Create(ctx context.Context, request resource.
 		return
 	}
 
-	credential, d := expandCredentialsValue(ctx, credentialsData)
-	response.Diagnostics.Append(d...)
-
 	input := &appfabric.CreateAppAuthorizationInput{}
 	response.Diagnostics.Append(fwflex.Expand(ctx, data, input)...)
 	if response.Diagnostics.HasError() {
@@ -218,7 +215,6 @@ func (r *appAuthorizationResource) Create(ctx context.Context, request resource.
 
 	input.AppBundleIdentifier = aws.String(data.AppBundleARN.ValueString())
 	input.ClientToken = aws.String(errs.Must(uuid.GenerateUUID()))
-	input.Credential = credential
 	input.Tags = getTagsIn(ctx)
 
 	output, err := conn.CreateAppAuthorization(ctx, input)
@@ -323,12 +319,6 @@ func (r *appAuthorizationResource) Update(ctx context.Context, request resource.
 			return
 		}
 
-		credential, diags := expandCredentialsValue(ctx, credentialsData)
-		response.Diagnostics.Append(diags...)
-		if diags.HasError() {
-			return
-		}
-
 		input := &appfabric.UpdateAppAuthorizationInput{}
 		response.Diagnostics.Append(fwflex.Expand(ctx, new, input)...)
 		if response.Diagnostics.HasError() {
@@ -337,7 +327,6 @@ func (r *appAuthorizationResource) Update(ctx context.Context, request resource.
 
 		input.AppAuthorizationIdentifier = fwflex.StringFromFramework(ctx, new.AppAuthorizationARN)
 		input.AppBundleIdentifier = fwflex.StringFromFramework(ctx, new.AppBundleARN)
-		input.Credential = credential
 
 		_, err := conn.UpdateAppAuthorization(ctx, input)
 
@@ -499,53 +488,6 @@ func waitAppAuthorizationDeleted(ctx context.Context, conn *appfabric.Client, ap
 	return nil, err
 }
 
-func expandCredentialsValue(ctx context.Context, credentialModels []credentialModel) (awstypes.Credential, diag.Diagnostics) {
-	credentials := []awstypes.Credential{}
-	var diags diag.Diagnostics
-
-	for _, item := range credentialModels {
-		if !item.ApiKeyCredential.IsNull() && (len(item.ApiKeyCredential.Elements()) > 0) {
-			var apiKey []apiKeyCredentialModel
-			diags.Append(item.ApiKeyCredential.ElementsAs(ctx, &apiKey, false)...)
-			apiKeycredential := expandAppAuthorizationAPIKeyCredential(ctx, apiKey)
-			credentials = append(credentials, apiKeycredential)
-		}
-		if (!item.Oauth2Credential.IsNull()) && (len(item.Oauth2Credential.Elements()) > 0) {
-			var oath2Credentials []oauth2CredentialModel
-			diags.Append(item.Oauth2Credential.ElementsAs(ctx, &oath2Credentials, false)...)
-			oath2Credential := expandAppAuthorizationOAuthCredential(ctx, oath2Credentials)
-			credentials = append(credentials, oath2Credential)
-		}
-	}
-
-	return credentials[0], diags
-}
-
-func expandAppAuthorizationAPIKeyCredential(ctx context.Context, apiKeyCredential []apiKeyCredentialModel) *awstypes.CredentialMemberApiKeyCredential {
-	if len(apiKeyCredential) == 0 {
-		return nil
-	}
-
-	return &awstypes.CredentialMemberApiKeyCredential{
-		Value: awstypes.ApiKeyCredential{
-			ApiKey: fwflex.StringFromFramework(ctx, apiKeyCredential[0].ApiKey),
-		},
-	}
-}
-
-func expandAppAuthorizationOAuthCredential(ctx context.Context, oauth2Credential []oauth2CredentialModel) *awstypes.CredentialMemberOauth2Credential {
-	if len(oauth2Credential) == 0 {
-		return nil
-	}
-
-	return &awstypes.CredentialMemberOauth2Credential{
-		Value: awstypes.Oauth2Credential{
-			ClientId:     fwflex.StringFromFramework(ctx, oauth2Credential[0].ClientId),
-			ClientSecret: fwflex.StringFromFramework(ctx, oauth2Credential[0].ClientSecret),
-		},
-	}
-}
-
 type appAuthorizationResourceModel struct {
 	App                 types.String                                     `tfsdk:"app"`
 	AppAuthorizationARN types.String                                     `tfsdk:"arn"`
@@ -583,9 +525,49 @@ func (m *appAuthorizationResourceModel) setID() {
 	m.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{m.AppAuthorizationARN.ValueString(), m.AppBundleARN.ValueString()}, appAuthorizationResourceIDPartCount, false)))
 }
 
+var (
+	_ fwflex.Expander = credentialModel{}
+)
+
 type credentialModel struct {
 	ApiKeyCredential fwtypes.ListNestedObjectValueOf[apiKeyCredentialModel] `tfsdk:"api_key_credential"`
 	Oauth2Credential fwtypes.ListNestedObjectValueOf[oauth2CredentialModel] `tfsdk:"oauth2_credential"`
+}
+
+func (m credentialModel) Expand(ctx context.Context) (result any, diags diag.Diagnostics) {
+	switch {
+	case !m.ApiKeyCredential.IsNull():
+		efsStorageConfigurationData, d := m.ApiKeyCredential.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		var r awstypes.CredentialMemberApiKeyCredential
+		diags.Append(fwflex.Expand(ctx, efsStorageConfigurationData, &r.Value)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		return &r, diags
+
+	case !m.Oauth2Credential.IsNull():
+		fsxStorageConfigurationData, d := m.Oauth2Credential.ToPtr(ctx)
+		diags.Append(d...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		var r awstypes.CredentialMemberOauth2Credential
+		diags.Append(fwflex.Expand(ctx, fsxStorageConfigurationData, &r.Value)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		return &r, diags
+	}
+
+	return nil, diags
 }
 
 type apiKeyCredentialModel struct {


### PR DESCRIPTION
### Description

Converts `credentialModel` to `fwflex.Expander`. Prevents error log when expanding
