### PR TITLE
[Bug]: Fix unreturned `sdkdiag.AppendErrorf` function calls

### DIFF
--- a/.changelog/38854.txt
+++ b/.changelog/38854.txt
@@ -1,0 +1,24 @@
+```release-note:bug
+resource/aws_rolesanywhere_trust_anchor: Fix unreturned `sdkdiags.AppendErrorf` function calls
+```
+```release-note:bug
+resource/aws_rolesanywhere_profile: Fix unreturned `sdkdiags.AppendErrorf` function calls
+```
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Fix unreturned `sdkdiags.AppendErrorf` function calls
+```
+```release-note:bug
+resource/aws_ecs_cluster_capacity_providers: Fix unreturned `sdkdiags.AppendErrorf` function calls
+```
+```release-note:bug
+resource/aws_fms_policy: Fix unreturned `sdkdiags.AppendErrorf` function calls
+```
+```release-note:bug
+resource/aws_appstream_stack: Fix unreturned `sdkdiags.AppendErrorf` function calls
+```
+```release-note:bug
+resource/aws_controltower_landing_zone: Fix unreturned `sdkdiags.AppendErrorf` function calls
+```
+```release-note:bug
+data-source/aws_acm_certificate: Fix unreturned `sdkdiags.AppendErrorf` function calls
+```

--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -634,3 +634,28 @@ rules:
     patterns:
       - pattern-regex: "(Create|Read|Update|Delete)Context:"
     severity: ERROR
+
+  - id: unreturned-sdkdiag-AppendErrorf
+    languages: [go]
+    message: Calls to `sdkdiag.AppendErrorf()` should be returned or set to the `diags` variable
+    paths:
+      include:
+        - internal/
+    patterns:
+      - pattern: |
+          if err != nil {
+            sdkdiag.AppendErrorf($DIAGS, ...)
+          }
+      - pattern-not: |
+          if err != nil {
+            return sdkdiag.AppendErrorf($DIAGS, ...)
+          }
+      - pattern-not: |
+          if err != nil {
+            return ..., sdkdiag.AppendErrorf($DIAGS, ...)
+          }
+      - pattern-not: |
+          if err != nil {
+            $DIAGS = sdkdiag.AppendErrorf($DIAGS, ...)
+          }
+    severity: ERROR

--- a/internal/service/acm/certificate_data_source.go
+++ b/internal/service/acm/certificate_data_source.go
@@ -105,7 +105,7 @@ func dataSourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta
 		},
 	)
 	if tfresource.NotFound(err) {
-		sdkdiag.AppendErrorf(diags, "XXX no ACM Certificate matching domain (%s)", domain)
+		return sdkdiag.AppendErrorf(diags, "XXX no ACM Certificate matching domain (%s)", domain)
 	} else if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading ACM Certificates: %s", err)
 	}

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -409,7 +409,7 @@ func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		_, err := conn.UpdateStack(ctx, input)
 
 		if err != nil {
-			sdkdiag.AppendErrorf(diags, "updating Appstream Stack (%s): %s", d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating Appstream Stack (%s): %s", d.Id(), err)
 		}
 	}
 

--- a/internal/service/controltower/landing_zone.go
+++ b/internal/service/controltower/landing_zone.go
@@ -214,7 +214,7 @@ func resourceLandingZoneDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if _, err := waitLandingZoneOperationSucceeded(ctx, conn, aws.ToString(output.OperationIdentifier), d.Timeout(schema.TimeoutDelete)); err != nil {
-		sdkdiag.AppendErrorf(diags, "waiting for ControlTower Landing Zone (%s) delete: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for ControlTower Landing Zone (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags

--- a/internal/service/ecs/cluster_capacity_providers.go
+++ b/internal/service/ecs/cluster_capacity_providers.go
@@ -115,7 +115,7 @@ func resourceClusterCapacityProvidersRead(ctx context.Context, d *schema.Resourc
 	cluster, err := findClusterByNameOrARN(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		sdkdiag.AppendErrorf(diags, "[WARN] ECS Cluster Capacity Providers (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] ECS Cluster Capacity Providers (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}

--- a/internal/service/fms/policy.go
+++ b/internal/service/fms/policy.go
@@ -269,17 +269,17 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("delete_unused_fm_managed_resources", policy.DeleteUnusedFMManagedResources)
 	d.Set(names.AttrDescription, policy.PolicyDescription)
 	if err := d.Set("exclude_map", flattenPolicyMap(policy.ExcludeMap)); err != nil {
-		sdkdiag.AppendErrorf(diags, "setting exclude_map: %s", err)
+		diags = sdkdiag.AppendErrorf(diags, "setting exclude_map: %s", err)
 	}
 	d.Set("exclude_resource_tags", policy.ExcludeResourceTags)
 	if err := d.Set("include_map", flattenPolicyMap(policy.IncludeMap)); err != nil {
-		sdkdiag.AppendErrorf(diags, "setting include_map: %s", err)
+		diags = sdkdiag.AppendErrorf(diags, "setting include_map: %s", err)
 	}
 	d.Set(names.AttrName, policy.PolicyName)
 	d.Set("policy_update_token", policy.PolicyUpdateToken)
 	d.Set("remediation_enabled", policy.RemediationEnabled)
 	if err := d.Set(names.AttrResourceTags, flattenResourceTags(policy.ResourceTags)); err != nil {
-		sdkdiag.AppendErrorf(diags, "setting resource_tags: %s", err)
+		diags = sdkdiag.AppendErrorf(diags, "setting resource_tags: %s", err)
 	}
 	d.Set(names.AttrResourceType, policy.ResourceType)
 	d.Set("resource_type_list", policy.ResourceTypeList)
@@ -290,7 +290,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 		"policy_option":        flattenPolicyOption(policy.SecurityServicePolicyData.PolicyOption),
 	}}
 	if err := d.Set("security_service_policy_data", securityServicePolicy); err != nil {
-		sdkdiag.AppendErrorf(diags, "setting security_service_policy_data: %s", err)
+		diags = sdkdiag.AppendErrorf(diags, "setting security_service_policy_data: %s", err)
 	}
 
 	return diags

--- a/internal/service/rolesanywhere/profile.go
+++ b/internal/service/rolesanywhere/profile.go
@@ -192,12 +192,12 @@ func resourceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		if n == true {
 			err := enableProfile(ctx, d.Id(), meta)
 			if err != nil {
-				sdkdiag.AppendErrorf(diags, "enabling RolesAnywhere Profile (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "enabling RolesAnywhere Profile (%s): %s", d.Id(), err)
 			}
 		} else {
 			err := disableProfile(ctx, d.Id(), meta)
 			if err != nil {
-				sdkdiag.AppendErrorf(diags, "disabling RolesAnywhere Profile (%s): %s", d.Id(), err)
+				return sdkdiag.AppendErrorf(diags, "disabling RolesAnywhere Profile (%s): %s", d.Id(), err)
 			}
 		}
 	}

--- a/internal/service/rolesanywhere/trust_anchor.go
+++ b/internal/service/rolesanywhere/trust_anchor.go
@@ -164,11 +164,11 @@ func resourceTrustAnchorUpdate(ctx context.Context, d *schema.ResourceData, meta
 			_, n := d.GetChange(names.AttrEnabled)
 			if n == true {
 				if err := enableTrustAnchor(ctx, d.Id(), meta); err != nil {
-					sdkdiag.AppendErrorf(diags, "enabling RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "enabling RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
 				}
 			} else {
 				if err := disableTrustAnchor(ctx, d.Id(), meta); err != nil {
-					sdkdiag.AppendErrorf(diags, "disabling RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
+					return sdkdiag.AppendErrorf(diags, "disabling RolesAnywhere Trust Anchor (%s): %s", d.Id(), err)
 				}
 			}
 		}

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -290,7 +290,7 @@ func resourceBucketLifecycleConfigurationCreate(ctx context.Context, d *schema.R
 	_, err = waitLifecycleRulesEquals(ctx, conn, bucket, expectedBucketOwner, rules, d.Timeout(schema.TimeoutCreate))
 
 	if err != nil {
-		sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Lifecycle Configuration (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Lifecycle Configuration (%s) create: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceBucketLifecycleConfigurationRead(ctx, d, meta)...)
@@ -388,7 +388,7 @@ func resourceBucketLifecycleConfigurationUpdate(ctx context.Context, d *schema.R
 	_, err = waitLifecycleRulesEquals(ctx, conn, bucket, expectedBucketOwner, rules, d.Timeout(schema.TimeoutUpdate))
 
 	if err != nil {
-		sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Lifecycle Configuration (%s) update: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for S3 Bucket Lifecycle Configuration (%s) update: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceBucketLifecycleConfigurationRead(ctx, d, meta)...)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes various calls to the `sdkdiag.AppendErrorf` function which are neither returned nor re-assigned to the `diags` variable.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38769

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=acm TESTS=TestAccACMCertificateDataSource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/acm/... -v -count 1 -parallel 20 -run='TestAccACMCertificateDataSource_'  -timeout 360m

--- PASS: TestAccACMCertificateDataSource_tags (17.25s)
--- PASS: TestAccACMCertificateDataSource_keyTypes (18.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/acm        24.817s
```
```console
% make testacc PKG=appstream TESTS=TestAccAppStreamStack_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamStack_'  -timeout 360m

--- PASS: TestAccAppStreamStack_disappears (33.89s)
--- PASS: TestAccAppStreamStack_applicationSettings_removeFromDisabled (41.20s)
--- PASS: TestAccAppStreamStack_basic (54.97s)
--- PASS: TestAccAppStreamStack_applicationSettings_removeFromEnabled (55.92s)
--- PASS: TestAccAppStreamStack_withTags (56.27s)
--- PASS: TestAccAppStreamStack_complete (56.69s)
--- PASS: TestAccAppStreamStack_streamingExperienceSettings_basic (70.81s)
--- PASS: TestAccAppStreamStack_applicationSettings_basic (71.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  81.569s
```

```console
% make testacc PKG=ecs TESTS=TestAccECSClusterCapacityProviders_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSClusterCapacityProviders_'  -timeout 360m

=== NAME  TestAccECSClusterCapacityProviders_destroy
    cluster_capacity_providers_test.go:120: Step 1/2 error: Check failed: Check 2/2 error: RegisteredContainerInstancesCount = 0, want 2
--- PASS: TestAccECSClusterCapacityProviders_defaults (47.98s)
--- PASS: TestAccECSClusterCapacityProviders_basic (48.20s)
--- PASS: TestAccECSClusterCapacityProviders_disappears (56.22s)
--- PASS: TestAccECSClusterCapacityProviders_Update_defaultStrategy (113.11s)
--- PASS: TestAccECSClusterCapacityProviders_Update_capacityProviders (113.13s)
--- FAIL: TestAccECSClusterCapacityProviders_destroy (169.06s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ecs        179.063s
```

Failure unrelated to this change.

```console
% make testacc PKG=rolesanywhere TESTS=TestAccRolesAnywhereProfile_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/rolesanywhere/... -v -count 1 -parallel 20 -run='TestAccRolesAnywhereProfile_'  -timeout 360m

--- PASS: TestAccRolesAnywhereProfile_disappears (16.78s)
--- PASS: TestAccRolesAnywhereProfile_enabled (46.73s)
--- PASS: TestAccRolesAnywhereProfile_tags (51.98s)
--- PASS: TestAccRolesAnywhereProfile_basic (60.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rolesanywhere      66.542s
```

```console
% make testacc PKG=s3 TESTS=TestAccS3BucketLifecycleConfiguration_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketLifecycleConfiguration_'  -timeout 360m

=== NAME  TestAccS3BucketLifecycleConfiguration_directoryBucket
    bucket_lifecycle_configuration_test.go:1056: Step 1/1, expected an error with pattern, no match on: Error running apply: exit status 1

        Error: creating S3 Bucket (tf-acc-test-503241382809497100--use1-az6--x-s3) Lifecycle Configuration: operation error S3: PutBucketLifecycleConfiguration, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Put "https://s3express-control.aws-global.amazonaws.com/tf-acc-test-503241382809497100--use1-az6--x-s3?lifecycle=": dial tcp: lookup s3express-control.aws-global.amazonaws.com: no such host

          with aws_s3_bucket_lifecycle_configuration.test,
          on terraform_plugin_test.tf line 35, in resource "aws_s3_bucket_lifecycle_configuration" "test":
          35: resource "aws_s3_bucket_lifecycle_configuration" "test" {

--- FAIL: TestAccS3BucketLifecycleConfiguration_directoryBucket (13.50s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_noChange (71.76s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_withChange (71.80s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (76.54s)
=== CONT  TestAccS3BucketLifecycleConfiguration_filterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (86.73s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (87.53s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (87.60s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disappears
--- PASS: TestAccS3BucketLifecycleConfiguration_prefix (87.60s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disableRule
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (87.64s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (87.64s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (74.16s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (87.69s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (87.72s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (87.74s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (87.76s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (87.78s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (88.18s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (130.30s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (64.26s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (48.44s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (64.29s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (65.50s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (66.14s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (158.96s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (159.03s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (136.76s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (214.88s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (184.62s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/s3 278.401s
```

Failure unrelated to this change.