### PR TITLE
fix: `TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible` test in `redshiftserverless`

### DIFF
--- a/internal/service/redshiftserverless/workgroup_test.go
+++ b/internal/service/redshiftserverless/workgroup_test.go
@@ -404,11 +404,6 @@ resource "aws_redshiftserverless_workgroup" "test" {
   base_capacity  = %[2]d
 }
 
-resource "aws_redshiftserverless_snapshot" "test" {
-  namespace_name   = aws_redshiftserverless_workgroup.test.namespace_name
-  snapshot_name    = %[1]q
-  retention_period = 10
-}
 `, rName, baseCapacity)
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The `Redshift Serverless Workgroup` resource can only update capacity arguments if a snapshot or recovery point exist.
Because the first recovery point can take a few minutes, you cannot update capacity arguments till this point has been created.

This means that the `TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible` test which immediately after the initial creation tries to update the resource which in turn will fail.
That will also happen for any consumers of this resource that when they want to resize immediately after creation it will fail.

The API will return the following, I inaccurately assumed the API meant an actual snapshot but a recovery point suffices as well.
```
ValidationException: Failed to update the RPU capacity for Serverless workgroup. Wait until at least one snapshot exists and retry.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible' PKG=redshiftserverless
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/redshiftserverless/... -v -count 1 -parallel 20  -run=TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible -timeout 360m
=== RUN   TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible
=== PAUSE TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible
=== CONT  TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible
--- PASS: TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible (2371.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless 2376.403s
```
