### PR TITLE
docs: fix broken example code for aws_pipes_pipe

### DIFF
--- a/website/docs/r/pipes_pipe.html.markdown
+++ b/website/docs/r/pipes_pipe.html.markdown
@@ -183,7 +183,7 @@ resource "aws_pipes_pipe" "example" {
   }
 
   target_parameters {
-    sqs_queue {
+    sqs_queue_parameters {
       message_deduplication_id = "example-dedupe"
       message_group_id         = "example-group"
     }


### PR DESCRIPTION
### Description

The  [example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/pipes_pipe#sqs-source-and-target-configuration-usage) in the documentation  fails when running `terraform validate`. The error message is

> Blocks of type "sqs_queue" are not expected here.

As mentioned in #38842 the correct name is `sqs_queue_parameters`.
In the References section I added a link to the source code/ schema for `target_parameters`.

### Relations

Closes #38842 

### References

- [Source code reference](https://github.com/hashicorp/terraform-provider-aws/blob/26accfa55c799e121ae1de17845facab0f920d6d/internal/service/pipes/target_parameters.go#L755)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.