### PR TITLE
r/aws_ecs_service: fix crash from nil service_registries item

### DIFF
--- a/.changelog/38883.txt
+++ b/.changelog/38883.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ecs_service: Fix crash from nil `service_registries` item
+```

--- a/internal/service/ecs/flex.go
+++ b/internal/service/ecs/flex.go
@@ -164,6 +164,10 @@ func expandServiceRegistries(tfList []interface{}) []awstypes.ServiceRegistry {
 	apiObjects := make([]awstypes.ServiceRegistry, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
+		if tfMapRaw == nil {
+			continue
+		}
+
 		tfMap := tfMapRaw.(map[string]interface{})
 		apiObject := awstypes.ServiceRegistry{
 			RegistryArn: aws.String(tfMap["registry_arn"].(string)),


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This appears only to be possible with dynamic blocks as explicitly setting a nil `service_registries` block will prompt for the required attributes within the block. However, this fix should prevent the nil value from being expanded and causing a crash under the dynamic block scenario.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34166

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ecs TESTS=TestAccECSService_ServiceRegistries
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSService_ServiceRegistries'  -timeout 360m

--- PASS: TestAccECSService_ServiceRegistries_basic (145.59s)
--- PASS: TestAccECSService_ServiceRegistries_container (145.60s)
--- PASS: TestAccECSService_ServiceRegistries_removal (156.46s)
--- PASS: TestAccECSService_ServiceRegistries_changes (279.51s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecs        285.700s
```
