### PR TITLE
docs: Add remove_headers_config example

### DIFF
--- a/website/docs/r/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/r/cloudfront_response_headers_policy.html.markdown
@@ -64,7 +64,7 @@ resource "aws_cloudfront_response_headers_policy" "example" {
 }
 ```
 
-The example below creates a CloudFront response headers policy with a custom headers config and server timing headers config.
+The example below creates a CloudFront response headers policy with a custom headers config, remove headers config and server timing headers config.
 
 ```terraform
 resource "aws_cloudfront_response_headers_policy" "example" {
@@ -75,6 +75,12 @@ resource "aws_cloudfront_response_headers_policy" "example" {
       header   = "X-Permitted-Cross-Domain-Policies"
       override = true
       value    = "none"
+    }
+  }
+
+  remove_headers_config {
+    items { 
+      header = "Set-Cookie" 
     }
   }
 

--- a/website/docs/r/cloudfront_response_headers_policy.html.markdown
+++ b/website/docs/r/cloudfront_response_headers_policy.html.markdown
@@ -79,8 +79,8 @@ resource "aws_cloudfront_response_headers_policy" "example" {
   }
 
   remove_headers_config {
-    items { 
-      header = "Set-Cookie" 
+    items {
+      header = "Set-Cookie"
     }
   }
 


### PR DESCRIPTION
### Description
Add `remove_headers_config` example for the `aws_cloudfront_response_headers_policy` resource


### Relations
Closes #38174


### References

[Resource Page](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy)


### Output from Acceptance Testing

Not applicable. Only documentation is updated.
