### PR TITLE
Add OS requirement to development environment docs

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -4,6 +4,7 @@
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.26+ (to run acceptance tests)
 - [Go](https://golang.org/doc/install) 1.22+ (to build the provider plugin)
+- Mac, Linux or WSL (to build the provider plugin)
 
 ## Quick Start
 


### PR DESCRIPTION
### Description

This adds an extra requirement to the Development Environment docs, making it clear that raw Windows OS can't be used for building the plugin, since it requires `make` to be available.
