### PR TITLE
Correct case name in new resource dev guide

### DIFF
--- a/docs/add-a-new-resource.md
+++ b/docs/add-a-new-resource.md
@@ -29,7 +29,7 @@ In the `internal/service/<service>/<service>.go` file you will see a `Schema` pr
 
 Typically you will add arguments to represent the values that are under control by Terraform, and attributes to supply read-only values as references for Terraform. These are distinguished by Schema Behavior.
 
-Attribute names are to be specified in `camel_case` as opposed to the AWS API which is `CamelCase`.
+Attribute names are to be specified in `snake_case` as opposed to the AWS API which is `CamelCase`.
 
 ### Implement CRUD handlers
 


### PR DESCRIPTION
### Description

The guide was making a distinction between different cases but used the same name for both. It looks like it intended to use the actual case name for the `snake_case` example