### PR TITLE
Use `attr.Value` `Value<type>Pointer` functions instead of `aws.<type>(v.Value<type>())`

### DIFF
--- a/.ci/semgrep/framework/flex.yml
+++ b/.ci/semgrep/framework/flex.yml
@@ -1,15 +1,13 @@
 rules:
   - id: flex-type-from-framework
     languages: [go]
-    message: Prefer `flex.<type>FromFramework` to `aws.<type>(x.Value<type>())`
-    paths:
-      include:
-        - internal/service/cognitoidp
+    message: Prefer `x.Value<type>Pointer()` to `aws.<type>(x.Value<type>())`
     patterns:
       - pattern: aws.$TYPE($X.$VALFUNC())
       - metavariable-comparison:
           metavariable: $VALFUNC
           comparison: re.match("\AValue", str($VALFUNC))
+    fix: $X.$VALFUNCPointer()
     severity: WARNING
 
   - id: manual-expander-functions

--- a/docs/data-handling-and-conversion.md
+++ b/docs/data-handling-and-conversion.md
@@ -614,7 +614,7 @@ Define FLatten and EXpand (i.e., flex) functions at the _most local level_ possi
 
     ```go
     input := service.ExampleOperationInput{
-        AttributeName: aws.String(plan.AttributeName.ValueBool())
+        AttributeName: plan.AttributeName.ValueBoolPointer()
     }
     ```
     
@@ -634,7 +634,7 @@ Define FLatten and EXpand (i.e., flex) functions at the _most local level_ possi
     input := service.ExampleOperationInput{}
     
     if !plan.AttributeName.IsUnknown() && !plan.AttributeName.IsNull() {
-        input.AttributeName = aws.Bool(plan.AttributeName.ValueBool())
+        input.AttributeName = plan.AttributeName.ValueBoolPointer()
     }
     ```
     
@@ -678,7 +678,7 @@ Define FLatten and EXpand (i.e., flex) functions at the _most local level_ possi
     input := service.ExampleOperationInput{}
     
     if !plan.AttributeName.IsNull() {
-        input.AttributeName = aws.Float64(plan.AttributeName.ValueFloat64())
+        input.AttributeName = plan.AttributeName.ValueFloat64Pointer()
     }
     ```
     
@@ -714,7 +714,7 @@ Define FLatten and EXpand (i.e., flex) functions at the _most local level_ possi
     input := service.ExampleOperationInput{}
     
     if !plan.AttributeName.IsNull() {
-        input.AttributeName = aws.Int64(plan.AttributeName.ValueInt64())
+        input.AttributeName = plan.AttributeName.ValueInt64Pointer()
     }
     ```
     
@@ -1003,7 +1003,7 @@ Define FLatten and EXpand (i.e., flex) functions at the _most local level_ possi
     input := service.ExampleOperationInput{}
     
     if !plan.AttributeName.IsNull() {
-        input.AttributeName = aws.String(plan.AttributeName.ValueString())
+        input.AttributeName = plan.AttributeName.ValueStringPointer()
     }
     ```
     
@@ -1095,7 +1095,7 @@ Define FLatten and EXpand (i.e., flex) functions at the _most local level_ possi
     func expandStructure(tfList []structureData) *service.Structure {
         // ...
 
-        apiObject.NestedAttributeName = aws.Bool(tfObj.NestedAttributeName.ValueBool())
+        apiObject.NestedAttributeName = tfObj.NestedAttributeName.ValueBoolPointer()
 
         // ...
     }
@@ -1108,7 +1108,7 @@ Define FLatten and EXpand (i.e., flex) functions at the _most local level_ possi
         // ...
 
         if !tfObj.NestedAttributeName.IsUnknown() && !tfObj.NestedAttributeName.IsNull() {
-            apiObject.NestedAttributeName = aws.Bool(tfObj.NestedAttributeName.ValueBool())
+            apiObject.NestedAttributeName = tfObj.NestedAttributeName.ValueBoolPointer()
         }
 
         // ...
@@ -1181,7 +1181,7 @@ Define FLatten and EXpand (i.e., flex) functions at the _most local level_ possi
         // ...
 
         if !tfObj.NestedAttributeName.IsUnknown() && !tfObj.NestedAttributeName.IsNull() {
-            apiObject.NestedAttributeName = aws.Float64(tfObj.NestedAttributeName.ValueFloat64())
+            apiObject.NestedAttributeName = tfObj.NestedAttributeName.ValueFloat64Pointer()
         }
 
         // ...
@@ -1240,7 +1240,7 @@ Define FLatten and EXpand (i.e., flex) functions at the _most local level_ possi
         // ...
 
         if !tfObj.NestedAttributeName.IsUnknown() && !tfObj.NestedAttributeName.IsNull() {
-            apiObject.NestedAttributeName = aws.Int64(tfObj.NestedAttributeName.ValueInt64())
+            apiObject.NestedAttributeName = tfObj.NestedAttributeName.ValueInt64Pointer()
         }
 
         // ...
@@ -1655,7 +1655,7 @@ Define FLatten and EXpand (i.e., flex) functions at the _most local level_ possi
         // ...
 
         if !tfObj.NestedAttributeName.IsUnknown() && !tfObj.NestedAttributeName.IsNull() {
-            apiObject.NestedAttributeName = aws.String(tfObj.NestedAttributeName.ValueString())
+            apiObject.NestedAttributeName = tfObj.NestedAttributeName.ValueStringPointer()
         }
 
         // ...

--- a/internal/service/amp/scraper.go
+++ b/internal/service/amp/scraper.go
@@ -244,7 +244,7 @@ func (r *scraperResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	if !data.Alias.IsNull() {
-		input.Alias = aws.String(data.Alias.ValueString())
+		input.Alias = data.Alias.ValueStringPointer()
 	}
 
 	output, err := conn.CreateScraper(ctx, input)
@@ -368,7 +368,7 @@ func (r *scraperResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	_, err := conn.DeleteScraper(ctx, &amp.DeleteScraperInput{
 		ClientToken: aws.String(sdkid.UniqueId()),
-		ScraperId:   aws.String(data.ID.ValueString()),
+		ScraperId:   data.ID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/appconfig/environment.go
+++ b/internal/service/appconfig/environment.go
@@ -154,14 +154,14 @@ func (r *resourceEnvironment) Create(ctx context.Context, request resource.Creat
 	}
 
 	input := &appconfig.CreateEnvironmentInput{
-		Name:          aws.String(plan.Name.ValueString()),
+		Name:          plan.Name.ValueStringPointer(),
 		ApplicationId: aws.String(appId),
 		Tags:          getTagsIn(ctx),
 		Monitors:      expandMonitors(monitors),
 	}
 
 	if !(plan.Description.IsNull() || plan.Description.IsUnknown()) {
-		input.Description = aws.String(plan.Description.ValueString())
+		input.Description = plan.Description.ValueStringPointer()
 	}
 
 	environment, err := conn.CreateEnvironment(ctx, input)
@@ -239,11 +239,11 @@ func (r *resourceEnvironment) Update(ctx context.Context, request resource.Updat
 		updateInput := plan.updateEnvironmentInput()
 
 		if !plan.Description.Equal(state.Description) {
-			updateInput.Description = aws.String(plan.Description.ValueString())
+			updateInput.Description = plan.Description.ValueStringPointer()
 		}
 
 		if !plan.Name.Equal(state.Name) {
-			updateInput.Name = aws.String(plan.Name.ValueString())
+			updateInput.Name = plan.Name.ValueStringPointer()
 		}
 
 		if !plan.Monitors.Equal(state.Monitors) {
@@ -394,22 +394,22 @@ func (d *resourceEnvironmentData) refreshFromUpdateOutput(ctx context.Context, m
 
 func (d *resourceEnvironmentData) getEnvironmentInput() *appconfig.GetEnvironmentInput {
 	return &appconfig.GetEnvironmentInput{
-		ApplicationId: aws.String(d.ApplicationID.ValueString()),
-		EnvironmentId: aws.String(d.EnvironmentID.ValueString()),
+		ApplicationId: d.ApplicationID.ValueStringPointer(),
+		EnvironmentId: d.EnvironmentID.ValueStringPointer(),
 	}
 }
 
 func (d *resourceEnvironmentData) updateEnvironmentInput() *appconfig.UpdateEnvironmentInput {
 	return &appconfig.UpdateEnvironmentInput{
-		ApplicationId: aws.String(d.ApplicationID.ValueString()),
-		EnvironmentId: aws.String(d.EnvironmentID.ValueString()),
+		ApplicationId: d.ApplicationID.ValueStringPointer(),
+		EnvironmentId: d.EnvironmentID.ValueStringPointer(),
 	}
 }
 
 func (d *resourceEnvironmentData) deleteEnvironmentInput() *appconfig.DeleteEnvironmentInput {
 	return &appconfig.DeleteEnvironmentInput{
-		ApplicationId: aws.String(d.ApplicationID.ValueString()),
-		EnvironmentId: aws.String(d.EnvironmentID.ValueString()),
+		ApplicationId: d.ApplicationID.ValueStringPointer(),
+		EnvironmentId: d.EnvironmentID.ValueStringPointer(),
 	}
 }
 
@@ -456,11 +456,11 @@ type monitorData struct {
 
 func (m monitorData) expand() awstypes.Monitor {
 	result := awstypes.Monitor{
-		AlarmArn: aws.String(m.AlarmARN.ValueString()),
+		AlarmArn: m.AlarmARN.ValueStringPointer(),
 	}
 
 	if !m.AlarmRoleARN.IsNull() {
-		result.AlarmRoleArn = aws.String(m.AlarmRoleARN.ValueString())
+		result.AlarmRoleArn = m.AlarmRoleARN.ValueStringPointer()
 	}
 
 	return result

--- a/internal/service/appfabric/app_authorization.go
+++ b/internal/service/appfabric/app_authorization.go
@@ -217,7 +217,7 @@ func (r *appAuthorizationResource) Create(ctx context.Context, request resource.
 		return
 	}
 
-	input.AppBundleIdentifier = aws.String(data.AppBundleARN.ValueString())
+	input.AppBundleIdentifier = data.AppBundleARN.ValueStringPointer()
 	input.ClientToken = aws.String(errs.Must(uuid.GenerateUUID()))
 	input.Tags = getTagsIn(ctx)
 

--- a/internal/service/appfabric/app_bundle.go
+++ b/internal/service/appfabric/app_bundle.go
@@ -143,7 +143,7 @@ func (r *appBundleResource) Delete(ctx context.Context, request resource.DeleteR
 	conn := r.Meta().AppFabricClient(ctx)
 
 	_, err := conn.DeleteAppBundle(ctx, &appfabric.DeleteAppBundleInput{
-		AppBundleIdentifier: aws.String(data.ID.ValueString()),
+		AppBundleIdentifier: data.ID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/appfabric/ingestion.go
+++ b/internal/service/appfabric/ingestion.go
@@ -182,8 +182,8 @@ func (r *ingestionResource) Delete(ctx context.Context, request resource.DeleteR
 	conn := r.Meta().AppFabricClient(ctx)
 
 	_, err := conn.DeleteIngestion(ctx, &appfabric.DeleteIngestionInput{
-		AppBundleIdentifier: aws.String(data.AppBundleARN.ValueString()),
-		IngestionIdentifier: aws.String(data.ARN.ValueString()),
+		AppBundleIdentifier: data.AppBundleARN.ValueStringPointer(),
+		IngestionIdentifier: data.ARN.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/appfabric/ingestion_destination.go
+++ b/internal/service/appfabric/ingestion_destination.go
@@ -259,9 +259,9 @@ func (r *ingestionDestinationResource) Create(ctx context.Context, request resou
 	}
 
 	// Additional fields.
-	input.AppBundleIdentifier = aws.String(data.AppBundleARN.ValueString())
+	input.AppBundleIdentifier = data.AppBundleARN.ValueStringPointer()
 	input.ClientToken = aws.String(errs.Must(uuid.GenerateUUID()))
-	input.IngestionIdentifier = aws.String(data.IngestionARN.ValueString())
+	input.IngestionIdentifier = data.IngestionARN.ValueStringPointer()
 	input.Tags = getTagsIn(ctx)
 
 	output, err := conn.CreateIngestionDestination(ctx, input)
@@ -384,9 +384,9 @@ func (r *ingestionDestinationResource) Update(ctx context.Context, request resou
 		}
 
 		// Additional fields.
-		input.AppBundleIdentifier = aws.String(new.AppBundleARN.ValueString())
-		input.IngestionDestinationIdentifier = aws.String(new.ARN.ValueString())
-		input.IngestionIdentifier = aws.String(new.IngestionARN.ValueString())
+		input.AppBundleIdentifier = new.AppBundleARN.ValueStringPointer()
+		input.IngestionDestinationIdentifier = new.ARN.ValueStringPointer()
+		input.IngestionIdentifier = new.IngestionARN.ValueStringPointer()
 
 		_, err := conn.UpdateIngestionDestination(ctx, input)
 
@@ -416,9 +416,9 @@ func (r *ingestionDestinationResource) Delete(ctx context.Context, request resou
 	conn := r.Meta().AppFabricClient(ctx)
 
 	_, err := conn.DeleteIngestionDestination(ctx, &appfabric.DeleteIngestionDestinationInput{
-		AppBundleIdentifier:            aws.String(data.AppBundleARN.ValueString()),
-		IngestionDestinationIdentifier: aws.String(data.ARN.ValueString()),
-		IngestionIdentifier:            aws.String(data.IngestionARN.ValueString()),
+		AppBundleIdentifier:            data.AppBundleARN.ValueStringPointer(),
+		IngestionDestinationIdentifier: data.ARN.ValueStringPointer(),
+		IngestionIdentifier:            data.IngestionARN.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/appsync/source_api_association.go
+++ b/internal/service/appsync/source_api_association.go
@@ -321,12 +321,12 @@ func (r *sourceAPIAssociationResource) Delete(ctx context.Context, request resou
 		return
 	}
 
-	in := &appsync.DisassociateSourceGraphqlApiInput{
-		AssociationId:       aws.String(state.AssociationId.ValueString()),
-		MergedApiIdentifier: aws.String(state.MergedAPIArn.ValueString()),
+	in := appsync.DisassociateSourceGraphqlApiInput{
+		AssociationId:       state.AssociationId.ValueStringPointer(),
+		MergedApiIdentifier: state.MergedAPIArn.ValueStringPointer(),
 	}
 
-	_, err := conn.DisassociateSourceGraphqlApi(ctx, in)
+	_, err := conn.DisassociateSourceGraphqlApi(ctx, &in)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return

--- a/internal/service/auditmanager/account_registration.go
+++ b/internal/service/auditmanager/account_registration.go
@@ -6,7 +6,6 @@ package auditmanager
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/auditmanager/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -69,10 +68,10 @@ func (r *resourceAccountRegistration) Create(ctx context.Context, req resource.C
 
 	in := auditmanager.RegisterAccountInput{}
 	if !plan.DelegatedAdminAccount.IsNull() {
-		in.DelegatedAdminAccount = aws.String(plan.DelegatedAdminAccount.ValueString())
+		in.DelegatedAdminAccount = plan.DelegatedAdminAccount.ValueStringPointer()
 	}
 	if !plan.KmsKey.IsNull() {
-		in.KmsKey = aws.String(plan.KmsKey.ValueString())
+		in.KmsKey = plan.KmsKey.ValueStringPointer()
 	}
 	out, err := conn.RegisterAccount(ctx, &in)
 	if err != nil {
@@ -132,10 +131,10 @@ func (r *resourceAccountRegistration) Update(ctx context.Context, req resource.U
 		!plan.KmsKey.Equal(state.KmsKey) {
 		in := auditmanager.RegisterAccountInput{}
 		if !plan.DelegatedAdminAccount.IsNull() {
-			in.DelegatedAdminAccount = aws.String(plan.DelegatedAdminAccount.ValueString())
+			in.DelegatedAdminAccount = plan.DelegatedAdminAccount.ValueStringPointer()
 		}
 		if !plan.KmsKey.IsNull() {
-			in.KmsKey = aws.String(plan.KmsKey.ValueString())
+			in.KmsKey = plan.KmsKey.ValueStringPointer()
 		}
 		out, err := conn.RegisterAccount(ctx, &in)
 		if err != nil {

--- a/internal/service/auditmanager/assessment.go
+++ b/internal/service/auditmanager/assessment.go
@@ -188,15 +188,15 @@ func (r *resourceAssessment) Create(ctx context.Context, req resource.CreateRequ
 
 	in := auditmanager.CreateAssessmentInput{
 		AssessmentReportsDestination: expandAssessmentReportsDestination(reportsDestination),
-		FrameworkId:                  aws.String(plan.FrameworkID.ValueString()),
-		Name:                         aws.String(plan.Name.ValueString()),
+		FrameworkId:                  plan.FrameworkID.ValueStringPointer(),
+		Name:                         plan.Name.ValueStringPointer(),
 		Roles:                        expandAssessmentRoles(roles),
 		Scope:                        scopeInput,
 		Tags:                         getTagsIn(ctx),
 	}
 
 	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
+		in.Description = plan.Description.ValueStringPointer()
 	}
 
 	// Include retry handling to allow for IAM propagation
@@ -306,15 +306,15 @@ func (r *resourceAssessment) Update(ctx context.Context, req resource.UpdateRequ
 		}
 
 		in := &auditmanager.UpdateAssessmentInput{
-			AssessmentId:                 aws.String(plan.ID.ValueString()),
-			AssessmentName:               aws.String(plan.Name.ValueString()),
+			AssessmentId:                 plan.ID.ValueStringPointer(),
+			AssessmentName:               plan.Name.ValueStringPointer(),
 			AssessmentReportsDestination: expandAssessmentReportsDestination(reportsDestination),
 			Roles:                        expandAssessmentRoles(roles),
 			Scope:                        scopeInput,
 		}
 
 		if !plan.Description.IsNull() {
-			in.AssessmentDescription = aws.String(plan.Description.ValueString())
+			in.AssessmentDescription = plan.Description.ValueStringPointer()
 		}
 
 		out, err := conn.UpdateAssessment(ctx, in)
@@ -351,7 +351,7 @@ func (r *resourceAssessment) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	_, err := conn.DeleteAssessment(ctx, &auditmanager.DeleteAssessmentInput{
-		AssessmentId: aws.String(state.ID.ValueString()),
+		AssessmentId: state.ID.ValueStringPointer(),
 	})
 	if err != nil {
 		var nfe *awstypes.ResourceNotFoundException
@@ -499,7 +499,7 @@ func expandAssessmentReportsDestination(tfList []assessmentReportsDestinationDat
 	}
 	rd := tfList[0]
 	return &awstypes.AssessmentReportsDestination{
-		Destination:     aws.String(rd.Destination.ValueString()),
+		Destination:     rd.Destination.ValueStringPointer(),
 		DestinationType: awstypes.AssessmentReportDestinationType(rd.DestinationType.ValueString()),
 	}
 }
@@ -508,7 +508,7 @@ func expandAssessmentRoles(tfList []assessmentRolesData) []awstypes.Role {
 	var roles []awstypes.Role
 	for _, item := range tfList {
 		new := awstypes.Role{
-			RoleArn:  aws.String(item.RoleARN.ValueString()),
+			RoleArn:  item.RoleARN.ValueStringPointer(),
 			RoleType: awstypes.RoleType(item.RoleType.ValueString()),
 		}
 		roles = append(roles, new)
@@ -539,7 +539,7 @@ func expandAssessmentScopeAWSAccounts(tfList []assessmentScopeAWSAccountsData) [
 	var accounts []awstypes.AWSAccount
 	for _, item := range tfList {
 		new := awstypes.AWSAccount{
-			Id: aws.String(item.ID.ValueString()),
+			Id: item.ID.ValueStringPointer(),
 		}
 		accounts = append(accounts, new)
 	}
@@ -550,7 +550,7 @@ func expandAssessmentScopeAWSServices(tfList []assessmentScopeAWSServicesData) [
 	var services []awstypes.AWSService
 	for _, item := range tfList {
 		new := awstypes.AWSService{
-			ServiceName: aws.String(item.ServiceName.ValueString()),
+			ServiceName: item.ServiceName.ValueStringPointer(),
 		}
 		services = append(services, new)
 	}

--- a/internal/service/auditmanager/assessment_delegation.go
+++ b/internal/service/auditmanager/assessment_delegation.go
@@ -111,15 +111,15 @@ func (r *resourceAssessmentDelegation) Create(ctx context.Context, req resource.
 	}
 
 	delegationIn := awstypes.CreateDelegationRequest{
-		RoleArn:      aws.String(plan.RoleARN.ValueString()),
+		RoleArn:      plan.RoleARN.ValueStringPointer(),
 		RoleType:     awstypes.RoleType(plan.RoleType.ValueString()),
-		ControlSetId: aws.String(plan.ControlSetID.ValueString()),
+		ControlSetId: plan.ControlSetID.ValueStringPointer(),
 	}
 	if !plan.Comment.IsNull() {
-		delegationIn.Comment = aws.String(plan.Comment.ValueString())
+		delegationIn.Comment = plan.Comment.ValueStringPointer()
 	}
 	in := auditmanager.BatchCreateDelegationByAssessmentInput{
-		AssessmentId:             aws.String(plan.AssessmentID.ValueString()),
+		AssessmentId:             plan.AssessmentID.ValueStringPointer(),
 		CreateDelegationRequests: []awstypes.CreateDelegationRequest{delegationIn},
 	}
 
@@ -224,7 +224,7 @@ func (r *resourceAssessmentDelegation) Delete(ctx context.Context, req resource.
 	}
 
 	_, err := conn.BatchDeleteDelegationByAssessment(ctx, &auditmanager.BatchDeleteDelegationByAssessmentInput{
-		AssessmentId:  aws.String(state.AssessmentID.ValueString()),
+		AssessmentId:  state.AssessmentID.ValueStringPointer(),
 		DelegationIds: []string{state.DelegationID.ValueString()},
 	})
 	if err != nil {

--- a/internal/service/auditmanager/assessment_report.go
+++ b/internal/service/auditmanager/assessment_report.go
@@ -87,11 +87,11 @@ func (r *resourceAssessmentReport) Create(ctx context.Context, req resource.Crea
 	}
 
 	in := auditmanager.CreateAssessmentReportInput{
-		AssessmentId: aws.String(plan.AssessmentID.ValueString()),
-		Name:         aws.String(plan.Name.ValueString()),
+		AssessmentId: plan.AssessmentID.ValueStringPointer(),
+		Name:         plan.Name.ValueStringPointer(),
 	}
 	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
+		in.Description = plan.Description.ValueStringPointer()
 	}
 
 	out, err := conn.CreateAssessmentReport(ctx, &in)
@@ -165,8 +165,8 @@ func (r *resourceAssessmentReport) Delete(ctx context.Context, req resource.Dele
 	//   deleted. You can only delete assessment reports that are completed or failed
 	err := tfresource.Retry(ctx, reportCompletionTimeout, func() *retry.RetryError {
 		_, err := conn.DeleteAssessmentReport(ctx, &auditmanager.DeleteAssessmentReportInput{
-			AssessmentId:       aws.String(state.AssessmentID.ValueString()),
-			AssessmentReportId: aws.String(state.ID.ValueString()),
+			AssessmentId:       state.AssessmentID.ValueStringPointer(),
+			AssessmentReportId: state.ID.ValueStringPointer(),
 		})
 		if err != nil {
 			var ve *awstypes.ValidationException

--- a/internal/service/auditmanager/control.go
+++ b/internal/service/auditmanager/control.go
@@ -150,21 +150,21 @@ func (r *resourceControl) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	in := auditmanager.CreateControlInput{
-		Name:                  aws.String(plan.Name.ValueString()),
+		Name:                  plan.Name.ValueStringPointer(),
 		ControlMappingSources: cmsInput,
 		Tags:                  getTagsIn(ctx),
 	}
 	if !plan.ActionPlanInstructions.IsNull() {
-		in.ActionPlanInstructions = aws.String(plan.ActionPlanInstructions.ValueString())
+		in.ActionPlanInstructions = plan.ActionPlanInstructions.ValueStringPointer()
 	}
 	if !plan.ActionPlanTitle.IsNull() {
-		in.ActionPlanTitle = aws.String(plan.ActionPlanTitle.ValueString())
+		in.ActionPlanTitle = plan.ActionPlanTitle.ValueStringPointer()
 	}
 	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
+		in.Description = plan.Description.ValueStringPointer()
 	}
 	if !plan.TestingInformation.IsNull() {
-		in.TestingInformation = aws.String(plan.TestingInformation.ValueString())
+		in.TestingInformation = plan.TestingInformation.ValueStringPointer()
 	}
 
 	out, err := conn.CreateControl(ctx, &in)
@@ -247,21 +247,21 @@ func (r *resourceControl) Update(ctx context.Context, req resource.UpdateRequest
 		}
 
 		in := &auditmanager.UpdateControlInput{
-			ControlId:             aws.String(plan.ID.ValueString()),
-			Name:                  aws.String(plan.Name.ValueString()),
+			ControlId:             plan.ID.ValueStringPointer(),
+			Name:                  plan.Name.ValueStringPointer(),
 			ControlMappingSources: cmsInput,
 		}
 		if !plan.ActionPlanInstructions.IsNull() {
-			in.ActionPlanInstructions = aws.String(plan.ActionPlanInstructions.ValueString())
+			in.ActionPlanInstructions = plan.ActionPlanInstructions.ValueStringPointer()
 		}
 		if !plan.ActionPlanTitle.IsNull() {
-			in.ActionPlanTitle = aws.String(plan.ActionPlanTitle.ValueString())
+			in.ActionPlanTitle = plan.ActionPlanTitle.ValueStringPointer()
 		}
 		if !plan.Description.IsNull() {
-			in.Description = aws.String(plan.Description.ValueString())
+			in.Description = plan.Description.ValueStringPointer()
 		}
 		if !plan.TestingInformation.IsNull() {
-			in.TestingInformation = aws.String(plan.TestingInformation.ValueString())
+			in.TestingInformation = plan.TestingInformation.ValueStringPointer()
 		}
 
 		out, err := conn.UpdateControl(ctx, in)
@@ -295,7 +295,7 @@ func (r *resourceControl) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	_, err := conn.DeleteControl(ctx, &auditmanager.DeleteControlInput{
-		ControlId: aws.String(state.ID.ValueString()),
+		ControlId: state.ID.ValueStringPointer(),
 	})
 	if err != nil {
 		var nfe *awstypes.ResourceNotFoundException
@@ -445,13 +445,13 @@ func expandControlMappingSourcesCreate(ctx context.Context, tfList []controlMapp
 
 	for _, item := range tfList {
 		new := awstypes.CreateControlMappingSource{
-			SourceName:        aws.String(item.SourceName.ValueString()),
+			SourceName:        item.SourceName.ValueStringPointer(),
 			SourceSetUpOption: awstypes.SourceSetUpOption(item.SourceSetUpOption.ValueString()),
 			SourceType:        awstypes.SourceType(item.SourceType.ValueString()),
 		}
 
 		if !item.SourceDescription.IsNull() {
-			new.SourceDescription = aws.String(item.SourceDescription.ValueString())
+			new.SourceDescription = item.SourceDescription.ValueStringPointer()
 		}
 		if !item.SourceFrequency.IsNull() {
 			new.SourceFrequency = awstypes.SourceFrequency(item.SourceFrequency.ValueString())
@@ -462,7 +462,7 @@ func expandControlMappingSourcesCreate(ctx context.Context, tfList []controlMapp
 			new.SourceKeyword = expandSourceKeyword(sk)
 		}
 		if !item.TroubleshootingText.IsNull() {
-			new.TroubleshootingText = aws.String(item.TroubleshootingText.ValueString())
+			new.TroubleshootingText = item.TroubleshootingText.ValueStringPointer()
 		}
 		ccms = append(ccms, new)
 	}
@@ -475,14 +475,14 @@ func expandControlMappingSourcesUpdate(ctx context.Context, tfList []controlMapp
 
 	for _, item := range tfList {
 		new := awstypes.ControlMappingSource{
-			SourceId:          aws.String(item.SourceID.ValueString()),
-			SourceName:        aws.String(item.SourceName.ValueString()),
+			SourceId:          item.SourceID.ValueStringPointer(),
+			SourceName:        item.SourceName.ValueStringPointer(),
 			SourceSetUpOption: awstypes.SourceSetUpOption(item.SourceSetUpOption.ValueString()),
 			SourceType:        awstypes.SourceType(item.SourceType.ValueString()),
 		}
 
 		if !item.SourceDescription.IsNull() {
-			new.SourceDescription = aws.String(item.SourceDescription.ValueString())
+			new.SourceDescription = item.SourceDescription.ValueStringPointer()
 		}
 		if !item.SourceFrequency.IsNull() {
 			new.SourceFrequency = awstypes.SourceFrequency(item.SourceFrequency.ValueString())
@@ -493,7 +493,7 @@ func expandControlMappingSourcesUpdate(ctx context.Context, tfList []controlMapp
 			new.SourceKeyword = expandSourceKeyword(sk)
 		}
 		if !item.TroubleshootingText.IsNull() {
-			new.TroubleshootingText = aws.String(item.TroubleshootingText.ValueString())
+			new.TroubleshootingText = item.TroubleshootingText.ValueStringPointer()
 		}
 		cms = append(cms, new)
 	}
@@ -507,7 +507,7 @@ func expandSourceKeyword(tfList []sourceKeywordData) *awstypes.SourceKeyword {
 	sk := tfList[0]
 	return &awstypes.SourceKeyword{
 		KeywordInputType: awstypes.KeywordInputType(sk.KeywordInputType.ValueString()),
-		KeywordValue:     aws.String(sk.KeywordValue.ValueString()),
+		KeywordValue:     sk.KeywordValue.ValueStringPointer(),
 	}
 }
 

--- a/internal/service/auditmanager/framework.go
+++ b/internal/service/auditmanager/framework.go
@@ -125,16 +125,16 @@ func (r *resourceFramework) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	in := auditmanager.CreateAssessmentFrameworkInput{
-		Name:        aws.String(plan.Name.ValueString()),
+		Name:        plan.Name.ValueStringPointer(),
 		ControlSets: csInput,
 		Tags:        getTagsIn(ctx),
 	}
 
 	if !plan.ComplianceType.IsNull() {
-		in.ComplianceType = aws.String(plan.ComplianceType.ValueString())
+		in.ComplianceType = plan.ComplianceType.ValueStringPointer()
 	}
 	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
+		in.Description = plan.Description.ValueStringPointer()
 	}
 
 	out, err := conn.CreateAssessmentFramework(ctx, &in)
@@ -216,15 +216,15 @@ func (r *resourceFramework) Update(ctx context.Context, req resource.UpdateReque
 
 		in := &auditmanager.UpdateAssessmentFrameworkInput{
 			ControlSets: csInput,
-			FrameworkId: aws.String(plan.ID.ValueString()),
-			Name:        aws.String(plan.Name.ValueString()),
+			FrameworkId: plan.ID.ValueStringPointer(),
+			Name:        plan.Name.ValueStringPointer(),
 		}
 
 		if !plan.ComplianceType.IsNull() {
-			in.ComplianceType = aws.String(plan.ComplianceType.ValueString())
+			in.ComplianceType = plan.ComplianceType.ValueStringPointer()
 		}
 		if !plan.Description.IsNull() {
-			in.Description = aws.String(plan.Description.ValueString())
+			in.Description = plan.Description.ValueStringPointer()
 		}
 
 		out, err := conn.UpdateAssessmentFramework(ctx, in)
@@ -258,7 +258,7 @@ func (r *resourceFramework) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	_, err := conn.DeleteAssessmentFramework(ctx, &auditmanager.DeleteAssessmentFrameworkInput{
-		FrameworkId: aws.String(state.ID.ValueString()),
+		FrameworkId: state.ID.ValueStringPointer(),
 	})
 	if err != nil {
 		var nfe *awstypes.ResourceNotFoundException
@@ -395,7 +395,7 @@ func expandFrameworkControlSetsCreate(ctx context.Context, tfList []frameworkCon
 		diags.Append(item.Controls.ElementsAs(ctx, &controls, false)...)
 
 		new := awstypes.CreateAssessmentFrameworkControlSet{
-			Name:     aws.String(item.Name.ValueString()),
+			Name:     item.Name.ValueStringPointer(),
 			Controls: expandFrameworkControlSetsControls(controls),
 		}
 
@@ -414,8 +414,8 @@ func expandFrameworkControlSetsUpdate(ctx context.Context, tfList []frameworkCon
 
 		new := awstypes.UpdateAssessmentFrameworkControlSet{
 			Controls: expandFrameworkControlSetsControls(controls),
-			Id:       aws.String(item.ID.ValueString()),
-			Name:     aws.String(item.Name.ValueString()),
+			Id:       item.ID.ValueStringPointer(),
+			Name:     item.Name.ValueStringPointer(),
 		}
 
 		ucs = append(ucs, new)
@@ -431,7 +431,7 @@ func expandFrameworkControlSetsControls(tfList []frameworkControlSetsControlsDat
 	var controlsInput []awstypes.CreateAssessmentFrameworkControl
 	for _, item := range tfList {
 		new := awstypes.CreateAssessmentFrameworkControl{
-			Id: aws.String(item.ID.ValueString()),
+			Id: item.ID.ValueStringPointer(),
 		}
 		controlsInput = append(controlsInput, new)
 	}

--- a/internal/service/auditmanager/framework_share.go
+++ b/internal/service/auditmanager/framework_share.go
@@ -90,12 +90,12 @@ func (r *resourceFrameworkShare) Create(ctx context.Context, req resource.Create
 	}
 
 	in := auditmanager.StartAssessmentFrameworkShareInput{
-		DestinationAccount: aws.String(plan.DestinationAccount.ValueString()),
-		DestinationRegion:  aws.String(plan.DestinationRegion.ValueString()),
-		FrameworkId:        aws.String(plan.FrameworkID.ValueString()),
+		DestinationAccount: plan.DestinationAccount.ValueStringPointer(),
+		DestinationRegion:  plan.DestinationRegion.ValueStringPointer(),
+		FrameworkId:        plan.FrameworkID.ValueStringPointer(),
 	}
 	if !plan.Comment.IsNull() {
-		in.Comment = aws.String(plan.Comment.ValueString())
+		in.Comment = plan.Comment.ValueStringPointer()
 	}
 	out, err := conn.StartAssessmentFrameworkShare(ctx, &in)
 	if err != nil {
@@ -161,7 +161,7 @@ func (r *resourceFrameworkShare) Delete(ctx context.Context, req resource.Delete
 	// Framework share requests in certain statuses must be revoked before deletion
 	if CanBeRevoked(state.Status.ValueString()) {
 		in := auditmanager.UpdateAssessmentFrameworkShareInput{
-			RequestId:   aws.String(state.ID.ValueString()),
+			RequestId:   state.ID.ValueStringPointer(),
 			RequestType: awstypes.ShareRequestTypeSent,
 			Action:      awstypes.ShareRequestActionRevoke,
 		}
@@ -175,7 +175,7 @@ func (r *resourceFrameworkShare) Delete(ctx context.Context, req resource.Delete
 	}
 
 	in := auditmanager.DeleteAssessmentFrameworkShareInput{
-		RequestId:   aws.String(state.ID.ValueString()),
+		RequestId:   state.ID.ValueStringPointer(),
 		RequestType: awstypes.ShareRequestTypeSent,
 	}
 	_, err := conn.DeleteAssessmentFrameworkShare(ctx, &in)

--- a/internal/service/auditmanager/organization_admin_account_registration.go
+++ b/internal/service/auditmanager/organization_admin_account_registration.go
@@ -6,7 +6,6 @@ package auditmanager
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/auditmanager"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -64,7 +63,7 @@ func (r *resourceOrganizationAdminAccountRegistration) Create(ctx context.Contex
 	}
 
 	in := auditmanager.RegisterOrganizationAdminAccountInput{
-		AdminAccountId: aws.String(plan.AdminAccountID.ValueString()),
+		AdminAccountId: plan.AdminAccountID.ValueStringPointer(),
 	}
 	out, err := conn.RegisterOrganizationAdminAccount(ctx, &in)
 	if err != nil {
@@ -125,7 +124,7 @@ func (r *resourceOrganizationAdminAccountRegistration) Delete(ctx context.Contex
 	}
 
 	_, err := conn.DeregisterOrganizationAdminAccount(ctx, &auditmanager.DeregisterOrganizationAdminAccountInput{
-		AdminAccountId: aws.String(state.AdminAccountID.ValueString()),
+		AdminAccountId: state.AdminAccountID.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -319,7 +319,7 @@ func (r *resourceExport) Update(ctx context.Context, req resource.UpdateRequest,
 			return
 		}
 
-		in.ExportArn = aws.String(plan.ID.ValueString())
+		in.ExportArn = plan.ID.ValueStringPointer()
 
 		out, err := conn.UpdateExport(ctx, in)
 		if err != nil {
@@ -363,7 +363,7 @@ func (r *resourceExport) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 
 	in := &bcmdataexports.DeleteExportInput{
-		ExportArn: aws.String(state.ID.ValueString()),
+		ExportArn: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteExport(ctx, in)

--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -453,7 +453,7 @@ func (r *resourceGuardrail) Update(ctx context.Context, req resource.UpdateReque
 		!plan.Name.Equal(state.Name) ||
 		!plan.Description.Equal(state.Description) {
 		in := &bedrock.UpdateGuardrailInput{
-			GuardrailIdentifier: aws.String(plan.GuardrailID.ValueString()),
+			GuardrailIdentifier: plan.GuardrailID.ValueStringPointer(),
 		}
 		resp.Diagnostics.Append(fwflex.Expand(ctx, plan, in, flexOpt)...)
 		if resp.Diagnostics.HasError() {
@@ -511,7 +511,7 @@ func (r *resourceGuardrail) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	in := &bedrock.DeleteGuardrailInput{
-		GuardrailIdentifier: aws.String(state.GuardrailID.ValueString()),
+		GuardrailIdentifier: state.GuardrailID.ValueStringPointer(),
 	}
 	if _, err := conn.DeleteGuardrail(ctx, in); err != nil {
 		if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/bedrockagent/agent_versions_data_source.go
+++ b/internal/service/bedrockagent/agent_versions_data_source.go
@@ -6,7 +6,6 @@ package bedrockagent
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockagent"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/bedrockagent/types"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
@@ -99,7 +98,7 @@ func (d *dataSourceAgentVersions) Read(ctx context.Context, req datasource.ReadR
 	}
 
 	paginator := bedrockagent.NewListAgentVersionsPaginator(conn, &bedrockagent.ListAgentVersionsInput{
-		AgentId: aws.String(data.AgentID.ValueString()),
+		AgentId: data.AgentID.ValueStringPointer(),
 	})
 
 	var out bedrockagent.ListAgentVersionsOutput

--- a/internal/service/bedrockagent/data_source.go
+++ b/internal/service/bedrockagent/data_source.go
@@ -497,8 +497,8 @@ func (r *dataSourceResource) Delete(ctx context.Context, request resource.Delete
 	conn := r.Meta().BedrockAgentClient(ctx)
 
 	_, err := conn.DeleteDataSource(ctx, &bedrockagent.DeleteDataSourceInput{
-		DataSourceId:    aws.String(data.DataSourceID.ValueString()),
-		KnowledgeBaseId: aws.String(data.KnowledgeBaseID.ValueString()),
+		DataSourceId:    data.DataSourceID.ValueStringPointer(),
+		KnowledgeBaseId: data.KnowledgeBaseID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/bedrockagent/knowledge_base.go
+++ b/internal/service/bedrockagent/knowledge_base.go
@@ -461,7 +461,7 @@ func (r *knowledgeBaseResource) Delete(ctx context.Context, request resource.Del
 	conn := r.Meta().BedrockAgentClient(ctx)
 
 	_, err := conn.DeleteKnowledgeBase(ctx, &bedrockagent.DeleteKnowledgeBaseInput{
-		KnowledgeBaseId: aws.String(data.KnowledgeBaseID.ValueString()),
+		KnowledgeBaseId: data.KnowledgeBaseID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/chatbot/slack_channel_configuration.go
+++ b/internal/service/chatbot/slack_channel_configuration.go
@@ -268,7 +268,7 @@ func (r *slackChannelConfigurationResource) Delete(ctx context.Context, request 
 	})
 
 	input := &chatbot.DeleteSlackChannelConfigurationInput{
-		ChatConfigurationArn: aws.String(data.ChatConfigurationARN.ValueString()),
+		ChatConfigurationArn: data.ChatConfigurationARN.ValueStringPointer(),
 	}
 
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, r.DeleteTimeout(ctx, data.Timeouts), func() (interface{}, error) {

--- a/internal/service/chatbot/teams_channel_configuration.go
+++ b/internal/service/chatbot/teams_channel_configuration.go
@@ -272,7 +272,7 @@ func (r *teamsChannelConfigurationResource) Delete(ctx context.Context, request 
 	})
 
 	input := &chatbot.DeleteMicrosoftTeamsChannelConfigurationInput{
-		ChatConfigurationArn: aws.String(data.ChatConfigurationARN.ValueString()),
+		ChatConfigurationArn: data.ChatConfigurationARN.ValueStringPointer(),
 	}
 
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, r.DeleteTimeout(ctx, data.Timeouts), func() (interface{}, error) {

--- a/internal/service/cloudfront/continuous_deployment_policy.go
+++ b/internal/service/cloudfront/continuous_deployment_policy.go
@@ -235,9 +235,9 @@ func (r *continuousDeploymentPolicyResource) Update(ctx context.Context, request
 			return
 		}
 
-		input.Id = aws.String(new.ID.ValueString())
+		input.Id = new.ID.ValueStringPointer()
 		// Use state ETag value. The planned value will be unknown.
-		input.IfMatch = aws.String(old.ETag.ValueString())
+		input.IfMatch = old.ETag.ValueStringPointer()
 
 		output, err := conn.UpdateContinuousDeploymentPolicy(ctx, input)
 

--- a/internal/service/cloudtrail/organization_delegated_admin_account.go
+++ b/internal/service/cloudtrail/organization_delegated_admin_account.go
@@ -172,7 +172,7 @@ func (r *organizationDelegatedAdminAccountResource) Delete(ctx context.Context, 
 	conn := r.Meta().CloudTrailClient(ctx)
 
 	_, err := conn.DeregisterOrganizationDelegatedAdmin(ctx, &cloudtrail.DeregisterOrganizationDelegatedAdminInput{
-		DelegatedAdminAccountId: aws.String(data.ID.ValueString()),
+		DelegatedAdminAccountId: data.ID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.AccountNotRegisteredException](err) {

--- a/internal/service/codeguruprofiler/profiling_group.go
+++ b/internal/service/codeguruprofiler/profiling_group.go
@@ -223,7 +223,7 @@ func (r *resourceProfilingGroup) Delete(ctx context.Context, req resource.Delete
 	}
 
 	in := &codeguruprofiler.DeleteProfilingGroupInput{
-		ProfilingGroupName: aws.String(state.ID.ValueString()),
+		ProfilingGroupName: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteProfilingGroup(ctx, in)

--- a/internal/service/datazone/domain.go
+++ b/internal/service/datazone/domain.go
@@ -152,17 +152,17 @@ func (r *resourceDomain) Create(ctx context.Context, req resource.CreateRequest,
 
 	in := &datazone.CreateDomainInput{
 		ClientToken:         aws.String(sdkid.UniqueId()),
-		DomainExecutionRole: aws.String(plan.DomainExecutionRole.ValueString()),
-		Name:                aws.String(plan.Name.ValueString()),
+		DomainExecutionRole: plan.DomainExecutionRole.ValueStringPointer(),
+		Name:                plan.Name.ValueStringPointer(),
 		Tags:                getTagsIn(ctx),
 	}
 
 	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
+		in.Description = plan.Description.ValueStringPointer()
 	}
 
 	if !plan.KmsKeyIdentifier.IsNull() {
-		in.KmsKeyIdentifier = aws.String(plan.KmsKeyIdentifier.ValueString())
+		in.KmsKeyIdentifier = plan.KmsKeyIdentifier.ValueStringPointer()
 	}
 
 	if !plan.SingleSignOn.IsNull() {
@@ -272,19 +272,19 @@ func (r *resourceDomain) Update(ctx context.Context, req resource.UpdateRequest,
 		!plan.SingleSignOn.Equal(state.SingleSignOn) {
 		in := &datazone.UpdateDomainInput{
 			ClientToken: aws.String(sdkid.UniqueId()),
-			Identifier:  aws.String(plan.ID.ValueString()),
+			Identifier:  plan.ID.ValueStringPointer(),
 		}
 
 		if !plan.Description.IsNull() {
-			in.Description = aws.String(plan.Description.ValueString())
+			in.Description = plan.Description.ValueStringPointer()
 		}
 
 		if !plan.DomainExecutionRole.IsNull() {
-			in.DomainExecutionRole = aws.String(plan.DomainExecutionRole.ValueString())
+			in.DomainExecutionRole = plan.DomainExecutionRole.ValueStringPointer()
 		}
 
 		if !plan.Name.IsNull() {
-			in.Name = aws.String(plan.Name.ValueString())
+			in.Name = plan.Name.ValueStringPointer()
 		}
 
 		if !plan.SingleSignOn.IsNull() {
@@ -330,7 +330,7 @@ func (r *resourceDomain) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	in := &datazone.DeleteDomainInput{
 		ClientToken: aws.String(sdkid.UniqueId()),
-		Identifier:  aws.String(state.ID.ValueString()),
+		Identifier:  state.ID.ValueStringPointer(),
 	}
 
 	if !state.SkipDeletionCheck.IsNull() {

--- a/internal/service/datazone/environment_blueprint_configuration.go
+++ b/internal/service/datazone/environment_blueprint_configuration.go
@@ -94,17 +94,17 @@ func (r *resourceEnvironmentBlueprintConfiguration) Create(ctx context.Context, 
 	}
 
 	in := &datazone.PutEnvironmentBlueprintConfigurationInput{
-		DomainIdentifier:               aws.String(plan.DomainId.ValueString()),
+		DomainIdentifier:               plan.DomainId.ValueStringPointer(),
 		EnabledRegions:                 flex.ExpandFrameworkStringValueList(ctx, plan.EnabledRegions),
-		EnvironmentBlueprintIdentifier: aws.String(plan.EnvironmentBlueprintId.ValueString()),
+		EnvironmentBlueprintIdentifier: plan.EnvironmentBlueprintId.ValueStringPointer(),
 	}
 
 	if !plan.ManageAccessRoleArn.IsNull() {
-		in.ManageAccessRoleArn = aws.String(plan.ManageAccessRoleArn.ValueString())
+		in.ManageAccessRoleArn = plan.ManageAccessRoleArn.ValueStringPointer()
 	}
 
 	if !plan.ProvisioningRoleArn.IsNull() {
-		in.ProvisioningRoleArn = aws.String(plan.ProvisioningRoleArn.ValueString())
+		in.ProvisioningRoleArn = plan.ProvisioningRoleArn.ValueStringPointer()
 	}
 
 	if !plan.RegionalParameters.IsNull() {
@@ -187,17 +187,17 @@ func (r *resourceEnvironmentBlueprintConfiguration) Update(ctx context.Context, 
 		!plan.ProvisioningRoleArn.Equal(state.ProvisioningRoleArn) ||
 		!plan.RegionalParameters.Equal(state.RegionalParameters) {
 		in := &datazone.PutEnvironmentBlueprintConfigurationInput{
-			DomainIdentifier:               aws.String(plan.DomainId.ValueString()),
+			DomainIdentifier:               plan.DomainId.ValueStringPointer(),
 			EnabledRegions:                 flex.ExpandFrameworkStringValueList(ctx, plan.EnabledRegions),
-			EnvironmentBlueprintIdentifier: aws.String(plan.EnvironmentBlueprintId.ValueString()),
+			EnvironmentBlueprintIdentifier: plan.EnvironmentBlueprintId.ValueStringPointer(),
 		}
 
 		if !plan.ManageAccessRoleArn.IsNull() {
-			in.ManageAccessRoleArn = aws.String(plan.ManageAccessRoleArn.ValueString())
+			in.ManageAccessRoleArn = plan.ManageAccessRoleArn.ValueStringPointer()
 		}
 
 		if !plan.ProvisioningRoleArn.IsNull() {
-			in.ProvisioningRoleArn = aws.String(plan.ProvisioningRoleArn.ValueString())
+			in.ProvisioningRoleArn = plan.ProvisioningRoleArn.ValueStringPointer()
 		}
 
 		if !plan.RegionalParameters.IsNull() {
@@ -240,8 +240,8 @@ func (r *resourceEnvironmentBlueprintConfiguration) Delete(ctx context.Context, 
 	}
 
 	in := &datazone.DeleteEnvironmentBlueprintConfigurationInput{
-		DomainIdentifier:               aws.String(state.DomainId.ValueString()),
-		EnvironmentBlueprintIdentifier: aws.String(state.EnvironmentBlueprintId.ValueString()),
+		DomainIdentifier:               state.DomainId.ValueStringPointer(),
+		EnvironmentBlueprintIdentifier: state.EnvironmentBlueprintId.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteEnvironmentBlueprintConfiguration(ctx, in)

--- a/internal/service/datazone/project.go
+++ b/internal/service/datazone/project.go
@@ -283,7 +283,7 @@ func (r *resourceProject) Delete(ctx context.Context, req resource.DeleteRequest
 
 	in := &datazone.DeleteProjectInput{
 		DomainIdentifier: state.DomainIdentifier.ValueStringPointer(),
-		Identifier:       aws.String((*state.ID.ValueStringPointer())),
+		Identifier:       state.ID.ValueStringPointer(),
 	}
 	if !state.SkipDeletionCheck.IsNull() {
 		in.SkipDeletionCheck = state.SkipDeletionCheck.ValueBoolPointer()

--- a/internal/service/devopsguru/notification_channel.go
+++ b/internal/service/devopsguru/notification_channel.go
@@ -192,7 +192,7 @@ func (r *resourceNotificationChannel) Delete(ctx context.Context, req resource.D
 	}
 
 	in := &devopsguru.RemoveNotificationChannelInput{
-		Id: aws.String(state.ID.ValueString()),
+		Id: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.RemoveNotificationChannel(ctx, in)

--- a/internal/service/drs/replication_configuration_template.go
+++ b/internal/service/drs/replication_configuration_template.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/drs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/drs/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -284,7 +283,7 @@ func (r *replicationConfigurationTemplateResource) Delete(ctx context.Context, r
 	})
 
 	input := &drs.DeleteReplicationConfigurationTemplateInput{
-		ReplicationConfigurationTemplateID: aws.String(data.ID.ValueString()),
+		ReplicationConfigurationTemplateID: data.ID.ValueStringPointer(),
 	}
 
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (interface{}, error) {

--- a/internal/service/dynamodb/resource_policy.go
+++ b/internal/service/dynamodb/resource_policy.go
@@ -192,7 +192,7 @@ func (r *resourcePolicyResource) Delete(ctx context.Context, request resource.De
 	conn := r.Meta().DynamoDBClient(ctx)
 
 	_, err := conn.DeleteResourcePolicy(ctx, &dynamodb.DeleteResourcePolicyInput{
-		ResourceArn: aws.String(data.ID.ValueString()),
+		ResourceArn: data.ID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.PolicyNotFoundException](err) || errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/emr/supported_instance_types_data_source.go
+++ b/internal/service/emr/supported_instance_types_data_source.go
@@ -6,7 +6,6 @@ package emr
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/emr"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/emr/types"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -99,7 +98,7 @@ func (d *dataSourceSupportedInstanceTypes) Read(ctx context.Context, req datasou
 	data.ID = types.StringValue(data.ReleaseLabel.ValueString())
 
 	input := &emr.ListSupportedInstanceTypesInput{
-		ReleaseLabel: aws.String(data.ReleaseLabel.ValueString()),
+		ReleaseLabel: data.ReleaseLabel.ValueStringPointer(),
 	}
 
 	var results []awstypes.SupportedInstanceType

--- a/internal/service/fms/resource_set.go
+++ b/internal/service/fms/resource_set.go
@@ -260,7 +260,7 @@ func (r *resourceResourceSet) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	in := &fms.DeleteResourceSetInput{
-		Identifier: aws.String(state.ID.ValueString()),
+		Identifier: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteResourceSet(ctx, in)

--- a/internal/service/guardduty/malware_protection_plan.go
+++ b/internal/service/guardduty/malware_protection_plan.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
@@ -298,7 +297,7 @@ func (r *resourceMalwareProtectionPlan) Delete(ctx context.Context, req resource
 	}
 
 	_, err := conn.DeleteMalwareProtectionPlan(ctx, &guardduty.DeleteMalwareProtectionPlanInput{
-		MalwareProtectionPlanId: aws.String(state.ID.ValueString()),
+		MalwareProtectionPlanId: state.ID.ValueStringPointer(),
 	})
 	if err != nil {
 		var nfe *awstypes.ResourceNotFoundException

--- a/internal/service/lambda/runtime_management_config.go
+++ b/internal/service/lambda/runtime_management_config.go
@@ -180,11 +180,11 @@ func (r *resourceRuntimeManagementConfig) Delete(ctx context.Context, req resour
 	}
 
 	in := &lambda.PutRuntimeManagementConfigInput{
-		FunctionName:    aws.String(state.FunctionName.ValueString()),
+		FunctionName:    state.FunctionName.ValueStringPointer(),
 		UpdateRuntimeOn: awstypes.UpdateRuntimeOnAuto,
 	}
 	if !state.Qualifier.IsNull() && state.Qualifier.ValueString() != "" {
-		in.Qualifier = aws.String(state.Qualifier.ValueString())
+		in.Qualifier = state.Qualifier.ValueStringPointer()
 	}
 
 	_, err := conn.PutRuntimeManagementConfig(ctx, in)

--- a/internal/service/lexv2models/bot.go
+++ b/internal/service/lexv2models/bot.go
@@ -160,7 +160,7 @@ func (r *resourceBot) Create(ctx context.Context, req resource.CreateRequest, re
 	dpInput := expandDataPrivacy(ctx, dp)
 
 	in := lexmodelsv2.CreateBotInput{
-		BotName:                 aws.String(plan.Name.ValueString()),
+		BotName:                 plan.Name.ValueStringPointer(),
 		DataPrivacy:             dpInput,
 		IdleSessionTTLInSeconds: aws.Int32(int32(plan.IdleSessionTTLInSeconds.ValueInt64())),
 		RoleArn:                 flex.StringFromFramework(ctx, plan.RoleARN),
@@ -172,7 +172,7 @@ func (r *resourceBot) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 
 	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
+		in.Description = plan.Description.ValueStringPointer()
 	}
 
 	var bm []membersData
@@ -310,7 +310,7 @@ func (r *resourceBot) Update(ctx context.Context, req resource.UpdateRequest, re
 		}
 
 		if !plan.Description.IsNull() {
-			in.Description = aws.String(plan.Description.ValueString())
+			in.Description = plan.Description.ValueStringPointer()
 		}
 
 		if !plan.Members.IsNull() {
@@ -366,7 +366,7 @@ func (r *resourceBot) Delete(ctx context.Context, req resource.DeleteRequest, re
 	}
 
 	in := &lexmodelsv2.DeleteBotInput{
-		BotId: aws.String(state.ID.ValueString()),
+		BotId: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteBot(ctx, in)

--- a/internal/service/lexv2models/bot_locale.go
+++ b/internal/service/lexv2models/bot_locale.go
@@ -144,14 +144,14 @@ func (r *resourceBotLocale) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	in := &lexmodelsv2.CreateBotLocaleInput{
-		BotId:                        aws.String(plan.BotID.ValueString()),
-		BotVersion:                   aws.String(plan.BotVersion.ValueString()),
-		LocaleId:                     aws.String(plan.LocaleID.ValueString()),
-		NluIntentConfidenceThreshold: aws.Float64(plan.NluIntentCOnfidenceThreshold.ValueFloat64()),
+		BotId:                        plan.BotID.ValueStringPointer(),
+		BotVersion:                   plan.BotVersion.ValueStringPointer(),
+		LocaleId:                     plan.LocaleID.ValueStringPointer(),
+		NluIntentConfidenceThreshold: plan.NluIntentCOnfidenceThreshold.ValueFloat64Pointer(),
 	}
 
 	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
+		in.Description = plan.Description.ValueStringPointer()
 	}
 	if !plan.VoiceSettings.IsNull() {
 		var tfList []voiceSettingsData
@@ -276,14 +276,14 @@ func (r *resourceBotLocale) Update(ctx context.Context, req resource.UpdateReque
 		!plan.VoiceSettings.Equal(state.VoiceSettings) ||
 		!plan.NluIntentCOnfidenceThreshold.Equal(state.NluIntentCOnfidenceThreshold) {
 		in := &lexmodelsv2.UpdateBotLocaleInput{
-			BotId:                        aws.String(plan.BotID.ValueString()),
-			BotVersion:                   aws.String(plan.BotVersion.ValueString()),
-			LocaleId:                     aws.String(plan.LocaleID.ValueString()),
-			NluIntentConfidenceThreshold: aws.Float64(plan.NluIntentCOnfidenceThreshold.ValueFloat64()),
+			BotId:                        plan.BotID.ValueStringPointer(),
+			BotVersion:                   plan.BotVersion.ValueStringPointer(),
+			LocaleId:                     plan.LocaleID.ValueStringPointer(),
+			NluIntentConfidenceThreshold: plan.NluIntentCOnfidenceThreshold.ValueFloat64Pointer(),
 		}
 
 		if !plan.Description.IsNull() {
-			in.Description = aws.String(plan.Description.ValueString())
+			in.Description = plan.Description.ValueStringPointer()
 		}
 		if !plan.VoiceSettings.IsNull() {
 			var tfList []voiceSettingsData
@@ -336,9 +336,9 @@ func (r *resourceBotLocale) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	in := &lexmodelsv2.DeleteBotLocaleInput{
-		LocaleId:   aws.String(state.LocaleID.ValueString()),
-		BotId:      aws.String(state.BotID.ValueString()),
-		BotVersion: aws.String(state.BotVersion.ValueString()),
+		LocaleId:   state.LocaleID.ValueStringPointer(),
+		BotId:      state.BotID.ValueStringPointer(),
+		BotVersion: state.BotVersion.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteBotLocale(ctx, in)

--- a/internal/service/lexv2models/bot_version.go
+++ b/internal/service/lexv2models/bot_version.go
@@ -115,12 +115,12 @@ func (r *resourceBotVersion) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	in := &lexmodelsv2.CreateBotVersionInput{
-		BotId:                         aws.String(plan.BotID.ValueString()),
+		BotId:                         plan.BotID.ValueStringPointer(),
 		BotVersionLocaleSpecification: expandLocalSpecification(localeSpec),
 	}
 
 	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
+		in.Description = plan.Description.ValueStringPointer()
 	}
 
 	out, err := conn.CreateBotVersion(ctx, in)
@@ -214,8 +214,8 @@ func (r *resourceBotVersion) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	in := &lexmodelsv2.DeleteBotVersionInput{
-		BotId:      aws.String(state.BotID.ValueString()),
-		BotVersion: aws.String(state.BotVersion.ValueString()),
+		BotId:      state.BotID.ValueStringPointer(),
+		BotVersion: state.BotVersion.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteBotVersion(ctx, in)
@@ -331,7 +331,7 @@ func expandLocalSpecification(tfMap map[string]versionLocaleDetailsData) map[str
 
 	tfObj := make(map[string]awstypes.BotVersionLocaleDetails)
 	for key, value := range tfMap {
-		tfObj[key] = awstypes.BotVersionLocaleDetails{SourceBotVersion: aws.String(value.SourceBotVersion.ValueString())}
+		tfObj[key] = awstypes.BotVersionLocaleDetails{SourceBotVersion: value.SourceBotVersion.ValueStringPointer()}
 	}
 
 	return tfObj

--- a/internal/service/lexv2models/intent.go
+++ b/internal/service/lexv2models/intent.go
@@ -1091,10 +1091,10 @@ func (r *resourceIntent) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 
 	in := &lexmodelsv2.DeleteIntentInput{
-		IntentId:   aws.String(state.IntentID.ValueString()),
-		BotId:      aws.String(state.BotID.ValueString()),
-		BotVersion: aws.String(state.BotVersion.ValueString()),
-		LocaleId:   aws.String(state.LocaleID.ValueString()),
+		IntentId:   state.IntentID.ValueStringPointer(),
+		BotId:      state.BotID.ValueStringPointer(),
+		BotVersion: state.BotVersion.ValueStringPointer(),
+		LocaleId:   state.LocaleID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteIntent(ctx, in)

--- a/internal/service/lexv2models/slot.go
+++ b/internal/service/lexv2models/slot.go
@@ -591,7 +591,7 @@ func (r *resourceSlot) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	in := &lexmodelsv2.CreateSlotInput{
-		SlotName: aws.String(plan.Name.ValueString()),
+		SlotName: plan.Name.ValueStringPointer(),
 	}
 
 	resp.Diagnostics.Append(flex.Expand(ctx, &plan, in, slotFlexOpt)...)
@@ -724,11 +724,11 @@ func (r *resourceSlot) Delete(ctx context.Context, req resource.DeleteRequest, r
 	}
 
 	in := &lexmodelsv2.DeleteSlotInput{
-		BotId:      aws.String(state.BotID.ValueString()),
-		BotVersion: aws.String(state.BotVersion.ValueString()),
-		IntentId:   aws.String(state.IntentID.ValueString()),
-		LocaleId:   aws.String(state.LocaleID.ValueString()),
-		SlotId:     aws.String(state.SlotID.ValueString()),
+		BotId:      state.BotID.ValueStringPointer(),
+		BotVersion: state.BotVersion.ValueStringPointer(),
+		IntentId:   state.IntentID.ValueStringPointer(),
+		LocaleId:   state.LocaleID.ValueStringPointer(),
+		SlotId:     state.SlotID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteSlot(ctx, in)

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -239,7 +239,7 @@ func (r *resourceSlotType) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	in := &lexmodelsv2.CreateSlotTypeInput{
-		SlotTypeName: aws.String(plan.Name.ValueString()),
+		SlotTypeName: plan.Name.ValueStringPointer(),
 	}
 	resp.Diagnostics.Append(flex.Expand(ctx, &plan, in, slotTypeFlexOpt)...)
 	if resp.Diagnostics.HasError() {
@@ -369,10 +369,10 @@ func (r *resourceSlotType) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	in := &lexmodelsv2.DeleteSlotTypeInput{
-		BotId:      aws.String(state.BotID.ValueString()),
-		BotVersion: aws.String(state.BotVersion.ValueString()),
-		LocaleId:   aws.String(state.LocaleID.ValueString()),
-		SlotTypeId: aws.String(state.SlotTypeID.ValueString()),
+		BotId:      state.BotID.ValueStringPointer(),
+		BotVersion: state.BotVersion.ValueStringPointer(),
+		LocaleId:   state.LocaleID.ValueStringPointer(),
+		SlotTypeId: state.SlotTypeID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteSlotType(ctx, in)

--- a/internal/service/m2/application.go
+++ b/internal/service/m2/application.go
@@ -314,7 +314,7 @@ func (r *applicationResource) Delete(ctx context.Context, request resource.Delet
 	conn := r.Meta().M2Client(ctx)
 
 	_, err := conn.DeleteApplication(ctx, &m2.DeleteApplicationInput{
-		ApplicationId: aws.String(data.ID.ValueString()),
+		ApplicationId: data.ID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/m2/environment.go
+++ b/internal/service/m2/environment.go
@@ -435,7 +435,7 @@ func (r *environmentResource) Delete(ctx context.Context, request resource.Delet
 	conn := r.Meta().M2Client(ctx)
 
 	_, err := conn.DeleteEnvironment(ctx, &m2.DeleteEnvironmentInput{
-		EnvironmentId: aws.String(data.ID.ValueString()),
+		EnvironmentId: data.ID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/networkfirewall/tls_inspection_configuration.go
+++ b/internal/service/networkfirewall/tls_inspection_configuration.go
@@ -392,7 +392,7 @@ func (r *tlsInspectionConfigurationResource) Update(ctx context.Context, request
 			return
 		}
 
-		input.UpdateToken = aws.String(old.UpdateToken.ValueString())
+		input.UpdateToken = old.UpdateToken.ValueStringPointer()
 
 		output, err := conn.UpdateTLSInspectionConfiguration(ctx, input)
 
@@ -436,7 +436,7 @@ func (r *tlsInspectionConfigurationResource) Delete(ctx context.Context, request
 	conn := r.Meta().NetworkFirewallClient(ctx)
 
 	_, err := conn.DeleteTLSInspectionConfiguration(ctx, &networkfirewall.DeleteTLSInspectionConfigurationInput{
-		TLSInspectionConfigurationArn: aws.String(data.ID.ValueString()),
+		TLSInspectionConfigurationArn: data.ID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/opensearchserverless/access_policy.go
+++ b/internal/service/opensearchserverless/access_policy.go
@@ -218,7 +218,7 @@ func (r *resourceAccessPolicy) Delete(ctx context.Context, req resource.DeleteRe
 
 	_, err := conn.DeleteAccessPolicy(ctx, &opensearchserverless.DeleteAccessPolicyInput{
 		ClientToken: aws.String(id.UniqueId()),
-		Name:        aws.String(state.Name.ValueString()),
+		Name:        state.Name.ValueStringPointer(),
 		Type:        awstypes.AccessPolicyType(state.Type.ValueString()),
 	})
 

--- a/internal/service/opensearchserverless/collection.go
+++ b/internal/service/opensearchserverless/collection.go
@@ -283,7 +283,7 @@ func (r *resourceCollection) Delete(ctx context.Context, req resource.DeleteRequ
 
 	_, err := conn.DeleteCollection(ctx, &opensearchserverless.DeleteCollectionInput{
 		ClientToken: aws.String(id.UniqueId()),
-		Id:          aws.String(state.ID.ValueString()),
+		Id:          state.ID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/opensearchserverless/security_policy.go
+++ b/internal/service/opensearchserverless/security_policy.go
@@ -219,7 +219,7 @@ func (r *resourceSecurityPolicy) Delete(ctx context.Context, req resource.Delete
 
 	_, err := conn.DeleteSecurityPolicy(ctx, &opensearchserverless.DeleteSecurityPolicyInput{
 		ClientToken: aws.String(id.UniqueId()),
-		Name:        aws.String(state.Name.ValueString()),
+		Name:        state.Name.ValueStringPointer(),
 		Type:        awstypes.SecurityPolicyType(state.Type.ValueString()),
 	})
 	if err != nil {

--- a/internal/service/opensearchserverless/vpc_endpoint.go
+++ b/internal/service/opensearchserverless/vpc_endpoint.go
@@ -124,9 +124,9 @@ func (r *resourceVpcEndpoint) Create(ctx context.Context, req resource.CreateReq
 
 	in := &opensearchserverless.CreateVpcEndpointInput{
 		ClientToken: aws.String(id.UniqueId()),
-		Name:        aws.String(plan.Name.ValueString()),
+		Name:        plan.Name.ValueStringPointer(),
 		SubnetIds:   flex.ExpandFrameworkStringValueSet(ctx, plan.SubnetIds),
-		VpcId:       aws.String(plan.VpcId.ValueString()),
+		VpcId:       plan.VpcId.ValueStringPointer(),
 	}
 
 	if !plan.SecurityGroupIds.IsNull() && !plan.SecurityGroupIds.IsUnknown() {
@@ -210,7 +210,7 @@ func (r *resourceVpcEndpoint) Update(ctx context.Context, req resource.UpdateReq
 
 	input := &opensearchserverless.UpdateVpcEndpointInput{
 		ClientToken: aws.String(id.UniqueId()),
-		Id:          aws.String(plan.ID.ValueString()),
+		Id:          plan.ID.ValueStringPointer(),
 	}
 
 	if !plan.SecurityGroupIds.Equal(state.SecurityGroupIds) {
@@ -290,7 +290,7 @@ func (r *resourceVpcEndpoint) Delete(ctx context.Context, req resource.DeleteReq
 
 	_, err := conn.DeleteVpcEndpoint(ctx, &opensearchserverless.DeleteVpcEndpointInput{
 		ClientToken: aws.String(id.UniqueId()),
-		Id:          aws.String(state.ID.ValueString()),
+		Id:          state.ID.ValueStringPointer(),
 	})
 
 	if err != nil {

--- a/internal/service/paymentcryptography/key.go
+++ b/internal/service/paymentcryptography/key.go
@@ -385,7 +385,7 @@ func (r *resourceKey) Delete(ctx context.Context, request resource.DeleteRequest
 	}
 
 	in := &paymentcryptography.DeleteKeyInput{
-		KeyIdentifier: aws.String(state.ID.ValueString()),
+		KeyIdentifier: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteKey(ctx, in)

--- a/internal/service/pinpoint/email_template.go
+++ b/internal/service/pinpoint/email_template.go
@@ -238,7 +238,7 @@ func (r *resourceEmailTemplate) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	in := &pinpoint.DeleteEmailTemplateInput{
-		TemplateName: aws.String(state.TemplateName.ValueString()),
+		TemplateName: state.TemplateName.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteEmailTemplate(ctx, in)

--- a/internal/service/pinpointsmsvoicev2/opt_out_list.go
+++ b/internal/service/pinpointsmsvoicev2/opt_out_list.go
@@ -147,7 +147,7 @@ func (r *optOutListResource) Delete(ctx context.Context, request resource.Delete
 	conn := r.Meta().PinpointSMSVoiceV2Client(ctx)
 
 	_, err := conn.DeleteOptOutList(ctx, &pinpointsmsvoicev2.DeleteOptOutListInput{
-		OptOutListName: aws.String(data.ID.ValueString()),
+		OptOutListName: data.ID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/pinpointsmsvoicev2/phone_number.go
+++ b/internal/service/pinpointsmsvoicev2/phone_number.go
@@ -320,7 +320,7 @@ func (r *phoneNumberResource) Delete(ctx context.Context, request resource.Delet
 	conn := r.Meta().PinpointSMSVoiceV2Client(ctx)
 
 	_, err := conn.ReleasePhoneNumber(ctx, &pinpointsmsvoicev2.ReleasePhoneNumberInput{
-		PhoneNumberId: aws.String(data.PhoneNumberID.ValueString()),
+		PhoneNumberId: data.PhoneNumberID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/quicksight/iam_policy_assignment.go
+++ b/internal/service/quicksight/iam_policy_assignment.go
@@ -144,7 +144,7 @@ func (r *iamPolicyAssignmentResource) Create(ctx context.Context, req resource.C
 		in.Identities = expandIdentities(ctx, identities)
 	}
 	if !plan.PolicyARN.IsNull() {
-		in.PolicyArn = aws.String(plan.PolicyARN.ValueString())
+		in.PolicyArn = plan.PolicyARN.ValueStringPointer()
 	}
 
 	out, err := conn.CreateIAMPolicyAssignment(ctx, &in)
@@ -238,9 +238,9 @@ func (r *iamPolicyAssignmentResource) Update(ctx context.Context, req resource.U
 		!plan.Identities.Equal(state.Identities) ||
 		!plan.PolicyARN.Equal(state.PolicyARN) {
 		in := quicksight.UpdateIAMPolicyAssignmentInput{
-			AwsAccountId:     aws.String(plan.AWSAccountID.ValueString()),
-			Namespace:        aws.String(plan.Namespace.ValueString()),
-			AssignmentName:   aws.String(plan.AssignmentName.ValueString()),
+			AwsAccountId:     plan.AWSAccountID.ValueStringPointer(),
+			Namespace:        plan.Namespace.ValueStringPointer(),
+			AssignmentName:   plan.AssignmentName.ValueStringPointer(),
 			AssignmentStatus: awstypes.AssignmentStatus(plan.AssignmentStatus.ValueString()),
 		}
 
@@ -253,7 +253,7 @@ func (r *iamPolicyAssignmentResource) Update(ctx context.Context, req resource.U
 			in.Identities = expandIdentities(ctx, identities)
 		}
 		if !plan.PolicyARN.IsNull() {
-			in.PolicyArn = aws.String(plan.PolicyARN.ValueString())
+			in.PolicyArn = plan.PolicyARN.ValueStringPointer()
 		}
 
 		out, err := conn.UpdateIAMPolicyAssignment(ctx, &in)

--- a/internal/service/quicksight/template_alias.go
+++ b/internal/service/quicksight/template_alias.go
@@ -93,7 +93,7 @@ func (r *templateAliasResource) Create(ctx context.Context, req resource.CreateR
 		AliasName:             aws.String(aliasName),
 		AwsAccountId:          aws.String(awsAccountID),
 		TemplateId:            aws.String(templateID),
-		TemplateVersionNumber: aws.Int64(plan.TemplateVersionNumber.ValueInt64()),
+		TemplateVersionNumber: plan.TemplateVersionNumber.ValueInt64Pointer(),
 	}
 
 	out, err := conn.CreateTemplateAlias(ctx, in)
@@ -182,7 +182,7 @@ func (r *templateAliasResource) Update(ctx context.Context, req resource.UpdateR
 			AliasName:             aws.String(aliasName),
 			AwsAccountId:          aws.String(awsAccountID),
 			TemplateId:            aws.String(templateID),
-			TemplateVersionNumber: aws.Int64(plan.TemplateVersionNumber.ValueInt64()),
+			TemplateVersionNumber: plan.TemplateVersionNumber.ValueInt64Pointer(),
 		}
 
 		out, err := conn.UpdateTemplateAlias(ctx, in)

--- a/internal/service/quicksight/vpc_connection.go
+++ b/internal/service/quicksight/vpc_connection.go
@@ -166,8 +166,8 @@ func (r *vpcConnectionResource) Create(ctx context.Context, req resource.CreateR
 	awsAccountID, vpcConnectionID := flex.StringValueFromFramework(ctx, plan.AWSAccountID), flex.StringValueFromFramework(ctx, plan.VPCConnectionID)
 	in := &quicksight.CreateVPCConnectionInput{
 		AwsAccountId:     aws.String(awsAccountID),
-		Name:             aws.String(plan.Name.ValueString()),
-		RoleArn:          aws.String(plan.RoleArn.ValueString()),
+		Name:             plan.Name.ValueStringPointer(),
+		RoleArn:          plan.RoleArn.ValueStringPointer(),
 		SecurityGroupIds: flex.ExpandFrameworkStringValueSet(ctx, plan.SecurityGroupIds),
 		SubnetIds:        flex.ExpandFrameworkStringValueSet(ctx, plan.SubnetIds),
 		Tags:             getTagsIn(ctx),
@@ -287,8 +287,8 @@ func (r *vpcConnectionResource) Update(ctx context.Context, req resource.UpdateR
 		!plan.SubnetIds.Equal(state.SubnetIds) {
 		in := quicksight.UpdateVPCConnectionInput{
 			AwsAccountId:     aws.String(awsAccountID),
-			Name:             aws.String(plan.Name.ValueString()),
-			RoleArn:          aws.String(plan.RoleArn.ValueString()),
+			Name:             plan.Name.ValueStringPointer(),
+			RoleArn:          plan.RoleArn.ValueStringPointer(),
 			SecurityGroupIds: flex.ExpandFrameworkStringValueSet(ctx, plan.SecurityGroupIds),
 			SubnetIds:        flex.ExpandFrameworkStringValueSet(ctx, plan.SubnetIds),
 			VPCConnectionId:  aws.String(vpcConnectionID),

--- a/internal/service/rds/export_task.go
+++ b/internal/service/rds/export_task.go
@@ -152,17 +152,17 @@ func (r *resourceExportTask) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	in := rds.StartExportTaskInput{
-		ExportTaskIdentifier: aws.String(plan.ExportTaskIdentifier.ValueString()),
-		IamRoleArn:           aws.String(plan.IAMRoleArn.ValueString()),
-		KmsKeyId:             aws.String(plan.KMSKeyID.ValueString()),
-		S3BucketName:         aws.String(plan.S3BucketName.ValueString()),
-		SourceArn:            aws.String(plan.SourceArn.ValueString()),
+		ExportTaskIdentifier: plan.ExportTaskIdentifier.ValueStringPointer(),
+		IamRoleArn:           plan.IAMRoleArn.ValueStringPointer(),
+		KmsKeyId:             plan.KMSKeyID.ValueStringPointer(),
+		S3BucketName:         plan.S3BucketName.ValueStringPointer(),
+		SourceArn:            plan.SourceArn.ValueStringPointer(),
 	}
 	if !plan.ExportOnly.IsNull() {
 		in.ExportOnly = flex.ExpandFrameworkStringValueList(ctx, plan.ExportOnly)
 	}
 	if !plan.S3Prefix.IsNull() && !plan.S3Prefix.IsUnknown() {
-		in.S3Prefix = aws.String(plan.S3Prefix.ValueString())
+		in.S3Prefix = plan.S3Prefix.ValueStringPointer()
 	}
 
 	outStart, err := conn.StartExportTask(ctx, &in)
@@ -242,7 +242,7 @@ func (r *resourceExportTask) Delete(ctx context.Context, req resource.DeleteRequ
 	// Attempt to cancel the export task, but ignore errors where the task is in an invalid
 	// state (ie. completed or failed) which can't be cancelled
 	_, err := conn.CancelExportTask(ctx, &rds.CancelExportTaskInput{
-		ExportTaskIdentifier: aws.String(state.ID.ValueString()),
+		ExportTaskIdentifier: state.ID.ValueStringPointer(),
 	})
 	if err != nil {
 		var stateFault *awstypes.InvalidExportTaskStateFault

--- a/internal/service/rds/integration.go
+++ b/internal/service/rds/integration.go
@@ -222,7 +222,7 @@ func (r *integrationResource) Delete(ctx context.Context, request resource.Delet
 	conn := r.Meta().RDSClient(ctx)
 
 	_, err := conn.DeleteIntegration(ctx, &rds.DeleteIntegrationInput{
-		IntegrationIdentifier: aws.String(data.ID.ValueString()),
+		IntegrationIdentifier: data.ID.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.IntegrationNotFoundFault](err) {

--- a/internal/service/redshift/data_share_authorization.go
+++ b/internal/service/redshift/data_share_authorization.go
@@ -119,7 +119,7 @@ func (r *resourceDataShareAuthorization) Create(ctx context.Context, req resourc
 	}
 
 	if !plan.AllowWrites.IsNull() {
-		in.AllowWrites = aws.Bool(plan.AllowWrites.ValueBool())
+		in.AllowWrites = plan.AllowWrites.ValueBoolPointer()
 	}
 
 	out, err := conn.AuthorizeDataShare(ctx, in)
@@ -198,8 +198,8 @@ func (r *resourceDataShareAuthorization) Delete(ctx context.Context, req resourc
 	}
 
 	in := &redshift.DeauthorizeDataShareInput{
-		DataShareArn:       aws.String(state.DataShareARN.ValueString()),
-		ConsumerIdentifier: aws.String(state.ConsumerIdentifier.ValueString()),
+		DataShareArn:       state.DataShareARN.ValueStringPointer(),
+		ConsumerIdentifier: state.ConsumerIdentifier.ValueStringPointer(),
 	}
 
 	_, err := conn.DeauthorizeDataShare(ctx, in)

--- a/internal/service/redshift/data_share_consumer_association.go
+++ b/internal/service/redshift/data_share_consumer_association.go
@@ -140,10 +140,10 @@ func (r *resourceDataShareConsumerAssociation) Create(ctx context.Context, req r
 	}
 
 	if !plan.AllowWrites.IsNull() {
-		in.AllowWrites = aws.Bool(plan.AllowWrites.ValueBool())
+		in.AllowWrites = plan.AllowWrites.ValueBoolPointer()
 	}
 	if !plan.AssociateEntireAccount.IsNull() {
-		in.AssociateEntireAccount = aws.Bool(plan.AssociateEntireAccount.ValueBool())
+		in.AssociateEntireAccount = plan.AssociateEntireAccount.ValueBoolPointer()
 	}
 	if !plan.ConsumerARN.IsNull() {
 		in.ConsumerArn = aws.String(consumerARN)
@@ -236,16 +236,16 @@ func (r *resourceDataShareConsumerAssociation) Delete(ctx context.Context, req r
 	}
 
 	in := &redshift.DisassociateDataShareConsumerInput{
-		DataShareArn: aws.String(state.DataShareARN.ValueString()),
+		DataShareArn: state.DataShareARN.ValueStringPointer(),
 	}
 	if !state.AssociateEntireAccount.IsNull() && state.AssociateEntireAccount.ValueBool() {
 		in.DisassociateEntireAccount = aws.Bool(true)
 	}
 	if !state.ConsumerARN.IsNull() {
-		in.ConsumerArn = aws.String(state.ConsumerARN.ValueString())
+		in.ConsumerArn = state.ConsumerARN.ValueStringPointer()
 	}
 	if !state.ConsumerRegion.IsNull() {
-		in.ConsumerRegion = aws.String(state.ConsumerRegion.ValueString())
+		in.ConsumerRegion = state.ConsumerRegion.ValueStringPointer()
 	}
 
 	_, err := conn.DisassociateDataShareConsumer(ctx, in)

--- a/internal/service/redshift/logging.go
+++ b/internal/service/redshift/logging.go
@@ -210,7 +210,7 @@ func (r *resourceLogging) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	in := &redshift.DisableLoggingInput{
-		ClusterIdentifier: aws.String(state.ID.ValueString()),
+		ClusterIdentifier: state.ID.ValueStringPointer(),
 	}
 
 	// Retry InvalidClusterState faults, which can occur when logging is being enabled.

--- a/internal/service/redshift/producer_data_shares_data_source.go
+++ b/internal/service/redshift/producer_data_shares_data_source.go
@@ -6,7 +6,6 @@ package redshift
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -80,7 +79,7 @@ func (d *dataSourceProducerDataShares) Read(ctx context.Context, req datasource.
 	data.ID = types.StringValue(data.ProducerARN.ValueString())
 
 	input := &redshift.DescribeDataSharesForProducerInput{
-		ProducerArn: aws.String(data.ProducerARN.ValueString()),
+		ProducerArn: data.ProducerARN.ValueStringPointer(),
 	}
 	if !data.Status.IsNull() {
 		input.Status = awstypes.DataShareStatusForProducer(data.Status.ValueString())

--- a/internal/service/redshift/snapshot_copy.go
+++ b/internal/service/redshift/snapshot_copy.go
@@ -158,7 +158,7 @@ func (r *resourceSnapshotCopy) Update(ctx context.Context, req resource.UpdateRe
 
 	if !plan.RetentionPeriod.Equal(state.RetentionPeriod) {
 		in := &redshift.ModifySnapshotCopyRetentionPeriodInput{
-			ClusterIdentifier: aws.String(plan.ClusterIdentifier.ValueString()),
+			ClusterIdentifier: plan.ClusterIdentifier.ValueStringPointer(),
 			RetentionPeriod:   aws.Int32(int32(plan.RetentionPeriod.ValueInt64())),
 		}
 
@@ -194,7 +194,7 @@ func (r *resourceSnapshotCopy) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	in := &redshift.DisableSnapshotCopyInput{
-		ClusterIdentifier: aws.String(state.ID.ValueString()),
+		ClusterIdentifier: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DisableSnapshotCopy(ctx, in)

--- a/internal/service/redshiftserverless/custom_domain_association.go
+++ b/internal/service/redshiftserverless/custom_domain_association.go
@@ -164,9 +164,9 @@ func (r *customDomainAssociationResource) Update(ctx context.Context, request re
 	conn := r.Meta().RedshiftServerlessClient(ctx)
 
 	input := &redshiftserverless.UpdateCustomDomainAssociationInput{
-		CustomDomainCertificateArn: aws.String(new.CustomDomainCertificateARN.ValueString()),
-		CustomDomainName:           aws.String(new.CustomDomainName.ValueString()),
-		WorkgroupName:              aws.String(new.WorkgroupName.ValueString()),
+		CustomDomainCertificateArn: new.CustomDomainCertificateARN.ValueStringPointer(),
+		CustomDomainName:           new.CustomDomainName.ValueStringPointer(),
+		WorkgroupName:              new.WorkgroupName.ValueStringPointer(),
 	}
 
 	output, err := conn.UpdateCustomDomainAssociation(ctx, input)
@@ -193,8 +193,8 @@ func (r *customDomainAssociationResource) Delete(ctx context.Context, request re
 	conn := r.Meta().RedshiftServerlessClient(ctx)
 
 	_, err := conn.DeleteCustomDomainAssociation(ctx, &redshiftserverless.DeleteCustomDomainAssociationInput{
-		CustomDomainName: aws.String(data.CustomDomainName.ValueString()),
-		WorkgroupName:    aws.String(data.WorkgroupName.ValueString()),
+		CustomDomainName: data.CustomDomainName.ValueStringPointer(),
+		WorkgroupName:    data.WorkgroupName.ValueStringPointer(),
 	})
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/rekognition/stream_processor.go
+++ b/internal/service/rekognition/stream_processor.go
@@ -685,7 +685,7 @@ func (r *resourceStreamProcessor) Delete(ctx context.Context, req resource.Delet
 	}
 
 	in := &rekognition.DeleteStreamProcessorInput{
-		Name: aws.String(state.Name.ValueString()),
+		Name: state.Name.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteStreamProcessor(ctx, in)

--- a/internal/service/resourceexplorer2/search_data_source.go
+++ b/internal/service/resourceexplorer2/search_data_source.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
@@ -84,10 +83,10 @@ func (d *dataSourceSearch) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	input := &resourceexplorer2.SearchInput{
-		QueryString: aws.String(data.QueryString.ValueString()),
+		QueryString: data.QueryString.ValueStringPointer(),
 	}
 	if !data.ViewArn.IsNull() {
-		input.ViewArn = aws.String(data.ViewArn.ValueString())
+		input.ViewArn = data.ViewArn.ValueStringPointer()
 	}
 
 	paginator := resourceexplorer2.NewSearchPaginator(conn, input)

--- a/internal/service/route53/cidr_location.go
+++ b/internal/service/route53/cidr_location.go
@@ -193,10 +193,10 @@ func (r *cidrLocationResource) Update(ctx context.Context, request resource.Upda
 			Changes: []awstypes.CidrCollectionChange{{
 				Action:       awstypes.CidrCollectionChangeActionPut,
 				CidrList:     add,
-				LocationName: aws.String(new.Name.ValueString()),
+				LocationName: new.Name.ValueStringPointer(),
 			}},
 			CollectionVersion: collectionVersion,
-			Id:                aws.String(new.CIDRCollectionID.ValueString()),
+			Id:                new.CIDRCollectionID.ValueStringPointer(),
 		}
 
 		_, err = conn.ChangeCidrCollection(ctx, input)
@@ -215,10 +215,10 @@ func (r *cidrLocationResource) Update(ctx context.Context, request resource.Upda
 			Changes: []awstypes.CidrCollectionChange{{
 				Action:       awstypes.CidrCollectionChangeActionDeleteIfExists,
 				CidrList:     del,
-				LocationName: aws.String(new.Name.ValueString()),
+				LocationName: new.Name.ValueStringPointer(),
 			}},
 			CollectionVersion: collectionVersion,
-			Id:                aws.String(new.CIDRCollectionID.ValueString()),
+			Id:                new.CIDRCollectionID.ValueStringPointer(),
 		}
 
 		_, err = conn.ChangeCidrCollection(ctx, input)
@@ -258,10 +258,10 @@ func (r *cidrLocationResource) Delete(ctx context.Context, request resource.Dele
 		Changes: []awstypes.CidrCollectionChange{{
 			Action:       awstypes.CidrCollectionChangeActionDeleteIfExists,
 			CidrList:     fwflex.ExpandFrameworkStringValueSet(ctx, data.CIDRBlocks),
-			LocationName: aws.String(data.Name.ValueString()),
+			LocationName: data.Name.ValueStringPointer(),
 		}},
 		CollectionVersion: collection.Version,
-		Id:                aws.String(data.CIDRCollectionID.ValueString()),
+		Id:                data.CIDRCollectionID.ValueStringPointer(),
 	}
 
 	_, err = conn.ChangeCidrCollection(ctx, input)

--- a/internal/service/route53domains/delegation_signer_record.go
+++ b/internal/service/route53domains/delegation_signer_record.go
@@ -206,8 +206,8 @@ func (r *delegationSignerRecordResource) Delete(ctx context.Context, request res
 	conn := r.Meta().Route53DomainsClient(ctx)
 
 	output, err := conn.DisassociateDelegationSignerFromDomain(ctx, &route53domains.DisassociateDelegationSignerFromDomainInput{
-		DomainName: aws.String(data.DomainName.ValueString()),
-		Id:         aws.String(data.DNSSECKeyID.ValueString()),
+		DomainName: data.DomainName.ValueStringPointer(),
+		Id:         data.DNSSECKeyID.ValueStringPointer(),
 	})
 
 	if err != nil {

--- a/internal/service/secretsmanager/secret_versions_data_source.go
+++ b/internal/service/secretsmanager/secret_versions_data_source.go
@@ -6,7 +6,6 @@ package secretsmanager
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -74,7 +73,7 @@ func (d *dataSourceSecretVersions) Read(ctx context.Context, req datasource.Read
 	}
 
 	paginator := secretsmanager.NewListSecretVersionIdsPaginator(conn, &secretsmanager.ListSecretVersionIdsInput{
-		SecretId: aws.String(data.SecretID.ValueString()),
+		SecretId: data.SecretID.ValueStringPointer(),
 	})
 
 	var out secretsmanager.ListSecretVersionIdsOutput

--- a/internal/service/securitylake/subscriber.go
+++ b/internal/service/securitylake/subscriber.go
@@ -378,7 +378,7 @@ func (r *subscriberResource) Delete(ctx context.Context, request resource.Delete
 	}
 
 	in := &securitylake.DeleteSubscriberInput{
-		SubscriberId: aws.String(data.ID.ValueString()),
+		SubscriberId: data.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteSubscriber(ctx, in)

--- a/internal/service/servicecatalogappregistry/application.go
+++ b/internal/service/servicecatalogappregistry/application.go
@@ -144,7 +144,7 @@ func (r *resourceApplication) Update(ctx context.Context, req resource.UpdateReq
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		in.Application = aws.String(plan.ID.ValueString()) // Set manually, AWS naming is inconsistent
+		in.Application = plan.ID.ValueStringPointer() // Set manually, AWS naming is inconsistent
 
 		out, err := conn.UpdateApplication(ctx, in)
 		if err != nil {
@@ -178,7 +178,7 @@ func (r *resourceApplication) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	in := &servicecatalogappregistry.DeleteApplicationInput{
-		Application: aws.String(state.ID.ValueString()),
+		Application: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteApplication(ctx, in)

--- a/internal/service/servicequotas/template.go
+++ b/internal/service/servicequotas/template.go
@@ -123,7 +123,7 @@ func (r *resourceTemplate) Create(ctx context.Context, req resource.CreateReques
 
 	in := &servicequotas.PutServiceQuotaIncreaseRequestIntoTemplateInput{
 		AwsRegion:    aws.String(region),
-		DesiredValue: aws.Float64(plan.Value.ValueFloat64()),
+		DesiredValue: plan.Value.ValueFloat64Pointer(),
 		QuotaCode:    aws.String(quotaCode),
 		ServiceCode:  aws.String(serviceCode),
 	}
@@ -199,10 +199,10 @@ func (r *resourceTemplate) Update(ctx context.Context, req resource.UpdateReques
 
 	if !plan.Value.Equal(state.Value) {
 		in := &servicequotas.PutServiceQuotaIncreaseRequestIntoTemplateInput{
-			AwsRegion:    aws.String(plan.Region.ValueString()),
-			DesiredValue: aws.Float64(plan.Value.ValueFloat64()),
-			QuotaCode:    aws.String(plan.QuotaCode.ValueString()),
-			ServiceCode:  aws.String(plan.ServiceCode.ValueString()),
+			AwsRegion:    plan.Region.ValueStringPointer(),
+			DesiredValue: plan.Value.ValueFloat64Pointer(),
+			QuotaCode:    plan.QuotaCode.ValueStringPointer(),
+			ServiceCode:  plan.ServiceCode.ValueStringPointer(),
 		}
 
 		out, err := conn.PutServiceQuotaIncreaseRequestIntoTemplate(ctx, in)
@@ -241,9 +241,9 @@ func (r *resourceTemplate) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	in := &servicequotas.DeleteServiceQuotaIncreaseRequestFromTemplateInput{
-		AwsRegion:   aws.String(state.Region.ValueString()),
-		QuotaCode:   aws.String(state.QuotaCode.ValueString()),
-		ServiceCode: aws.String(state.ServiceCode.ValueString()),
+		AwsRegion:   state.Region.ValueStringPointer(),
+		QuotaCode:   state.QuotaCode.ValueStringPointer(),
+		ServiceCode: state.ServiceCode.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteServiceQuotaIncreaseRequestFromTemplate(ctx, in)

--- a/internal/service/servicequotas/templates_data_source.go
+++ b/internal/service/servicequotas/templates_data_source.go
@@ -6,7 +6,6 @@ package servicequotas
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/servicequotas/types"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -90,7 +89,7 @@ func (d *dataSourceTemplates) Read(ctx context.Context, req datasource.ReadReque
 	}
 
 	input := servicequotas.ListServiceQuotaIncreaseRequestsInTemplateInput{
-		AwsRegion: aws.String(data.Region.ValueString()),
+		AwsRegion: data.Region.ValueStringPointer(),
 	}
 	out, err := conn.ListServiceQuotaIncreaseRequestsInTemplate(ctx, &input)
 	if err != nil {

--- a/internal/service/ssoadmin/application.go
+++ b/internal/service/ssoadmin/application.go
@@ -158,14 +158,14 @@ func (r *resourceApplication) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	in := &ssoadmin.CreateApplicationInput{
-		ApplicationProviderArn: aws.String(plan.ApplicationProviderARN.ValueString()),
-		InstanceArn:            aws.String(plan.InstanceARN.ValueString()),
-		Name:                   aws.String(plan.Name.ValueString()),
+		ApplicationProviderArn: plan.ApplicationProviderARN.ValueStringPointer(),
+		InstanceArn:            plan.InstanceARN.ValueStringPointer(),
+		Name:                   plan.Name.ValueStringPointer(),
 		Tags:                   getTagsIn(ctx),
 	}
 
 	if !plan.Description.IsNull() {
-		in.Description = aws.String(plan.Description.ValueString())
+		in.Description = plan.Description.ValueStringPointer()
 	}
 	if !plan.PortalOptions.IsNull() {
 		var tfList []portalOptionsData
@@ -287,14 +287,14 @@ func (r *resourceApplication) Update(ctx context.Context, req resource.UpdateReq
 		!plan.PortalOptions.Equal(state.PortalOptions) ||
 		!plan.Status.Equal(state.Status) {
 		in := &ssoadmin.UpdateApplicationInput{
-			ApplicationArn: aws.String(plan.ApplicationARN.ValueString()),
+			ApplicationArn: plan.ApplicationARN.ValueStringPointer(),
 		}
 
 		if !plan.Description.IsNull() {
-			in.Description = aws.String(plan.Description.ValueString())
+			in.Description = plan.Description.ValueStringPointer()
 		}
 		if !plan.Name.IsNull() {
-			in.Name = aws.String(plan.Name.ValueString())
+			in.Name = plan.Name.ValueStringPointer()
 		}
 		if !plan.PortalOptions.IsNull() {
 			var tfList []portalOptionsData
@@ -356,7 +356,7 @@ func (r *resourceApplication) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	in := &ssoadmin.DeleteApplicationInput{
-		ApplicationArn: aws.String(state.ApplicationARN.ValueString()),
+		ApplicationArn: state.ApplicationARN.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteApplication(ctx, in)
@@ -504,7 +504,7 @@ func expandSignInOptions(tfList []signInOptionsData) *awstypes.SignInOptions {
 	}
 
 	if !tfObj.ApplicationURL.IsNull() {
-		apiObject.ApplicationUrl = aws.String(tfObj.ApplicationURL.ValueString())
+		apiObject.ApplicationUrl = tfObj.ApplicationURL.ValueStringPointer()
 	}
 
 	return apiObject

--- a/internal/service/ssoadmin/application_access_scope.go
+++ b/internal/service/ssoadmin/application_access_scope.go
@@ -85,8 +85,8 @@ func (r *resourceApplicationAccessScope) Create(ctx context.Context, req resourc
 	}
 
 	in := &ssoadmin.PutApplicationAccessScopeInput{
-		ApplicationArn: aws.String(plan.ApplicationARN.ValueString()),
-		Scope:          aws.String(plan.Scope.ValueString()),
+		ApplicationArn: plan.ApplicationARN.ValueStringPointer(),
+		Scope:          plan.Scope.ValueStringPointer(),
 	}
 
 	if !plan.AuthorizedTargets.IsNull() {
@@ -181,8 +181,8 @@ func (r *resourceApplicationAccessScope) Delete(ctx context.Context, req resourc
 	}
 
 	in := &ssoadmin.DeleteApplicationAccessScopeInput{
-		ApplicationArn: aws.String(state.ApplicationARN.ValueString()),
-		Scope:          aws.String(state.Scope.ValueString()),
+		ApplicationArn: state.ApplicationARN.ValueStringPointer(),
+		Scope:          state.Scope.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteApplicationAccessScope(ctx, in)

--- a/internal/service/ssoadmin/application_assignment.go
+++ b/internal/service/ssoadmin/application_assignment.go
@@ -156,8 +156,8 @@ func (r *resourceApplicationAssignment) Delete(ctx context.Context, req resource
 	}
 
 	in := &ssoadmin.DeleteApplicationAssignmentInput{
-		ApplicationArn: aws.String(state.ApplicationARN.ValueString()),
-		PrincipalId:    aws.String(state.PrincipalID.ValueString()),
+		ApplicationArn: state.ApplicationARN.ValueStringPointer(),
+		PrincipalId:    state.PrincipalID.ValueStringPointer(),
 		PrincipalType:  awstypes.PrincipalType(state.PrincipalType.ValueString()),
 	}
 

--- a/internal/service/ssoadmin/application_assignment_configuration.go
+++ b/internal/service/ssoadmin/application_assignment_configuration.go
@@ -69,8 +69,8 @@ func (r *resourceApplicationAssignmentConfiguration) Create(ctx context.Context,
 	plan.ID = types.StringValue(plan.ApplicationARN.ValueString())
 
 	in := &ssoadmin.PutApplicationAssignmentConfigurationInput{
-		ApplicationArn:     aws.String(plan.ApplicationARN.ValueString()),
-		AssignmentRequired: aws.Bool(plan.AssignmentRequired.ValueBool()),
+		ApplicationArn:     plan.ApplicationARN.ValueStringPointer(),
+		AssignmentRequired: plan.AssignmentRequired.ValueBoolPointer(),
 	}
 
 	_, err := conn.PutApplicationAssignmentConfiguration(ctx, in)
@@ -124,8 +124,8 @@ func (r *resourceApplicationAssignmentConfiguration) Update(ctx context.Context,
 
 	if !plan.AssignmentRequired.Equal(state.AssignmentRequired) {
 		in := &ssoadmin.PutApplicationAssignmentConfigurationInput{
-			ApplicationArn:     aws.String(plan.ApplicationARN.ValueString()),
-			AssignmentRequired: aws.Bool(plan.AssignmentRequired.ValueBool()),
+			ApplicationArn:     plan.ApplicationARN.ValueStringPointer(),
+			AssignmentRequired: plan.AssignmentRequired.ValueBoolPointer(),
 		}
 
 		_, err := conn.PutApplicationAssignmentConfiguration(ctx, in)
@@ -153,7 +153,7 @@ func (r *resourceApplicationAssignmentConfiguration) Delete(ctx context.Context,
 	}
 
 	in := &ssoadmin.PutApplicationAssignmentConfigurationInput{
-		ApplicationArn:     aws.String(state.ApplicationARN.ValueString()),
+		ApplicationArn:     state.ApplicationARN.ValueStringPointer(),
 		AssignmentRequired: aws.Bool(true),
 	}
 

--- a/internal/service/ssoadmin/application_assignments_data_source.go
+++ b/internal/service/ssoadmin/application_assignments_data_source.go
@@ -6,7 +6,6 @@ package ssoadmin
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -75,7 +74,7 @@ func (d *dataSourceApplicationAssignments) Read(ctx context.Context, req datasou
 	}
 
 	paginator := ssoadmin.NewListApplicationAssignmentsPaginator(conn, &ssoadmin.ListApplicationAssignmentsInput{
-		ApplicationArn: aws.String(data.ApplicationARN.ValueString()),
+		ApplicationArn: data.ApplicationARN.ValueStringPointer(),
 	})
 
 	var out ssoadmin.ListApplicationAssignmentsOutput

--- a/internal/service/ssoadmin/principal_application_assignments_data_source.go
+++ b/internal/service/ssoadmin/principal_application_assignments_data_source.go
@@ -6,7 +6,6 @@ package ssoadmin
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -83,8 +82,8 @@ func (d *dataSourcePrincipalApplicationAssignments) Read(ctx context.Context, re
 	}
 
 	paginator := ssoadmin.NewListApplicationAssignmentsForPrincipalPaginator(conn, &ssoadmin.ListApplicationAssignmentsForPrincipalInput{
-		InstanceArn:   aws.String(data.InstanceARN.ValueString()),
-		PrincipalId:   aws.String(data.PrincipalID.ValueString()),
+		InstanceArn:   data.InstanceARN.ValueStringPointer(),
+		PrincipalId:   data.PrincipalID.ValueStringPointer(),
 		PrincipalType: awstypes.PrincipalType(data.PrincipalType.ValueString()),
 	})
 

--- a/internal/service/ssoadmin/trusted_token_issuer.go
+++ b/internal/service/ssoadmin/trusted_token_issuer.go
@@ -141,14 +141,14 @@ func (r *resourceTrustedTokenIssuer) Create(ctx context.Context, req resource.Cr
 	}
 
 	in := &ssoadmin.CreateTrustedTokenIssuerInput{
-		InstanceArn:            aws.String(plan.InstanceARN.ValueString()),
-		Name:                   aws.String(plan.Name.ValueString()),
+		InstanceArn:            plan.InstanceARN.ValueStringPointer(),
+		Name:                   plan.Name.ValueStringPointer(),
 		TrustedTokenIssuerType: awstypes.TrustedTokenIssuerType(plan.TrustedTokenIssuerType.ValueString()),
 		Tags:                   getTagsIn(ctx),
 	}
 
 	if !plan.ClientToken.IsNull() {
-		in.ClientToken = aws.String(plan.ClientToken.ValueString())
+		in.ClientToken = plan.ClientToken.ValueStringPointer()
 	}
 
 	if !plan.TrustedTokenIssuerConfiguration.IsNull() {
@@ -250,11 +250,11 @@ func (r *resourceTrustedTokenIssuer) Update(ctx context.Context, req resource.Up
 
 	if !plan.Name.Equal(state.Name) || !plan.TrustedTokenIssuerConfiguration.Equal(state.TrustedTokenIssuerConfiguration) {
 		in := &ssoadmin.UpdateTrustedTokenIssuerInput{
-			TrustedTokenIssuerArn: aws.String(plan.ID.ValueString()),
+			TrustedTokenIssuerArn: plan.ID.ValueStringPointer(),
 		}
 
 		if !plan.Name.IsNull() {
-			in.Name = aws.String(plan.Name.ValueString())
+			in.Name = plan.Name.ValueStringPointer()
 		}
 
 		if !plan.TrustedTokenIssuerConfiguration.IsNull() {
@@ -314,7 +314,7 @@ func (r *resourceTrustedTokenIssuer) Delete(ctx context.Context, req resource.De
 	}
 
 	in := &ssoadmin.DeleteTrustedTokenIssuerInput{
-		TrustedTokenIssuerArn: aws.String(state.ID.ValueString()),
+		TrustedTokenIssuerArn: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteTrustedTokenIssuer(ctx, in)
@@ -388,9 +388,9 @@ func expandOIDCJWTConfiguration(tfList []OIDCJWTConfigurationData) *awstypes.Oid
 	tfObj := tfList[0]
 
 	apiObject := &awstypes.OidcJwtConfiguration{
-		ClaimAttributePath:         aws.String(tfObj.ClaimAttributePath.ValueString()),
-		IdentityStoreAttributePath: aws.String(tfObj.IdentityStoreAttributePath.ValueString()),
-		IssuerUrl:                  aws.String(tfObj.IssuerUrl.ValueString()),
+		ClaimAttributePath:         tfObj.ClaimAttributePath.ValueStringPointer(),
+		IdentityStoreAttributePath: tfObj.IdentityStoreAttributePath.ValueStringPointer(),
+		IssuerUrl:                  tfObj.IssuerUrl.ValueStringPointer(),
 		JwksRetrievalOption:        awstypes.JwksRetrievalOption(tfObj.JWKSRetrievalOption.ValueString()),
 	}
 
@@ -423,8 +423,8 @@ func expandOIDCJWTUpdateConfiguration(tfList []OIDCJWTConfigurationData) *awstyp
 	tfObj := tfList[0]
 
 	apiObject := &awstypes.OidcJwtUpdateConfiguration{
-		ClaimAttributePath:         aws.String(tfObj.ClaimAttributePath.ValueString()),
-		IdentityStoreAttributePath: aws.String(tfObj.IdentityStoreAttributePath.ValueString()),
+		ClaimAttributePath:         tfObj.ClaimAttributePath.ValueStringPointer(),
+		IdentityStoreAttributePath: tfObj.IdentityStoreAttributePath.ValueStringPointer(),
 		JwksRetrievalOption:        awstypes.JwksRetrievalOption(tfObj.JWKSRetrievalOption.ValueString()),
 	}
 

--- a/internal/service/timestreaminfluxdb/db_instance.go
+++ b/internal/service/timestreaminfluxdb/db_instance.go
@@ -456,7 +456,7 @@ func (r *resourceDBInstance) Update(ctx context.Context, req resource.UpdateRequ
 	if !plan.DBParameterGroupIdentifier.Equal(state.DBParameterGroupIdentifier) ||
 		!plan.LogDeliveryConfiguration.Equal(state.LogDeliveryConfiguration) {
 		in := timestreaminfluxdb.UpdateDbInstanceInput{
-			Identifier: aws.String(plan.ID.ValueString()),
+			Identifier: plan.ID.ValueStringPointer(),
 		}
 
 		resp.Diagnostics.Append(flex.Expand(ctx, plan, &in)...)
@@ -507,7 +507,7 @@ func (r *resourceDBInstance) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	in := &timestreaminfluxdb.DeleteDbInstanceInput{
-		Identifier: aws.String(state.ID.ValueString()),
+		Identifier: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteDbInstance(ctx, in)

--- a/internal/service/verifiedpermissions/policy.go
+++ b/internal/service/verifiedpermissions/policy.go
@@ -246,7 +246,7 @@ func (r *resourcePolicy) Create(ctx context.Context, req resource.CreateRequest,
 	in := &verifiedpermissions.CreatePolicyInput{}
 
 	in.ClientToken = aws.String(id.UniqueId())
-	in.PolicyStoreId = aws.String(plan.PolicyStoreID.ValueString())
+	in.PolicyStoreId = plan.PolicyStoreID.ValueStringPointer()
 
 	def, diags := plan.Definition.ToPtr(ctx)
 	resp.Diagnostics.Append(diags...)
@@ -277,7 +277,7 @@ func (r *resourcePolicy) Create(ctx context.Context, req resource.CreateRequest,
 		}
 
 		value := awstypes.TemplateLinkedPolicyDefinition{
-			PolicyTemplateId: aws.String(templateLinked.PolicyTemplateID.ValueString()),
+			PolicyTemplateId: templateLinked.PolicyTemplateID.ValueStringPointer(),
 		}
 
 		if !templateLinked.Principal.IsNull() {
@@ -488,8 +488,8 @@ func (r *resourcePolicy) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 
 	in := &verifiedpermissions.DeletePolicyInput{
-		PolicyId:      aws.String(state.PolicyID.ValueString()),
-		PolicyStoreId: aws.String(state.PolicyStoreID.ValueString()),
+		PolicyId:      state.PolicyID.ValueStringPointer(),
+		PolicyStoreId: state.PolicyStoreID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeletePolicy(ctx, in)

--- a/internal/service/verifiedpermissions/policy_template.go
+++ b/internal/service/verifiedpermissions/policy_template.go
@@ -223,8 +223,8 @@ func (r *resourcePolicyTemplate) Delete(ctx context.Context, request resource.De
 	})
 
 	input := &verifiedpermissions.DeletePolicyTemplateInput{
-		PolicyStoreId:    aws.String(state.PolicyStoreID.ValueString()),
-		PolicyTemplateId: aws.String(state.PolicyTemplateID.ValueString()),
+		PolicyStoreId:    state.PolicyStoreID.ValueStringPointer(),
+		PolicyTemplateId: state.PolicyTemplateID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeletePolicyTemplate(ctx, input)

--- a/internal/service/workspaces/connection_alias.go
+++ b/internal/service/workspaces/connection_alias.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/workspaces"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/workspaces/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -104,7 +103,7 @@ func (r *resourceConnectionAlias) Create(ctx context.Context, req resource.Creat
 	}
 
 	in := &workspaces.CreateConnectionAliasInput{
-		ConnectionString: aws.String(plan.ConnectionString.ValueString()),
+		ConnectionString: plan.ConnectionString.ValueStringPointer(),
 		Tags:             getTagsIn(ctx),
 	}
 
@@ -188,7 +187,7 @@ func (r *resourceConnectionAlias) Delete(ctx context.Context, req resource.Delet
 	}
 
 	in := &workspaces.DeleteConnectionAliasInput{
-		AliasId: aws.String(state.ID.ValueString()),
+		AliasId: state.ID.ValueStringPointer(),
 	}
 
 	_, err := conn.DeleteConnectionAlias(ctx, in)


### PR DESCRIPTION
### Description

Take `attr.Value` pointers directly instead of address of value. i.e. instead of

```go
aws.String(data.Alias.ValueString())
```

use

```go
data.Alias.ValueStringPointer 
```

In addition to looking cleaner, this will reduce the number of small memory allocations.
