### PR TITLE
AutoFlex: Add note about not using AutoFlex for SDK to Framework migrations

### DIFF
--- a/docs/data-handling-and-conversion.md
+++ b/docs/data-handling-and-conversion.md
@@ -184,6 +184,11 @@ When using the Terraform Plugin SDK v2, flattening and expanding functions must 
 AutoFlex provides two entry-point functions, `Flatten` and `Expand` defined in the package `github.com/hashicorp/terraform-provider-aws/internal/framework/flex`.
 Without configuration, these two functions should be able to convert most provider and AWS API structures.
 
+!!! note
+    AutoFlex should only be used when creating new resource and data source types.
+    It should not be used when converting a resource implementation from Terraform Plugin SDK v2 to Terraform Plugin Framework.
+    AutoFlex does not currently provide a mechanism for preserving zero-value behavior from Terraform Plugin SDK v2, which can cause breaking changes.
+
 AutoFlex uses field names to map between the source and target structures:
 
 1. An exact, case-sensitive match


### PR DESCRIPTION
### Description

Updates AutoFlex documentation with note about not using it for SDK to Framework migrations
