### PR TITLE
r/aws_ses_configuration_set: fix crash when `reputation_metrics_enabled` is set

### DIFF
--- a/.changelog/38921.txt
+++ b/.changelog/38921.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ses_configuration_set: Fix crash when `reputation_metrics_enabled` is set to `true`
+```

--- a/internal/service/ses/configuration_set.go
+++ b/internal/service/ses/configuration_set.go
@@ -127,7 +127,7 @@ func resourceConfigurationSetCreate(ctx context.Context, d *schema.ResourceData,
 	if v := d.Get("reputation_metrics_enabled"); v.(bool) {
 		input := &ses.UpdateConfigurationSetReputationMetricsEnabledInput{
 			ConfigurationSetName: aws.String(configurationSetName),
-			Enabled:              aws.ToBool(v.(*bool)),
+			Enabled:              v.(bool),
 		}
 
 		_, err := conn.UpdateConfigurationSetReputationMetricsEnabled(ctx, input)


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Migration of this service to AWS SDK for Go V2 unintentionally introduced an assertion to a pointer to bool, rather than a bool.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38918
Relates #38568


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ses TESTS=TestAccSESConfigurationSet_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/ses/... -v -count 1 -parallel 20 -run='TestAccSESConfigurationSet_'  -timeout 360m

--- PASS: TestAccSESConfigurationSet_disappears (13.24s)
--- PASS: TestAccSESConfigurationSet_deliveryOptions (15.27s)
--- PASS: TestAccSESConfigurationSet_basic (15.29s)
--- PASS: TestAccSESConfigurationSet_emptyDeliveryOptions (20.05s)
--- PASS: TestAccSESConfigurationSet_sendingEnabled (29.13s)
--- PASS: TestAccSESConfigurationSet_Update_emptyDeliveryOptions (35.44s)
--- PASS: TestAccSESConfigurationSet_reputationMetricsEnabled (37.59s)
--- PASS: TestAccSESConfigurationSet_Update_deliveryOptions (37.92s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ses        43.956s
```

