### PR TITLE
r/aws_datazone_project: properly surface import id parsing errors

### DIFF
--- a/.changelog/38924.txt
+++ b/.changelog/38924.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_datazone_project: Properly surface import `id` parsing errors
+```

--- a/internal/service/datazone/project.go
+++ b/internal/service/datazone/project.go
@@ -318,7 +318,9 @@ func (r *resourceProject) ImportState(ctx context.Context, req resource.ImportSt
 
 	if len(parts) != 2 {
 		resp.Diagnostics.AddError("Resource Import Invalid ID", fmt.Sprintf(`Unexpected format for import ID (%s), use: "DomainIdentifier:Id"`, req.ID))
+		return
 	}
+
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain_identifier"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.AttrID), parts[1])...)
 }
@@ -326,7 +328,7 @@ func (r *resourceProject) ImportState(ctx context.Context, req resource.ImportSt
 func waitProjectCreated(ctx context.Context, conn *datazone.Client, domain string, identifier string, timeout time.Duration) (*datazone.GetProjectOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{},
-		Target:                    enum.Slice[awstypes.ProjectStatus](awstypes.ProjectStatusActive),
+		Target:                    enum.Slice(awstypes.ProjectStatusActive),
 		Refresh:                   statusProject(ctx, conn, domain, identifier),
 		Timeout:                   timeout,
 		NotFoundChecks:            40,
@@ -343,7 +345,7 @@ func waitProjectCreated(ctx context.Context, conn *datazone.Client, domain strin
 
 func waitProjectDeleted(ctx context.Context, conn *datazone.Client, domain string, identifier string, timeout time.Duration) (*datazone.GetProjectOutput, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice[awstypes.ProjectStatus](awstypes.ProjectStatusDeleting, awstypes.ProjectStatusActive),
+		Pending: enum.Slice(awstypes.ProjectStatusDeleting, awstypes.ProjectStatusActive),
 		Target:  []string{},
 		Refresh: statusProject(ctx, conn, domain, identifier),
 		Timeout: timeout,

--- a/website/docs/r/datazone_project.html.markdown
+++ b/website/docs/r/datazone_project.html.markdown
@@ -34,14 +34,14 @@ resource "aws_datazone_project" "test" {
 
 The following arguments are required:
 
-* `domain_identifier` - (Required) Identifier of domain which the project is part of. Must follow the regex of ^dzd[-_][a-zA-Z0-9_-]{1,36}$.
-* `name` - (Required) Name of the project. Must follow the regex of ^[\w -]+$. and have a length of at most 64.
+* `domain_identifier` - (Required) Identifier of domain which the project is part of. Must follow the regex of `^dzd[-_][a-zA-Z0-9_-]{1,36}$`.
+* `name` - (Required) Name of the project. Must follow the regex of `^[\w -]+$`. and have a length of at most 64.
 
 The following arguments are optional:
 
 * `skip_deletion_check` - (Optional) Optional flag to delete all child entities within the project.
 * `description` - (Optional) Description of project.
-* `glossary_terms` - (Optional) List of glossary terms that can be used in the project. The list cannot be empty or include over 20 values. Each value must follow the regex of [a-zA-Z0-9_-]{1,36}$.
+* `glossary_terms` - (Optional) List of glossary terms that can be used in the project. The list cannot be empty or include over 20 values. Each value must follow the regex of `[a-zA-Z0-9_-]{1,36}$`.
 
 ## Attribute Reference
 
@@ -56,7 +56,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `failure_reasons` - List of error messages if operation cannot be completed.
 * `glossary_terms` - Business glossary terms that can be used in the project.
 * `last_updated_at` - Timestamp of when the project was last updated.
-* `project_status` -  Enum that conveys state of project. Can be ACTIVE, DELETING, or DELETE_FAILED.
+* `project_status` -  Enum that conveys state of project. Can be `ACTIVE`, `DELETING`, or `DELETE_FAILED`.
 
 ## Timeouts
 
@@ -67,17 +67,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DataZone Project using the `id`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DataZone Project using a colon-delimited string combining `domain_id` and `id`. For example:
 
 ```terraform
 import {
   to = aws_datazone_project.example
-  id = "projectid123"
+  id = "domain-1234:project-1234"
 }
 ```
 
-Using `terraform import`, import DataZone Project using the `id`. For example:
+Using `terraform import`, import DataZone Project using a colon-delimited string combining `domain_id` and `id`. For example:
 
 ```console
-% terraform import aws_datazone_project.example projectid123
+% terraform import aws_datazone_project.example domain-1234:project-1234
 ```


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously a diagnostic was appended to the response but the method did not return, resulting in an index out of bounds error when a non-delimited value is provided as the import identifier.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38923


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=datazone TESTS=TestAccDataZoneProject_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/datazone/... -v -count 1 -parallel 20 -run='TestAccDataZoneProject_'  -timeout 360m

--- PASS: TestAccDataZoneProject_disappears (27.44s)
--- PASS: TestAccDataZoneProject_basic (29.53s)
--- PASS: TestAccDataZoneProject_update (41.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datazone   47.580s
```
