### PR TITLE
[Docs]: Data Source: aws_cloudfront_origin_access_control example is for aws_cloudfront_origin_access_identity

### DIFF
--- a/website/docs/d/cloudfront_origin_access_control.html.markdown
+++ b/website/docs/d/cloudfront_origin_access_control.html.markdown
@@ -15,7 +15,7 @@ Use this data source to retrieve information for an Amazon CloudFront origin acc
 The below example retrieves a CloudFront origin access control config.
 
 ```terraform
-data "aws_cloudfront_origin_access_identity" "example" {
+data "aws_cloudfront_origin_access_control" "example" {
   id = "E2T5VTFBZJ3BJB"
 }
 ```


### PR DESCRIPTION
Documentation Link
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_origin_access_control

Description
I am attempting to use the (recently added in 5.59.0 I believe) data source for a CloudFront Origin Access Control. However, the example in the documentation shows the incorrect data source name:

data "aws_cloudfront_origin_access_identity" "example" {
id = "E2T5VTFBZJ3BJB"
}
It should look like:

data "aws_cloudfront_origin_access_control" "example" {
id = "E2T5VTFBZJ3BJB"
}

Closes #38754