### PR TITLE
Migrate `WorkLink` resources to AWS SDK v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -240,6 +240,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.23.4
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.51.5
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.32.4
+	github.com/aws/aws-sdk-go-v2/service/worklink v1.22.4
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.21.4
 	github.com/aws/aws-sdk-go-v2/service/xray v1.27.4
@@ -307,7 +308,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.18 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.5 // indirect
-	github.com/aws/aws-sdk-go-v2/service/worklink v1.22.4 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect
 	github.com/bufbuild/protocompile v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -305,6 +305,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.18 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/worklink v1.22.4 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect
 	github.com/bufbuild/protocompile v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -508,6 +508,8 @@ github.com/aws/aws-sdk-go-v2/service/wafv2 v1.51.5 h1:0JcKRIwypcn+qjFntLrJ6S1KZQ
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.51.5/go.mod h1:P95v1j9QVTk6fFciQhk/PnY0nYPGWixtJC/G7e2TY3M=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.32.4 h1:9Qd0MjFLUAUJqHf450+moANwNIh/d9cZ7ilP62CvfBw=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.32.4/go.mod h1:kIGecw/fUgEttRZPxglmcpyZdStWWJvWKJRmMyKiwDE=
+github.com/aws/aws-sdk-go-v2/service/worklink v1.22.4 h1:ocpfluH1mGYGRhjc89zlMr83P75qRkyET+GuRXj6twI=
+github.com/aws/aws-sdk-go-v2/service/worklink v1.22.4/go.mod h1:t5Ii3SqJrHijXgRbAWOfD30e/uuNxaVnQdLfji/yGQ4=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.45.1 h1:O2IZDp8Y+6ywBfIyBGMDljfQzRvnO2Fn85eV1+2Ovlg=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.45.1/go.mod h1:NpECdAtx0GNmx6ANGHmgDxqV6LQq59cxs7lY7vUiLUY=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.21.4 h1:jzF1yA5OeQuHzuPgdNiQ7no4wWGJ7hnYlPelVloFrXg=

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -230,6 +230,7 @@ import (
 	wafregional_sdkv2 "github.com/aws/aws-sdk-go-v2/service/wafregional"
 	wafv2_sdkv2 "github.com/aws/aws-sdk-go-v2/service/wafv2"
 	wellarchitected_sdkv2 "github.com/aws/aws-sdk-go-v2/service/wellarchitected"
+	worklink_sdkv2 "github.com/aws/aws-sdk-go-v2/service/worklink"
 	workspaces_sdkv2 "github.com/aws/aws-sdk-go-v2/service/workspaces"
 	workspacesweb_sdkv2 "github.com/aws/aws-sdk-go-v2/service/workspacesweb"
 	xray_sdkv2 "github.com/aws/aws-sdk-go-v2/service/xray"
@@ -244,7 +245,6 @@ import (
 	opsworks_sdkv1 "github.com/aws/aws-sdk-go/service/opsworks"
 	quicksight_sdkv1 "github.com/aws/aws-sdk-go/service/quicksight"
 	simpledb_sdkv1 "github.com/aws/aws-sdk-go/service/simpledb"
-	worklink_sdkv1 "github.com/aws/aws-sdk-go/service/worklink"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -1197,8 +1197,8 @@ func (c *AWSClient) WellArchitectedClient(ctx context.Context) *wellarchitected_
 	return errs.Must(client[*wellarchitected_sdkv2.Client](ctx, c, names.WellArchitected, make(map[string]any)))
 }
 
-func (c *AWSClient) WorkLinkConn(ctx context.Context) *worklink_sdkv1.WorkLink {
-	return errs.Must(conn[*worklink_sdkv1.WorkLink](ctx, c, names.WorkLink, make(map[string]any)))
+func (c *AWSClient) WorkLinkClient(ctx context.Context) *worklink_sdkv2.Client {
+	return errs.Must(client[*worklink_sdkv2.Client](ctx, c, names.WorkLink, make(map[string]any)))
 }
 
 func (c *AWSClient) WorkSpacesClient(ctx context.Context) *workspaces_sdkv2.Client {

--- a/internal/service/worklink/exports_test.go
+++ b/internal/service/worklink/exports_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package worklink
+
+// Exports for use in tests only.
+var (
+	FindFleetByARN                            = findFleetByARN
+	FindWebsiteCertificateAuthorityByARNAndID = findWebsiteCertificateAuthorityByARNAndID
+
+	DecodeWebsiteCertificateAuthorityAssociationResourceID = decodeWebsiteCertificateAuthorityAssociationResourceID
+	FleetStateRefresh                                      = fleetStateRefresh
+	WebsiteCertificateAuthorityAssociationStateRefresh     = websiteCertificateAuthorityAssociationStateRefresh
+)

--- a/internal/service/worklink/fleet_test.go
+++ b/internal/service/worklink/fleet_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestAccWorkLinkFleet_basic(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
@@ -55,7 +55,7 @@ func TestAccWorkLinkFleet_basic(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_displayName(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
@@ -91,7 +91,7 @@ func TestAccWorkLinkFleet_displayName(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_optimizeForEndUserLocation(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
@@ -127,7 +127,7 @@ func TestAccWorkLinkFleet_optimizeForEndUserLocation(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_auditStreamARN(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
@@ -156,7 +156,7 @@ func TestAccWorkLinkFleet_auditStreamARN(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_network(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
@@ -202,7 +202,7 @@ func TestAccWorkLinkFleet_network(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_deviceCaCertificate(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
@@ -238,7 +238,7 @@ func TestAccWorkLinkFleet_deviceCaCertificate(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_identityProvider(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
@@ -273,7 +273,7 @@ func TestAccWorkLinkFleet_identityProvider(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_disappears(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)

--- a/internal/service/worklink/fleet_test.go
+++ b/internal/service/worklink/fleet_test.go
@@ -10,9 +10,8 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/worklink"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/worklink"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -20,10 +19,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfworklink "github.com/hashicorp/terraform-provider-aws/internal/service/worklink"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccWorkLinkFleet_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
@@ -53,6 +55,8 @@ func TestAccWorkLinkFleet_basic(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_displayName(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
@@ -87,6 +91,8 @@ func TestAccWorkLinkFleet_displayName(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_optimizeForEndUserLocation(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
@@ -121,6 +127,8 @@ func TestAccWorkLinkFleet_optimizeForEndUserLocation(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_auditStreamARN(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
@@ -148,6 +156,8 @@ func TestAccWorkLinkFleet_auditStreamARN(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_network(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
@@ -192,6 +202,8 @@ func TestAccWorkLinkFleet_network(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_deviceCaCertificate(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
@@ -226,6 +238,8 @@ func TestAccWorkLinkFleet_deviceCaCertificate(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_identityProvider(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
@@ -259,6 +273,8 @@ func TestAccWorkLinkFleet_identityProvider(t *testing.T) {
 }
 
 func TestAccWorkLinkFleet_disappears(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_fleet.test"
@@ -292,13 +308,13 @@ func testAccCheckFleetDisappears(ctx context.Context, resourceName string) resou
 			return fmt.Errorf("No resource ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkClient(ctx)
 
 		input := &worklink.DeleteFleetInput{
 			FleetArn: aws.String(rs.Primary.ID),
 		}
 
-		if _, err := conn.DeleteFleetWithContext(ctx, input); err != nil {
+		if _, err := conn.DeleteFleet(ctx, input); err != nil {
 			return err
 		}
 
@@ -319,25 +335,23 @@ func testAccCheckFleetDisappears(ctx context.Context, resourceName string) resou
 
 func testAccCheckFleetDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_worklink_fleet" {
 				continue
 			}
 
-			_, err := conn.DescribeFleetMetadataWithContext(ctx, &worklink.DescribeFleetMetadataInput{
-				FleetArn: aws.String(rs.Primary.ID),
-			})
+			_, err := tfworklink.FindFleetByARN(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
 
 			if err != nil {
-				// Return nil if the Worklink Fleet is already destroyed
-				if tfawserr.ErrCodeEquals(err, worklink.ErrCodeResourceNotFoundException) {
-					return nil
-				}
-
 				return err
 			}
+
 			return fmt.Errorf("Worklink Fleet %s still exists", rs.Primary.ID)
 		}
 
@@ -356,23 +370,25 @@ func testAccCheckFleetExists(ctx context.Context, n string) resource.TestCheckFu
 			return fmt.Errorf("No Worklink Fleet ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkConn(ctx)
-		_, err := conn.DescribeFleetMetadataWithContext(ctx, &worklink.DescribeFleetMetadataInput{
-			FleetArn: aws.String(rs.Primary.ID),
-		})
+		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkClient(ctx)
+		_, err := tfworklink.FindFleetByARN(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
 
 		return err
 	}
 }
 
 func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkClient(ctx)
 
 	input := &worklink.ListFleetsInput{
-		MaxResults: aws.Int64(1),
+		MaxResults: aws.Int32(1),
 	}
 
-	_, err := conn.ListFleetsWithContext(ctx, input)
+	_, err := conn.ListFleets(ctx, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/worklink/flex.go
+++ b/internal/service/worklink/flex.go
@@ -4,8 +4,8 @@
 package worklink
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/worklink"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/worklink"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -13,15 +13,14 @@ import (
 func flattenIdentityProviderConfigResponse(c *worklink.DescribeIdentityProviderConfigurationOutput) []map[string]interface{} {
 	config := make(map[string]interface{})
 
-	if c.IdentityProviderType == nil && c.IdentityProviderSamlMetadata == nil {
+	if c.IdentityProviderSamlMetadata == nil {
 		return nil
 	}
 
-	if c.IdentityProviderType != nil {
-		config[names.AttrType] = aws.StringValue(c.IdentityProviderType)
-	}
+	config[names.AttrType] = c.IdentityProviderType
+
 	if c.IdentityProviderSamlMetadata != nil {
-		config["saml_metadata"] = aws.StringValue(c.IdentityProviderSamlMetadata)
+		config["saml_metadata"] = aws.ToString(c.IdentityProviderSamlMetadata)
 	}
 
 	return []map[string]interface{}{config}
@@ -34,13 +33,13 @@ func flattenNetworkConfigResponse(c *worklink.DescribeCompanyNetworkConfiguratio
 		return nil
 	}
 
-	if len(c.SubnetIds) == 0 && len(c.SecurityGroupIds) == 0 && aws.StringValue(c.VpcId) == "" {
+	if len(c.SubnetIds) == 0 && len(c.SecurityGroupIds) == 0 && aws.ToString(c.VpcId) == "" {
 		return nil
 	}
 
-	config[names.AttrSubnetIDs] = flex.FlattenStringSet(c.SubnetIds)
-	config[names.AttrSecurityGroupIDs] = flex.FlattenStringSet(c.SecurityGroupIds)
-	config[names.AttrVPCID] = aws.StringValue(c.VpcId)
+	config[names.AttrSubnetIDs] = flex.FlattenStringValueSet(c.SubnetIds)
+	config[names.AttrSecurityGroupIDs] = flex.FlattenStringValueSet(c.SecurityGroupIds)
+	config[names.AttrVPCID] = aws.ToString(c.VpcId)
 
 	return []map[string]interface{}{config}
 }

--- a/internal/service/worklink/generate.go
+++ b/internal/service/worklink/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ServiceTagsMap -UpdateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ServiceTagsMap -UpdateTags -KVTValues -SkipTypesImp
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/worklink/service_endpoint_resolver_gen.go
+++ b/internal/service/worklink/service_endpoint_resolver_gen.go
@@ -6,65 +6,63 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 
-	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	worklink_sdkv2 "github.com/aws/aws-sdk-go-v2/service/worklink"
+	smithyendpoints "github.com/aws/smithy-go/endpoints"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 )
 
-var _ endpoints_sdkv1.Resolver = resolverSDKv1{}
+var _ worklink_sdkv2.EndpointResolverV2 = resolverSDKv2{}
 
-type resolverSDKv1 struct {
-	ctx context.Context
+type resolverSDKv2 struct {
+	defaultResolver worklink_sdkv2.EndpointResolverV2
 }
 
-func newEndpointResolverSDKv1(ctx context.Context) resolverSDKv1 {
-	return resolverSDKv1{
-		ctx: ctx,
+func newEndpointResolverSDKv2() resolverSDKv2 {
+	return resolverSDKv2{
+		defaultResolver: worklink_sdkv2.NewDefaultEndpointResolverV2(),
 	}
 }
 
-func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoints_sdkv1.Options)) (endpoint endpoints_sdkv1.ResolvedEndpoint, err error) {
-	ctx := r.ctx
+func (r resolverSDKv2) ResolveEndpoint(ctx context.Context, params worklink_sdkv2.EndpointParameters) (endpoint smithyendpoints.Endpoint, err error) {
+	params = params.WithDefaults()
+	useFIPS := aws_sdkv2.ToBool(params.UseFIPS)
 
-	var opt endpoints_sdkv1.Options
-	opt.Set(opts...)
+	if eps := params.Endpoint; aws_sdkv2.ToString(eps) != "" {
+		tflog.Debug(ctx, "setting endpoint", map[string]any{
+			"tf_aws.endpoint": endpoint,
+		})
 
-	useFIPS := opt.UseFIPSEndpoint == endpoints_sdkv1.FIPSEndpointStateEnabled
+		if useFIPS {
+			tflog.Debug(ctx, "endpoint set, ignoring UseFIPSEndpoint setting")
+			params.UseFIPS = aws_sdkv2.Bool(false)
+		}
 
-	defaultResolver := endpoints_sdkv1.DefaultResolver()
-
-	if useFIPS {
+		return r.defaultResolver.ResolveEndpoint(ctx, params)
+	} else if useFIPS {
 		ctx = tflog.SetField(ctx, "tf_aws.use_fips", useFIPS)
 
-		endpoint, err = defaultResolver.EndpointFor(service, region, opts...)
+		endpoint, err = r.defaultResolver.ResolveEndpoint(ctx, params)
 		if err != nil {
 			return endpoint, err
 		}
 
 		tflog.Debug(ctx, "endpoint resolved", map[string]any{
-			"tf_aws.endpoint": endpoint.URL,
+			"tf_aws.endpoint": endpoint.URI.String(),
 		})
 
-		var endpointURL *url.URL
-		endpointURL, err = url.Parse(endpoint.URL)
-		if err != nil {
-			return endpoint, err
-		}
-
-		hostname := endpointURL.Hostname()
+		hostname := endpoint.URI.Hostname()
 		_, err = net.LookupHost(hostname)
 		if err != nil {
 			if dnsErr, ok := errs.As[*net.DNSError](err); ok && dnsErr.IsNotFound {
 				tflog.Debug(ctx, "default endpoint host not found, disabling FIPS", map[string]any{
 					"tf_aws.hostname": hostname,
 				})
-				opts = append(opts, func(o *endpoints_sdkv1.Options) {
-					o.UseFIPSEndpoint = endpoints_sdkv1.FIPSEndpointStateDisabled
-				})
+				params.UseFIPS = aws_sdkv2.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up accessanalyzer endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up worklink endpoint %q: %s", hostname, err)
 				return
 			}
 		} else {
@@ -72,5 +70,13 @@ func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoin
 		}
 	}
 
-	return defaultResolver.EndpointFor(service, region, opts...)
+	return r.defaultResolver.ResolveEndpoint(ctx, params)
+}
+
+func withBaseEndpoint(endpoint string) func(*worklink_sdkv2.Options) {
+	return func(o *worklink_sdkv2.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}
 }

--- a/internal/service/worklink/service_endpoints_gen_test.go
+++ b/internal/service/worklink/service_endpoints_gen_test.go
@@ -4,18 +4,22 @@ package worklink_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	worklink_sdkv1 "github.com/aws/aws-sdk-go/service/worklink"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	worklink_sdkv2 "github.com/aws/aws-sdk-go-v2/service/worklink"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -240,57 +244,63 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 }
 
 func defaultEndpoint(region string) (url.URL, error) {
-	r := endpoints.DefaultResolver()
+	r := worklink_sdkv2.NewDefaultEndpointResolverV2()
 
-	ep, err := r.EndpointFor(worklink_sdkv1.EndpointsID, region, func(opt *endpoints.Options) {
-		opt.ResolveUnknownService = true
+	ep, err := r.ResolveEndpoint(context.Background(), worklink_sdkv2.EndpointParameters{
+		Region: aws_sdkv2.String(region),
 	})
 	if err != nil {
 		return url.URL{}, err
 	}
 
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
 	}
 
-	return *url, nil
+	return ep.URI, nil
 }
 
 func defaultFIPSEndpoint(region string) (url.URL, error) {
-	r := endpoints.DefaultResolver()
+	r := worklink_sdkv2.NewDefaultEndpointResolverV2()
 
-	ep, err := r.EndpointFor(worklink_sdkv1.EndpointsID, region, func(opt *endpoints.Options) {
-		opt.ResolveUnknownService = true
-		opt.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	ep, err := r.ResolveEndpoint(context.Background(), worklink_sdkv2.EndpointParameters{
+		Region:  aws_sdkv2.String(region),
+		UseFIPS: aws_sdkv2.Bool(true),
 	})
 	if err != nil {
 		return url.URL{}, err
 	}
 
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
 	}
 
-	return *url, nil
+	return ep.URI, nil
 }
 
 func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCallParams {
 	t.Helper()
 
-	client := meta.WorkLinkConn(ctx)
+	client := meta.WorkLinkClient(ctx)
 
-	req, _ := client.ListFleetsRequest(&worklink_sdkv1.ListFleetsInput{})
+	var result apiCallParams
 
-	req.HTTPRequest.URL.Path = "/"
-
-	return apiCallParams{
-		endpoint: req.HTTPRequest.URL.String(),
-		region:   aws_sdkv1.StringValue(client.Config.Region),
+	_, err := client.ListFleets(ctx, &worklink_sdkv2.ListFleetsInput{},
+		func(opts *worklink_sdkv2.Options) {
+			opts.APIOptions = append(opts.APIOptions,
+				addRetrieveEndpointURLMiddleware(t, &result.endpoint),
+				addRetrieveRegionMiddleware(&result.region),
+				addCancelRequestMiddleware(),
+			)
+		},
+	)
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	} else if !errors.Is(err, errCancelOperation) {
+		t.Fatalf("Unexpected error: %s", err)
 	}
+
+	return result
 }
 
 func withNoConfig(_ *caseSetup) {
@@ -467,6 +477,89 @@ func testEndpointCase(t *testing.T, region string, testcase endpointTestCase, ca
 	if e, a := testcase.expected.region, callParams.region; e != a {
 		t.Errorf("expected region %q, got %q", e, a)
 	}
+}
+
+func addRetrieveEndpointURLMiddleware(t *testing.T, endpoint *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			retrieveEndpointURLMiddleware(t, endpoint),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveEndpointURLMiddleware(t *testing.T, endpoint *string) middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Retrieve Endpoint",
+		func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			t.Helper()
+
+			request, ok := in.Request.(*smithyhttp.Request)
+			if !ok {
+				t.Fatalf("Expected *github.com/aws/smithy-go/transport/http.Request, got %s", fullTypeName(in.Request))
+			}
+
+			url := request.URL
+			url.RawQuery = ""
+			url.Path = "/"
+
+			*endpoint = url.String()
+
+			return next.HandleFinalize(ctx, in)
+		})
+}
+
+func addRetrieveRegionMiddleware(region *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Serialize.Add(
+			retrieveRegionMiddleware(region),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
+	return middleware.SerializeMiddlewareFunc(
+		"Test: Retrieve Region",
+		func(ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler) (middleware.SerializeOutput, middleware.Metadata, error) {
+			*region = awsmiddleware.GetRegion(ctx)
+
+			return next.HandleSerialize(ctx, in)
+		},
+	)
+}
+
+var errCancelOperation = fmt.Errorf("Test: Canceling request")
+
+func addCancelRequestMiddleware() func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			cancelRequestMiddleware(),
+			middleware.After,
+		)
+	}
+}
+
+// cancelRequestMiddleware creates a Smithy middleware that intercepts the request before sending and cancels it
+func cancelRequestMiddleware() middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Cancel Requests",
+		func(_ context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, errCancelOperation
+		})
+}
+
+func fullTypeName(i interface{}) string {
+	return fullValueTypeName(reflect.ValueOf(i))
+}
+
+func fullValueTypeName(v reflect.Value) string {
+	if v.Kind() == reflect.Ptr {
+		return "*" + fullValueTypeName(reflect.Indirect(v))
+	}
+
+	requestType := v.Type()
+	return fmt.Sprintf("%s.%s", requestType.PkgPath(), requestType.Name())
 }
 
 func generateSharedConfigFile(config configFile) string {

--- a/internal/service/worklink/service_package_gen.go
+++ b/internal/service/worklink/service_package_gen.go
@@ -5,10 +5,8 @@ package worklink
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	worklink_sdkv1 "github.com/aws/aws-sdk-go/service/worklink"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	worklink_sdkv2 "github.com/aws/aws-sdk-go-v2/service/worklink"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -31,12 +29,14 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceFleet,
+			Factory:  resourceFleet,
 			TypeName: "aws_worklink_fleet",
+			Name:     "Fleet",
 		},
 		{
-			Factory:  ResourceWebsiteCertificateAuthorityAssociation,
+			Factory:  resourceWebsiteCertificateAuthorityAssociation,
 			TypeName: "aws_worklink_website_certificate_authority_association",
+			Name:     "Website Certificate Authority Association",
 		},
 	}
 }
@@ -45,22 +45,14 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.WorkLink
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*worklink_sdkv1.WorkLink, error) {
-	sess := config[names.AttrSession].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*worklink_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	cfg := aws_sdkv1.Config{}
-
-	if endpoint := config[names.AttrEndpoint].(string); endpoint != "" {
-		tflog.Debug(ctx, "setting endpoint", map[string]any{
-			"tf_aws.endpoint": endpoint,
-		})
-		cfg.Endpoint = aws_sdkv1.String(endpoint)
-	} else {
-		cfg.EndpointResolver = newEndpointResolverSDKv1(ctx)
-	}
-
-	return worklink_sdkv1.New(sess.Copy(&cfg)), nil
+	return worklink_sdkv2.NewFromConfig(cfg,
+		worklink_sdkv2.WithEndpointResolverV2(newEndpointResolverSDKv2()),
+		withBaseEndpoint(config[names.AttrEndpoint].(string)),
+	), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/worklink/tags_gen.go
+++ b/internal/service/worklink/tags_gen.go
@@ -5,9 +5,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/worklink"
-	"github.com/aws/aws-sdk-go/service/worklink/worklinkiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/worklink"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
@@ -19,12 +18,12 @@ import (
 // listTags lists worklink service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn worklinkiface.WorkLinkAPI, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *worklink.Client, identifier string, optFns ...func(*worklink.Options)) (tftags.KeyValueTags, error) {
 	input := &worklink.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResourceWithContext(ctx, input)
+	output, err := conn.ListTagsForResource(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -36,7 +35,7 @@ func listTags(ctx context.Context, conn worklinkiface.WorkLinkAPI, identifier st
 // ListTags lists worklink service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).WorkLinkConn(ctx), identifier)
+	tags, err := listTags(ctx, meta.(*conns.AWSClient).WorkLinkClient(ctx), identifier)
 
 	if err != nil {
 		return err
@@ -49,21 +48,21 @@ func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier stri
 	return nil
 }
 
-// map[string]*string handling
+// map[string]string handling
 
 // Tags returns worklink service tags.
-func Tags(tags tftags.KeyValueTags) map[string]*string {
-	return aws.StringMap(tags.Map())
+func Tags(tags tftags.KeyValueTags) map[string]string {
+	return tags.Map()
 }
 
 // KeyValueTags creates tftags.KeyValueTags from worklink service tags.
-func KeyValueTags(ctx context.Context, tags map[string]*string) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags map[string]string) tftags.KeyValueTags {
 	return tftags.New(ctx, tags)
 }
 
 // getTagsIn returns worklink service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) map[string]*string {
+func getTagsIn(ctx context.Context) map[string]string {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -74,7 +73,7 @@ func getTagsIn(ctx context.Context) map[string]*string {
 }
 
 // setTagsOut sets worklink service tags in Context.
-func setTagsOut(ctx context.Context, tags map[string]*string) {
+func setTagsOut(ctx context.Context, tags map[string]string) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = option.Some(KeyValueTags(ctx, tags))
 	}
@@ -83,7 +82,7 @@ func setTagsOut(ctx context.Context, tags map[string]*string) {
 // updateTags updates worklink service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn worklinkiface.WorkLinkAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *worklink.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*worklink.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -94,10 +93,10 @@ func updateTags(ctx context.Context, conn worklinkiface.WorkLinkAPI, identifier 
 	if len(removedTags) > 0 {
 		input := &worklink.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -112,7 +111,7 @@ func updateTags(ctx context.Context, conn worklinkiface.WorkLinkAPI, identifier 
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -125,5 +124,5 @@ func updateTags(ctx context.Context, conn worklinkiface.WorkLinkAPI, identifier 
 // UpdateTags updates worklink service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).WorkLinkConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).WorkLinkClient(ctx), identifier, oldTags, newTags)
 }

--- a/internal/service/worklink/website_certificate_authority_association_test.go
+++ b/internal/service/worklink/website_certificate_authority_association_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_basic(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
@@ -54,7 +54,7 @@ func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_basic(t *testing.T) {
 }
 
 func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_displayName(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
@@ -91,7 +91,7 @@ func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_displayName(t *testin
 }
 
 func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_disappears(t *testing.T) {
-	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+	acctest.Skip(t, "skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release")
 
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)

--- a/internal/service/worklink/website_certificate_authority_association_test.go
+++ b/internal/service/worklink/website_certificate_authority_association_test.go
@@ -10,9 +10,6 @@ import (
 	"time"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/worklink"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -20,10 +17,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfworklink "github.com/hashicorp/terraform-provider-aws/internal/service/worklink"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
@@ -54,6 +54,8 @@ func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_basic(t *testing.T) {
 }
 
 func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_displayName(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
@@ -89,6 +91,8 @@ func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_displayName(t *testin
 }
 
 func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_disappears(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon Worklink has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	suffix := sdkacctest.RandStringFromCharSet(20, sdkacctest.CharSetAlpha)
 	resourceName := "aws_worklink_website_certificate_authority_association.test"
@@ -113,25 +117,23 @@ func TestAccWorkLinkWebsiteCertificateAuthorityAssociation_disappears(t *testing
 
 func testAccCheckWebsiteCertificateAuthorityAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_worklink_website_certificate_authority_association" {
 				continue
 			}
 
-			_, err := conn.DescribeWebsiteCertificateAuthorityWithContext(ctx, &worklink.DescribeWebsiteCertificateAuthorityInput{
-				FleetArn:    aws.String(rs.Primary.Attributes["fleet_arn"]),
-				WebsiteCaId: aws.String(rs.Primary.ID),
-			})
+			_, err := tfworklink.FindWebsiteCertificateAuthorityByARNAndID(ctx, conn, rs.Primary.Attributes["fleet_arn"], rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
 
 			if err != nil {
-				if tfawserr.ErrCodeEquals(err, worklink.ErrCodeResourceNotFoundException) {
-					return nil
-				}
-
 				return err
 			}
+
 			return fmt.Errorf("Worklink Website Certificate Authority Association(%s) still exists", rs.Primary.ID)
 		}
 
@@ -150,18 +152,16 @@ func testAccCheckWebsiteCertificateAuthorityAssociationDisappears(ctx context.Co
 			return fmt.Errorf("No resource ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkClient(ctx)
+
 		fleetArn, websiteCaID, err := tfworklink.DecodeWebsiteCertificateAuthorityAssociationResourceID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		input := &worklink.DisassociateWebsiteCertificateAuthorityInput{
-			FleetArn:    aws.String(fleetArn),
-			WebsiteCaId: aws.String(websiteCaID),
-		}
+		_, err = tfworklink.FindWebsiteCertificateAuthorityByARNAndID(ctx, conn, fleetArn, websiteCaID)
 
-		if _, err := conn.DisassociateWebsiteCertificateAuthorityWithContext(ctx, input); err != nil {
+		if err != nil {
 			return err
 		}
 
@@ -195,16 +195,13 @@ func testAccCheckWebsiteCertificateAuthorityAssociationExists(ctx context.Contex
 			return fmt.Errorf("WorkLink Fleet ARN is missing, should be set.")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkLinkClient(ctx)
 		fleetArn, websiteCaID, err := tfworklink.DecodeWebsiteCertificateAuthorityAssociationResourceID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		_, err = conn.DescribeWebsiteCertificateAuthorityWithContext(ctx, &worklink.DescribeWebsiteCertificateAuthorityInput{
-			FleetArn:    aws.String(fleetArn),
-			WebsiteCaId: aws.String(websiteCaID),
-		})
+		_, err = tfworklink.FindWebsiteCertificateAuthorityByARNAndID(ctx, conn, fleetArn, websiteCaID)
 
 		return err
 	}

--- a/names/data/names_data.hcl
+++ b/names/data/names_data.hcl
@@ -9523,7 +9523,7 @@ service "worklink" {
 
   sdk {
     id             = "WorkLink"
-    client_version = [1]
+    client_version = [2]
   }
 
   names {

--- a/tools/tfsdk2fw/go.mod
+++ b/tools/tfsdk2fw/go.mod
@@ -263,6 +263,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.23.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.51.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.32.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/worklink v1.22.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.45.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.21.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/xray v1.27.4 // indirect

--- a/tools/tfsdk2fw/go.sum
+++ b/tools/tfsdk2fw/go.sum
@@ -512,6 +512,8 @@ github.com/aws/aws-sdk-go-v2/service/wafv2 v1.51.5 h1:0JcKRIwypcn+qjFntLrJ6S1KZQ
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.51.5/go.mod h1:P95v1j9QVTk6fFciQhk/PnY0nYPGWixtJC/G7e2TY3M=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.32.4 h1:9Qd0MjFLUAUJqHf450+moANwNIh/d9cZ7ilP62CvfBw=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.32.4/go.mod h1:kIGecw/fUgEttRZPxglmcpyZdStWWJvWKJRmMyKiwDE=
+github.com/aws/aws-sdk-go-v2/service/worklink v1.22.4 h1:ocpfluH1mGYGRhjc89zlMr83P75qRkyET+GuRXj6twI=
+github.com/aws/aws-sdk-go-v2/service/worklink v1.22.4/go.mod h1:t5Ii3SqJrHijXgRbAWOfD30e/uuNxaVnQdLfji/yGQ4=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.45.1 h1:O2IZDp8Y+6ywBfIyBGMDljfQzRvnO2Fn85eV1+2Ovlg=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.45.1/go.mod h1:NpECdAtx0GNmx6ANGHmgDxqV6LQq59cxs7lY7vUiLUY=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.21.4 h1:jzF1yA5OeQuHzuPgdNiQ7no4wWGJ7hnYlPelVloFrXg=


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR migrates the `WorkLink` resources to AWS SDKv2.

Because this service has been deprecated all tests are skipped with an explanation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/36227
Relates https://github.com/hashicorp/terraform-provider-aws/issues/32976

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAcc' PKG=worklink
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/worklink/... -v -count 1 -parallel 20  -run=TestAcc -timeout 360m
=== RUN   TestAccWorkLinkFleet_basic
    fleet_test.go:27: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkFleet_basic (0.00s)
=== RUN   TestAccWorkLinkFleet_displayName
    fleet_test.go:58: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkFleet_displayName (0.00s)
=== RUN   TestAccWorkLinkFleet_optimizeForEndUserLocation
    fleet_test.go:94: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkFleet_optimizeForEndUserLocation (0.00s)
=== RUN   TestAccWorkLinkFleet_auditStreamARN
    fleet_test.go:130: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkFleet_auditStreamARN (0.00s)
=== RUN   TestAccWorkLinkFleet_network
    fleet_test.go:159: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkFleet_network (0.00s)
=== RUN   TestAccWorkLinkFleet_deviceCaCertificate
    fleet_test.go:205: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkFleet_deviceCaCertificate (0.00s)
=== RUN   TestAccWorkLinkFleet_identityProvider
    fleet_test.go:241: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkFleet_identityProvider (0.00s)
=== RUN   TestAccWorkLinkFleet_disappears
    fleet_test.go:276: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkFleet_disappears (0.00s)
=== RUN   TestAccWorkLinkWebsiteCertificateAuthorityAssociation_basic
    website_certificate_authority_association_test.go:25: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkWebsiteCertificateAuthorityAssociation_basic (0.00s)
=== RUN   TestAccWorkLinkWebsiteCertificateAuthorityAssociation_displayName
    website_certificate_authority_association_test.go:57: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkWebsiteCertificateAuthorityAssociation_displayName (0.00s)
=== RUN   TestAccWorkLinkWebsiteCertificateAuthorityAssociation_disappears
    website_certificate_authority_association_test.go:94: skipping test; Amazon WorkLink has been deprecated and will be removed in the next major release
--- SKIP: TestAccWorkLinkWebsiteCertificateAuthorityAssociation_disappears (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/worklink   4.733s
```
