### PR TITLE
Migrate `OpsWorks` resources to AWS SDK v2

### DIFF
--- a/.changelog/37871.txt
+++ b/.changelog/37871.txt
@@ -1,3 +1,3 @@
-`release-note:enhancement
+```release-note:enhancement
 resource/aws_batch_job_definition: Add `ecs_properties` argument
 ```

--- a/go.mod
+++ b/go.mod
@@ -303,6 +303,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.18 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.16 // indirect
+	github.com/aws/aws-sdk-go-v2/service/opsworks v1.24.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.5 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,8 @@ github.com/aws/aws-sdk-go-v2/service/oam v1.13.5 h1:51VYR5C0+/QEUrFURnwIGvT1eyia
 github.com/aws/aws-sdk-go-v2/service/oam v1.13.5/go.mod h1:dwn0suVbD6cdXDZQsEr5iYf4dhxDVr5wEAKSiCLSSQ8=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.13.4 h1:3Y4N61NHpii/6m38masM+VYJgnHhGtktEyJVZcTv0nc=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.13.4/go.mod h1:pQOhum5PBwXCSspA6bT4EZLhpawWF2aHTToUu/5vIBg=
+github.com/aws/aws-sdk-go-v2/service/opsworks v1.24.4 h1:2bzNoZZWJ8+lRIBfY/FSOdcRIfMYAae9DFwcYxIwD5w=
+github.com/aws/aws-sdk-go-v2/service/opsworks v1.24.4/go.mod h1:yjoW6GYtJ1dRtOth68jEL3gYgSXVJicc2Ljcjxt3s/4=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.30.3 h1:gYS53GRIaSesL04BlZA9MEBzDlENidWR/JDBXhZonFs=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.30.3/go.mod h1:qdJX3WZbuAan5dXCoinnJjuY1QERCpv3glXeI3+wbeA=
 github.com/aws/aws-sdk-go-v2/service/osis v1.12.4 h1:D1+hSpaeBVydbHUc86o1Yv3EhOcM0CRazxOokfpC33g=

--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -16,9 +16,7 @@ import (
 	config_sdkv2 "github.com/aws/aws-sdk-go-v2/config"
 	apigatewayv2_types "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
 	s3_sdkv2 "github.com/aws/aws-sdk-go-v2/service/s3"
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
 	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	opsworks_sdkv1 "github.com/aws/aws-sdk-go/service/opsworks"
 	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -59,16 +57,6 @@ func (c *AWSClient) CredentialsProvider(context.Context) aws_sdkv2.CredentialsPr
 
 func (c *AWSClient) AwsConfig(context.Context) aws_sdkv2.Config { // nosemgrep:ci.aws-in-func-name
 	return c.awsConfig.Copy()
-}
-
-// OpsWorksConnForRegion returns an AWS SDK For Go v1 OpsWorks API client for the specified AWS Region.
-// If the specified region is not the default a new "simple" client is created.
-// This new client does not use any configured endpoint override.
-func (c *AWSClient) OpsWorksConnForRegion(ctx context.Context, region string) *opsworks_sdkv1.OpsWorks {
-	if region == c.Region {
-		return c.OpsWorksConn(ctx)
-	}
-	return opsworks_sdkv1.New(c.session, aws_sdkv1.NewConfig().WithRegion(region))
 }
 
 // PartitionHostname returns a hostname with the provider domain suffix for the partition

--- a/internal/conns/awsclient_gen.go
+++ b/internal/conns/awsclient_gen.go
@@ -158,6 +158,7 @@ import (
 	networkmonitor_sdkv2 "github.com/aws/aws-sdk-go-v2/service/networkmonitor"
 	oam_sdkv2 "github.com/aws/aws-sdk-go-v2/service/oam"
 	opensearchserverless_sdkv2 "github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
+	opsworks_sdkv2 "github.com/aws/aws-sdk-go-v2/service/opsworks"
 	organizations_sdkv2 "github.com/aws/aws-sdk-go-v2/service/organizations"
 	osis_sdkv2 "github.com/aws/aws-sdk-go-v2/service/osis"
 	outposts_sdkv2 "github.com/aws/aws-sdk-go-v2/service/outposts"
@@ -241,7 +242,6 @@ import (
 	neptune_sdkv1 "github.com/aws/aws-sdk-go/service/neptune"
 	networkmanager_sdkv1 "github.com/aws/aws-sdk-go/service/networkmanager"
 	opensearchservice_sdkv1 "github.com/aws/aws-sdk-go/service/opensearchservice"
-	opsworks_sdkv1 "github.com/aws/aws-sdk-go/service/opsworks"
 	quicksight_sdkv1 "github.com/aws/aws-sdk-go/service/quicksight"
 	simpledb_sdkv1 "github.com/aws/aws-sdk-go/service/simpledb"
 	worklink_sdkv1 "github.com/aws/aws-sdk-go/service/worklink"
@@ -905,8 +905,8 @@ func (c *AWSClient) OpenSearchServerlessClient(ctx context.Context) *opensearchs
 	return errs.Must(client[*opensearchserverless_sdkv2.Client](ctx, c, names.OpenSearchServerless, make(map[string]any)))
 }
 
-func (c *AWSClient) OpsWorksConn(ctx context.Context) *opsworks_sdkv1.OpsWorks {
-	return errs.Must(conn[*opsworks_sdkv1.OpsWorks](ctx, c, names.OpsWorks, make(map[string]any)))
+func (c *AWSClient) OpsWorksClient(ctx context.Context) *opsworks_sdkv2.Client {
+	return errs.Must(client[*opsworks_sdkv2.Client](ctx, c, names.OpsWorks, make(map[string]any)))
 }
 
 func (c *AWSClient) OrganizationsClient(ctx context.Context) *organizations_sdkv2.Client {

--- a/internal/service/opsworks/application.go
+++ b/internal/service/opsworks/application.go
@@ -9,21 +9,25 @@ import (
 	"log"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/opsworks"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_opsworks_application")
-func ResourceApplication() *schema.Resource {
+// @SDKResource("aws_opsworks_application", name="Application")
+func resourceApplication() *schema.Resource {
 	return &schema.Resource{
 
 		CreateWithoutTimeout: resourceApplicationCreate,
@@ -46,9 +50,9 @@ func ResourceApplication() *schema.Resource {
 				ForceNew: true,
 			},
 			names.AttrType: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice(opsworks.AppType_Values(), false),
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.AppType](),
 			},
 			"stack_id": {
 				Type:     schema.TypeString,
@@ -81,9 +85,11 @@ func ResourceApplication() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrType: {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(append(opsworks.SourceType_Values(), "other"), false),
+							Type:     schema.TypeString,
+							Required: true,
+							// Because the SDK only accepts typed arguments from SourceType, we cannot add `other` even though the API will accept it.
+							// This service has been deprecated and will only for completeness sake be migrated, will remove the validation as to not cause a client validation expection but rather let AWS API handle it.
+							//ValidateFunc: validation.StringInSlice(append(opsworks.SourceType_Values(), "other"), false),
 						},
 
 						names.AttrURL: {
@@ -230,31 +236,32 @@ func resourceApplicationValidate(d *schema.ResourceData) error {
 		return fmt.Errorf("Only one ssl_configuration is permitted.")
 	}
 
-	if d.Get(names.AttrType) == opsworks.AppTypeNodejs || d.Get(names.AttrType) == opsworks.AppTypeJava {
+	attrType := awstypes.AppType(d.Get(names.AttrType).(string))
+	if attrType == awstypes.AppTypeNodejs || attrType == awstypes.AppTypeJava {
 		// allowed attributes: none
 		if d.Get("document_root").(string) != "" || d.Get("rails_env").(string) != "" || d.Get("auto_bundle_on_deploy").(string) != "" || d.Get("aws_flow_ruby_settings").(string) != "" {
-			return fmt.Errorf("No additional attributes are allowed for app type '%s'.", d.Get(names.AttrType).(string))
+			return fmt.Errorf("No additional attributes are allowed for app type '%s'.", attrType)
 		}
-	} else if d.Get(names.AttrType) == opsworks.AppTypeRails {
+	} else if attrType == awstypes.AppTypeRails {
 		// allowed attributes: document_root, rails_env, auto_bundle_on_deploy
 		if d.Get("aws_flow_ruby_settings").(string) != "" {
-			return fmt.Errorf("Only 'document_root, rails_env, auto_bundle_on_deploy' are allowed for app type '%s'.", opsworks.AppTypeRails)
+			return fmt.Errorf("Only 'document_root, rails_env, auto_bundle_on_deploy' are allowed for app type '%s'.", awstypes.AppTypeRails)
 		}
 		// rails_env is required
 		if _, ok := d.GetOk("rails_env"); !ok {
 			return fmt.Errorf("Set rails_env must be set if type is set to rails.")
 		}
-	} else if d.Get(names.AttrType) == opsworks.AppTypePhp || d.Get(names.AttrType) == opsworks.AppTypeStatic || d.Get(names.AttrType) == opsworks.AppTypeOther {
-		log.Printf("[DEBUG] the app type is : %s", d.Get(names.AttrType).(string))
+	} else if attrType == awstypes.AppTypePhp || attrType == awstypes.AppTypeStatic || attrType == awstypes.AppTypeOther {
+		log.Printf("[DEBUG] the app type is : %s", attrType)
 		log.Printf("[DEBUG] the attributes are: document_root '%s', rails_env '%s', auto_bundle_on_deploy '%s', aws_flow_ruby_settings '%s'", d.Get("document_root").(string), d.Get("rails_env").(string), d.Get("auto_bundle_on_deploy").(string), d.Get("aws_flow_ruby_settings").(string))
 		// allowed attributes: document_root
 		if d.Get("rails_env").(string) != "" || d.Get("auto_bundle_on_deploy").(string) != "" || d.Get("aws_flow_ruby_settings").(string) != "" {
-			return fmt.Errorf("Only 'document_root' is allowed for app type '%s'.", d.Get(names.AttrType).(string))
+			return fmt.Errorf("Only 'document_root' is allowed for app type '%s'.", attrType)
 		}
-	} else if d.Get(names.AttrType) == opsworks.AppTypeAwsFlowRuby {
+	} else if attrType == awstypes.AppTypeAwsFlowRuby {
 		// allowed attributes: aws_flow_ruby_settings
 		if d.Get("document_root").(string) != "" || d.Get("rails_env").(string) != "" || d.Get("auto_bundle_on_deploy").(string) != "" {
-			return fmt.Errorf("Only 'aws_flow_ruby_settings' is allowed for app type '%s'.", d.Get(names.AttrType).(string))
+			return fmt.Errorf("Only 'aws_flow_ruby_settings' is allowed for app type '%s'.", attrType)
 		}
 	}
 
@@ -263,19 +270,13 @@ func resourceApplicationValidate(d *schema.ResourceData) error {
 
 func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
-
-	req := &opsworks.DescribeAppsInput{
-		AppIds: []*string{
-			aws.String(d.Id()),
-		},
-	}
+	conn := meta.(*conns.AWSClient).OpsWorksClient(ctx)
 
 	log.Printf("[DEBUG] Reading OpsWorks Application: %s", d.Id())
 
-	resp, err := conn.DescribeAppsWithContext(ctx, req)
+	output, err := findAppByID(ctx, conn, d.Id())
 
-	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		log.Printf("[DEBUG] OpsWorks Application (%s) not found", d.Id())
 		d.SetId("")
 		return diags
@@ -285,33 +286,30 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 		return sdkdiag.AppendErrorf(diags, "reading OpsWorks Application (%s): %s", d.Id(), err)
 	}
 
-	app := resp.Apps[0]
-	log.Printf("[DEBUG] Opsworks Application: %#v", app)
-
-	d.Set(names.AttrName, app.Name)
-	d.Set("stack_id", app.StackId)
-	d.Set(names.AttrType, app.Type)
-	d.Set(names.AttrDescription, app.Description)
-	d.Set("domains", flex.FlattenStringList(app.Domains))
-	d.Set("enable_ssl", app.EnableSsl)
-	err = resourceSetApplicationSSL(d, app.SslConfiguration)
+	d.Set(names.AttrName, output.Name)
+	d.Set("stack_id", output.StackId)
+	d.Set(names.AttrType, output.Type)
+	d.Set(names.AttrDescription, output.Description)
+	d.Set("domains", output.Domains)
+	d.Set("enable_ssl", output.EnableSsl)
+	err = resourceSetApplicationSSL(d, output.SslConfiguration)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading OpsWorks Application (%s): setting ssl_configuration: %s", d.Id(), err)
 	}
-	err = resourceSetApplicationSource(d, app.AppSource)
+	err = resourceSetApplicationSource(d, output.AppSource)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading OpsWorks Application (%s): setting app_source: %s", d.Id(), err)
 	}
-	resourceSetApplicationsDataSource(d, app.DataSources)
-	resourceSetApplicationEnvironmentVariable(d, app.Environment)
-	resourceSetApplicationAttributes(d, app.Attributes)
+	resourceSetApplicationsDataSource(d, output.DataSources)
+	resourceSetApplicationEnvironmentVariable(d, output.Environment)
+	resourceSetApplicationAttributes(d, output.Attributes)
 
 	return diags
 }
 
 func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := meta.(*conns.AWSClient).OpsWorksClient(ctx)
 
 	err := resourceApplicationValidate(d)
 	if err != nil {
@@ -322,9 +320,9 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 		Name:             aws.String(d.Get(names.AttrName).(string)),
 		Shortname:        aws.String(d.Get("short_name").(string)),
 		StackId:          aws.String(d.Get("stack_id").(string)),
-		Type:             aws.String(d.Get(names.AttrType).(string)),
+		Type:             awstypes.AppType(d.Get(names.AttrType).(string)),
 		Description:      aws.String(d.Get(names.AttrDescription).(string)),
-		Domains:          flex.ExpandStringList(d.Get("domains").([]interface{})),
+		Domains:          flex.ExpandStringValueList(d.Get("domains").([]interface{})),
 		EnableSsl:        aws.Bool(d.Get("enable_ssl").(bool)),
 		SslConfiguration: resourceApplicationSSL(d),
 		AppSource:        resourceApplicationSource(d),
@@ -333,19 +331,19 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 		Attributes:       resourceApplicationAttributes(d),
 	}
 
-	resp, err := conn.CreateAppWithContext(ctx, req)
+	resp, err := conn.CreateApp(ctx, req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating OpsWorks Application: %s", err)
 	}
 
-	d.SetId(aws.StringValue(resp.AppId))
+	d.SetId(aws.ToString(resp.AppId))
 
 	return append(diags, resourceApplicationRead(ctx, d, meta)...)
 }
 
 func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := meta.(*conns.AWSClient).OpsWorksClient(ctx)
 
 	err := resourceApplicationValidate(d)
 	if err != nil {
@@ -355,9 +353,9 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 	req := &opsworks.UpdateAppInput{
 		AppId:            aws.String(d.Id()),
 		Name:             aws.String(d.Get(names.AttrName).(string)),
-		Type:             aws.String(d.Get(names.AttrType).(string)),
+		Type:             awstypes.AppType(d.Get(names.AttrType).(string)),
 		Description:      aws.String(d.Get(names.AttrDescription).(string)),
-		Domains:          flex.ExpandStringList(d.Get("domains").([]interface{})),
+		Domains:          flex.ExpandStringValueList(d.Get("domains").([]interface{})),
 		EnableSsl:        aws.Bool(d.Get("enable_ssl").(bool)),
 		SslConfiguration: resourceApplicationSSL(d),
 		AppSource:        resourceApplicationSource(d),
@@ -368,7 +366,7 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	log.Printf("[DEBUG] Updating OpsWorks Application: %s", d.Id())
 
-	_, err = conn.UpdateAppWithContext(ctx, req)
+	_, err = conn.UpdateApp(ctx, req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating OpsWorks Application (%s): %s", d.Id(), err)
 	}
@@ -378,14 +376,14 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := meta.(*conns.AWSClient).OpsWorksClient(ctx)
 
 	log.Printf("[DEBUG] Deleting OpsWorks Application: %s", d.Id())
-	_, err := conn.DeleteAppWithContext(ctx, &opsworks.DeleteAppInput{
+	_, err := conn.DeleteApp(ctx, &opsworks.DeleteAppInput{
 		AppId: aws.String(d.Id()),
 	})
 
-	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags
 	}
 
@@ -396,16 +394,40 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceFindEnvironmentVariable(key string, vs []*opsworks.EnvironmentVariable) *opsworks.EnvironmentVariable {
+func findAppByID(ctx context.Context, conn *opsworks.Client, id string) (*awstypes.App, error) {
+	input := &opsworks.DescribeAppsInput{
+		AppIds: []string{id},
+	}
+
+	output, err := conn.DescribeApps(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Apps == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return tfresource.AssertSingleValueResult(output.Apps)
+}
+
+func resourceFindEnvironmentVariable(key string, vs []awstypes.EnvironmentVariable) *awstypes.EnvironmentVariable {
 	for _, v := range vs {
-		if aws.StringValue(v.Key) == key {
-			return v
+		if aws.ToString(v.Key) == key {
+			return &v
 		}
 	}
 	return nil
 }
 
-func resourceSetApplicationEnvironmentVariable(d *schema.ResourceData, vs []*opsworks.EnvironmentVariable) {
+func resourceSetApplicationEnvironmentVariable(d *schema.ResourceData, vs []awstypes.EnvironmentVariable) {
 	if len(vs) == 0 {
 		d.Set(names.AttrEnvironment, nil)
 		return
@@ -419,10 +441,10 @@ func resourceSetApplicationEnvironmentVariable(d *schema.ResourceData, vs []*ops
 	for i := 0; i < len(values); i++ {
 		value := values[i].(map[string]interface{})
 		if v := resourceFindEnvironmentVariable(value[names.AttrKey].(string), vs); v != nil {
-			if !aws.BoolValue(v.Secure) {
-				value["secure"] = aws.BoolValue(v.Secure)
-				value[names.AttrKey] = aws.StringValue(v.Key)
-				value[names.AttrValue] = aws.StringValue(v.Value)
+			if !aws.ToBool(v.Secure) {
+				value["secure"] = aws.ToBool(v.Secure)
+				value[names.AttrKey] = aws.ToString(v.Key)
+				value[names.AttrValue] = aws.ToString(v.Value)
 				values[i] = value
 			}
 		} else {
@@ -434,14 +456,14 @@ func resourceSetApplicationEnvironmentVariable(d *schema.ResourceData, vs []*ops
 	d.Set(names.AttrEnvironment, values)
 }
 
-func resourceApplicationEnvironmentVariable(d *schema.ResourceData) []*opsworks.EnvironmentVariable {
+func resourceApplicationEnvironmentVariable(d *schema.ResourceData) []awstypes.EnvironmentVariable {
 	environmentVariables := d.Get(names.AttrEnvironment).(*schema.Set).List()
-	result := make([]*opsworks.EnvironmentVariable, len(environmentVariables))
+	result := make([]awstypes.EnvironmentVariable, len(environmentVariables))
 
 	for i := 0; i < len(environmentVariables); i++ {
 		env := environmentVariables[i].(map[string]interface{})
 
-		result[i] = &opsworks.EnvironmentVariable{
+		result[i] = awstypes.EnvironmentVariable{
 			Key:    aws.String(env[names.AttrKey].(string)),
 			Value:  aws.String(env[names.AttrValue].(string)),
 			Secure: aws.Bool(env["secure"].(bool)),
@@ -450,14 +472,14 @@ func resourceApplicationEnvironmentVariable(d *schema.ResourceData) []*opsworks.
 	return result
 }
 
-func resourceApplicationSource(d *schema.ResourceData) *opsworks.Source {
+func resourceApplicationSource(d *schema.ResourceData) *awstypes.Source {
 	count := d.Get("app_source.#").(int)
 	if count == 0 {
 		return nil
 	}
 
-	return &opsworks.Source{
-		Type:     aws.String(d.Get("app_source.0.type").(string)),
+	return &awstypes.Source{
+		Type:     awstypes.SourceType(d.Get("app_source.0.type").(string)),
 		Url:      aws.String(d.Get("app_source.0.url").(string)),
 		Username: aws.String(d.Get("app_source.0.username").(string)),
 		Password: aws.String(d.Get("app_source.0.password").(string)),
@@ -466,21 +488,21 @@ func resourceApplicationSource(d *schema.ResourceData) *opsworks.Source {
 	}
 }
 
-func resourceSetApplicationSource(d *schema.ResourceData, v *opsworks.Source) error {
+func resourceSetApplicationSource(d *schema.ResourceData, v *awstypes.Source) error {
 	nv := make([]interface{}, 0, 1)
 	if v != nil {
 		m := make(map[string]interface{})
-		if v.Type != nil {
-			m[names.AttrType] = aws.StringValue(v.Type)
-		}
+
+		m[names.AttrType] = v.Type
+
 		if v.Url != nil {
-			m[names.AttrURL] = aws.StringValue(v.Url)
+			m[names.AttrURL] = aws.ToString(v.Url)
 		}
 		if v.Username != nil {
-			m[names.AttrUsername] = aws.StringValue(v.Username)
+			m[names.AttrUsername] = aws.ToString(v.Username)
 		}
 		if v.Revision != nil {
-			m["revision"] = aws.StringValue(v.Revision)
+			m["revision"] = aws.ToString(v.Revision)
 		}
 
 		// v.Password and v.SshKey will, on read, contain the placeholder string
@@ -495,15 +517,15 @@ func resourceSetApplicationSource(d *schema.ResourceData, v *opsworks.Source) er
 	return d.Set("app_source", nv)
 }
 
-func resourceApplicationsDataSource(d *schema.ResourceData) []*opsworks.DataSource {
+func resourceApplicationsDataSource(d *schema.ResourceData) []awstypes.DataSource {
 	arn := d.Get("data_source_arn").(string)
 	databaseName := d.Get("data_source_database_name").(string)
 	databaseType := d.Get("data_source_type").(string)
 
-	result := make([]*opsworks.DataSource, 1)
+	result := make([]awstypes.DataSource, 1)
 
 	if len(arn) > 0 || len(databaseName) > 0 || len(databaseType) > 0 {
-		result[0] = &opsworks.DataSource{
+		result[0] = awstypes.DataSource{
 			Arn:          aws.String(arn),
 			DatabaseName: aws.String(databaseName),
 			Type:         aws.String(databaseType),
@@ -512,7 +534,7 @@ func resourceApplicationsDataSource(d *schema.ResourceData) []*opsworks.DataSour
 	return result
 }
 
-func resourceSetApplicationsDataSource(d *schema.ResourceData, v []*opsworks.DataSource) {
+func resourceSetApplicationsDataSource(d *schema.ResourceData, v []awstypes.DataSource) {
 	d.Set("data_source_arn", nil)
 	d.Set("data_source_database_name", nil)
 	d.Set("data_source_type", nil)
@@ -526,34 +548,34 @@ func resourceSetApplicationsDataSource(d *schema.ResourceData, v []*opsworks.Dat
 	d.Set("data_source_type", v[0].Type)
 }
 
-func resourceApplicationSSL(d *schema.ResourceData) *opsworks.SslConfiguration {
+func resourceApplicationSSL(d *schema.ResourceData) *awstypes.SslConfiguration {
 	count := d.Get("ssl_configuration.#").(int)
 	if count == 0 {
 		return nil
 	}
 
-	return &opsworks.SslConfiguration{
+	return &awstypes.SslConfiguration{
 		PrivateKey:  aws.String(d.Get("ssl_configuration.0.private_key").(string)),
 		Certificate: aws.String(d.Get("ssl_configuration.0.certificate").(string)),
 		Chain:       aws.String(d.Get("ssl_configuration.0.chain").(string)),
 	}
 }
 
-func resourceSetApplicationSSL(d *schema.ResourceData, v *opsworks.SslConfiguration) error {
+func resourceSetApplicationSSL(d *schema.ResourceData, v *awstypes.SslConfiguration) error {
 	nv := make([]interface{}, 0, 1)
 	set := false
 	if v != nil {
 		m := make(map[string]interface{})
 		if v.PrivateKey != nil {
-			m[names.AttrPrivateKey] = aws.StringValue(v.PrivateKey)
+			m[names.AttrPrivateKey] = aws.ToString(v.PrivateKey)
 			set = true
 		}
 		if v.Certificate != nil {
-			m[names.AttrCertificate] = aws.StringValue(v.Certificate)
+			m[names.AttrCertificate] = aws.ToString(v.Certificate)
 			set = true
 		}
 		if v.Chain != nil {
-			m["chain"] = aws.StringValue(v.Chain)
+			m["chain"] = aws.ToString(v.Chain)
 			set = true
 		}
 		if set {
@@ -564,17 +586,17 @@ func resourceSetApplicationSSL(d *schema.ResourceData, v *opsworks.SslConfigurat
 	return d.Set("ssl_configuration", nv)
 }
 
-func resourceApplicationAttributes(d *schema.ResourceData) map[string]*string {
-	attributes := make(map[string]*string)
+func resourceApplicationAttributes(d *schema.ResourceData) map[string]string {
+	attributes := make(map[string]string)
 
 	if val := d.Get("document_root").(string); len(val) > 0 {
-		attributes[opsworks.AppAttributesKeysDocumentRoot] = aws.String(val)
+		attributes[string(awstypes.AppAttributesKeysDocumentRoot)] = val
 	}
 	if val := d.Get("aws_flow_ruby_settings").(string); len(val) > 0 {
-		attributes[opsworks.AppAttributesKeysAwsFlowRubySettings] = aws.String(val)
+		attributes[string(awstypes.AppAttributesKeysAwsFlowRubySettings)] = val
 	}
 	if val := d.Get("rails_env").(string); len(val) > 0 {
-		attributes[opsworks.AppAttributesKeysRailsEnv] = aws.String(val)
+		attributes[string(awstypes.AppAttributesKeysRailsEnv)] = val
 	}
 	if val := d.Get("auto_bundle_on_deploy").(string); len(val) > 0 {
 		if val == "1" {
@@ -582,38 +604,39 @@ func resourceApplicationAttributes(d *schema.ResourceData) map[string]*string {
 		} else if val == "0" {
 			val = "false"
 		}
-		attributes[opsworks.AppAttributesKeysAutoBundleOnDeploy] = aws.String(val)
+		attributes[string(awstypes.AppAttributesKeysAutoBundleOnDeploy)] = val
 	}
 
 	return attributes
 }
 
-func resourceSetApplicationAttributes(d *schema.ResourceData, v map[string]*string) {
+func resourceSetApplicationAttributes(d *schema.ResourceData, v map[string]string) {
 	d.Set("document_root", nil)
 	d.Set("rails_env", nil)
 	d.Set("aws_flow_ruby_settings", nil)
 	d.Set("auto_bundle_on_deploy", nil)
 
-	if d.Get(names.AttrType) == opsworks.AppTypeNodejs || d.Get(names.AttrType) == opsworks.AppTypeJava {
+	attrType := d.Get(names.AttrType)
+	if attrType == awstypes.AppTypeNodejs || attrType == awstypes.AppTypeJava {
 		return
-	} else if d.Get(names.AttrType) == opsworks.AppTypeRails {
-		if val, ok := v[opsworks.AppAttributesKeysDocumentRoot]; ok {
+	} else if attrType == awstypes.AppTypeRails {
+		if val, ok := v[string(awstypes.AppAttributesKeysDocumentRoot)]; ok {
 			d.Set("document_root", val)
 		}
-		if val, ok := v[opsworks.AppAttributesKeysRailsEnv]; ok {
+		if val, ok := v[string(awstypes.AppAttributesKeysRailsEnv)]; ok {
 			d.Set("rails_env", val)
 		}
-		if val, ok := v[opsworks.AppAttributesKeysAutoBundleOnDeploy]; ok {
+		if val, ok := v[string(awstypes.AppAttributesKeysAutoBundleOnDeploy)]; ok {
 			d.Set("auto_bundle_on_deploy", val)
 		}
 		return
-	} else if d.Get(names.AttrType) == opsworks.AppTypePhp || d.Get(names.AttrType) == opsworks.AppTypeStatic || d.Get(names.AttrType) == opsworks.AppTypeOther {
-		if val, ok := v[opsworks.AppAttributesKeysDocumentRoot]; ok {
+	} else if attrType == awstypes.AppTypePhp || attrType == awstypes.AppTypeStatic || attrType == awstypes.AppTypeOther {
+		if val, ok := v[string(awstypes.AppAttributesKeysDocumentRoot)]; ok {
 			d.Set("document_root", val)
 		}
 		return
-	} else if d.Get(names.AttrType) == opsworks.AppTypeAwsFlowRuby {
-		if val, ok := v[opsworks.AppAttributesKeysAwsFlowRubySettings]; ok {
+	} else if attrType == awstypes.AppTypeAwsFlowRuby {
+		if val, ok := v[string(awstypes.AppAttributesKeysAwsFlowRubySettings)]; ok {
 			d.Set("aws_flow_ruby_settings", val)
 		}
 		return

--- a/internal/service/opsworks/application.go
+++ b/internal/service/opsworks/application.go
@@ -88,7 +88,7 @@ func resourceApplication() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							// Because the SDK only accepts typed arguments from SourceType, we cannot add `other` even though the API will accept it.
-							// This service has been deprecated and will only for completeness sake be migrated, will remove the validation as to not cause a client validation expection but rather let AWS API handle it.
+							// This service has been deprecated and will only for completeness sake be migrated, will remove the validation as to not cause a client validation exception but rather let AWS API handle it.
 							//ValidateFunc: validation.StringInSlice(append(opsworks.SourceType_Values(), "other"), false),
 						},
 

--- a/internal/service/opsworks/custom_layer.go
+++ b/internal/service/opsworks/custom_layer.go
@@ -4,15 +4,15 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // @SDKResource("aws_opsworks_custom_layer", name="Custom Layer")
 // @Tags(identifierAttribute="arn")
-func ResourceCustomLayer() *schema.Resource {
+func resourceCustomLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:        opsworks.LayerTypeCustom,
+		TypeName:        awstypes.LayerTypeCustom,
 		CustomShortName: true,
 
 		// The "custom" layer type has no additional attributes.

--- a/internal/service/opsworks/custom_layer_test.go
+++ b/internal/service/opsworks/custom_layer_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -18,13 +18,15 @@ import (
 )
 
 func TestAccOpsWorksCustomLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_custom_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCustomLayerDestroy(ctx),
@@ -78,16 +80,16 @@ func TestAccOpsWorksCustomLayer_basic(t *testing.T) {
 	})
 }
 
-// _disappears and _tags for OpsWorks Layers are tested via aws_opsworks_rails_app_layer.
-
 func TestAccOpsWorksCustomLayer_update(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_custom_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCustomLayerDestroy(ctx),
@@ -154,14 +156,16 @@ func TestAccOpsWorksCustomLayer_update(t *testing.T) {
 }
 
 func TestAccOpsWorksCustomLayer_cloudWatch(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_custom_layer.test"
 	logGroupResourceName := "aws_cloudwatch_log_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCustomLayerDestroy(ctx),
@@ -237,13 +241,15 @@ func TestAccOpsWorksCustomLayer_cloudWatch(t *testing.T) {
 }
 
 func TestAccOpsWorksCustomLayer_loadBasedAutoScaling(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_custom_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckCustomLayerDestroy(ctx),

--- a/internal/service/opsworks/ecs_cluster_layer.go
+++ b/internal/service/opsworks/ecs_cluster_layer.go
@@ -4,21 +4,21 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
 // @SDKResource("aws_opsworks_ecs_cluster_layer", name="ECS Cluster Layer")
 // @Tags(identifierAttribute="arn")
-func ResourceECSClusterLayer() *schema.Resource {
+func resourceECSClusterLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         opsworks.LayerTypeEcsCluster,
+		TypeName:         awstypes.LayerTypeEcsCluster,
 		DefaultLayerName: "Ecs Cluster",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"ecs_cluster_arn": {
-				AttrName:     opsworks.LayerAttributesKeysEcsClusterArn,
+				AttrName:     awstypes.LayerAttributesKeysEcsClusterArn,
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,

--- a/internal/service/opsworks/ecs_cluster_layer_test.go
+++ b/internal/service/opsworks/ecs_cluster_layer_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,13 +17,15 @@ import (
 )
 
 func TestAccOpsWorksECSClusterLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	stackName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_ecs_cluster_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckECSClusterLayerDestroy(ctx),
@@ -39,8 +41,6 @@ func TestAccOpsWorksECSClusterLayer_basic(t *testing.T) {
 		},
 	})
 }
-
-// _disappears and _tags for OpsWorks Layers are tested via aws_opsworks_rails_app_layer.
 
 func testAccCheckECSClusterLayerDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/internal/service/opsworks/exports_test.go
+++ b/internal/service/opsworks/exports_test.go
@@ -1,0 +1,20 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package opsworks
+
+// Exports for use in tests only.
+var (
+	ResourceRailsAppLayer = resourceRailsAppLayer
+	ResourceRDSDBInstance = resourceRDSDBInstance
+	ResourceStack         = resourceStack
+	ResourceUserProfile   = resourceUserProfile
+
+	FindAppByID                   = findAppByID
+	FindInstanceByID              = findInstanceByID
+	FindLayerByID                 = findLayerByID
+	FindPermissionByTwoPartKey    = findPermissionByTwoPartKey
+	FindRDSDBInstanceByTwoPartKey = findRDSDBInstanceByTwoPartKey
+	FindStackByID                 = findStackByID
+	FindUserProfileByARN          = findUserProfileByARN
+)

--- a/internal/service/opsworks/ganglia_layer.go
+++ b/internal/service/opsworks/ganglia_layer.go
@@ -4,32 +4,32 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_opsworks_ganglia_layer", name="Ganglia Layer")
 // @Tags(identifierAttribute="arn")
-func ResourceGangliaLayer() *schema.Resource {
+func resourceGangliaLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         opsworks.LayerTypeMonitoringMaster,
+		TypeName:         awstypes.LayerTypeMonitoringMaster,
 		DefaultLayerName: "Ganglia",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			names.AttrPassword: {
-				AttrName:  opsworks.LayerAttributesKeysGangliaPassword,
+				AttrName:  awstypes.LayerAttributesKeysGangliaPassword,
 				Type:      schema.TypeString,
 				Required:  true,
 				WriteOnly: true,
 			},
 			names.AttrURL: {
-				AttrName: opsworks.LayerAttributesKeysGangliaUrl,
+				AttrName: awstypes.LayerAttributesKeysGangliaUrl,
 				Type:     schema.TypeString,
 				Default:  "/ganglia",
 			},
 			names.AttrUsername: {
-				AttrName: opsworks.LayerAttributesKeysGangliaUser,
+				AttrName: awstypes.LayerAttributesKeysGangliaUser,
 				Type:     schema.TypeString,
 				Default:  "opsworks",
 			},

--- a/internal/service/opsworks/ganglia_layer_test.go
+++ b/internal/service/opsworks/ganglia_layer_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,13 +16,15 @@ import (
 )
 
 func TestAccOpsWorksGangliaLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_ganglia_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckGangliaLayerDestroy(ctx),

--- a/internal/service/opsworks/generate.go
+++ b/internal/service/opsworks/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -ListTags -ListTagsOp=ListTags -ServiceTagsMap -UpdateTags -CreateTags
+//go:generate go run ../../generate/tags/main.go -AWSSDKVersion=2 -ListTags -ListTagsOp=ListTags -ServiceTagsMap -UpdateTags -CreateTags -SkipTypesImp -KVTValues
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/service/opsworks/haproxy_layer.go
+++ b/internal/service/opsworks/haproxy_layer.go
@@ -4,46 +4,46 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // @SDKResource("aws_opsworks_haproxy_layer", name="HAProxy Layer")
 // @Tags(identifierAttribute="arn")
-func ResourceHAProxyLayer() *schema.Resource {
+func resourceHAProxyLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         opsworks.LayerTypeLb,
+		TypeName:         awstypes.LayerTypeLb,
 		DefaultLayerName: "HAProxy",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"healthcheck_method": {
-				AttrName: opsworks.LayerAttributesKeysHaproxyHealthCheckMethod,
+				AttrName: awstypes.LayerAttributesKeysHaproxyHealthCheckMethod,
 				Type:     schema.TypeString,
 				Default:  "OPTIONS",
 			},
 			"healthcheck_url": {
-				AttrName: opsworks.LayerAttributesKeysHaproxyHealthCheckUrl,
+				AttrName: awstypes.LayerAttributesKeysHaproxyHealthCheckUrl,
 				Type:     schema.TypeString,
 				Default:  "/",
 			},
 			"stats_enabled": {
-				AttrName: opsworks.LayerAttributesKeysEnableHaproxyStats,
+				AttrName: awstypes.LayerAttributesKeysEnableHaproxyStats,
 				Type:     schema.TypeBool,
 				Default:  true,
 			},
 			"stats_password": {
-				AttrName:  opsworks.LayerAttributesKeysHaproxyStatsPassword,
+				AttrName:  awstypes.LayerAttributesKeysHaproxyStatsPassword,
 				Type:      schema.TypeString,
 				WriteOnly: true,
 				Required:  true,
 			},
 			"stats_url": {
-				AttrName: opsworks.LayerAttributesKeysHaproxyStatsUrl,
+				AttrName: awstypes.LayerAttributesKeysHaproxyStatsUrl,
 				Type:     schema.TypeString,
 				Default:  "/haproxy?stats",
 			},
 			"stats_user": {
-				AttrName: opsworks.LayerAttributesKeysHaproxyStatsUser,
+				AttrName: awstypes.LayerAttributesKeysHaproxyStatsUser,
 				Type:     schema.TypeString,
 				Default:  "opsworks",
 			},

--- a/internal/service/opsworks/haproxy_layer_test.go
+++ b/internal/service/opsworks/haproxy_layer_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,13 +16,15 @@ import (
 )
 
 func TestAccOpsWorksHAProxyLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_haproxy_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckHAProxyLayerDestroy(ctx),

--- a/internal/service/opsworks/instance.go
+++ b/internal/service/opsworks/instance.go
@@ -10,22 +10,25 @@ import (
 	"log"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/opsworks"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_opsworks_instance")
-func ResourceInstance() *schema.Resource {
+// @SDKResource("aws_opsworks_instance", name="Instance")
+func resourceInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceInstanceCreate,
 		ReadWithoutTimeout:   resourceInstanceRead,
@@ -56,16 +59,16 @@ func ResourceInstance() *schema.Resource {
 			},
 
 			"architecture": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "x86_64",
-				ValidateFunc: validation.StringInSlice(opsworks.Architecture_Values(), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "x86_64",
+				ValidateDiagFunc: enum.Validate[awstypes.Architecture](),
 			},
 
 			"auto_scaling_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice(opsworks.AutoScalingType_Values(), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.AutoScalingType](),
 			},
 
 			names.AttrAvailabilityZone: {
@@ -216,11 +219,11 @@ func ResourceInstance() *schema.Resource {
 			},
 
 			"root_device_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice(opsworks.RootDeviceType_Values(), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Computed:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.RootDeviceType](),
 			},
 
 			"root_device_volume_id": {
@@ -292,11 +295,11 @@ func ResourceInstance() *schema.Resource {
 			},
 
 			"virtualization_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice(opsworks.VirtualizationType_Values(), false),
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.VirtualizationType](),
 			},
 
 			"ebs_block_device": {
@@ -460,19 +463,11 @@ func resourceInstanceValidate(d *schema.ResourceData) error {
 
 func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := meta.(*conns.AWSClient).OpsWorksClient(ctx)
 
-	req := &opsworks.DescribeInstancesInput{
-		InstanceIds: []*string{
-			aws.String(d.Id()),
-		},
-	}
+	output, err := findInstanceByID(ctx, conn, d.Id())
 
-	log.Printf("[DEBUG] Reading OpsWorks instance: %s", d.Id())
-
-	resp, err := conn.DescribeInstancesWithContext(ctx, req)
-
-	if !d.IsNewResource() && tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] OpsWorks instance %s not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -482,67 +477,54 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "reading OpsWorks Instance (%s): %s", d.Id(), err)
 	}
 
-	// If nothing was found, then return no state
-	if len(resp.Instances) == 0 || resp.Instances[0] == nil || resp.Instances[0].InstanceId == nil {
-		log.Printf("[WARN] OpsWorks instance %s not found, removing from state", d.Id())
-		d.SetId("")
-		return diags
-	}
-
-	instance := resp.Instances[0]
-
-	d.SetId(aws.StringValue(instance.InstanceId))
-	d.Set("agent_version", instance.AgentVersion)
-	d.Set("ami_id", instance.AmiId)
-	d.Set("architecture", instance.Architecture)
-	d.Set("auto_scaling_type", instance.AutoScalingType)
-	d.Set(names.AttrAvailabilityZone, instance.AvailabilityZone)
-	d.Set(names.AttrCreatedAt, instance.CreatedAt)
-	d.Set("ebs_optimized", instance.EbsOptimized)
-	d.Set("ec2_instance_id", instance.Ec2InstanceId)
-	d.Set("ecs_cluster_arn", instance.EcsClusterArn)
-	d.Set("elastic_ip", instance.ElasticIp)
-	d.Set("hostname", instance.Hostname)
-	d.Set("infrastructure_class", instance.InfrastructureClass)
-	d.Set("install_updates_on_boot", instance.InstallUpdatesOnBoot)
-	d.Set("instance_profile_arn", instance.InstanceProfileArn)
-	d.Set(names.AttrInstanceType, instance.InstanceType)
-	d.Set("last_service_error_id", instance.LastServiceErrorId)
-	var layerIds []string
-	for _, v := range instance.LayerIds {
-		layerIds = append(layerIds, aws.StringValue(v))
-	}
-	layerIds, err = sortListBasedonTFFile(layerIds, d)
+	d.SetId(aws.ToString(output.InstanceId))
+	d.Set("agent_version", output.AgentVersion)
+	d.Set("ami_id", output.AmiId)
+	d.Set("architecture", output.Architecture)
+	d.Set("auto_scaling_type", output.AutoScalingType)
+	d.Set(names.AttrAvailabilityZone, output.AvailabilityZone)
+	d.Set(names.AttrCreatedAt, output.CreatedAt)
+	d.Set("ebs_optimized", output.EbsOptimized)
+	d.Set("ec2_instance_id", output.Ec2InstanceId)
+	d.Set("ecs_cluster_arn", output.EcsClusterArn)
+	d.Set("elastic_ip", output.ElasticIp)
+	d.Set("hostname", output.Hostname)
+	d.Set("infrastructure_class", output.InfrastructureClass)
+	d.Set("install_updates_on_boot", output.InstallUpdatesOnBoot)
+	d.Set("instance_profile_arn", output.InstanceProfileArn)
+	d.Set(names.AttrInstanceType, output.InstanceType)
+	d.Set("last_service_error_id", output.LastServiceErrorId)
+	layerIds, err := sortListBasedonTFFile(output.LayerIds, d)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "sorting layer_ids attribute: %#v", err)
 	}
 	if err := d.Set("layer_ids", layerIds); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting layer_ids attribute: %#v, error: %#v", layerIds, err)
 	}
-	d.Set("os", instance.Os)
-	d.Set("platform", instance.Platform)
-	d.Set("private_dns", instance.PrivateDns)
-	d.Set("private_ip", instance.PrivateIp)
-	d.Set("public_dns", instance.PublicDns)
-	d.Set("public_ip", instance.PublicIp)
-	d.Set("registered_by", instance.RegisteredBy)
-	d.Set("reported_agent_version", instance.ReportedAgentVersion)
-	d.Set("reported_os_family", instance.ReportedOs.Family)
-	d.Set("reported_os_name", instance.ReportedOs.Name)
-	d.Set("reported_os_version", instance.ReportedOs.Version)
-	d.Set("root_device_type", instance.RootDeviceType)
-	d.Set("root_device_volume_id", instance.RootDeviceVolumeId)
-	d.Set("ssh_host_dsa_key_fingerprint", instance.SshHostDsaKeyFingerprint)
-	d.Set("ssh_host_rsa_key_fingerprint", instance.SshHostRsaKeyFingerprint)
-	d.Set("ssh_key_name", instance.SshKeyName)
-	d.Set("stack_id", instance.StackId)
-	d.Set(names.AttrStatus, instance.Status)
-	d.Set(names.AttrSubnetID, instance.SubnetId)
-	d.Set("tenancy", instance.Tenancy)
-	d.Set("virtualization_type", instance.VirtualizationType)
+	d.Set("os", output.Os)
+	d.Set("platform", output.Platform)
+	d.Set("private_dns", output.PrivateDns)
+	d.Set("private_ip", output.PrivateIp)
+	d.Set("public_dns", output.PublicDns)
+	d.Set("public_ip", output.PublicIp)
+	d.Set("registered_by", output.RegisteredBy)
+	d.Set("reported_agent_version", output.ReportedAgentVersion)
+	d.Set("reported_os_family", output.ReportedOs.Family)
+	d.Set("reported_os_name", output.ReportedOs.Name)
+	d.Set("reported_os_version", output.ReportedOs.Version)
+	d.Set("root_device_type", output.RootDeviceType)
+	d.Set("root_device_volume_id", output.RootDeviceVolumeId)
+	d.Set("ssh_host_dsa_key_fingerprint", output.SshHostDsaKeyFingerprint)
+	d.Set("ssh_host_rsa_key_fingerprint", output.SshHostRsaKeyFingerprint)
+	d.Set("ssh_key_name", output.SshKeyName)
+	d.Set("stack_id", output.StackId)
+	d.Set(names.AttrStatus, output.Status)
+	d.Set(names.AttrSubnetID, output.SubnetId)
+	d.Set("tenancy", output.Tenancy)
+	d.Set("virtualization_type", output.VirtualizationType)
 
 	// Read BlockDeviceMapping
-	ibds := readBlockDevices(instance)
+	ibds := readBlockDevices(output)
 
 	if err := d.Set("ebs_block_device", ibds["ebs"]); err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading OpsWorks Instance (%s): setting ebs_block_device: %s", d.Id(), err)
@@ -559,9 +541,9 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	// Read Security Groups
-	sgs := make([]string, 0, len(instance.SecurityGroupIds))
-	for _, sg := range instance.SecurityGroupIds {
-		sgs = append(sgs, *sg)
+	sgs := make([]string, 0, len(output.SecurityGroupIds))
+	for _, sg := range output.SecurityGroupIds {
+		sgs = append(sgs, sg)
 	}
 	if err := d.Set(names.AttrSecurityGroupIDs, sgs); err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading OpsWorks Instance (%s): setting security_group_ids: %s", d.Id(), err)
@@ -571,7 +553,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := meta.(*conns.AWSClient).OpsWorksClient(ctx)
 
 	err := resourceInstanceValidate(d)
 	if err != nil {
@@ -580,11 +562,11 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	req := &opsworks.CreateInstanceInput{
 		AgentVersion:         aws.String(d.Get("agent_version").(string)),
-		Architecture:         aws.String(d.Get("architecture").(string)),
+		Architecture:         awstypes.Architecture(d.Get("architecture").(string)),
 		EbsOptimized:         aws.Bool(d.Get("ebs_optimized").(bool)),
 		InstallUpdatesOnBoot: aws.Bool(d.Get("install_updates_on_boot").(bool)),
 		InstanceType:         aws.String(d.Get(names.AttrInstanceType).(string)),
-		LayerIds:             flex.ExpandStringList(d.Get("layer_ids").([]interface{})),
+		LayerIds:             flex.ExpandStringValueList(d.Get("layer_ids").([]interface{})),
 		StackId:              aws.String(d.Get("stack_id").(string)),
 	}
 
@@ -594,7 +576,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("auto_scaling_type"); ok {
-		req.AutoScalingType = aws.String(v.(string))
+		req.AutoScalingType = awstypes.AutoScalingType(v.(string))
 	}
 
 	if v, ok := d.GetOk(names.AttrAvailabilityZone); ok {
@@ -610,7 +592,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("root_device_type"); ok {
-		req.RootDeviceType = aws.String(v.(string))
+		req.RootDeviceType = awstypes.RootDeviceType(v.(string))
 	}
 
 	if v, ok := d.GetOk("ssh_key_name"); ok {
@@ -629,13 +611,13 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		req.VirtualizationType = aws.String(v.(string))
 	}
 
-	var blockDevices []*opsworks.BlockDeviceMapping
+	var blockDevices []awstypes.BlockDeviceMapping
 
 	if v, ok := d.GetOk("ebs_block_device"); ok {
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
 			bd := v.(map[string]interface{})
-			ebs := &opsworks.EbsBlockDevice{
+			ebs := &awstypes.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd[names.AttrDeleteOnTermination].(bool)),
 			}
 
@@ -644,18 +626,18 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			}
 
 			if v, ok := bd[names.AttrVolumeSize].(int); ok && v != 0 {
-				ebs.VolumeSize = aws.Int64(int64(v))
+				ebs.VolumeSize = aws.Int32(int32(v))
 			}
 
 			if v, ok := bd[names.AttrVolumeType].(string); ok && v != "" {
-				ebs.VolumeType = aws.String(v)
+				ebs.VolumeType = awstypes.VolumeType(v)
 			}
 
 			if v, ok := bd[names.AttrIOPS].(int); ok && v > 0 {
-				ebs.Iops = aws.Int64(int64(v))
+				ebs.Iops = aws.Int32(int32(v))
 			}
 
-			blockDevices = append(blockDevices, &opsworks.BlockDeviceMapping{
+			blockDevices = append(blockDevices, awstypes.BlockDeviceMapping{
 				DeviceName: aws.String(bd[names.AttrDeviceName].(string)),
 				Ebs:        ebs,
 			})
@@ -666,7 +648,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
 			bd := v.(map[string]interface{})
-			blockDevices = append(blockDevices, &opsworks.BlockDeviceMapping{
+			blockDevices = append(blockDevices, awstypes.BlockDeviceMapping{
 				DeviceName:  aws.String(bd[names.AttrDeviceName].(string)),
 				VirtualName: aws.String(bd[names.AttrVirtualName].(string)),
 			})
@@ -680,23 +662,23 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 		for _, v := range vL {
 			bd := v.(map[string]interface{})
-			ebs := &opsworks.EbsBlockDevice{
+			ebs := &awstypes.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd[names.AttrDeleteOnTermination].(bool)),
 			}
 
 			if v, ok := bd[names.AttrVolumeSize].(int); ok && v != 0 {
-				ebs.VolumeSize = aws.Int64(int64(v))
+				ebs.VolumeSize = aws.Int32(int32(v))
 			}
 
 			if v, ok := bd[names.AttrVolumeType].(string); ok && v != "" {
-				ebs.VolumeType = aws.String(v)
+				ebs.VolumeType = awstypes.VolumeType(v)
 			}
 
 			if v, ok := bd[names.AttrIOPS].(int); ok && v > 0 {
-				ebs.Iops = aws.Int64(int64(v))
+				ebs.Iops = aws.Int32(int32(v))
 			}
 
-			blockDevices = append(blockDevices, &opsworks.BlockDeviceMapping{
+			blockDevices = append(blockDevices, awstypes.BlockDeviceMapping{
 				DeviceName: aws.String("ROOT_DEVICE"),
 				Ebs:        ebs,
 			})
@@ -711,7 +693,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	var resp *opsworks.CreateInstanceOutput
 
-	resp, err = conn.CreateInstanceWithContext(ctx, req)
+	resp, err = conn.CreateInstance(ctx, req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating OpsWorks Instance: %s", err)
 	}
@@ -720,7 +702,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return sdkdiag.AppendErrorf(diags, "creating OpsWorks Instance: no instance returned")
 	}
 
-	instanceId := aws.StringValue(resp.InstanceId)
+	instanceId := aws.ToString(resp.InstanceId)
 	d.SetId(instanceId)
 
 	if v, ok := d.GetOk(names.AttrState); ok && v.(string) == instanceStatusRunning {
@@ -735,7 +717,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := meta.(*conns.AWSClient).OpsWorksClient(ctx)
 
 	err := resourceInstanceValidate(d)
 	if err != nil {
@@ -745,7 +727,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	req := &opsworks.UpdateInstanceInput{
 		InstanceId:           aws.String(d.Id()),
 		AgentVersion:         aws.String(d.Get("agent_version").(string)),
-		Architecture:         aws.String(d.Get("architecture").(string)),
+		Architecture:         awstypes.Architecture(d.Get("architecture").(string)),
 		InstallUpdatesOnBoot: aws.Bool(d.Get("install_updates_on_boot").(bool)),
 	}
 
@@ -755,7 +737,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("auto_scaling_type"); ok {
-		req.AutoScalingType = aws.String(v.(string))
+		req.AutoScalingType = awstypes.AutoScalingType(v.(string))
 	}
 
 	if v, ok := d.GetOk("hostname"); ok {
@@ -767,7 +749,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("layer_ids"); ok {
-		req.LayerIds = flex.ExpandStringList(v.([]interface{}))
+		req.LayerIds = flex.ExpandStringValueList(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("os"); ok {
@@ -780,7 +762,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	log.Printf("[DEBUG] Updating OpsWorks instance: %s", d.Id())
 
-	_, err = conn.UpdateInstanceWithContext(ctx, req)
+	_, err = conn.UpdateInstance(ctx, req)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating OpsWorks Instance (%s): %s", d.Id(), err)
 	}
@@ -817,7 +799,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := meta.(*conns.AWSClient).OpsWorksClient(ctx)
 
 	if v, ok := d.GetOk(names.AttrStatus); ok && v.(string) != instanceStatusStopped {
 		err := stopInstance(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
@@ -834,9 +816,9 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 
 	log.Printf("[DEBUG] Deleting OpsWorks instance: %s", d.Id())
 
-	_, err := conn.DeleteInstanceWithContext(ctx, req)
+	_, err := conn.DeleteInstance(ctx, req)
 
-	if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags
 	}
 
@@ -851,6 +833,30 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
+func findInstanceByID(ctx context.Context, conn *opsworks.Client, id string) (*awstypes.Instance, error) {
+	input := &opsworks.DescribeInstancesInput{
+		InstanceIds: []string{id},
+	}
+
+	output, err := conn.DescribeInstances(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.Instances == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return tfresource.AssertSingleValueResult(output.Instances)
+}
+
 func resourceInstanceImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	// Neither delete_eip nor delete_ebs can be fetched
 	// from any API call, so we need to default to the values
@@ -861,7 +867,7 @@ func resourceInstanceImport(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func startInstance(ctx context.Context, d *schema.ResourceData, meta interface{}, wait bool, timeout time.Duration) error {
-	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := meta.(*conns.AWSClient).OpsWorksClient(ctx)
 
 	req := &opsworks.StartInstanceInput{
 		InstanceId: aws.String(d.Id()),
@@ -869,7 +875,7 @@ func startInstance(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 	log.Printf("[DEBUG] Starting OpsWorks instance: %s", d.Id())
 
-	_, err := conn.StartInstanceWithContext(ctx, req)
+	_, err := conn.StartInstance(ctx, req)
 
 	if err != nil {
 		return fmt.Errorf("starting instance: %w", err)
@@ -887,7 +893,7 @@ func startInstance(ctx context.Context, d *schema.ResourceData, meta interface{}
 }
 
 func stopInstance(ctx context.Context, d *schema.ResourceData, meta interface{}, timeout time.Duration) error {
-	conn := meta.(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := meta.(*conns.AWSClient).OpsWorksClient(ctx)
 
 	req := &opsworks.StopInstanceInput{
 		InstanceId: aws.String(d.Id()),
@@ -895,7 +901,7 @@ func stopInstance(ctx context.Context, d *schema.ResourceData, meta interface{},
 
 	log.Printf("[DEBUG] Stopping OpsWorks instance: %s", d.Id())
 
-	_, err := conn.StopInstanceWithContext(ctx, req)
+	_, err := conn.StopInstance(ctx, req)
 
 	if err != nil {
 		return fmt.Errorf("stopping instance: %w", err)
@@ -910,7 +916,7 @@ func stopInstance(ctx context.Context, d *schema.ResourceData, meta interface{},
 	return nil
 }
 
-func waitInstanceDeleted(ctx context.Context, conn *opsworks.OpsWorks, instanceId string) error {
+func waitInstanceDeleted(ctx context.Context, conn *opsworks.Client, instanceId string) error {
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{instanceStatusStopped, instanceStatusTerminating, instanceStatusTerminated},
 		Target:     []string{},
@@ -924,7 +930,7 @@ func waitInstanceDeleted(ctx context.Context, conn *opsworks.OpsWorks, instanceI
 	return err
 }
 
-func waitInstanceStarted(ctx context.Context, conn *opsworks.OpsWorks, instanceId string, timeout time.Duration) error {
+func waitInstanceStarted(ctx context.Context, conn *opsworks.Client, instanceId string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{instanceStatusRequested, instanceStatusPending, instanceStatusBooting, instanceStatusRunningSetup},
 		Target:     []string{instanceStatusOnline},
@@ -937,7 +943,7 @@ func waitInstanceStarted(ctx context.Context, conn *opsworks.OpsWorks, instanceI
 	return err
 }
 
-func waitInstanceStopped(ctx context.Context, conn *opsworks.OpsWorks, instanceId string, timeout time.Duration) error {
+func waitInstanceStopped(ctx context.Context, conn *opsworks.Client, instanceId string, timeout time.Duration) error {
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{instanceStatusStopping, instanceStatusTerminating, instanceStatusShuttingDown, instanceStatusTerminated},
 		Target:     []string{instanceStatusStopped},
@@ -950,13 +956,13 @@ func waitInstanceStopped(ctx context.Context, conn *opsworks.OpsWorks, instanceI
 	return err
 }
 
-func instanceStatus(ctx context.Context, conn *opsworks.OpsWorks, instanceID string) retry.StateRefreshFunc {
+func instanceStatus(ctx context.Context, conn *opsworks.Client, instanceID string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := conn.DescribeInstancesWithContext(ctx, &opsworks.DescribeInstancesInput{
-			InstanceIds: []*string{aws.String(instanceID)},
+		resp, err := conn.DescribeInstances(ctx, &opsworks.DescribeInstancesInput{
+			InstanceIds: []string{instanceID},
 		})
 
-		if tfawserr.ErrCodeEquals(err, opsworks.ErrCodeResourceNotFoundException) {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 			return nil, "", nil
 		}
 
@@ -964,18 +970,18 @@ func instanceStatus(ctx context.Context, conn *opsworks.OpsWorks, instanceID str
 			return nil, "", err
 		}
 
-		if resp == nil || len(resp.Instances) == 0 || resp.Instances[0] == nil {
+		if resp == nil || len(resp.Instances) == 0 {
 			// Sometimes AWS just has consistency issues and doesn't see
 			// our instance yet. Return an empty state.
 			return nil, "", nil
 		}
 
 		i := resp.Instances[0]
-		return i, aws.StringValue(i.Status), nil
+		return i, aws.ToString(i.Status), nil
 	}
 }
 
-func readBlockDevices(instance *opsworks.Instance) map[string]interface{} {
+func readBlockDevices(instance *awstypes.Instance) map[string]interface{} {
 	blockDevices := make(map[string]interface{})
 	blockDevices["ebs"] = make([]map[string]interface{}, 0)
 	blockDevices["ephemeral"] = make([]map[string]interface{}, 0)
@@ -988,29 +994,29 @@ func readBlockDevices(instance *opsworks.Instance) map[string]interface{} {
 	for _, bdm := range instance.BlockDeviceMappings {
 		bd := make(map[string]interface{})
 		if bdm.Ebs != nil && bdm.Ebs.DeleteOnTermination != nil {
-			bd[names.AttrDeleteOnTermination] = aws.BoolValue(bdm.Ebs.DeleteOnTermination)
+			bd[names.AttrDeleteOnTermination] = aws.ToBool(bdm.Ebs.DeleteOnTermination)
 		}
 		if bdm.Ebs != nil && bdm.Ebs.VolumeSize != nil {
-			bd[names.AttrVolumeSize] = aws.Int64Value(bdm.Ebs.VolumeSize)
+			bd[names.AttrVolumeSize] = aws.ToInt32(bdm.Ebs.VolumeSize)
 		}
-		if bdm.Ebs != nil && bdm.Ebs.VolumeType != nil {
-			bd[names.AttrVolumeType] = aws.StringValue(bdm.Ebs.VolumeType)
+		if bdm.Ebs != nil {
+			bd[names.AttrVolumeType] = bdm.Ebs.VolumeType
 		}
 		if bdm.Ebs != nil && bdm.Ebs.Iops != nil {
-			bd[names.AttrIOPS] = aws.Int64Value(bdm.Ebs.Iops)
+			bd[names.AttrIOPS] = aws.ToInt32(bdm.Ebs.Iops)
 		}
-		if aws.StringValue(bdm.DeviceName) == "ROOT_DEVICE" {
+		if aws.ToString(bdm.DeviceName) == "ROOT_DEVICE" {
 			blockDevices["root"] = bd
 		} else {
 			if bdm.DeviceName != nil {
-				bd[names.AttrDeviceName] = aws.StringValue(bdm.DeviceName)
+				bd[names.AttrDeviceName] = aws.ToString(bdm.DeviceName)
 			}
 			if bdm.VirtualName != nil {
-				bd[names.AttrVirtualName] = aws.StringValue(bdm.VirtualName)
+				bd[names.AttrVirtualName] = aws.ToString(bdm.VirtualName)
 				blockDevices["ephemeral"] = append(blockDevices["ephemeral"].([]map[string]interface{}), bd)
 			} else {
 				if bdm.Ebs != nil && bdm.Ebs.SnapshotId != nil {
-					bd[names.AttrSnapshotID] = aws.StringValue(bdm.Ebs.SnapshotId)
+					bd[names.AttrSnapshotID] = aws.ToString(bdm.Ebs.SnapshotId)
 				}
 				blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), bd)
 			}

--- a/internal/service/opsworks/instance.go
+++ b/internal/service/opsworks/instance.go
@@ -542,9 +542,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	// Read Security Groups
 	sgs := make([]string, 0, len(output.SecurityGroupIds))
-	for _, sg := range output.SecurityGroupIds {
-		sgs = append(sgs, sg)
-	}
+	sgs = append(sgs, output.SecurityGroupIds...)
 	if err := d.Set(names.AttrSecurityGroupIDs, sgs); err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading OpsWorks Instance (%s): setting security_group_ids: %s", d.Id(), err)
 	}

--- a/internal/service/opsworks/java_app_layer.go
+++ b/internal/service/opsworks/java_app_layer.go
@@ -4,40 +4,40 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // @SDKResource("aws_opsworks_java_app_layer", name="Java App Layer")
 // @Tags(identifierAttribute="arn")
-func ResourceJavaAppLayer() *schema.Resource {
+func resourceJavaAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         opsworks.LayerTypeJavaApp,
+		TypeName:         awstypes.LayerTypeJavaApp,
 		DefaultLayerName: "Java App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"app_server": {
-				AttrName: opsworks.LayerAttributesKeysJavaAppServer,
+				AttrName: awstypes.LayerAttributesKeysJavaAppServer,
 				Type:     schema.TypeString,
 				Default:  "tomcat",
 			},
 			"app_server_version": {
-				AttrName: opsworks.LayerAttributesKeysJavaAppServerVersion,
+				AttrName: awstypes.LayerAttributesKeysJavaAppServerVersion,
 				Type:     schema.TypeString,
 				Default:  "7",
 			},
 			"jvm_options": {
-				AttrName: opsworks.LayerAttributesKeysJvmOptions,
+				AttrName: awstypes.LayerAttributesKeysJvmOptions,
 				Type:     schema.TypeString,
 				Default:  "",
 			},
 			"jvm_type": {
-				AttrName: opsworks.LayerAttributesKeysJvm,
+				AttrName: awstypes.LayerAttributesKeysJvm,
 				Type:     schema.TypeString,
 				Default:  "openjdk",
 			},
 			"jvm_version": {
-				AttrName: opsworks.LayerAttributesKeysJvmVersion,
+				AttrName: awstypes.LayerAttributesKeysJvmVersion,
 				Type:     schema.TypeString,
 				Default:  "7",
 			},

--- a/internal/service/opsworks/java_app_layer_test.go
+++ b/internal/service/opsworks/java_app_layer_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,13 +16,15 @@ import (
 )
 
 func TestAccOpsWorksJavaAppLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_java_app_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckJavaAppLayerDestroy(ctx),

--- a/internal/service/opsworks/layers_test.go
+++ b/internal/service/opsworks/layers_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-func testAccCheckLayerExists(ctx context.Context, n string, v *opsworks.Layer) resource.TestCheckFunc {
+func testAccCheckLayerExists(ctx context.Context, n string, v *awstypes.Layer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -27,7 +27,7 @@ func testAccCheckLayerExists(ctx context.Context, n string, v *opsworks.Layer) r
 			return fmt.Errorf("No OpsWorks Layer ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksClient(ctx)
 
 		output, err := tfopsworks.FindLayerByID(ctx, conn, rs.Primary.ID)
 
@@ -42,7 +42,7 @@ func testAccCheckLayerExists(ctx context.Context, n string, v *opsworks.Layer) r
 }
 
 func testAccCheckLayerDestroy(ctx context.Context, resourceType string, s *terraform.State) error { // nosemgrep:ci.semgrep.acctest.naming.destroy-check-signature
-	conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksClient(ctx)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != resourceType {

--- a/internal/service/opsworks/memcached_layer.go
+++ b/internal/service/opsworks/memcached_layer.go
@@ -4,20 +4,20 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // @SDKResource("aws_opsworks_memcached_layer", name="Memcached Layer")
 // @Tags(identifierAttribute="arn")
-func ResourceMemcachedLayer() *schema.Resource {
+func resourceMemcachedLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         opsworks.LayerTypeMemcached,
+		TypeName:         awstypes.LayerTypeMemcached,
 		DefaultLayerName: "Memcached",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"allocated_memory": {
-				AttrName: opsworks.LayerAttributesKeysMemcachedMemory,
+				AttrName: awstypes.LayerAttributesKeysMemcachedMemory,
 				Type:     schema.TypeInt,
 				Default:  512,
 			},

--- a/internal/service/opsworks/memcached_layer_test.go
+++ b/internal/service/opsworks/memcached_layer_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,13 +16,15 @@ import (
 )
 
 func TestAccOpsWorksMemcachedLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_memcached_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckMemcachedLayerDestroy(ctx),

--- a/internal/service/opsworks/mysql_layer.go
+++ b/internal/service/opsworks/mysql_layer.go
@@ -4,25 +4,25 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // @SDKResource("aws_opsworks_mysql_layer", name="MySQL Layer")
 // @Tags(identifierAttribute="arn")
-func ResourceMySQLLayer() *schema.Resource {
+func resourceMySQLLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         opsworks.LayerTypeDbMaster,
+		TypeName:         awstypes.LayerTypeDbMaster,
 		DefaultLayerName: "MySQL",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"root_password": {
-				AttrName:  opsworks.LayerAttributesKeysMysqlRootPassword,
+				AttrName:  awstypes.LayerAttributesKeysMysqlRootPassword,
 				Type:      schema.TypeString,
 				WriteOnly: true,
 			},
 			"root_password_on_all_instances": {
-				AttrName: opsworks.LayerAttributesKeysMysqlRootPasswordUbiquitous,
+				AttrName: awstypes.LayerAttributesKeysMysqlRootPasswordUbiquitous,
 				Type:     schema.TypeBool,
 				Default:  true,
 			},

--- a/internal/service/opsworks/mysql_layer_test.go
+++ b/internal/service/opsworks/mysql_layer_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,13 +16,15 @@ import (
 )
 
 func TestAccOpsWorksMySQLLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_mysql_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckMySQLLayerDestroy(ctx),

--- a/internal/service/opsworks/nodejs_app_layer.go
+++ b/internal/service/opsworks/nodejs_app_layer.go
@@ -4,20 +4,20 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // @SDKResource("aws_opsworks_nodejs_app_layer", name="NodeJS App Layer")
 // @Tags(identifierAttribute="arn")
-func ResourceNodejsAppLayer() *schema.Resource {
+func resourceNodejsAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         opsworks.LayerTypeNodejsApp,
+		TypeName:         awstypes.LayerTypeNodejsApp,
 		DefaultLayerName: "Node.js App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"nodejs_version": {
-				AttrName: opsworks.LayerAttributesKeysNodejsVersion,
+				AttrName: awstypes.LayerAttributesKeysNodejsVersion,
 				Type:     schema.TypeString,
 				Default:  "0.10.38",
 			},

--- a/internal/service/opsworks/nodejs_app_layer_test.go
+++ b/internal/service/opsworks/nodejs_app_layer_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,13 +16,15 @@ import (
 )
 
 func TestAccOpsWorksNodejsAppLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_nodejs_app_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNodejsAppLayerDestroy(ctx),

--- a/internal/service/opsworks/permission_test.go
+++ b/internal/service/opsworks/permission_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -19,13 +19,15 @@ import (
 )
 
 func TestAccOpsWorksPermission_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_permission.test"
-	var opsperm opsworks.Permission
+	var opsperm awstypes.Permission
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -72,13 +74,15 @@ func TestAccOpsWorksPermission_basic(t *testing.T) {
 
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/4804
 func TestAccOpsWorksPermission_self(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var opsperm opsworks.Permission
+	var opsperm awstypes.Permission
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_permission.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -103,7 +107,7 @@ func TestAccOpsWorksPermission_self(t *testing.T) {
 	})
 }
 
-func testAccCheckPermissionExists(ctx context.Context, n string, v *opsworks.Permission) resource.TestCheckFunc {
+func testAccCheckPermissionExists(ctx context.Context, n string, v *awstypes.Permission) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -114,7 +118,7 @@ func testAccCheckPermissionExists(ctx context.Context, n string, v *opsworks.Per
 			return fmt.Errorf("No OpsWorks Layer ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksClient(ctx)
 
 		output, err := tfopsworks.FindPermissionByTwoPartKey(ctx, conn, rs.Primary.Attributes["user_arn"], rs.Primary.Attributes["stack_id"])
 

--- a/internal/service/opsworks/php_app_layer.go
+++ b/internal/service/opsworks/php_app_layer.go
@@ -4,15 +4,15 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // @SDKResource("aws_opsworks_php_app_layer", name="PHP App Layer")
 // @Tags(identifierAttribute="arn")
-func ResourcePHPAppLayer() *schema.Resource {
+func resourcePHPAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         opsworks.LayerTypePhpApp,
+		TypeName:         awstypes.LayerTypePhpApp,
 		DefaultLayerName: "PHP App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{},

--- a/internal/service/opsworks/php_app_layer_test.go
+++ b/internal/service/opsworks/php_app_layer_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,13 +16,15 @@ import (
 )
 
 func TestAccOpsWorksPHPAppLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_php_app_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckPHPAppLayerDestroy(ctx),

--- a/internal/service/opsworks/rails_app_layer.go
+++ b/internal/service/opsworks/rails_app_layer.go
@@ -4,45 +4,45 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // @SDKResource("aws_opsworks_rails_app_layer", name="Rails App Layer")
 // @Tags(identifierAttribute="arn")
-func ResourceRailsAppLayer() *schema.Resource {
+func resourceRailsAppLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         opsworks.LayerTypeRailsApp,
+		TypeName:         awstypes.LayerTypeRailsApp,
 		DefaultLayerName: "Rails App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
 			"app_server": {
-				AttrName: opsworks.LayerAttributesKeysRailsStack,
+				AttrName: awstypes.LayerAttributesKeysRailsStack,
 				Type:     schema.TypeString,
 				Default:  "apache_passenger",
 			},
 			"bundler_version": {
-				AttrName: opsworks.LayerAttributesKeysBundlerVersion,
+				AttrName: awstypes.LayerAttributesKeysBundlerVersion,
 				Type:     schema.TypeString,
 				Default:  "1.5.3",
 			},
 			"manage_bundler": {
-				AttrName: opsworks.LayerAttributesKeysManageBundler,
+				AttrName: awstypes.LayerAttributesKeysManageBundler,
 				Type:     schema.TypeBool,
 				Default:  true,
 			},
 			"passenger_version": {
-				AttrName: opsworks.LayerAttributesKeysPassengerVersion,
+				AttrName: awstypes.LayerAttributesKeysPassengerVersion,
 				Type:     schema.TypeString,
 				Default:  "4.0.46",
 			},
 			"ruby_version": {
-				AttrName: opsworks.LayerAttributesKeysRubyVersion,
+				AttrName: awstypes.LayerAttributesKeysRubyVersion,
 				Type:     schema.TypeString,
 				Default:  "2.0.0",
 			},
 			"rubygems_version": {
-				AttrName: opsworks.LayerAttributesKeysRubygemsVersion,
+				AttrName: awstypes.LayerAttributesKeysRubygemsVersion,
 				Type:     schema.TypeString,
 				Default:  "2.2.2",
 			},

--- a/internal/service/opsworks/rails_app_layer_test.go
+++ b/internal/service/opsworks/rails_app_layer_test.go
@@ -9,8 +9,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -20,13 +19,15 @@ import (
 )
 
 func TestAccOpsWorksRailsAppLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_rails_app_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRailsAppLayerDestroy(ctx),
@@ -76,13 +77,15 @@ func TestAccOpsWorksRailsAppLayer_basic(t *testing.T) {
 }
 
 func TestAccOpsWorksRailsAppLayer_disappears(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_rails_app_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRailsAppLayerDestroy(ctx),
@@ -100,13 +103,15 @@ func TestAccOpsWorksRailsAppLayer_disappears(t *testing.T) {
 }
 
 func TestAccOpsWorksRailsAppLayer_tags(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_rails_app_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRailsAppLayerDestroy(ctx),
@@ -141,20 +146,22 @@ func TestAccOpsWorksRailsAppLayer_tags(t *testing.T) {
 }
 
 func TestAccOpsWorksRailsAppLayer_tagsAlternateRegion(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_rails_app_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.OpsWorks)
 			// This test requires a very particular AWS Region configuration
 			// in order to exercise the OpsWorks classic endpoint functionality.
 			acctest.PreCheckMultipleRegion(t, 2)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-			acctest.PreCheckAlternateRegionIs(t, endpoints.UsWest1RegionID)
+			acctest.PreCheckRegion(t, names.USEast1RegionID)
+			acctest.PreCheckAlternateRegionIs(t, names.USWest1RegionID)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
@@ -190,13 +197,15 @@ func TestAccOpsWorksRailsAppLayer_tagsAlternateRegion(t *testing.T) {
 }
 
 func TestAccOpsWorksRailsAppLayer_update(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_rails_app_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRailsAppLayerDestroy(ctx),
@@ -237,13 +246,15 @@ func TestAccOpsWorksRailsAppLayer_update(t *testing.T) {
 }
 
 func TestAccOpsWorksRailsAppLayer_elb(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_rails_app_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRailsAppLayerDestroy(ctx),

--- a/internal/service/opsworks/rds_db_instance_test.go
+++ b/internal/service/opsworks/rds_db_instance_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -20,17 +20,19 @@ import (
 )
 
 func TestAccOpsWorksRDSDBInstance_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var v opsworks.RdsDbInstance
+	var v awstypes.RdsDbInstance
 	resourceName := "aws_opsworks_rds_db_instance.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRDSDBInstanceDestroy(ctx),
@@ -64,17 +66,19 @@ func TestAccOpsWorksRDSDBInstance_basic(t *testing.T) {
 }
 
 func TestAccOpsWorksRDSDBInstance_disappears(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var v opsworks.RdsDbInstance
+	var v awstypes.RdsDbInstance
 	resourceName := "aws_opsworks_rds_db_instance.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRDSDBInstanceDestroy(ctx),
@@ -91,7 +95,7 @@ func TestAccOpsWorksRDSDBInstance_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckRDSDBInstanceExists(ctx context.Context, n string, v *opsworks.RdsDbInstance) resource.TestCheckFunc {
+func testAccCheckRDSDBInstanceExists(ctx context.Context, n string, v *awstypes.RdsDbInstance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -102,7 +106,7 @@ func testAccCheckRDSDBInstanceExists(ctx context.Context, n string, v *opsworks.
 			return fmt.Errorf("No OpsWorks RDS DB Instance ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksClient(ctx)
 
 		output, err := tfopsworks.FindRDSDBInstanceByTwoPartKey(ctx, conn, rs.Primary.Attributes["rds_db_instance_arn"], rs.Primary.Attributes["stack_id"])
 
@@ -118,7 +122,7 @@ func testAccCheckRDSDBInstanceExists(ctx context.Context, n string, v *opsworks.
 
 func testAccCheckRDSDBInstanceDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_opsworks_rds_db_instance" {

--- a/internal/service/opsworks/service_endpoint_resolver_gen.go
+++ b/internal/service/opsworks/service_endpoint_resolver_gen.go
@@ -6,65 +6,63 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/url"
 
-	endpoints_sdkv1 "github.com/aws/aws-sdk-go/aws/endpoints"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	opsworks_sdkv2 "github.com/aws/aws-sdk-go-v2/service/opsworks"
+	smithyendpoints "github.com/aws/smithy-go/endpoints"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 )
 
-var _ endpoints_sdkv1.Resolver = resolverSDKv1{}
+var _ opsworks_sdkv2.EndpointResolverV2 = resolverSDKv2{}
 
-type resolverSDKv1 struct {
-	ctx context.Context
+type resolverSDKv2 struct {
+	defaultResolver opsworks_sdkv2.EndpointResolverV2
 }
 
-func newEndpointResolverSDKv1(ctx context.Context) resolverSDKv1 {
-	return resolverSDKv1{
-		ctx: ctx,
+func newEndpointResolverSDKv2() resolverSDKv2 {
+	return resolverSDKv2{
+		defaultResolver: opsworks_sdkv2.NewDefaultEndpointResolverV2(),
 	}
 }
 
-func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoints_sdkv1.Options)) (endpoint endpoints_sdkv1.ResolvedEndpoint, err error) {
-	ctx := r.ctx
+func (r resolverSDKv2) ResolveEndpoint(ctx context.Context, params opsworks_sdkv2.EndpointParameters) (endpoint smithyendpoints.Endpoint, err error) {
+	params = params.WithDefaults()
+	useFIPS := aws_sdkv2.ToBool(params.UseFIPS)
 
-	var opt endpoints_sdkv1.Options
-	opt.Set(opts...)
+	if eps := params.Endpoint; aws_sdkv2.ToString(eps) != "" {
+		tflog.Debug(ctx, "setting endpoint", map[string]any{
+			"tf_aws.endpoint": endpoint,
+		})
 
-	useFIPS := opt.UseFIPSEndpoint == endpoints_sdkv1.FIPSEndpointStateEnabled
+		if useFIPS {
+			tflog.Debug(ctx, "endpoint set, ignoring UseFIPSEndpoint setting")
+			params.UseFIPS = aws_sdkv2.Bool(false)
+		}
 
-	defaultResolver := endpoints_sdkv1.DefaultResolver()
-
-	if useFIPS {
+		return r.defaultResolver.ResolveEndpoint(ctx, params)
+	} else if useFIPS {
 		ctx = tflog.SetField(ctx, "tf_aws.use_fips", useFIPS)
 
-		endpoint, err = defaultResolver.EndpointFor(service, region, opts...)
+		endpoint, err = r.defaultResolver.ResolveEndpoint(ctx, params)
 		if err != nil {
 			return endpoint, err
 		}
 
 		tflog.Debug(ctx, "endpoint resolved", map[string]any{
-			"tf_aws.endpoint": endpoint.URL,
+			"tf_aws.endpoint": endpoint.URI.String(),
 		})
 
-		var endpointURL *url.URL
-		endpointURL, err = url.Parse(endpoint.URL)
-		if err != nil {
-			return endpoint, err
-		}
-
-		hostname := endpointURL.Hostname()
+		hostname := endpoint.URI.Hostname()
 		_, err = net.LookupHost(hostname)
 		if err != nil {
 			if dnsErr, ok := errs.As[*net.DNSError](err); ok && dnsErr.IsNotFound {
 				tflog.Debug(ctx, "default endpoint host not found, disabling FIPS", map[string]any{
 					"tf_aws.hostname": hostname,
 				})
-				opts = append(opts, func(o *endpoints_sdkv1.Options) {
-					o.UseFIPSEndpoint = endpoints_sdkv1.FIPSEndpointStateDisabled
-				})
+				params.UseFIPS = aws_sdkv2.Bool(false)
 			} else {
-				err = fmt.Errorf("looking up accessanalyzer endpoint %q: %s", hostname, err)
+				err = fmt.Errorf("looking up opsworks endpoint %q: %s", hostname, err)
 				return
 			}
 		} else {
@@ -72,5 +70,13 @@ func (r resolverSDKv1) EndpointFor(service, region string, opts ...func(*endpoin
 		}
 	}
 
-	return defaultResolver.EndpointFor(service, region, opts...)
+	return r.defaultResolver.ResolveEndpoint(ctx, params)
+}
+
+func withBaseEndpoint(endpoint string) func(*opsworks_sdkv2.Options) {
+	return func(o *opsworks_sdkv2.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws_sdkv2.String(endpoint)
+		}
+	}
 }

--- a/internal/service/opsworks/service_endpoints_gen_test.go
+++ b/internal/service/opsworks/service_endpoints_gen_test.go
@@ -4,18 +4,22 @@ package opsworks_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	opsworks_sdkv1 "github.com/aws/aws-sdk-go/service/opsworks"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	opsworks_sdkv2 "github.com/aws/aws-sdk-go-v2/service/opsworks"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -240,54 +244,63 @@ func TestEndpointConfiguration(t *testing.T) { //nolint:paralleltest // uses t.S
 }
 
 func defaultEndpoint(region string) (url.URL, error) {
-	r := endpoints.DefaultResolver()
+	r := opsworks_sdkv2.NewDefaultEndpointResolverV2()
 
-	ep, err := r.EndpointFor(opsworks_sdkv1.EndpointsID, region)
-	if err != nil {
-		return url.URL{}, err
-	}
-
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
-	}
-
-	return *url, nil
-}
-
-func defaultFIPSEndpoint(region string) (url.URL, error) {
-	r := endpoints.DefaultResolver()
-
-	ep, err := r.EndpointFor(opsworks_sdkv1.EndpointsID, region, func(opt *endpoints.Options) {
-		opt.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	ep, err := r.ResolveEndpoint(context.Background(), opsworks_sdkv2.EndpointParameters{
+		Region: aws_sdkv2.String(region),
 	})
 	if err != nil {
 		return url.URL{}, err
 	}
 
-	url, _ := url.Parse(ep.URL)
-
-	if url.Path == "" {
-		url.Path = "/"
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
 	}
 
-	return *url, nil
+	return ep.URI, nil
+}
+
+func defaultFIPSEndpoint(region string) (url.URL, error) {
+	r := opsworks_sdkv2.NewDefaultEndpointResolverV2()
+
+	ep, err := r.ResolveEndpoint(context.Background(), opsworks_sdkv2.EndpointParameters{
+		Region:  aws_sdkv2.String(region),
+		UseFIPS: aws_sdkv2.Bool(true),
+	})
+	if err != nil {
+		return url.URL{}, err
+	}
+
+	if ep.URI.Path == "" {
+		ep.URI.Path = "/"
+	}
+
+	return ep.URI, nil
 }
 
 func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCallParams {
 	t.Helper()
 
-	client := meta.OpsWorksConn(ctx)
+	client := meta.OpsWorksClient(ctx)
 
-	req, _ := client.DescribeAppsRequest(&opsworks_sdkv1.DescribeAppsInput{})
+	var result apiCallParams
 
-	req.HTTPRequest.URL.Path = "/"
-
-	return apiCallParams{
-		endpoint: req.HTTPRequest.URL.String(),
-		region:   aws_sdkv1.StringValue(client.Config.Region),
+	_, err := client.DescribeApps(ctx, &opsworks_sdkv2.DescribeAppsInput{},
+		func(opts *opsworks_sdkv2.Options) {
+			opts.APIOptions = append(opts.APIOptions,
+				addRetrieveEndpointURLMiddleware(t, &result.endpoint),
+				addRetrieveRegionMiddleware(&result.region),
+				addCancelRequestMiddleware(),
+			)
+		},
+	)
+	if err == nil {
+		t.Fatal("Expected an error, got none")
+	} else if !errors.Is(err, errCancelOperation) {
+		t.Fatalf("Unexpected error: %s", err)
 	}
+
+	return result
 }
 
 func withNoConfig(_ *caseSetup) {
@@ -464,6 +477,89 @@ func testEndpointCase(t *testing.T, region string, testcase endpointTestCase, ca
 	if e, a := testcase.expected.region, callParams.region; e != a {
 		t.Errorf("expected region %q, got %q", e, a)
 	}
+}
+
+func addRetrieveEndpointURLMiddleware(t *testing.T, endpoint *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			retrieveEndpointURLMiddleware(t, endpoint),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveEndpointURLMiddleware(t *testing.T, endpoint *string) middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Retrieve Endpoint",
+		func(ctx context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			t.Helper()
+
+			request, ok := in.Request.(*smithyhttp.Request)
+			if !ok {
+				t.Fatalf("Expected *github.com/aws/smithy-go/transport/http.Request, got %s", fullTypeName(in.Request))
+			}
+
+			url := request.URL
+			url.RawQuery = ""
+			url.Path = "/"
+
+			*endpoint = url.String()
+
+			return next.HandleFinalize(ctx, in)
+		})
+}
+
+func addRetrieveRegionMiddleware(region *string) func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Serialize.Add(
+			retrieveRegionMiddleware(region),
+			middleware.After,
+		)
+	}
+}
+
+func retrieveRegionMiddleware(region *string) middleware.SerializeMiddleware {
+	return middleware.SerializeMiddlewareFunc(
+		"Test: Retrieve Region",
+		func(ctx context.Context, in middleware.SerializeInput, next middleware.SerializeHandler) (middleware.SerializeOutput, middleware.Metadata, error) {
+			*region = awsmiddleware.GetRegion(ctx)
+
+			return next.HandleSerialize(ctx, in)
+		},
+	)
+}
+
+var errCancelOperation = fmt.Errorf("Test: Canceling request")
+
+func addCancelRequestMiddleware() func(*middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Finalize.Add(
+			cancelRequestMiddleware(),
+			middleware.After,
+		)
+	}
+}
+
+// cancelRequestMiddleware creates a Smithy middleware that intercepts the request before sending and cancels it
+func cancelRequestMiddleware() middleware.FinalizeMiddleware {
+	return middleware.FinalizeMiddlewareFunc(
+		"Test: Cancel Requests",
+		func(_ context.Context, in middleware.FinalizeInput, next middleware.FinalizeHandler) (middleware.FinalizeOutput, middleware.Metadata, error) {
+			return middleware.FinalizeOutput{}, middleware.Metadata{}, errCancelOperation
+		})
+}
+
+func fullTypeName(i interface{}) string {
+	return fullValueTypeName(reflect.ValueOf(i))
+}
+
+func fullValueTypeName(v reflect.Value) string {
+	if v.Kind() == reflect.Ptr {
+		return "*" + fullValueTypeName(reflect.Indirect(v))
+	}
+
+	requestType := v.Type()
+	return fmt.Sprintf("%s.%s", requestType.PkgPath(), requestType.Name())
 }
 
 func generateSharedConfigFile(config configFile) string {

--- a/internal/service/opsworks/service_package_gen.go
+++ b/internal/service/opsworks/service_package_gen.go
@@ -5,10 +5,8 @@ package opsworks
 import (
 	"context"
 
-	aws_sdkv1 "github.com/aws/aws-sdk-go/aws"
-	session_sdkv1 "github.com/aws/aws-sdk-go/aws/session"
-	opsworks_sdkv1 "github.com/aws/aws-sdk-go/service/opsworks"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	opsworks_sdkv2 "github.com/aws/aws-sdk-go-v2/service/opsworks"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -31,11 +29,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceApplication,
+			Factory:  resourceApplication,
 			TypeName: "aws_opsworks_application",
+			Name:     "Application",
 		},
 		{
-			Factory:  ResourceCustomLayer,
+			Factory:  resourceCustomLayer,
 			TypeName: "aws_opsworks_custom_layer",
 			Name:     "Custom Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -43,7 +42,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceECSClusterLayer,
+			Factory:  resourceECSClusterLayer,
 			TypeName: "aws_opsworks_ecs_cluster_layer",
 			Name:     "ECS Cluster Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -51,7 +50,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceGangliaLayer,
+			Factory:  resourceGangliaLayer,
 			TypeName: "aws_opsworks_ganglia_layer",
 			Name:     "Ganglia Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -59,7 +58,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceHAProxyLayer,
+			Factory:  resourceHAProxyLayer,
 			TypeName: "aws_opsworks_haproxy_layer",
 			Name:     "HAProxy Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -67,11 +66,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceInstance,
+			Factory:  resourceInstance,
 			TypeName: "aws_opsworks_instance",
+			Name:     "Instance",
 		},
 		{
-			Factory:  ResourceJavaAppLayer,
+			Factory:  resourceJavaAppLayer,
 			TypeName: "aws_opsworks_java_app_layer",
 			Name:     "Java App Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -79,7 +79,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceMemcachedLayer,
+			Factory:  resourceMemcachedLayer,
 			TypeName: "aws_opsworks_memcached_layer",
 			Name:     "Memcached Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -87,7 +87,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceMySQLLayer,
+			Factory:  resourceMySQLLayer,
 			TypeName: "aws_opsworks_mysql_layer",
 			Name:     "MySQL Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -95,7 +95,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceNodejsAppLayer,
+			Factory:  resourceNodejsAppLayer,
 			TypeName: "aws_opsworks_nodejs_app_layer",
 			Name:     "NodeJS App Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -103,11 +103,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourcePermission,
+			Factory:  resourcePermission,
 			TypeName: "aws_opsworks_permission",
+			Name:     "Permission",
 		},
 		{
-			Factory:  ResourcePHPAppLayer,
+			Factory:  resourcePHPAppLayer,
 			TypeName: "aws_opsworks_php_app_layer",
 			Name:     "PHP App Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -115,7 +116,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceRailsAppLayer,
+			Factory:  resourceRailsAppLayer,
 			TypeName: "aws_opsworks_rails_app_layer",
 			Name:     "Rails App Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -123,17 +124,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceRDSDBInstance,
+			Factory:  resourceRDSDBInstance,
 			TypeName: "aws_opsworks_rds_db_instance",
+			Name:     "RDS DB Instance",
 		},
 		{
-			Factory:  ResourceStack,
+			Factory:  resourceStack,
 			TypeName: "aws_opsworks_stack",
 			Name:     "Stack",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
-			Factory:  ResourceStaticWebLayer,
+			Factory:  resourceStaticWebLayer,
 			TypeName: "aws_opsworks_static_web_layer",
 			Name:     "Static Web Layer",
 			Tags: &types.ServicePackageResourceTags{
@@ -141,8 +143,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceUserProfile,
+			Factory:  resourceUserProfile,
 			TypeName: "aws_opsworks_user_profile",
+			Name:     "Profile",
 		},
 	}
 }
@@ -151,22 +154,14 @@ func (p *servicePackage) ServicePackageName() string {
 	return names.OpsWorks
 }
 
-// NewConn returns a new AWS SDK for Go v1 client for this service package's AWS API.
-func (p *servicePackage) NewConn(ctx context.Context, config map[string]any) (*opsworks_sdkv1.OpsWorks, error) {
-	sess := config[names.AttrSession].(*session_sdkv1.Session)
+// NewClient returns a new AWS SDK for Go v2 client for this service package's AWS API.
+func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (*opsworks_sdkv2.Client, error) {
+	cfg := *(config["aws_sdkv2_config"].(*aws_sdkv2.Config))
 
-	cfg := aws_sdkv1.Config{}
-
-	if endpoint := config[names.AttrEndpoint].(string); endpoint != "" {
-		tflog.Debug(ctx, "setting endpoint", map[string]any{
-			"tf_aws.endpoint": endpoint,
-		})
-		cfg.Endpoint = aws_sdkv1.String(endpoint)
-	} else {
-		cfg.EndpointResolver = newEndpointResolverSDKv1(ctx)
-	}
-
-	return opsworks_sdkv1.New(sess.Copy(&cfg)), nil
+	return opsworks_sdkv2.NewFromConfig(cfg,
+		opsworks_sdkv2.WithEndpointResolverV2(newEndpointResolverSDKv2()),
+		withBaseEndpoint(config[names.AttrEndpoint].(string)),
+	), nil
 }
 
 func ServicePackage(ctx context.Context) conns.ServicePackage {

--- a/internal/service/opsworks/stack_test.go
+++ b/internal/service/opsworks/stack_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -23,15 +23,17 @@ import (
 )
 
 func TestAccOpsWorksStack_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_stack.test"
-	var v opsworks.Stack
+	var v awstypes.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.OpsWorks)
 			testAccPreCheckStacks(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
@@ -78,15 +80,17 @@ func TestAccOpsWorksStack_basic(t *testing.T) {
 }
 
 func TestAccOpsWorksStack_disappears(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_stack.test"
-	var v opsworks.Stack
+	var v awstypes.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.OpsWorks)
 			testAccPreCheckStacks(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
@@ -106,15 +110,17 @@ func TestAccOpsWorksStack_disappears(t *testing.T) {
 }
 
 func TestAccOpsWorksStack_noVPC_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_stack.test"
-	var v opsworks.Stack
+	var v awstypes.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.OpsWorks)
 			testAccPreCheckStacks(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
@@ -148,15 +154,17 @@ func TestAccOpsWorksStack_noVPC_basic(t *testing.T) {
 }
 
 func TestAccOpsWorksStack_noVPC_defaultAZ(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_stack.test"
-	var v opsworks.Stack
+	var v awstypes.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.OpsWorks)
 			testAccPreCheckStacks(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
@@ -182,15 +190,17 @@ func TestAccOpsWorksStack_noVPC_defaultAZ(t *testing.T) {
 }
 
 func TestAccOpsWorksStack_tags(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_stack.test"
-	var v opsworks.Stack
+	var v awstypes.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.OpsWorks)
 			testAccPreCheckStacks(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
@@ -232,21 +242,23 @@ func TestAccOpsWorksStack_tags(t *testing.T) {
 }
 
 func TestAccOpsWorksStack_tagsAlternateRegion(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_stack.test"
-	var v opsworks.Stack
+	var v awstypes.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.OpsWorks)
 			testAccPreCheckStacks(ctx, t)
 			// This test requires a very particular AWS Region configuration
 			// in order to exercise the OpsWorks classic endpoint functionality.
 			acctest.PreCheckMultipleRegion(t, 2)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-			acctest.PreCheckAlternateRegionIs(t, endpoints.UsWest1RegionID)
+			acctest.PreCheckRegion(t, names.USEast1RegionID)
+			acctest.PreCheckAlternateRegionIs(t, names.USWest1RegionID)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
@@ -259,7 +271,7 @@ func TestAccOpsWorksStack_tagsAlternateRegion(t *testing.T) {
 					resource.TestCheckResourceAttrWith(resourceName, names.AttrARN, func(value string) error {
 						if !regexache.MustCompile(arn.ARN{
 							Partition: acctest.Partition(),
-							Service:   opsworks.ServiceName,
+							Service:   names.OpsWorks,
 							Region:    acctest.AlternateRegion(),
 							AccountID: acctest.AccountID(),
 							Resource:  `stack/.+/`,
@@ -271,7 +283,7 @@ func TestAccOpsWorksStack_tagsAlternateRegion(t *testing.T) {
 					}),
 					resource.TestCheckResourceAttr(resourceName, names.AttrRegion, acctest.AlternateRegion()),
 					// "In this case, the actual API endpoint of the stack is in us-east-1."
-					resource.TestCheckResourceAttr(resourceName, "stack_endpoint", endpoints.UsEast1RegionID),
+					resource.TestCheckResourceAttr(resourceName, "stack_endpoint", names.USEast1RegionID),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
@@ -303,15 +315,17 @@ func TestAccOpsWorksStack_tagsAlternateRegion(t *testing.T) {
 }
 
 func TestAccOpsWorksStack_allAttributes(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_stack.test"
-	var v opsworks.Stack
+	var v awstypes.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.OpsWorks)
 			testAccPreCheckStacks(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
@@ -439,15 +453,17 @@ func TestAccOpsWorksStack_allAttributes(t *testing.T) {
 }
 
 func TestAccOpsWorksStack_windows(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_stack.test"
-	var v opsworks.Stack
+	var v awstypes.Stack
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID)
+			acctest.PreCheckPartitionHasService(t, names.OpsWorks)
 			testAccPreCheckStacks(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
@@ -484,11 +500,11 @@ func TestAccOpsWorksStack_windows(t *testing.T) {
 }
 
 func testAccPreCheckStacks(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)
+	conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksClient(ctx)
 
 	input := &opsworks.DescribeStacksInput{}
 
-	_, err := conn.DescribeStacksWithContext(ctx, input)
+	_, err := conn.DescribeStacks(ctx, input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)
@@ -499,14 +515,14 @@ func testAccPreCheckStacks(ctx context.Context, t *testing.T) {
 	}
 }
 
-func testAccCheckStackExists(ctx context.Context, n string, v *opsworks.Stack) resource.TestCheckFunc {
+func testAccCheckStackExists(ctx context.Context, n string, v *awstypes.Stack) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksClient(ctx)
 
 		output, err := tfopsworks.FindStackByID(ctx, conn, rs.Primary.ID)
 
@@ -522,7 +538,7 @@ func testAccCheckStackExists(ctx context.Context, n string, v *opsworks.Stack) r
 
 func testAccCheckStackDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_opsworks_stack" {

--- a/internal/service/opsworks/static_web_layer.go
+++ b/internal/service/opsworks/static_web_layer.go
@@ -4,15 +4,15 @@
 package opsworks
 
 import (
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // @SDKResource("aws_opsworks_static_web_layer", name="Static Web Layer")
 // @Tags(identifierAttribute="arn")
-func ResourceStaticWebLayer() *schema.Resource {
+func resourceStaticWebLayer() *schema.Resource {
 	layerType := &opsworksLayerType{
-		TypeName:         opsworks.LayerTypeWeb,
+		TypeName:         awstypes.LayerTypeWeb,
 		DefaultLayerName: "Static Web Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{},

--- a/internal/service/opsworks/static_web_layer_test.go
+++ b/internal/service/opsworks/static_web_layer_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opsworks/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,13 +16,15 @@ import (
 )
 
 func TestAccOpsWorksStaticWebLayer_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
-	var v opsworks.Layer
+	var v awstypes.Layer
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_static_web_layer.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckStaticWebLayerDestroy(ctx),

--- a/internal/service/opsworks/tags_gen.go
+++ b/internal/service/opsworks/tags_gen.go
@@ -5,9 +5,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/opsworks"
-	"github.com/aws/aws-sdk-go/service/opsworks/opsworksiface"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/opsworks"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/logging"
@@ -19,12 +18,12 @@ import (
 // listTags lists opsworks service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func listTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier string) (tftags.KeyValueTags, error) {
+func listTags(ctx context.Context, conn *opsworks.Client, identifier string, optFns ...func(*opsworks.Options)) (tftags.KeyValueTags, error) {
 	input := &opsworks.ListTagsInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsWithContext(ctx, input)
+	output, err := conn.ListTags(ctx, input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -36,7 +35,7 @@ func listTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier st
 // ListTags lists opsworks service tags and set them in Context.
 // It is called from outside this package.
 func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier string) error {
-	tags, err := listTags(ctx, meta.(*conns.AWSClient).OpsWorksConn(ctx), identifier)
+	tags, err := listTags(ctx, meta.(*conns.AWSClient).OpsWorksClient(ctx), identifier)
 
 	if err != nil {
 		return err
@@ -49,21 +48,21 @@ func (p *servicePackage) ListTags(ctx context.Context, meta any, identifier stri
 	return nil
 }
 
-// map[string]*string handling
+// map[string]string handling
 
 // Tags returns opsworks service tags.
-func Tags(tags tftags.KeyValueTags) map[string]*string {
-	return aws.StringMap(tags.Map())
+func Tags(tags tftags.KeyValueTags) map[string]string {
+	return tags.Map()
 }
 
 // KeyValueTags creates tftags.KeyValueTags from opsworks service tags.
-func KeyValueTags(ctx context.Context, tags map[string]*string) tftags.KeyValueTags {
+func KeyValueTags(ctx context.Context, tags map[string]string) tftags.KeyValueTags {
 	return tftags.New(ctx, tags)
 }
 
 // getTagsIn returns opsworks service tags from Context.
 // nil is returned if there are no input tags.
-func getTagsIn(ctx context.Context) map[string]*string {
+func getTagsIn(ctx context.Context) map[string]string {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		if tags := Tags(inContext.TagsIn.UnwrapOrDefault()); len(tags) > 0 {
 			return tags
@@ -74,25 +73,25 @@ func getTagsIn(ctx context.Context) map[string]*string {
 }
 
 // setTagsOut sets opsworks service tags in Context.
-func setTagsOut(ctx context.Context, tags map[string]*string) {
+func setTagsOut(ctx context.Context, tags map[string]string) {
 	if inContext, ok := tftags.FromContext(ctx); ok {
 		inContext.TagsOut = option.Some(KeyValueTags(ctx, tags))
 	}
 }
 
 // createTags creates opsworks service tags for new resources.
-func createTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier string, tags map[string]*string) error {
+func createTags(ctx context.Context, conn *opsworks.Client, identifier string, tags map[string]string, optFns ...func(*opsworks.Options)) error {
 	if len(tags) == 0 {
 		return nil
 	}
 
-	return updateTags(ctx, conn, identifier, nil, tags)
+	return updateTags(ctx, conn, identifier, nil, tags, optFns...)
 }
 
 // updateTags updates opsworks service tags.
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
-func updateTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier string, oldTagsMap, newTagsMap any) error {
+func updateTags(ctx context.Context, conn *opsworks.Client, identifier string, oldTagsMap, newTagsMap any, optFns ...func(*opsworks.Options)) error {
 	oldTags := tftags.New(ctx, oldTagsMap)
 	newTags := tftags.New(ctx, newTagsMap)
 
@@ -103,10 +102,10 @@ func updateTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier 
 	if len(removedTags) > 0 {
 		input := &opsworks.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
-			TagKeys:     aws.StringSlice(removedTags.Keys()),
+			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResourceWithContext(ctx, input)
+		_, err := conn.UntagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -121,7 +120,7 @@ func updateTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier 
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResourceWithContext(ctx, input)
+		_, err := conn.TagResource(ctx, input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -134,5 +133,5 @@ func updateTags(ctx context.Context, conn opsworksiface.OpsWorksAPI, identifier 
 // UpdateTags updates opsworks service tags.
 // It is called from outside this package.
 func (p *servicePackage) UpdateTags(ctx context.Context, meta any, identifier string, oldTags, newTags any) error {
-	return updateTags(ctx, meta.(*conns.AWSClient).OpsWorksConn(ctx), identifier, oldTags, newTags)
+	return updateTags(ctx, meta.(*conns.AWSClient).OpsWorksClient(ctx), identifier, oldTags, newTags)
 }

--- a/internal/service/opsworks/user_profile_test.go
+++ b/internal/service/opsworks/user_profile_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/opsworks"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -20,13 +19,15 @@ import (
 )
 
 func TestAccOpsWorksUserProfile_basic(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_user_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckUserProfileDestroy(ctx),
@@ -54,12 +55,14 @@ func TestAccOpsWorksUserProfile_basic(t *testing.T) {
 }
 
 func TestAccOpsWorksUserProfile_disappears(t *testing.T) {
+	acctest.Skip(t, "skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release")
+
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_opsworks_user_profile.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, opsworks.EndpointsID) },
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.OpsWorks) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.OpsWorksServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckUserProfileDestroy(ctx),
@@ -87,7 +90,7 @@ func testAccCheckUserProfileExists(ctx context.Context, n string) resource.TestC
 			return fmt.Errorf("No OpsWorks User Profile ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksClient(ctx)
 
 		_, err := tfopsworks.FindUserProfileByARN(ctx, conn, rs.Primary.ID)
 
@@ -97,7 +100,7 @@ func testAccCheckUserProfileExists(ctx context.Context, n string) resource.TestC
 
 func testAccCheckUserProfileDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksConn(ctx)
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OpsWorksClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_opsworks_user_profile" {

--- a/names/data/names_data.hcl
+++ b/names/data/names_data.hcl
@@ -6644,7 +6644,7 @@ service "opsworks" {
 
   sdk {
     id             = "OpsWorks"
-    client_version = [1]
+    client_version = [2]
   }
 
   names {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR migrates the `OpsWorks` resources to AWS SDKv2.

Because this service has been deprecated all tests are skipped with an explanation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/36193
Relates https://github.com/hashicorp/terraform-provider-aws/issues/32976

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAcc' PKG=opsworks
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/opsworks/... -v -count 1 -parallel 20  -run=TestAcc -timeout 360m
=== RUN   TestAccOpsWorksApplication_basic
    application_test.go:25: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksApplication_basic (0.00s)
=== RUN   TestAccOpsWorksCustomLayer_basic
    custom_layer_test.go:21: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksCustomLayer_basic (0.00s)
=== RUN   TestAccOpsWorksCustomLayer_update
    custom_layer_test.go:84: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksCustomLayer_update (0.00s)
=== RUN   TestAccOpsWorksCustomLayer_cloudWatch
    custom_layer_test.go:159: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksCustomLayer_cloudWatch (0.00s)
=== RUN   TestAccOpsWorksCustomLayer_loadBasedAutoScaling
    custom_layer_test.go:244: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksCustomLayer_loadBasedAutoScaling (0.00s)
=== RUN   TestAccOpsWorksECSClusterLayer_basic
    ecs_cluster_layer_test.go:20: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksECSClusterLayer_basic (0.00s)
=== RUN   TestAccOpsWorksGangliaLayer_basic
    ganglia_layer_test.go:19: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksGangliaLayer_basic (0.00s)
=== RUN   TestAccOpsWorksHAProxyLayer_basic
    haproxy_layer_test.go:19: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksHAProxyLayer_basic (0.00s)
=== RUN   TestAccOpsWorksInstance_basic
    instance_test.go:24: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksInstance_basic (0.00s)
=== RUN   TestAccOpsWorksInstance_updateHostNameForceNew
    instance_test.go:78: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksInstance_updateHostNameForceNew (0.00s)
=== RUN   TestAccOpsWorksJavaAppLayer_basic
    java_app_layer_test.go:19: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksJavaAppLayer_basic (0.00s)
=== RUN   TestAccOpsWorksMemcachedLayer_basic
    memcached_layer_test.go:19: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksMemcachedLayer_basic (0.00s)
=== RUN   TestAccOpsWorksMySQLLayer_basic
    mysql_layer_test.go:19: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksMySQLLayer_basic (0.00s)
=== RUN   TestAccOpsWorksNodejsAppLayer_basic
    nodejs_app_layer_test.go:19: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksNodejsAppLayer_basic (0.00s)
=== RUN   TestAccOpsWorksPermission_basic
    permission_test.go:22: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksPermission_basic (0.00s)
=== RUN   TestAccOpsWorksPermission_self
    permission_test.go:77: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksPermission_self (0.00s)
=== RUN   TestAccOpsWorksPHPAppLayer_basic
    php_app_layer_test.go:19: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksPHPAppLayer_basic (0.00s)
=== RUN   TestAccOpsWorksRailsAppLayer_basic
    rails_app_layer_test.go:22: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksRailsAppLayer_basic (0.00s)
=== RUN   TestAccOpsWorksRailsAppLayer_disappears
    rails_app_layer_test.go:80: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksRailsAppLayer_disappears (0.00s)
=== RUN   TestAccOpsWorksRailsAppLayer_tags
    rails_app_layer_test.go:106: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksRailsAppLayer_tags (0.00s)
=== RUN   TestAccOpsWorksRailsAppLayer_tagsAlternateRegion
    rails_app_layer_test.go:149: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksRailsAppLayer_tagsAlternateRegion (0.00s)
=== RUN   TestAccOpsWorksRailsAppLayer_update
    rails_app_layer_test.go:200: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksRailsAppLayer_update (0.00s)
=== RUN   TestAccOpsWorksRailsAppLayer_elb
    rails_app_layer_test.go:249: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksRailsAppLayer_elb (0.00s)
=== RUN   TestAccOpsWorksRDSDBInstance_basic
    rds_db_instance_test.go:23: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksRDSDBInstance_basic (0.00s)
=== RUN   TestAccOpsWorksRDSDBInstance_disappears
    rds_db_instance_test.go:69: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksRDSDBInstance_disappears (0.00s)
=== RUN   TestAccOpsWorksStack_basic
    stack_test.go:26: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksStack_basic (0.00s)
=== RUN   TestAccOpsWorksStack_disappears
    stack_test.go:83: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksStack_disappears (0.00s)
=== RUN   TestAccOpsWorksStack_noVPC_basic
    stack_test.go:113: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksStack_noVPC_basic (0.00s)
=== RUN   TestAccOpsWorksStack_noVPC_defaultAZ
    stack_test.go:157: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksStack_noVPC_defaultAZ (0.00s)
=== RUN   TestAccOpsWorksStack_tags
    stack_test.go:193: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksStack_tags (0.00s)
=== RUN   TestAccOpsWorksStack_tagsAlternateRegion
    stack_test.go:245: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksStack_tagsAlternateRegion (0.00s)
=== RUN   TestAccOpsWorksStack_allAttributes
    stack_test.go:318: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksStack_allAttributes (0.00s)
=== RUN   TestAccOpsWorksStack_windows
    stack_test.go:456: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksStack_windows (0.00s)
=== RUN   TestAccOpsWorksStaticWebLayer_basic
    static_web_layer_test.go:19: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksStaticWebLayer_basic (0.00s)
=== RUN   TestAccOpsWorksUserProfile_basic
    user_profile_test.go:22: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksUserProfile_basic (0.00s)
=== RUN   TestAccOpsWorksUserProfile_disappears
    user_profile_test.go:58: skipping test; Amazon OpsWorks has been deprecated and will be removed in the next major release
--- SKIP: TestAccOpsWorksUserProfile_disappears (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opsworks	4.642s
```
