### PR TITLE
f/dynamodb_table: add `restore_source_table_arn` to support cross region table restore

### DIFF
--- a/.changelog/38953.txt
+++ b/.changelog/38953.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dynamodb_table: Add `restore_source_table_arn` attribute
+```

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -357,20 +357,6 @@ func CheckResourceAttrRegionalARN(resourceName, attributeName, arnService, arnRe
 	}
 }
 
-// CheckResourceAttrAlterateRegionalARN ensures the Terraform state exactly matches a formatted ARN with region
-func CheckResourceAttrAlternateRegionalARN(resourceName, attributeName, arnService, arnResource string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		attributeValue := arn.ARN{
-			AccountID: AccountID(),
-			Partition: Partition(),
-			Region:    AlternateRegion(),
-			Resource:  arnResource,
-			Service:   arnService,
-		}.String()
-		return resource.TestCheckResourceAttr(resourceName, attributeName, attributeValue)(s)
-	}
-}
-
 // CheckResourceAttrRegionalARNNoAccount ensures the Terraform state exactly matches a formatted ARN with region but without account ID
 func CheckResourceAttrRegionalARNNoAccount(resourceName, attributeName, arnService, arnResource string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -357,6 +357,20 @@ func CheckResourceAttrRegionalARN(resourceName, attributeName, arnService, arnRe
 	}
 }
 
+// CheckResourceAttrAlterateRegionalARN ensures the Terraform state exactly matches a formatted ARN with region
+func CheckResourceAttrAlternateRegionalARN(resourceName, attributeName, arnService, arnResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		attributeValue := arn.ARN{
+			AccountID: AccountID(),
+			Partition: Partition(),
+			Region:    AlternateRegion(),
+			Resource:  arnResource,
+			Service:   arnService,
+		}.String()
+		return resource.TestCheckResourceAttr(resourceName, attributeName, attributeValue)(s)
+	}
+}
+
 // CheckResourceAttrRegionalARNNoAccount ensures the Terraform state exactly matches a formatted ARN with region but without account ID
 func CheckResourceAttrRegionalARNNoAccount(resourceName, attributeName, arnService, arnResource string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -99,7 +99,12 @@ func resourceTable() *schema.Resource {
 				return nil
 			},
 			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
-				if name, arn := diff.Get("restore_source_name"), diff.Get("resource_source_table_arn"); name != "" || arn != "" {
+				if v := diff.Get("restore_source_name"); v != "" {
+					return nil
+				}
+
+				if !diff.GetRawPlan().GetAttr("restore_source_table_arn").IsWhollyKnown() ||
+					diff.Get("restore_source_table_arn") != "" {
 					return nil
 				}
 

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -99,7 +99,7 @@ func resourceTable() *schema.Resource {
 				return nil
 			},
 			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
-				if v := diff.Get("restore_source_name"); v != "" {
+				if name, arn := diff.Get("restore_source_name"), diff.Get("resource_source_table_arn"); name != "" || arn != "" {
 					return nil
 				}
 
@@ -115,6 +115,9 @@ func resourceTable() *schema.Resource {
 			customdiff.ForceNewIfChange("restore_source_name", func(_ context.Context, old, new, meta interface{}) bool {
 				// If they differ force new unless new is cleared
 				// https://github.com/hashicorp/terraform-provider-aws/issues/25214
+				return old.(string) != new.(string) && new.(string) != ""
+			}),
+			customdiff.ForceNewIfChange("restore_source_table_arn", func(_ context.Context, old, new, meta interface{}) bool {
 				return old.(string) != new.(string) && new.(string) != ""
 			}),
 			validateTTLCustomDiff,
@@ -309,7 +312,7 @@ func resourceTable() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,
-				ConflictsWith: []string{"restore_source_name"},
+				ConflictsWith: []string{"restore_source_name", "restore_source_table_arn"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"input_compression_type": {
@@ -380,10 +383,16 @@ func resourceTable() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidUTCTimestamp,
 			},
+			"restore_source_table_arn": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ValidateFunc:  verify.ValidARN,
+				ConflictsWith: []string{"import_table", "restore_source_name"},
+			},
 			"restore_source_name": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"import_table"},
+				ConflictsWith: []string{"import_table", "restore_source_table_arn"},
 			},
 			"restore_to_latest_time": {
 				Type:     schema.TypeBool,
@@ -484,10 +493,20 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		keySchemaMap["range_key"] = v.(string)
 	}
 
-	if v, ok := d.GetOk("restore_source_name"); ok {
+	sourceName, nameOk := d.GetOk("restore_source_name")
+	sourceArn, arnOk := d.GetOk("restore_source_table_arn")
+
+	if nameOk || arnOk {
 		input := &dynamodb.RestoreTableToPointInTimeInput{
-			SourceTableName: aws.String(v.(string)),
 			TargetTableName: aws.String(tableName),
+		}
+
+		if nameOk {
+			input.SourceTableName = aws.String(sourceName.(string))
+		}
+
+		if arnOk {
+			input.SourceTableArn = aws.String(sourceArn.(string))
 		}
 
 		if v, ok := d.GetOk("restore_date_time"); ok {

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1678,8 +1678,12 @@ func TestAccDynamoDBTable_encryption(t *testing.T) {
 	})
 }
 
-func TestAccDynamoDBTable_RestoreCrossAccount(t *testing.T) {
+func TestAccDynamoDBTable_restoreCrossAccount(t *testing.T) {
 	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf awstypes.TableDescription
 	resourceName := "aws_dynamodb_table.test"
 	resourceNameRestore := "aws_dynamodb_table.test_restore"

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1678,6 +1678,42 @@ func TestAccDynamoDBTable_encryption(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBTable_RestoreCrossAccount(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.TableDescription
+	resourceName := "aws_dynamodb_table.test"
+	resourceNameRestore := "aws_dynamodb_table.test_restore"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rNameRestore := fmt.Sprintf("%s-restore", rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
+		CheckDestroy:             testAccCheckTableDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableConfig_restoreCrossAccount(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckInitialTableExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceNameRestore, names.AttrName, rNameRestore),
+					acctest.CheckResourceAttrRegionalARN(resourceName, names.AttrARN, "dynamodb", fmt.Sprintf("table/%s", rName)),
+					acctest.CheckResourceAttrAlternateRegionalARN(resourceNameRestore, names.AttrARN, "dynamodb", fmt.Sprintf("table/%s", reNameRestore)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccDynamoDBTable_Replica_multiple(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -4612,4 +4648,60 @@ resource "aws_dynamodb_table" "test" {
   }
 }
 `, rName)
+}
+
+func testAccTableConfig_restoreCrossAccount(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(2),
+		fmt.Sprintf(`
+resource "aws_kms_key" "test" {
+  provider = "aws"
+
+  description             = %[1]q
+  deletion_window_in_days = 7
+}
+
+resource "aws_dynamodb_table" "test" {
+  provider = "aws"
+
+  name           = %[1]q
+  read_capacity  = 2
+  write_capacity = 2
+  hash_key       = "TestTableHashKey"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.test.arn
+  }
+}
+
+resource "aws_kms_key" "test_restore" {
+  provider = "awsalternate"
+
+  description             = "%[1]s-restore"
+  deletion_window_in_days = 7
+}
+
+resource "aws_dynamodb_table" "test_restore" {
+  provider = "awsalternate"
+
+  name                     = "%[1]s-restore"
+  restore_source_table_arn = aws_dynamodb_table.test.arn
+  restore_to_latest_time   = true
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.test_restore.arn
+  }
+}
+`, rName))
 }

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1678,7 +1678,7 @@ func TestAccDynamoDBTable_encryption(t *testing.T) {
 	})
 }
 
-func TestAccDynamoDBTable_restoreCrossAccount(t *testing.T) {
+func TestAccDynamoDBTable_restoreCrossRegion(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -1700,13 +1700,13 @@ func TestAccDynamoDBTable_restoreCrossAccount(t *testing.T) {
 		CheckDestroy:             testAccCheckTableDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTableConfig_restoreCrossAccount(rName),
+				Config: testAccTableConfig_restoreCrossRegion(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckInitialTableExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceNameRestore, names.AttrName, rNameRestore),
-					acctest.CheckResourceAttrRegionalARN(resourceName, names.AttrARN, "dynamodb", fmt.Sprintf("table/%s", rName)),
-					acctest.CheckResourceAttrAlternateRegionalARN(resourceNameRestore, names.AttrARN, "dynamodb", fmt.Sprintf("table/%s", rNameRestore)),
+					acctest.MatchResourceAttrRegionalARNRegion(resourceName, names.AttrARN, "dynamodb", acctest.Region(), regexache.MustCompile(`table/+.`)),
+					acctest.MatchResourceAttrRegionalARNRegion(resourceNameRestore, names.AttrARN, "dynamodb", acctest.AlternateRegion(), regexache.MustCompile(`table/+.`)),
 				),
 			},
 			{
@@ -4654,7 +4654,7 @@ resource "aws_dynamodb_table" "test" {
 `, rName)
 }
 
-func testAccTableConfig_restoreCrossAccount(rName string) string {
+func testAccTableConfig_restoreCrossRegion(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigMultipleRegionProvider(2),
 		fmt.Sprintf(`

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1702,7 +1702,7 @@ func TestAccDynamoDBTable_RestoreCrossAccount(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceNameRestore, names.AttrName, rNameRestore),
 					acctest.CheckResourceAttrRegionalARN(resourceName, names.AttrARN, "dynamodb", fmt.Sprintf("table/%s", rName)),
-					acctest.CheckResourceAttrAlternateRegionalARN(resourceNameRestore, names.AttrARN, "dynamodb", fmt.Sprintf("table/%s", reNameRestore)),
+					acctest.CheckResourceAttrAlternateRegionalARN(resourceNameRestore, names.AttrARN, "dynamodb", fmt.Sprintf("table/%s", rNameRestore)),
 				),
 			},
 			{

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -186,8 +186,9 @@ Optional arguments:
 * `replica` - (Optional) Configuration block(s) with [DynamoDB Global Tables V2 (version 2019.11.21)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html) replication configurations. See below.
 * `restore_date_time` - (Optional) Time of the point-in-time recovery point to restore.
 * `restore_source_name` - (Optional) Name of the table to restore. Must match the name of an existing table.
+* `restore_source_table_arn` - (Optional) ARN of the source table to restore. Must be supplied for cross-region restores.
 * `restore_to_latest_time` - (Optional) If set, restores table to the most recent point-in-time recovery point.
-* `server_side_encryption` - (Optional) Encryption at rest options. AWS DynamoDB tables are automatically encrypted at rest with an AWS-owned Customer Master Key if this argument isn't specified. See below.
+* `server_side_encryption` - (Optional) Encryption at rest options. AWS DynamoDB tables are automatically encrypted at rest with an AWS-owned Customer Master Key if this argument isn't specified. Must be supplied for cross-region restores. See below.
 * `stream_enabled` - (Optional) Whether Streams are enabled.
 * `stream_view_type` - (Optional) When an item in the table is modified, StreamViewType determines what information is written to the table's stream. Valid values are `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`.
 * `table_class` - (Optional) Storage class of the table.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #34911

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccDynamoDBTable_restoreCrossRegion' PKG=dynamodb

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/dynamodb/... -v -count 1 -parallel 20  -run=TestAccDynamoDBTable_restoreCrossRegion -timeout 360m
--- PASS: TestAccDynamoDBTable_restoreCrossRegion (820.98s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	831.689s
```

```console
% make testacc TESTARGS='-run=TestAccDynamoDBTable_ -short' PKG=dynamodb

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/dynamodb/... -v -count 1 -parallel 20  -run=TestAccDynamoDBTable_ -short -timeout 360m
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (5.33s)
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (10.39s)
=== NAME  TestAccDynamoDBTable_tableClass_migrate
    table_test.go:2587: Step 1/2 error: Check failed: Check 2/2 error: aws_dynamodb_table.test: Attribute 'table_class' expected "", got "STANDARD"
--- FAIL: TestAccDynamoDBTable_tableClass_migrate (22.91s)
--- PASS: TestAccDynamoDBTable_disappears (36.57s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (41.97s)
--- PASS: TestAccDynamoDBTable_basic (44.16s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (50.36s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (50.57s)
--- PASS: TestAccDynamoDBTable_TTL_validate (6.96s)
--- PASS: TestAccDynamoDBTable_deletion_protection (54.91s)
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (56.69s)
--- PASS: TestAccDynamoDBTable_TTL_update (57.94s)
--- PASS: TestAccDynamoDBTable_tags (58.00s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (60.34s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (60.65s)
--- PASS: TestAccDynamoDBTable_streamSpecification (66.11s)
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (57.04s)
--- PASS: TestAccDynamoDBTable_enablePITR (73.15s)
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (73.21s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (74.00s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (46.05s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (43.05s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (62.94s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (97.49s)
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (131.73s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (615.65s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	621.804s
FAIL
make: *** [testacc] Error 1
```

### Intermittent failure of `TestAccDynamoDBTable_tableClass_migrate `. 

failure not related to changes

```console
% make testacc TESTARGS='-run=TestAccDynamoDBTable_tableClass_migrate' PKG=dynamodb

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/dynamodb/... -v -count 1 -parallel 20  -run=TestAccDynamoDBTable_tableClass_migrate -timeout 360m
--- PASS: TestAccDynamoDBTable_tableClass_migrate (31.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	37.574s
```
