### PR TITLE
r/aws_cloudformation_stack_set_instance: fix crash during ID construction

### DIFF
--- a/.changelog/38969.txt
+++ b/.changelog/38969.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudformation_stack_set_instance: Fix crash during construction of the `id` attribute when `deployment_targets` does not include organizational unit IDs.
+```

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -249,7 +249,9 @@ func resourceStackSetInstanceCreate(ctx context.Context, d *schema.ResourceData,
 
 	if v, ok := d.GetOk("deployment_targets"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		dt := expandDeploymentTargets(v.([]interface{}))
-		accountOrOrgID = strings.Join(dt.OrganizationalUnitIds, "/")
+		if len(dt.OrganizationalUnitIds) > 0 {
+			accountOrOrgID = strings.Join(dt.OrganizationalUnitIds, "/")
+		}
 		input.DeploymentTargets = dt
 	} else {
 		d.Set(names.AttrAccountID, accountID)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes a crash caused by incorrect logic used to construct the multi-part key for `id` and improper handling of the error returned from the resource ID constructor helper.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38846

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc PKG=cloudformation TESTS=TestAccCloudFormationStackSetInstance_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/cloudformation/... -v -count 1 -parallel 20 -run='TestAccCloudFormationStackSetInstance_'  -timeout 360m

=== CONT  TestAccCloudFormationStackSetInstance_delegatedAdministrator
    stack_set_instance_test.go:375: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccCloudFormationStackSetInstance_delegatedAdministrator (0.91s)
=== NAME  TestAccCloudFormationStackSetInstance_concurrencyMode
    stack_set_instance_test.go:339: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSetInstance_concurrencyMode (1.27s)
=== NAME  TestAccCloudFormationStackSetInstance_operationPreferences
    stack_set_instance_test.go:304: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSetInstance_operationPreferences (5.82s)
=== NAME  TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU
    stack_set_instance_test.go:258: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU (6.21s)
=== NAME  TestAccCloudFormationStackSetInstance_deploymentTargets
    stack_set_instance_test.go:209: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSetInstance_deploymentTargets (14.76s)
--- PASS: TestAccCloudFormationStackSetInstance_Disappears_stackSet (67.25s)
--- PASS: TestAccCloudFormationStackSetInstance_basic (71.28s)
--- PASS: TestAccCloudFormationStackSetInstance_disappears (72.69s)
--- PASS: TestAccCloudFormationStackSetInstance_parameterOverrides (123.31s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     132.610s
```