### PR TITLE
docs: remove detail on default value for http_tokens

### DIFF
--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -369,7 +369,7 @@ The `metadata_options` block supports the following:
 * `http_endpoint` - (Optional) Whether the metadata service is available. Valid values include `enabled` or `disabled`. Defaults to `enabled`.
 * `http_protocol_ipv6` - (Optional) Whether the IPv6 endpoint for the instance metadata service is enabled. Defaults to `disabled`.
 * `http_put_response_hop_limit` - (Optional) Desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Valid values are integer from `1` to `64`. Defaults to `1`.
-* `http_tokens` - (Optional) Whether or not the metadata service requires session tokens, also referred to as _Instance Metadata Service Version 2 (IMDSv2)_. Valid values include `optional` or `required`. Defaults to `optional`.
+* `http_tokens` - (Optional) Whether or not the metadata service requires session tokens, also referred to as _Instance Metadata Service Version 2 (IMDSv2)_. Valid values include `optional` or `required`.
 * `instance_metadata_tags` - (Optional) Enables or disables access to instance tags from the instance metadata service. Valid values include `enabled` or `disabled`. Defaults to `disabled`.
 
 For more information, see the documentation on the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).


### PR DESCRIPTION
### Description

The default value does not reflect reality and in #38294 there were two proposals to deal with the situation.

- Option 1: remove the information about a default value for `http_tokens`
- Option 2: recommend to configure that option explicitly

In this pull request I applied option 1.

For option 2 I tried to understand how a good/ correct recommendation could look like and learned how the `http_tokens` value is set. In the References section I added a link to my starting point, a specific section of the AWS SDK Go v2 code base. There the default value for `http_tokens` is defined by 

```go
//   - If the value of ImdsSupport for the Amazon Machine Image (AMI) for your
//   instance is v2.0 and the account level default is set to no-preference , the
//   default is required .
//
//   - If the value of ImdsSupport for the Amazon Machine Image (AMI) for your
//   instance is v2.0 , but the account level default is set to V1 or V2 , the
//   default is optional .
```
In addition, it is pointed out that

```go
// The default value can also be affected by other combinations of parameters. For
// more information, see [Order of precedence for instance metadata options]in the Amazon EC2 User Guide.
```

Details on the  [order of precedence](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html#instance-metadata-options-order-of-precedence) are as below

>The hierarchy, with the highest precedence at the top, is as follows:
>
>Precedence 1: Instance configuration at launch – Values can be specified either in the launch template or in the instance configuration. Any values specified here override values specified at the account level or in the AMI.
>
>Precedence 2: Account settings – If a value is not specified at instance launch, then it is determined by the account-level settings (which are set for each AWS Region). Account-level settings either include a value for each metadata option, or indicate no preference at all.
>
>Precedence 3: AMI configuration – If a value is not specified at instance launch or at the account level, then it is determined by the AMI configuration. This applies only to HttpTokens and HttpPutResponseHopLimit.
>
>Each metadata option is evaluated separately. The instance can be configured with a mix of direct instance configuration, account-level defaults, and the configuration from the AMI.

Proposing users to "just" set the value of  `http_tokens` (option 2) does not feel appropriate:
 - I have not seen this kind of recommendation in other resources (maybe I just missed)
 - Without explanation it leaves users a bit clueless, why they need to do so. In my opinion, we also need then to provide an explanation or reference to documentation.

### Relations

- Closes #38294 


### References

- [aws-sdk-go-v2api_op_ModifyInstanceMetadataOptions.go ](https://github.com/aws/aws-sdk-go-v2/blob/38fe812f7abf976b6b1a5122c0c3bf303502cfc5/service/ec2/api_op_ModifyInstanceMetadataOptions.go#L81)  
The default behavior for `http_tokens`  is described here

### Output from Acceptance Testing

Not applicable, only documentation is updated.