### PR TITLE
Support conditional writes for `aws_s3_object`

### DIFF
--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -149,6 +149,10 @@ func resourceObject() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{names.AttrKMSKeyID},
 			},
+			"if_none_match": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			names.AttrForceDestroy: {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -530,6 +534,10 @@ func resourceObjectUpload(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if v, ok := d.GetOk("content_language"); ok {
 		input.ContentLanguage = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("if_none_match"); ok {
+		input.IfNoneMatch = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk(names.AttrContentType); ok {

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -32,6 +32,16 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+func init() {
+	acctest.RegisterServiceErrorCheckFunc("s3_conditional", testAccErrorCheckSkipService)
+}
+
+func testAccErrorCheckSkipService(t *testing.T) resource.ErrorCheckFunc {
+	return acctest.ErrorCheckSkipMessagesContaining(t,
+		"PreconditionFailed: At least one of the pre-conditions you specified did not hold",
+	)
+}
+
 func TestSDKv1CompatibleCleanKey(t *testing.T) {
 	t.Parallel()
 
@@ -1850,6 +1860,27 @@ func TestAccS3Object_optInRegion(t *testing.T) {
 	})
 }
 
+func TestAccS3Object_conditionalWrite(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	var obj s3.GetObjectOutput
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, "s3_conditional"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObjectConfig_conditionalWrite(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObjectExists(ctx, "aws_s3_object.object", &obj),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckObjectVersionIDDiffers(first, second *s3.GetObjectOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.ToString(first.VersionId) == aws.ToString(second.VersionId) {
@@ -2990,4 +3021,26 @@ resource "aws_s3_object" "object" {
   key    = "test-key"
 }
 `, rName))
+}
+
+func testAccObjectConfig_conditionalWrite(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+  force_destroy = false
+}
+
+resource "aws_s3_object" "object" {
+  bucket = aws_s3_bucket.test.bucket
+  key    = "conditional_object"
+}
+
+
+resource "aws_s3_object" "conditional_object" {
+  bucket = aws_s3_bucket.test.bucket
+  key    = "conditional_object"
+  if_none_match = "*"
+  depends_on = [aws_s3_object.object]
+}
+`, rName)
 }


### PR DESCRIPTION
### Description

Add support for conditional writes for `aws_s3_object`.


### Relations

Closes #38964

### References

https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html


### Output from Acceptance Testing


```console
% make testacc TESTS=TestAccS3Object_conditionalWrite PKG=s3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Object_conditionalWrite'  -timeout 360m
=== RUN   TestAccS3Object_conditionalWrite
=== PAUSE TestAccS3Object_conditionalWrite
=== CONT  TestAccS3Object_conditionalWrite
2024/08/21 22:47:31 [DEBUG] GET https://releases.hashicorp.com/terraform/1.9.5/index.json
2024/08/21 22:47:31 [DEBUG] GET https://releases.hashicorp.com/terraform/1.9.5/terraform_1.9.5_SHA256SUMS.72D7468F.sig
2024/08/21 22:47:31 [DEBUG] GET https://releases.hashicorp.com/terraform/1.9.5/terraform_1.9.5_SHA256SUMS
2024/08/21 22:47:31 [DEBUG] GET https://releases.hashicorp.com/terraform/1.9.5/terraform_1.9.5_linux_amd64.zip
    acctest.go:1715: skipping test for aws/us-west-1: Error running apply: exit status 1
        
        Error: uploading S3 Object (conditional_object) to Bucket (tf-acc-test-8092885133430460121): operation error S3: PutObject, https response error StatusCode: 412, RequestID: JN4JR2V115DMH2AS, HostID: 9OPfA/IVJ6KJS9/fCDvuOKqK48+n610mYXMwdieyGP6aAEwrgx/TKOwc0R7CTPHReVWF8ljaSUA=, api error PreconditionFailed: At least one of the pre-conditions you specified did not hold
        
          with aws_s3_object.conditional_object,
          on terraform_plugin_test.tf line 23, in resource "aws_s3_object" "conditional_object":
          23: resource "aws_s3_object" "conditional_object" {
        
--- SKIP: TestAccS3Object_conditionalWrite (6.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 6.838s
```
