### PR TITLE
r/aws_neptune_cluster:  Fixing Issue #38979 with incorrect default value used for cluster and instance parameter group

### DIFF
--- a/internal/service/neptune/cluster_instance.go
+++ b/internal/service/neptune/cluster_instance.go
@@ -124,7 +124,7 @@ func resourceClusterInstance() *schema.Resource {
 			"neptune_parameter_group_name": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "default.neptune1",
+				Computed: true,
 			},
 			"neptune_subnet_group_name": {
 				Type:     schema.TypeString,

--- a/internal/service/neptune/cluster_instance_test.go
+++ b/internal/service/neptune/cluster_instance_test.go
@@ -349,12 +349,12 @@ data "aws_neptune_orderable_db_instance" "test" {
   engine_version = aws_neptune_cluster.test.engine_version
   license_model  = "amazon-license"
 
-  preferred_instance_classes = ["db.t3.medium", "db.r5.large", "db.r4.large"]
+  preferred_instance_classes = ["db.t4g.medium", "db.r6g.large", "db.r5.large", "db.t3.medium", "db.r4.large"]
 }
 
 resource "aws_neptune_parameter_group" "test" {
   name   = %[1]q
-  family = "neptune1.3"
+  family = join( "", ["neptune",split(".",aws_neptune_cluster.test.engine_version)[0],".",split(".",aws_neptune_cluster.test.engine_version)[1]])
 
   parameter {
     name  = "neptune_query_timeout"
@@ -370,7 +370,6 @@ resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = slice(data.aws_availability_zones.available.names, 0, min(3, length(data.aws_availability_zones.available.names)))
   engine                               = "neptune"
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
 }
 `, rName))
@@ -496,7 +495,6 @@ resource "aws_neptune_subnet_group" "test" {
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   neptune_subnet_group_name            = aws_neptune_subnet_group.test.name
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
 }
 `, rName))
@@ -540,8 +538,6 @@ resource "aws_neptune_cluster" "test" {
   skip_final_snapshot = true
   storage_encrypted   = true
   kms_key_arn         = aws_kms_key.test.arn
-
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
 }
 `, rName))
 }

--- a/internal/service/neptune/cluster_test.go
+++ b/internal/service/neptune/cluster_test.go
@@ -36,6 +36,7 @@ func testAccClusterImportStep(n string) resource.TestStep {
 			"neptune_instance_parameter_group_name",
 			"skip_final_snapshot",
 			"snapshot_identifier",
+			"cluster_members",
 		},
 	}
 }
@@ -793,7 +794,6 @@ resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
   engine                               = "neptune"
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
 }
 `, rName))
@@ -803,7 +803,6 @@ func testAccClusterConfig_identifierGenerated() string {
 	return `
 resource "aws_neptune_cluster" "test" {
   engine                               = "neptune"
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
 }
 `
@@ -814,7 +813,6 @@ func testAccClusterConfig_identifierPrefix(prefix string) string {
 resource "aws_neptune_cluster" "test" {
   cluster_identifier_prefix            = %[1]q
   engine                               = "neptune"
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
 }
 `, prefix)
@@ -826,7 +824,6 @@ resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
   engine                               = "neptune"
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
 
   tags = {
@@ -842,7 +839,6 @@ resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
   engine                               = "neptune"
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
 
   tags = {
@@ -859,7 +855,6 @@ resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
   engine                               = "neptune"
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
   copy_tags_to_snapshot                = %[2]t
 }
@@ -872,7 +867,6 @@ resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
   engine                               = "neptune"
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
   deletion_protection                  = %[2]t
 }
@@ -884,8 +878,6 @@ func testAccClusterConfig_serverlessConfiguration(rName string) string {
 resource "aws_neptune_cluster" "test" {
   cluster_identifier_prefix            = %[1]q
   engine                               = "neptune"
-  engine_version                       = "1.2.0.1"
-  neptune_cluster_parameter_group_name = "default.neptune1.2"
   skip_final_snapshot                  = true
 
   serverless_v2_scaling_configuration {
@@ -901,7 +893,6 @@ func testAccClusterConfig_finalSnapshot(rName string) string {
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   final_snapshot_identifier            = %[1]q
 }
 `, rName))
@@ -986,7 +977,6 @@ EOF
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
 
   depends_on = [aws_iam_role.test, aws_iam_role.test-2]
@@ -1076,8 +1066,6 @@ resource "aws_neptune_cluster" "test" {
   skip_final_snapshot = true
   iam_roles           = [aws_iam_role.test.arn, aws_iam_role.test-2.arn]
 
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
-
   depends_on = [aws_iam_role.test, aws_iam_role.test-2]
 }
 `, rName))
@@ -1128,8 +1116,6 @@ resource "aws_neptune_cluster" "test" {
   skip_final_snapshot = true
   iam_roles           = [aws_iam_role.test.arn]
 
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
-
   depends_on = [aws_iam_role.test]
 }
 `, rName))
@@ -1137,6 +1123,50 @@ resource "aws_neptune_cluster" "test" {
 
 func testAccClusterConfig_kmsKey(rName string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_base(), fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "kms_admin" {
+	assume_role_policy = jsonencode({
+			Version = "2012-10-17"
+			Statement = [
+				{
+					Effect = "Allow"
+					Principal = {
+						AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+					}
+					Action = "sts:AssumeRole"
+				}
+			]
+	})
+
+	managed_policy_arns = [ "arn:aws:iam::aws:policy/NeptuneFullAccess" ]
+
+	inline_policy {
+		name = "kms-perms-for-neptune"
+		policy = jsonencode({
+			Version = "2012-10-17"
+			Statement = [
+			{
+				Action = [
+					"kms:Encrypt",
+					"kms:Decrypt",
+					"kms:GenerateDataKey",
+					"kms:ReEncryptTo",
+					"kms:GenerateDataKeyWithoutPlaintext",
+					"kms:CreateGrant",
+					"kms:ReEncryptFrom",
+					"kms:DescribeKey"
+				]
+				Effect   = "Allow"
+				Resource = "*"
+			},
+			]
+		})
+	}
+}
+
 resource "aws_kms_key" "test" {
   description = %[1]q
 
@@ -1146,13 +1176,52 @@ resource "aws_kms_key" "test" {
   "Id": "kms-tf-1",
   "Statement": [
     {
-      "Sid": "Enable IAM User Permissions",
+      "Sid": "Enable Permissions for root principal",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"
+    },
+    {
+      "Sid": "Allow use of the key for Neptune",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.kms_admin.arn}"
+      },
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+        "kms:ReEncryptTo",
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:CreateGrant",
+        "kms:ReEncryptFrom",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "Deny use of the key for non Neptune",
+      "Effect": "Deny",
+      "Principal": {
+        "AWS": "${aws_iam_role.kms_admin.arn}"
+      },
+      "Action": [
+        "kms:*"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringNotEquals": {
+          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+        }
+      }
     }
   ]
 }
@@ -1163,7 +1232,6 @@ resource "aws_kms_key" "test" {
 resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   storage_encrypted                    = true
   kms_key_arn                          = aws_kms_key.test.arn
   skip_final_snapshot                  = true
@@ -1178,8 +1246,6 @@ resource "aws_neptune_cluster" "test" {
   availability_zones  = local.availability_zone_names
   storage_encrypted   = true
   skip_final_snapshot = true
-
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
 }
 `, rName))
 }
@@ -1193,8 +1259,6 @@ resource "aws_neptune_cluster" "test" {
   preferred_backup_window      = "07:00-09:00"
   preferred_maintenance_window = "tue:04:00-tue:04:30"
   skip_final_snapshot          = true
-
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
 }
 `, rName))
 }
@@ -1209,8 +1273,6 @@ resource "aws_neptune_cluster" "test" {
   preferred_maintenance_window = "wed:01:00-wed:01:30"
   apply_immediately            = true
   skip_final_snapshot          = true
-
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
 }
 `, rName))
 }
@@ -1222,8 +1284,6 @@ resource "aws_neptune_cluster" "test" {
   availability_zones                  = local.availability_zone_names
   iam_database_authentication_enabled = true
   skip_final_snapshot                 = true
-
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
 }
 `, rName))
 }
@@ -1235,8 +1295,6 @@ resource "aws_neptune_cluster" "test" {
   availability_zones             = local.availability_zone_names
   skip_final_snapshot            = true
   enable_cloudwatch_logs_exports = ["audit", "slowquery"]
-
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
 }
 `, rName))
 }
@@ -1248,7 +1306,7 @@ data "aws_neptune_orderable_db_instance" "test" {
   engine_version = aws_neptune_cluster.test.engine_version
   license_model  = "amazon-license"
 
-  preferred_instance_classes = ["db.t3.medium", "db.r5.large", "db.r4.large"]
+  preferred_instance_classes = ["db.t4g.medium", "db.r6g.large", "db.r5.large", "db.t3.medium", "db.r4.large"]
 }
 
 resource "aws_neptune_cluster_instance" "test" {
@@ -1256,7 +1314,6 @@ resource "aws_neptune_cluster_instance" "test" {
   cluster_identifier           = aws_neptune_cluster.test.id
   apply_immediately            = true
   instance_class               = data.aws_neptune_orderable_db_instance.test.instance_class
-  neptune_parameter_group_name = aws_neptune_cluster.test.neptune_cluster_parameter_group_name
   promotion_tier               = "3"
 }
 `, rName))
@@ -1306,7 +1363,6 @@ data "aws_availability_zones" "alternate" {
 resource "aws_neptune_global_cluster" "test" {
   global_cluster_identifier = %[1]q
   engine                    = "neptune"
-  engine_version            = "1.2.0.0"
 }
 
 resource "aws_neptune_cluster" "primary" {
@@ -1315,14 +1371,12 @@ resource "aws_neptune_cluster" "primary" {
   global_cluster_identifier            = aws_neptune_global_cluster.test.id
   engine                               = aws_neptune_global_cluster.test.engine
   engine_version                       = aws_neptune_global_cluster.test.engine_version
-  neptune_cluster_parameter_group_name = "default.neptune1.2"
 }
 
 resource "aws_neptune_cluster_instance" "primary" {
   identifier                   = %[2]q
   cluster_identifier           = aws_neptune_cluster.primary.id
-  instance_class               = "db.r5.large"
-  neptune_parameter_group_name = "default.neptune1.2"
+  instance_class               = "db.r6g.large"
   engine_version               = aws_neptune_global_cluster.test.engine_version
 }
 
@@ -1362,7 +1416,6 @@ resource "aws_neptune_cluster" "secondary" {
   global_cluster_identifier            = aws_neptune_global_cluster.test.id
   engine                               = aws_neptune_global_cluster.test.engine
   engine_version                       = aws_neptune_global_cluster.test.engine_version
-  neptune_cluster_parameter_group_name = "default.neptune1.2"
 
   depends_on = [aws_neptune_cluster_instance.primary]
 
@@ -1375,15 +1428,58 @@ resource "aws_neptune_cluster_instance" "secondary" {
   provider                     = "awsalternate"
   identifier                   = %[3]q
   cluster_identifier           = aws_neptune_cluster.secondary.id
-  neptune_parameter_group_name = "default.neptune1.2"
   engine_version               = aws_neptune_global_cluster.test.engine_version
-  instance_class               = "db.r5.large"
+  instance_class               = "db.r6g.large"
 }
 `, rNameGlobal, rNamePrimary, rNameSecondary))
 }
 
 func testAccClusterConfig_restoreFromSnapshot(rName string) string {
 	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "kms_admin" {
+	assume_role_policy = jsonencode({
+			Version = "2012-10-17"
+			Statement = [
+				{
+					Effect = "Allow"
+					Principal = {
+						AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+					}
+					Action = "sts:AssumeRole"
+				}
+			]
+	})
+
+	managed_policy_arns = [ "arn:aws:iam::aws:policy/NeptuneFullAccess" ]
+
+	inline_policy {
+		name = "kms-perms-for-neptune"
+		policy = jsonencode({
+			Version = "2012-10-17"
+			Statement = [
+			{
+				Action = [
+					"kms:Encrypt",
+					"kms:Decrypt",
+					"kms:GenerateDataKey",
+					"kms:ReEncryptTo",
+					"kms:GenerateDataKeyWithoutPlaintext",
+					"kms:CreateGrant",
+					"kms:ReEncryptFrom",
+					"kms:DescribeKey"
+				]
+				Effect   = "Allow"
+				Resource = "*"
+			},
+			]
+		})
+	}
+}
+
 resource "aws_kms_key" "test1" {
   description = %[1]q
 
@@ -1393,13 +1489,52 @@ resource "aws_kms_key" "test1" {
   "Id": "kms-tf-1",
   "Statement": [
     {
-      "Sid": "Enable IAM User Permissions",
+      "Sid": "Enable Permissions for root principal",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"
+    },
+    {
+      "Sid": "Allow use of the key for Neptune",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.kms_admin.arn}"
+      },
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+        "kms:ReEncryptTo",
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:CreateGrant",
+        "kms:ReEncryptFrom",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "Deny use of the key for non Neptune",
+      "Effect": "Deny",
+      "Principal": {
+        "AWS": "${aws_iam_role.kms_admin.arn}"
+      },
+      "Action": [
+        "kms:*"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringNotEquals": {
+          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+        }
+      }
     }
   ]
 }
@@ -1416,13 +1551,52 @@ resource "aws_kms_key" "test2" {
   "Id": "kms-tf-2",
   "Statement": [
     {
-      "Sid": "Enable IAM User Permissions",
+      "Sid": "Enable Permissions for root principal",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"
+    },
+    {
+      "Sid": "Allow use of the key for Neptune",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.kms_admin.arn}"
+      },
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+        "kms:ReEncryptTo",
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:CreateGrant",
+        "kms:ReEncryptFrom",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "Deny use of the key for non Neptune",
+      "Effect": "Deny",
+      "Principal": {
+        "AWS": "${aws_iam_role.kms_admin.arn}"
+      },
+      "Action": [
+        "kms:*"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringNotEquals": {
+          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+        }
+      }
     }
   ]
 }
@@ -1445,7 +1619,6 @@ resource "aws_security_group" "test" {
 
 resource "aws_neptune_cluster" "source" {
   cluster_identifier                   = "%[1]s-src"
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
   storage_encrypted                    = true
   kms_key_arn                          = aws_kms_key.test1.arn
@@ -1457,7 +1630,7 @@ resource "aws_neptune_cluster_snapshot" "test" {
 }
 
 resource "aws_neptune_cluster_parameter_group" "test" {
-  family = "neptune1.3"
+  family = join( "", ["neptune",split(".",aws_neptune_cluster_snapshot.test.engine_version)[0],".",split(".",aws_neptune_cluster_snapshot.test.engine_version)[1]])
   name   = %[1]q
 
   parameter {
@@ -1489,8 +1662,6 @@ resource "aws_neptune_cluster" "test" {
   cluster_identifier                   = %[1]q
   availability_zones                   = local.availability_zone_names
   engine                               = "neptune"
-  engine_version                       = "1.3.0.0"
-  neptune_cluster_parameter_group_name = "default.neptune1.3"
   skip_final_snapshot                  = true
   storage_type                         = %[2]q
   apply_immediately                    = true

--- a/internal/service/neptune/consts.go
+++ b/internal/service/neptune/consts.go
@@ -55,6 +55,9 @@ const (
 	clusterStatusModifying                  = "modifying"
 	clusterStatusPreparingDataMigration     = "preparing-data-migration"
 	clusterStatusUpgrading                  = "upgrading"
+
+	// Non-standard status values.
+	clusterStatusAvailableWithPendingModifiedValues = "tf-available-with-pending-modified-values"
 )
 
 const (

--- a/internal/service/neptune/global_cluster.go
+++ b/internal/service/neptune/global_cluster.go
@@ -248,7 +248,7 @@ func resourceGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 					return sdkdiag.AppendErrorf(diags, "modifying Neptune Cluster (%s) engine version: %s", clusterID, err)
 				}
 
-				if _, err := waitDBClusterAvailable(ctx, conn, clusterID, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				if _, err := waitDBClusterAvailable(ctx, conn, clusterID, false, d.Timeout(schema.TimeoutUpdate)); err != nil {
 					return sdkdiag.AppendErrorf(diags, "waiting for Neptune Cluster (%s) update: %s", clusterID, err)
 				}
 			}


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fixing Issue #38979 where an incorrect default value was being used for
both the cluster and instance parameter group.
Changed preferred instance types for tests to use Graviton instances where possible to save on testing cost.
Updated KMS key policies used in tests as the previously used policies were overly permissive.
Fixed issue with waiting state used in tests for engine upgrades. Previous waiting functions did not take PendingModifiedValues into account when checking cluster status.
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations

Closes #38979 


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/neptune/latest/userguide/api-clusters.html#CreateDBCluster

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccNeptuneCluster PKG=neptune
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/neptune/... -v -count 1 -parallel 20 -run='TestAccNeptuneCluster'  -timeout 360m
=== RUN   TestAccNeptuneClusterEndpoint_basic
=== PAUSE TestAccNeptuneClusterEndpoint_basic
=== RUN   TestAccNeptuneClusterEndpoint_tags
=== PAUSE TestAccNeptuneClusterEndpoint_tags
=== RUN   TestAccNeptuneClusterEndpoint_disappears
=== PAUSE TestAccNeptuneClusterEndpoint_disappears
=== RUN   TestAccNeptuneClusterEndpoint_Disappears_cluster
=== PAUSE TestAccNeptuneClusterEndpoint_Disappears_cluster
=== RUN   TestAccNeptuneClusterInstance_basic
=== PAUSE TestAccNeptuneClusterInstance_basic
=== RUN   TestAccNeptuneClusterInstance_disappears
=== PAUSE TestAccNeptuneClusterInstance_disappears
=== RUN   TestAccNeptuneClusterInstance_identifierGenerated
=== PAUSE TestAccNeptuneClusterInstance_identifierGenerated
=== RUN   TestAccNeptuneClusterInstance_identifierPrefix
=== PAUSE TestAccNeptuneClusterInstance_identifierPrefix
=== RUN   TestAccNeptuneClusterInstance_tags
=== PAUSE TestAccNeptuneClusterInstance_tags
=== RUN   TestAccNeptuneClusterInstance_withAZ
=== PAUSE TestAccNeptuneClusterInstance_withAZ
=== RUN   TestAccNeptuneClusterInstance_withSubnetGroup
=== PAUSE TestAccNeptuneClusterInstance_withSubnetGroup
=== RUN   TestAccNeptuneClusterInstance_kmsKey
=== PAUSE TestAccNeptuneClusterInstance_kmsKey
=== RUN   TestAccNeptuneClusterParameterGroup_basic
=== PAUSE TestAccNeptuneClusterParameterGroup_basic
=== RUN   TestAccNeptuneClusterParameterGroup_disappears
=== PAUSE TestAccNeptuneClusterParameterGroup_disappears
=== RUN   TestAccNeptuneClusterParameterGroup_nameGenerated
=== PAUSE TestAccNeptuneClusterParameterGroup_nameGenerated
=== RUN   TestAccNeptuneClusterParameterGroup_namePrefix
=== PAUSE TestAccNeptuneClusterParameterGroup_namePrefix
=== RUN   TestAccNeptuneClusterParameterGroup_tags
=== PAUSE TestAccNeptuneClusterParameterGroup_tags
=== RUN   TestAccNeptuneClusterParameterGroup_description
=== PAUSE TestAccNeptuneClusterParameterGroup_description
=== RUN   TestAccNeptuneClusterParameterGroup_parameter
=== PAUSE TestAccNeptuneClusterParameterGroup_parameter
=== RUN   TestAccNeptuneClusterParameterGroup_parameterDefault
=== PAUSE TestAccNeptuneClusterParameterGroup_parameterDefault
=== RUN   TestAccNeptuneClusterSnapshot_basic
=== PAUSE TestAccNeptuneClusterSnapshot_basic
=== RUN   TestAccNeptuneClusterSnapshot_disappears
=== PAUSE TestAccNeptuneClusterSnapshot_disappears
=== RUN   TestAccNeptuneCluster_basic
=== PAUSE TestAccNeptuneCluster_basic
=== RUN   TestAccNeptuneCluster_disappears
=== PAUSE TestAccNeptuneCluster_disappears
=== RUN   TestAccNeptuneCluster_identifierGenerated
=== PAUSE TestAccNeptuneCluster_identifierGenerated
=== RUN   TestAccNeptuneCluster_identifierPrefix
=== PAUSE TestAccNeptuneCluster_identifierPrefix
=== RUN   TestAccNeptuneCluster_tags
=== PAUSE TestAccNeptuneCluster_tags
=== RUN   TestAccNeptuneCluster_copyTagsToSnapshot
=== PAUSE TestAccNeptuneCluster_copyTagsToSnapshot
=== RUN   TestAccNeptuneCluster_serverlessConfiguration
=== PAUSE TestAccNeptuneCluster_serverlessConfiguration
=== RUN   TestAccNeptuneCluster_takeFinalSnapshot
=== PAUSE TestAccNeptuneCluster_takeFinalSnapshot
=== RUN   TestAccNeptuneCluster_updateIAMRoles
=== PAUSE TestAccNeptuneCluster_updateIAMRoles
=== RUN   TestAccNeptuneCluster_kmsKey
=== PAUSE TestAccNeptuneCluster_kmsKey
=== RUN   TestAccNeptuneCluster_encrypted
=== PAUSE TestAccNeptuneCluster_encrypted
=== RUN   TestAccNeptuneCluster_backupsUpdate
=== PAUSE TestAccNeptuneCluster_backupsUpdate
=== RUN   TestAccNeptuneCluster_iamAuth
=== PAUSE TestAccNeptuneCluster_iamAuth
=== RUN   TestAccNeptuneCluster_updateCloudWatchLogsExports
=== PAUSE TestAccNeptuneCluster_updateCloudWatchLogsExports
=== RUN   TestAccNeptuneCluster_updateEngineVersion
=== PAUSE TestAccNeptuneCluster_updateEngineVersion
=== RUN   TestAccNeptuneCluster_updateEngineMajorVersion
=== PAUSE TestAccNeptuneCluster_updateEngineMajorVersion
=== RUN   TestAccNeptuneCluster_GlobalClusterIdentifier_PrimarySecondaryClusters
=== PAUSE TestAccNeptuneCluster_GlobalClusterIdentifier_PrimarySecondaryClusters
=== RUN   TestAccNeptuneCluster_deleteProtection
=== PAUSE TestAccNeptuneCluster_deleteProtection
=== RUN   TestAccNeptuneCluster_restoreFromSnapshot
=== PAUSE TestAccNeptuneCluster_restoreFromSnapshot
=== RUN   TestAccNeptuneCluster_storageType
=== PAUSE TestAccNeptuneCluster_storageType
=== CONT  TestAccNeptuneClusterEndpoint_basic
=== CONT  TestAccNeptuneClusterSnapshot_disappears
=== CONT  TestAccNeptuneCluster_encrypted
=== CONT  TestAccNeptuneCluster_kmsKey
=== CONT  TestAccNeptuneCluster_updateIAMRoles
=== CONT  TestAccNeptuneCluster_tags
=== CONT  TestAccNeptuneCluster_identifierPrefix
=== CONT  TestAccNeptuneCluster_identifierGenerated
=== CONT  TestAccNeptuneCluster_serverlessConfiguration
=== CONT  TestAccNeptuneCluster_takeFinalSnapshot
=== CONT  TestAccNeptuneCluster_copyTagsToSnapshot
=== CONT  TestAccNeptuneCluster_basic
=== CONT  TestAccNeptuneCluster_disappears
=== CONT  TestAccNeptuneClusterInstance_kmsKey
=== CONT  TestAccNeptuneClusterParameterGroup_tags
=== CONT  TestAccNeptuneClusterParameterGroup_namePrefix
=== CONT  TestAccNeptuneClusterSnapshot_basic
=== CONT  TestAccNeptuneClusterParameterGroup_nameGenerated
=== CONT  TestAccNeptuneClusterParameterGroup_disappears
=== CONT  TestAccNeptuneClusterParameterGroup_basic
--- PASS: TestAccNeptuneClusterParameterGroup_disappears (45.04s)
=== CONT  TestAccNeptuneCluster_updateEngineMajorVersion
--- PASS: TestAccNeptuneClusterParameterGroup_namePrefix (48.54s)
=== CONT  TestAccNeptuneCluster_storageType
--- PASS: TestAccNeptuneClusterParameterGroup_basic (49.72s)
=== CONT  TestAccNeptuneCluster_restoreFromSnapshot
--- PASS: TestAccNeptuneClusterParameterGroup_nameGenerated (50.04s)
=== CONT  TestAccNeptuneCluster_deleteProtection
--- PASS: TestAccNeptuneClusterParameterGroup_tags (64.86s)
=== CONT  TestAccNeptuneCluster_GlobalClusterIdentifier_PrimarySecondaryClusters
--- PASS: TestAccNeptuneCluster_disappears (148.46s)
=== CONT  TestAccNeptuneCluster_updateCloudWatchLogsExports
--- PASS: TestAccNeptuneCluster_encrypted (154.28s)
=== CONT  TestAccNeptuneCluster_updateEngineVersion
--- PASS: TestAccNeptuneCluster_identifierGenerated (158.66s)
=== CONT  TestAccNeptuneClusterInstance_identifierGenerated
--- PASS: TestAccNeptuneCluster_identifierPrefix (175.60s)
=== CONT  TestAccNeptuneClusterInstance_withSubnetGroup
--- PASS: TestAccNeptuneCluster_serverlessConfiguration (180.09s)
=== CONT  TestAccNeptuneClusterInstance_withAZ
--- PASS: TestAccNeptuneCluster_basic (180.15s)
=== CONT  TestAccNeptuneClusterInstance_tags
--- PASS: TestAccNeptuneClusterEndpoint_basic (201.14s)
=== CONT  TestAccNeptuneClusterInstance_identifierPrefix
--- PASS: TestAccNeptuneCluster_kmsKey (204.23s)
=== CONT  TestAccNeptuneClusterParameterGroup_parameter
--- PASS: TestAccNeptuneCluster_updateIAMRoles (220.92s)
=== CONT  TestAccNeptuneClusterParameterGroup_parameterDefault
--- PASS: TestAccNeptuneCluster_tags (220.99s)
=== CONT  TestAccNeptuneClusterParameterGroup_description
--- PASS: TestAccNeptuneClusterParameterGroup_parameter (18.10s)
=== CONT  TestAccNeptuneCluster_iamAuth
--- PASS: TestAccNeptuneClusterParameterGroup_parameterDefault (14.02s)
=== CONT  TestAccNeptuneClusterEndpoint_Disappears_cluster
--- PASS: TestAccNeptuneClusterParameterGroup_description (18.16s)
=== CONT  TestAccNeptuneClusterInstance_disappears
--- PASS: TestAccNeptuneCluster_storageType (192.47s)
=== CONT  TestAccNeptuneClusterInstance_basic
--- PASS: TestAccNeptuneCluster_copyTagsToSnapshot (244.42s)
=== CONT  TestAccNeptuneClusterEndpoint_disappears
--- PASS: TestAccNeptuneClusterSnapshot_disappears (244.81s)
=== CONT  TestAccNeptuneClusterEndpoint_tags
--- PASS: TestAccNeptuneClusterSnapshot_basic (245.59s)
=== CONT  TestAccNeptuneCluster_backupsUpdate
--- PASS: TestAccNeptuneCluster_deleteProtection (253.96s)
--- PASS: TestAccNeptuneCluster_takeFinalSnapshot (309.88s)
--- PASS: TestAccNeptuneCluster_iamAuth (126.35s)
--- PASS: TestAccNeptuneClusterEndpoint_Disappears_cluster (166.12s)
--- PASS: TestAccNeptuneCluster_updateCloudWatchLogsExports (264.30s)
--- PASS: TestAccNeptuneClusterEndpoint_disappears (170.35s)
--- PASS: TestAccNeptuneCluster_backupsUpdate (173.26s)
--- PASS: TestAccNeptuneClusterEndpoint_tags (209.57s)
--- PASS: TestAccNeptuneCluster_restoreFromSnapshot (453.14s)
--- PASS: TestAccNeptuneClusterInstance_kmsKey (1559.48s)
--- PASS: TestAccNeptuneClusterInstance_withAZ (1473.39s)
--- PASS: TestAccNeptuneClusterInstance_disappears (1429.74s)
--- PASS: TestAccNeptuneClusterInstance_identifierPrefix (1483.97s)
--- PASS: TestAccNeptuneClusterInstance_basic (1453.70s)
--- PASS: TestAccNeptuneClusterInstance_withSubnetGroup (1519.14s)
--- PASS: TestAccNeptuneClusterInstance_tags (1534.99s)
--- PASS: TestAccNeptuneClusterInstance_identifierGenerated (1576.20s)
--- PASS: TestAccNeptuneCluster_updateEngineVersion (1664.44s)
--- PASS: TestAccNeptuneCluster_updateEngineMajorVersion (2354.90s)
--- PASS: TestAccNeptuneCluster_GlobalClusterIdentifier_PrimarySecondaryClusters (3390.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/neptune    3455.409s

% make testacc TESTS=TestAccNeptuneGlobalCluster PKG=neptune
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/neptune/... -v -count 1 -parallel 20 -run='TestAccNeptuneGlobalCluster'  -timeout 360m
=== RUN   TestAccNeptuneGlobalCluster_basic
=== PAUSE TestAccNeptuneGlobalCluster_basic
=== RUN   TestAccNeptuneGlobalCluster_completeBasic
=== PAUSE TestAccNeptuneGlobalCluster_completeBasic
=== RUN   TestAccNeptuneGlobalCluster_disappears
=== PAUSE TestAccNeptuneGlobalCluster_disappears
=== RUN   TestAccNeptuneGlobalCluster_DeletionProtection
=== PAUSE TestAccNeptuneGlobalCluster_DeletionProtection
=== RUN   TestAccNeptuneGlobalCluster_Engine
=== PAUSE TestAccNeptuneGlobalCluster_Engine
=== RUN   TestAccNeptuneGlobalCluster_EngineVersion
=== PAUSE TestAccNeptuneGlobalCluster_EngineVersion
=== RUN   TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_basic
=== PAUSE TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_basic
=== RUN   TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_storageEncrypted
=== PAUSE TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_storageEncrypted
=== RUN   TestAccNeptuneGlobalCluster_StorageEncrypted
=== PAUSE TestAccNeptuneGlobalCluster_StorageEncrypted
=== CONT  TestAccNeptuneGlobalCluster_basic
=== CONT  TestAccNeptuneGlobalCluster_EngineVersion
=== CONT  TestAccNeptuneGlobalCluster_StorageEncrypted
=== CONT  TestAccNeptuneGlobalCluster_Engine
=== CONT  TestAccNeptuneGlobalCluster_disappears
=== CONT  TestAccNeptuneGlobalCluster_completeBasic
=== CONT  TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_basic
=== CONT  TestAccNeptuneGlobalCluster_DeletionProtection
=== CONT  TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_storageEncrypted
--- PASS: TestAccNeptuneGlobalCluster_disappears (29.04s)
--- PASS: TestAccNeptuneGlobalCluster_basic (33.05s)
--- PASS: TestAccNeptuneGlobalCluster_Engine (33.10s)
--- PASS: TestAccNeptuneGlobalCluster_StorageEncrypted (39.05s)
--- PASS: TestAccNeptuneGlobalCluster_DeletionProtection (67.79s)
--- PASS: TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_basic (155.90s)
--- PASS: TestAccNeptuneGlobalCluster_SourceDBClusterIdentifier_storageEncrypted (186.42s)
--- PASS: TestAccNeptuneGlobalCluster_completeBasic (194.18s)
--- PASS: TestAccNeptuneGlobalCluster_EngineVersion (1917.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/neptune    1917.971s
```
