### PR TITLE
Update ECS cluster name validation

### DIFF
--- a/.changelog/38993.txt
+++ b/.changelog/38993.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_ecs_cluster: Fix validation error with `name` attribute.
+```
+
+```release-note:bug
+resource/aws_ecs_cluster_capacity_providers: Fix validation error with `name` attribute.
+```

--- a/internal/service/ecs/validate.go
+++ b/internal/service/ecs/validate.go
@@ -14,7 +14,7 @@ func validateClusterName(v interface{}, k string) (ws []string, errors []error) 
 	return validation.All(
 		validation.StringLenBetween(1, 255),
 		validation.StringMatch(
-			regexache.MustCompile("^[a-zA-Z0-9-_]+$"),
+			regexache.MustCompile("^[0-9A-Za-z_-]+$"),
 			"The cluster name must consist of alphanumerics, hyphens, and underscores."),
 	)(v, k)
 }

--- a/internal/service/ecs/validate.go
+++ b/internal/service/ecs/validate.go
@@ -14,7 +14,7 @@ func validateClusterName(v interface{}, k string) (ws []string, errors []error) 
 	return validation.All(
 		validation.StringLenBetween(1, 255),
 		validation.StringMatch(
-			regexache.MustCompile("^[a-zA-Z0-9-_.]+$"),
+			regexache.MustCompile("^[a-zA-Z0-9-_]+$"),
 			"The cluster name must be 1-255 chars, consisting of only alphanumerics, hyphens, and underscores."),
 	)(v, k)
 }

--- a/internal/service/ecs/validate.go
+++ b/internal/service/ecs/validate.go
@@ -15,7 +15,7 @@ func validateClusterName(v interface{}, k string) (ws []string, errors []error) 
 		validation.StringLenBetween(1, 255),
 		validation.StringMatch(
 			regexache.MustCompile("^[a-zA-Z0-9-_]+$"),
-			"The cluster name must be 1-255 chars, consisting of only alphanumerics, hyphens, and underscores."),
+			"The cluster name must consist of alphanumerics, hyphens, and underscores."),
 	)(v, k)
 }
 

--- a/internal/service/ecs/validate.go
+++ b/internal/service/ecs/validate.go
@@ -14,8 +14,8 @@ func validateClusterName(v interface{}, k string) (ws []string, errors []error) 
 	return validation.All(
 		validation.StringLenBetween(1, 255),
 		validation.StringMatch(
-			regexache.MustCompile("[0-9A-Za-z_-]+"),
-			"The cluster name must consist of alphanumerics, hyphens, and underscores."),
+			regexache.MustCompile("^[a-zA-Z0-9-_.]+$"),
+			"The cluster name must be 1-255 chars, consisting of only alphanumerics, hyphens, and underscores."),
 	)(v, k)
 }
 


### PR DESCRIPTION
Previous regex was not complete and allowed for apply time failures

### Description

Updating the ECS `validateClusterName` which contained and incomplete regex allowing for many cases with plans that wouldn't fail as expected

### Relations

n/a

### References

n/a

### Output from Acceptance Testing

n/a

