### PR TITLE
r/aws_glue_trigger: fix crash when null `action` is configured

### DIFF
--- a/.changelog/38994.txt
+++ b/.changelog/38994.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_trigger: Fix crash when null `action` is configured
+```

--- a/internal/service/glue/trigger.go
+++ b/internal/service/glue/trigger.go
@@ -485,6 +485,9 @@ func expandActions(l []interface{}) []awstypes.Action {
 	actions := []awstypes.Action{}
 
 	for _, mRaw := range l {
+		if mRaw == nil {
+			continue
+		}
 		m := mRaw.(map[string]interface{})
 
 		action := awstypes.Action{}
@@ -520,6 +523,9 @@ func expandActions(l []interface{}) []awstypes.Action {
 }
 
 func expandTriggerNotificationProperty(l []interface{}) *awstypes.NotificationProperty {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
 	m := l[0].(map[string]interface{})
 
 	property := &awstypes.NotificationProperty{}
@@ -535,6 +541,9 @@ func expandConditions(l []interface{}) []awstypes.Condition {
 	conditions := []awstypes.Condition{}
 
 	for _, mRaw := range l {
+		if mRaw == nil {
+			continue
+		}
 		m := mRaw.(map[string]interface{})
 
 		condition := awstypes.Condition{
@@ -564,6 +573,9 @@ func expandConditions(l []interface{}) []awstypes.Condition {
 }
 
 func expandPredicate(l []interface{}) *awstypes.Predicate {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
 	m := l[0].(map[string]interface{})
 
 	predicate := &awstypes.Predicate{
@@ -664,6 +676,9 @@ func flattenTriggerNotificationProperty(property *awstypes.NotificationProperty)
 }
 
 func expandEventBatchingCondition(l []interface{}) *awstypes.EventBatchingCondition {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
 	m := l[0].(map[string]interface{})
 
 	ebc := &awstypes.EventBatchingCondition{


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously a null action caused the provider to panic. Now null actions are not expanded, which may result an error from the AWS API if only null actions are present, but prevents a complete crash.

Also addressed missing nil checks in the remaining expand functions for this resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31213


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=glue TESTS=TestAccGlueTrigger_Actions_null
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueTrigger_Actions_null'  -timeout 360m

--- PASS: TestAccGlueTrigger_Actions_null (6.53s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       15.712s
```

```console
% make testacc PKG=glue TESTS=TestAccGlueTrigger_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueTrigger_'  -timeout 360m

--- PASS: TestAccGlueTrigger_Actions_null (11.93s)
--- PASS: TestAccGlueTrigger_eventBatchingCondition (64.61s)
--- PASS: TestAccGlueTrigger_tags (94.60s)
--- PASS: TestAccGlueTrigger_Actions_security (95.74s)
--- PASS: TestAccGlueTrigger_description (99.00s)
--- PASS: TestAccGlueTrigger_Actions_notify (114.73s)
--- PASS: TestAccGlueTrigger_enabled (119.84s)
--- PASS: TestAccGlueTrigger_workflowName (129.65s)
--- PASS: TestAccGlueTrigger_crawler (134.58s)
--- PASS: TestAccGlueTrigger_basic (141.46s)
--- PASS: TestAccGlueTrigger_startOnCreate (152.00s)
--- PASS: TestAccGlueTrigger_predicate (160.11s)
--- PASS: TestAccGlueTrigger_disappears (166.73s)
--- PASS: TestAccGlueTrigger_onDemandDisable (168.17s)
--- PASS: TestAccGlueTrigger_schedule (173.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       182.908s
```