### PR TITLE
aws_rds_cluster: Fix Data API for serverlessv2

### DIFF
--- a/.changelog/38997.txt
+++ b/.changelog/38997.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Allow Web Service Data API (`enabled_http_endpoint`) to be enabled and disabled for `provisioned` engine mode and serverlessv2
+```

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -2556,6 +2556,13 @@ func TestAccRDSCluster_enableHTTPEndpoint(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enable_http_endpoint", acctest.CtFalse),
 				),
 			},
+			{
+				Config: testAccClusterConfig_enableHTTPEndpoint(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "enable_http_endpoint", acctest.CtTrue),
+				),
+			},
 		},
 	})
 }
@@ -2574,6 +2581,20 @@ func TestAccRDSCluster_enableHTTPEndpointProvisioned(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_enableHTTPEndpointProvisioned(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "enable_http_endpoint", acctest.CtTrue),
+				),
+			},
+			{
+				Config: testAccClusterConfig_enableHTTPEndpointProvisioned(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, "enable_http_endpoint", acctest.CtFalse),
+				),
+			},
 			{
 				Config: testAccClusterConfig_enableHTTPEndpointProvisioned(rName, true),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#data-api.enabling) clarifies this detail, but it's not mentioned in the Go SDK documentation. There are two methods to enable the HTTP endpoint (Data API): a newer method and an older method. The newer method, which applies to both provisioned and serverlessv2 engine modes, involves using the `EnableHTTPEndpoint` and `DisableHTTPEndpoint` operations. The older method involves modifying the DB cluster and setting the `EnableHttpEndpoint` field. Before this pull request, we were only using the older method.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes terraform-aws-modules/terraform-aws-rds-aurora#464
Closes #37125

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccRDSCluster_enableHTTPEndpoint K=rds            
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_enableHTTPEndpoint'  -timeout 360m
=== RUN   TestAccRDSCluster_enableHTTPEndpoint
=== PAUSE TestAccRDSCluster_enableHTTPEndpoint
=== RUN   TestAccRDSCluster_enableHTTPEndpointProvisioned
=== PAUSE TestAccRDSCluster_enableHTTPEndpointProvisioned
=== CONT  TestAccRDSCluster_enableHTTPEndpoint
=== CONT  TestAccRDSCluster_enableHTTPEndpointProvisioned
--- PASS: TestAccRDSCluster_enableHTTPEndpointProvisioned (274.08s)
--- PASS: TestAccRDSCluster_enableHTTPEndpoint (354.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	359.909s
```
