### PR TITLE
`aws_rds_cluster `: Add note about `master_user_secret` usage

### DIFF
--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -170,7 +170,7 @@ data "aws_db_cluster_snapshot" "example" {
 }
 
 resource "aws_rds_cluster" "example" {
-  # Because the global cluster is sourced from this cluster, the initial 
+  # Because the global cluster is sourced from this cluster, the initial
   # engine and engine_version values are defined here and automatically
   # inherited by the global cluster.
   engine         = "aurora"
@@ -406,7 +406,10 @@ load-balanced across replicas
 
 ### master_user_secret
 
-The `master_user_secret` configuration block supports the following attributes:
+~> **NOTE:** The `master_user_secret` block is a list. To reference elements, use [index notation](https://developer.hashicorp.com/terraform/language/expressions/types#indices-and-attributes). For example:<br><br>
+`aws_rds_cluster.this.master_user_secret[0].secret_arn`
+
+The `master_user_secret` block supports the following attributes:
 
 * `kms_key_id` - Amazon Web Services KMS key identifier that is used to encrypt the secret.
 * `secret_arn` - Amazon Resource Name (ARN) of the secret.


### PR DESCRIPTION
### Description

Adds a note to the `aws_rds_cluster` to give a bit of clarity around usage of `master_user_secret`.

### Relations

Closes #38948

### References

[Schema](https://github.com/hashicorp/terraform-provider-aws/blob/67c89ea17c8ee0ec8d86af82a9ffbe6ffc2318e3/internal/service/rds/cluster.go#L308-L327)

### Output from Acceptance Testing

N/a, docs
