### PR TITLE
fix: fixed bug for aws_mq_broker simplified version RabbitMQ 3.13 and ActiveMQ 5.18

### DIFF
--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -352,7 +352,7 @@ func TestAccMQBroker_basic_simplified_version(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBrokerExists(ctx, resourceName, &broker),
 					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "mq", regexache.MustCompile(`broker:+.`)),
-					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "authentication_strategy", "simple"),
 					resource.TestCheckResourceAttr(resourceName, "broker_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", acctest.Ct1),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
fixed bug for aws_mq_broker that simplified version RabbitMQ 3.13 and ActiveMQ 5.18 change to their corresponding patch version


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38930

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
> Starting from RabbitMQ 3.13, Amazon MQ will manage patch version upgrades for your brokers. All brokers on version 3.13 will be automatically upgraded to the latest compatible and secure patch version in your scheduled maintenance window.

https://aws.amazon.com/about-aws/whats-new/2024/07/amazon-mq-rabbitmq-version-3-13/


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% PKG=mq make testacc TESTS=TestAccMQBroker_basic

% PKG=mq make testacc TESTS=TestAccMQBroker_RabbitMQ_basic

% PKG=mq make test
...
```
