### PR TITLE
lexmodels: Fix crash in sweepers

### DIFF
--- a/internal/service/lexmodels/sweep.go
+++ b/internal/service/lexmodels/sweep.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
@@ -44,204 +43,187 @@ func RegisterSweepers() {
 func sweepBotAliases(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-
+	input := &lexmodelbuildingservice.GetBotsInput{}
 	conn := client.LexModelsClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
-
-	input := &lexmodelbuildingservice.GetBotsInput{}
 
 	pages := lexmodelbuildingservice.NewGetBotsPaginator(conn, input)
-
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error listing Lex Bot Alias for %s: %w", region, err))
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Lex Bot Alias sweep for %s: %s", region, err)
+			return nil
 		}
 
-		for _, bot := range page.Bots {
+		if err != nil {
+			return fmt.Errorf("error listing Lex Bots (%s): %w", region, err)
+		}
+
+		for _, v := range page.Bots {
+			botName := aws.ToString(v.Name)
 			input := &lexmodelbuildingservice.GetBotAliasesInput{
-				BotName: bot.Name,
+				BotName: aws.String(botName),
 			}
 
 			pages := lexmodelbuildingservice.NewGetBotAliasesPaginator(conn, input)
-
 			for pages.HasMorePages() {
 				page, err := pages.NextPage(ctx)
 
-				if err != nil {
-					errs = multierror.Append(errs, fmt.Errorf("error listing Lex Bot Alias for %s: %w", region, err))
+				if awsv2.SkipSweepError(err) {
+					log.Printf("[WARN] Skipping Lex Bot Alias sweep for %s: %s", region, err)
+					return nil
 				}
 
-				for _, botAlias := range page.BotAliases {
+				if err != nil {
+					return fmt.Errorf("error listing Lex Bot Aliases (%s): %w", region, err)
+				}
+
+				for _, v := range page.BotAliases {
+					botAliasName := aws.ToString(v.Name)
 					r := resourceBotAlias()
 					d := r.Data(nil)
-
-					d.SetId(fmt.Sprintf("%s:%s", aws.ToString(bot.Name), aws.ToString(botAlias.Name)))
-					d.Set("bot_name", bot.Name)
-					d.Set(names.AttrName, botAlias.Name)
+					d.SetId(fmt.Sprintf("%s:%s", botName, botAliasName))
+					d.Set("bot_name", botName)
+					d.Set(names.AttrName, botAliasName)
 
 					sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 				}
 			}
-
-			r := resourceBotAlias()
-			d := r.Data(nil)
-
-			d.SetId(aws.ToString(bot.Name))
-
-			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 	}
 
-	if err = sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Bot Alias for %s: %w", region, err))
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Lex Bot Aliases (%s): %w", region, err)
 	}
 
-	if awsv2.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping Lex Bot Alias sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepBots(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-
+	input := &lexmodelbuildingservice.GetBotsInput{}
 	conn := client.LexModelsClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
-
-	input := &lexmodelbuildingservice.GetBotsInput{}
 
 	pages := lexmodelbuildingservice.NewGetBotsPaginator(conn, input)
-
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error listing Lex Bot for %s: %w", region, err))
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Lex Bot sweep for %s: %s", region, err)
+			return nil
 		}
 
-		for _, bot := range page.Bots {
+		if err != nil {
+			return fmt.Errorf("error listing Lex Bots (%s): %w", region, err)
+		}
+
+		for _, v := range page.Bots {
 			r := resourceBot()
 			d := r.Data(nil)
-
-			d.SetId(aws.ToString(bot.Name))
+			d.SetId(aws.ToString(v.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 	}
 
-	if err = sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Bot for %s: %w", region, err))
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Lex Bots (%s): %w", region, err)
 	}
 
-	if awsv2.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping Lex Bot sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepIntents(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-
+	input := &lexmodelbuildingservice.GetIntentsInput{}
 	conn := client.LexModelsClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
-
-	input := &lexmodelbuildingservice.GetIntentsInput{}
 
 	pages := lexmodelbuildingservice.NewGetIntentsPaginator(conn, input)
-
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error listing Lex Intent for %s: %w", region, err))
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Lex Intent sweep for %s: %s", region, err)
+			return nil
 		}
 
-		for _, intent := range page.Intents {
+		if err != nil {
+			return fmt.Errorf("error listing Lex Intents (%s): %w", region, err)
+		}
+
+		for _, v := range page.Intents {
 			r := resourceIntent()
 			d := r.Data(nil)
-
-			d.SetId(aws.ToString(intent.Name))
+			d.SetId(aws.ToString(v.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 	}
 
-	if err = sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Intent for %s: %w", region, err))
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Lex Intents (%s): %w", region, err)
 	}
 
-	if awsv2.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping Lex Intent sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }
 
 func sweepSlotTypes(region string) error {
 	ctx := sweep.Context(region)
 	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-
+	input := &lexmodelbuildingservice.GetSlotTypesInput{}
 	conn := client.LexModelsClient(ctx)
 	sweepResources := make([]sweep.Sweepable, 0)
-	var errs *multierror.Error
-
-	input := &lexmodelbuildingservice.GetSlotTypesInput{}
 
 	pages := lexmodelbuildingservice.NewGetSlotTypesPaginator(conn, input)
-
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("error listing Lex Slot Type for %s: %w", region, err))
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Lex Slot Type sweep for %s: %s", region, err)
+			return nil
 		}
 
-		for _, slotType := range page.SlotTypes {
+		if err != nil {
+			return fmt.Errorf("error listing Lex Slot Types (%s): %w", region, err)
+		}
+
+		for _, v := range page.SlotTypes {
 			r := resourceSlotType()
 			d := r.Data(nil)
-
-			d.SetId(aws.ToString(slotType.Name))
+			d.SetId(aws.ToString(v.Name))
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 	}
 
-	if err = sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("error sweeping Lex Slot Type for %s: %w", region, err))
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Lex Slot Types (%s): %w", region, err)
 	}
 
-	if awsv2.SkipSweepError(errs.ErrorOrNil()) {
-		log.Printf("[WARN] Skipping Lex Slot Type sweep for %s: %s", region, errs)
-		return nil
-	}
-
-	return errs.ErrorOrNil()
+	return nil
 }

--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -18,12 +18,11 @@ func SkipSweepError(err error) bool {
 		return dnsErr.IsNotFound
 	}
 
-	// Example (GovCloud): AccessDeniedException: Feature is not accessible
-	if tfawserr.ErrMessageContains(err, "AccessDeniedException", "Feature is not accessible") {
-		return true
-	}
-	// Example (GovCloud): AccessDeniedException: Unable to determine service/operation name to be authorized
-	if tfawserr.ErrMessageContains(err, "AccessDeniedException", "Unable to determine service/operation name to be authorized") {
+	// GovCloud has endpoints that respond with (no message provided):
+	// AccessDeniedException:
+	// Since acceptance test sweepers are best effort and this response is very common,
+	// we allow bypassing this error globally instead of individual test sweeper fixes.
+	if tfawserr.ErrCodeEquals(err, "AccessDeniedException") {
 		return true
 	}
 	// Example (GovCloud): AccessGrantsInstanceNotExistsError: Access Grants Instance does not exist


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes:

```
2024/08/23 10:40:01 [DEBUG] Running Sweeper (aws_lex_bot_alias) in region (us-gov-east-1)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10fcc0758]

goroutine 1 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/lexmodels.sweepBotAliases({0x16f6af72b, 0xd})
	/Users/kewbank/altsrc.2/github.com/hashicorp/terraform-provider-aws/internal/service/lexmodels/sweep.go:67 +0x1f8
github.com/hashicorp/terraform-plugin-testing/helper/resource.runSweeperWithRegion({0x16f6af72b, 0xd}, 0x140011486f0, 0x1400109bd40, 0x140012ed6b0, 0x0)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.10.0/helper/resource/testing.go:273 +0x42c
github.com/hashicorp/terraform-plugin-testing/helper/resource.runSweeperWithRegion({0x16f6af72b, 0xd}, 0x14001148780, 0x1400109bd40, 0x140012ed6b0, 0x0)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.10.0/helper/resource/testing.go:253 +0x164
github.com/hashicorp/terraform-plugin-testing/helper/resource.runSweeperWithRegion({0x16f6af72b, 0xd}, 0x140011489c0, 0x1400109bd40, 0x140012ed6b0, 0x0)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.10.0/helper/resource/testing.go:253 +0x164
github.com/hashicorp/terraform-plugin-testing/helper/resource.runSweepers({0x14000758240, 0x1, 0x1400109bd40?}, 0x1400109bd40, 0x0)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.10.0/helper/resource/testing.go:151 +0x42c
github.com/hashicorp/terraform-plugin-testing/helper/resource.TestMain({0x1165d7e48, 0x140014a4000})
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.10.0/helper/resource/testing.go:129 +0xf4
github.com/hashicorp/terraform-provider-aws/internal/sweep_test.TestMain(0x140014a4000)
	/Users/kewbank/altsrc.2/github.com/hashicorp/terraform-provider-aws/internal/sweep/sweep_test.go:21 +0x7c
main.main()
	_testmain.go:49 +0x170
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/38474.