### PR TITLE
chore(ci): notify and prioritize `crash` labeled issues

### DIFF
--- a/.github/workflows/label-notifications.yml
+++ b/.github/workflows/label-notifications.yml
@@ -24,7 +24,6 @@ jobs:
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         env:
           ISSUE_TITLE: ${{ toJSON(github.event.issue.title || github.event.pull_request.title) }}
-          LABEL_NAME: ${{ github.event.label.name }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL }}
@@ -35,7 +34,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":warning: The following has been labeled as a $LABEL_NAME:"
+                    "text": ":warning: The following has been labeled as a ${{ github.event.label.name }}:"
                   }
                 },
                 {

--- a/.github/workflows/label-notifications.yml
+++ b/.github/workflows/label-notifications.yml
@@ -1,4 +1,4 @@
-name: Handle Regressions
+name: Handle Label Notifications
 permissions: {}
 
 on:
@@ -12,8 +12,8 @@ on:
 
 jobs:
   process:
-    name: Process Regression
-    if: github.event.label.name == 'regression'
+    name: Process Label
+    if: github.event.label.name == 'regression' || github.event.label.name == 'crash'
     runs-on: ubuntu-latest
 
     env:
@@ -24,6 +24,7 @@ jobs:
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         env:
           ISSUE_TITLE: ${{ toJSON(github.event.issue.title || github.event.pull_request.title) }}
+          LABEL_NAME: ${{ github.event.label.name }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL }}
@@ -34,7 +35,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":warning: The following has been labeled as a regression:"
+                    "text": ":warning: The following has been labeled as a $LABEL_NAME:"
                   }
                 },
                 {


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change extends the existing workflow which prioritized issues labeled `regression`, including sending a slack notification. The workflow has been named more generically and completes the same steps for issues labeled `crash`.

