### PR TITLE
Add Team Working Board Composite Action

### DIFF
--- a/.github/actions/team_working_board/README.md
+++ b/.github/actions/team_working_board/README.md
@@ -1,0 +1,33 @@
+# Team Working Board
+
+Used to automate the AWS Provider Team's working board.
+
+## Usage
+
+### Inputs
+
+| Input | Required | Description |
+| ----- | -------- | ----------- |
+| `github_token | true | The token used to authenticate with the GitHub API |
+| `item_url` | true | The URL of the Issue or Pull Request |
+| `move_to_top` | false | Whether to move the item to the top of the list |
+| `status` | false | The Status the item should be set to |
+| `view` | false | The View the item should be assigned to |
+
+### Example
+
+```yaml
+steps:
+  - name: Checkout
+    uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    with:
+      sparse-checkout: .github/actions/team_working_board
+
+  - name: Add Issue to Working Board
+    uses: ./.github/actions/team_working_board
+    with:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+      item_url: ${{ github.event.pull_request.html_url }}
+      status: "To Do"
+      view: "working-board"
+```

--- a/.github/actions/team_working_board/README.md
+++ b/.github/actions/team_working_board/README.md
@@ -8,7 +8,7 @@ Used to automate the AWS Provider Team's working board.
 
 | Input | Required | Description |
 | ----- | -------- | ----------- |
-| `github_token | true | The token used to authenticate with the GitHub API |
+| `github_token` | true | The token used to authenticate with the GitHub API |
 | `item_url` | true | The URL of the Issue or Pull Request |
 | `move_to_top` | false | Whether to move the item to the top of the list |
 | `status` | false | The Status the item should be set to |

--- a/.github/actions/team_working_board/action.yml
+++ b/.github/actions/team_working_board/action.yml
@@ -1,0 +1,151 @@
+name: Team Working Board
+description: Manages an item within the AWS Provider Team's working board
+
+inputs:
+  github_token:
+    description: The token used to authenticate with the GitHub API
+    required: true
+
+  item_url:
+    description: The URL of the Issue or Pull Request
+    required: true
+
+  move_to_top:
+    description: Whether to move the item to the top of the list
+    required: false
+
+  status:
+    description: The Status the item should be set to
+    required: false
+
+  view:
+    description: The View the item should be assigned to
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Add Item to Working Board
+      id: add_to_board
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        echo "project_item_id=$(gh project item-add 196 --owner hashicorp --url ${{ inputs.item_url }} --format json --jq '.id')" >> $GITHUB_OUTPUT
+
+    - name: Move Item to Top of Working Board
+      if: inputs.move_to_top == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        gh api graphql \
+          --field itemId="${{ steps.add_to_board.outputs.project_item_id }}" \
+          --raw-field query='
+            mutation($itemId:ID!) {
+              updateProjectV2ItemPosition(input:{itemId:$itemId, projectId:"PVT_kwDOAAuecM4AF-7h"}) {
+                clientMutationId
+              }
+            }'
+
+    - name: Get Current Status
+      id: get_status
+      if: inputs.status != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        echo "current=$(gh api graphql \
+          --field node=${{ steps.add_to_board.outputs.project_item_id }} \
+          --raw-field query='
+            query($node: ID!) {
+              node(id: $node) {
+                ...on ProjectV2Item {
+                  fieldValueByName(name: "Status") {
+                    ...on ProjectV2ItemFieldSingleSelectValue {
+                      name
+                    }
+                  }
+                }
+              }
+            }' --jq '.data.node.fieldValueByName.name')" >> $GITHUB_OUTPUT
+
+    - name: Get Desired Status ID
+      id: status_id
+      if: |
+        inputs.status != ''
+        && inputs.status != steps.get_status.outputs.current
+      shell: bash
+      run: |
+        echo "desired=$(echo '{
+          "To Do": "f75ad846",
+          "In Progress": "47fc9ee4",
+          "Maintainer PR": "28a034bc",
+          "Pending Merge": "043bc06e",
+          "Waiting": "e85f2e5d",
+          "Done": "98236657"
+        }' | jq --exit-status --arg desired "${{ inputs.status }}" '.[$desired]')" >> $GITHUB_OUTPUT
+
+    - name: Update Status
+      if: |
+        inputs.status != ''
+        && inputs.status != steps.get_status.outputs.current
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        gh project item-edit \
+          --id "${{ steps.add_to_board.outputs.project_item_id }}" \
+          --project-id "PVT_kwDOAAuecM4AF-7h" \
+          --field-id "PVTSSF_lADOAAuecM4AF-7hzgDcsQA" \
+          --single-select-option-id "${{ steps.status_id.outputs.desired }}"
+
+    - name: Get Current View
+      id: get_view
+      if: inputs.view != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        echo "current=$(gh api graphql \
+          --field node=${{ steps.add_to_board.outputs.project_item_id }} \
+          --raw-field query='
+            query($node: ID!) {
+              node(id: $node) {
+                ...on ProjectV2Item {
+                  fieldValueByName(name: "View") {
+                    ...on ProjectV2ItemFieldSingleSelectValue {
+                      name
+                    }
+                  }
+                }
+              }
+            }' --jq '.data.node.fieldValueByName.name')" >> $GITHUB_OUTPUT
+
+    - name: Get Desired View ID
+      id: view_id
+      if: |
+        inputs.view != ''
+        && inputs.view != steps.get_view.outputs.current
+      shell: bash
+      run: |
+        echo "desired=$(echo '{
+          "working-board": "8d366764",
+          "engineering-initiative": "a62d09b9"
+        }' | jq --exit-status --arg desired "${{ inputs.view }}" '.[$desired]')" >> $GITHUB_OUTPUT
+
+    - name: Update View
+      if: |
+        inputs.view != ''
+        && inputs.view != steps.get_view.outputs.current
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        view_option_id="$(| jq --exit-status --arg desired "${{ inputs.view }}" '.[$desired]')"
+
+        gh project item-edit \
+          --id "${{ steps.add_to_board.outputs.project_item_id }}" \
+          --project-id "PVT_kwDOAAuecM4AF-7h" \
+          --field-id "PVTSSF_lADOAAuecM4AF-7hzgMRB34" \
+          --single-select-option-id "${{ steps.view_id.outputs.desired }}"

--- a/.github/actions/team_working_board/action.yml
+++ b/.github/actions/team_working_board/action.yml
@@ -142,8 +142,6 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
       run: |
-        view_option_id="$(| jq --exit-status --arg desired "${{ inputs.view }}" '.[$desired]')"
-
         gh project item-edit \
           --id "${{ steps.add_to_board.outputs.project_item_id }}" \
           --project-id "PVT_kwDOAAuecM4AF-7h" \

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -147,6 +147,7 @@ jobs:
         uses: ./.github/actions/team_working_board
         with:
           github_token: ${{ steps.token.outputs.token }}
+          item_url: ${{ github.event.pull_request.html_url }}
           status: "Maintainer PR"
           view: "working-board"
 
@@ -157,6 +158,7 @@ jobs:
         uses: ./.github/actions/team_working_board
         with:
           github_token: ${{ steps.token.outputs.token }}
+          item_url: ${{ github.event.pull_request.html_url }}
           status: "In Progress"
           view: "working-board"
 
@@ -165,6 +167,7 @@ jobs:
         uses: ./.github/actions/team_working_board
         with:
           github_token: ${{ steps.token.outputs.token }}
+          item_url: ${{ github.event.pull_request.html_url }}
           view: "working-board"
 
       - name: Labeled Engineering Initiative
@@ -172,6 +175,7 @@ jobs:
         uses: ./.github/actions/team_working_board
         with:
           github_token: ${{ steps.token.outputs.token }}
+          item_url: ${{ github.event.pull_request.html_url }}
           view: "engineering-initiative"
 
   add_to_milestone:

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -119,13 +119,6 @@ jobs:
   project:
     name: Maintainer Work Board
     runs-on: ubuntu-latest
-    env:
-      # Some gh project calls take the project's ID, some take the project's number
-      PROJECT_ID: "PVT_kwDOAAuecM4AF-7h"
-      PROJECT_NUMBER: "196"
-      STATUS_FIELD_ID: "PVTSSF_lADOAAuecM4AF-7hzgDcsQA"
-      VIEW_FIELD_ID: "PVTSSF_lADOAAuecM4AF-7hzgMRB34"
-
     steps:
       - name: Generate GitHub App Token
         id: token
@@ -137,7 +130,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          sparse-checkout: .github/actions/community_check
+          sparse-checkout: .github/actions/
 
       - name: Community Check
         id: community_check
@@ -151,40 +144,35 @@ jobs:
         if: |
           github.event.action == 'opened'
           && steps.community_check.outputs.maintainer == 'true'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          # In order to update the item's Status field, we need to capture the project item id from the output
-          PROJECT_ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "hashicorp" --url "$ISSUE_URL" --format json | jq '.id')
-          gh project item-edit --id "$PROJECT_ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id ${{ vars.team_project_status_maintainer_pr }}
-          gh project item-edit --id "$PROJECT_ITEM_ID" --project-id "$PROJECT_ID" --field-id "$VIEW_FIELD_ID "--single-select-option-id ${{ vars.team_project_view_working_board }}
+        uses: ./.github/actions/team_working_board
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+          status: "Maintainer PR"
+          view: "working-board"
 
       - name: Assigned to Maintainers
         if: |
           github.event.action == 'assigned'
           && steps.community_check.outputs.maintainer == 'true'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          PROJECT_ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "hashicorp" --url "$ISSUE_URL" --format json | jq '.id')
-          gh project item-edit --id "$PROJECT_ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id ${{ vars.team_project_status_in_progress }}
-          gh project item-edit --id "$PROJECT_ITEM_ID" --project-id "$PROJECT_ID" --field-id "$VIEW_FIELD_ID" --single-select-option-id ${{ vars.team_project_view_working_board }}
+        uses: ./.github/actions/team_working_board
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+          status: "In Progress"
+          view: "working-board"
 
       - name: Labeled Prioritized
         if: github.event.label.name == 'prioritized'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          PROJECT_ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "hashicorp" --url "$ISSUE_URL" --format json | jq '.id')
-          gh project item-edit --id "$PROJECT_ITEM_ID" --project-id "$PROJECT_ID" --field-id "$VIEW_FIELD_ID" --single-select-option-id ${{ vars.team_project_view_working_board }}
+        uses: ./.github/actions/team_working_board
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+          view: "working-board"
 
       - name: Labeled Engineering Initiative
         if: github.event.label.name == 'engineering-initiative'
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          PROJECT_ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "hashicorp" --url "$ISSUE_URL" --format json | jq '.id')
-          gh project item-edit --id "$PROJECT_ITEM_ID" --project-id "$PROJECT_ID" --field-id "$VIEW_FIELD_ID" --single-select-option-id ${{ vars.team_project_view_engineering_initiative }}
+        uses: ./.github/actions/team_working_board
+        with:
+          github_token: ${{ steps.token.outputs.token }}
+          view: "engineering-initiative"
 
   add_to_milestone:
     name: Add Merged Pull Requests and Related Issues to Milestone


### PR DESCRIPTION
### Description

Adds a new Composite Action to automate the team's working board. This lets us add logic to prevent no-op calls to `gh project item-edit` that have been failing lately. Bonus points, it cleans up the calling workflow files quite a bit, and will allow us to remove some of the infrastructure around the working board variables.

I used `act` to test locally using my test project, so it wasn't perfectly 1:1, but it worked. Since I'm not able to test this particularly well locally, I only moved `pull_request_target.yml` over to the new composite action, until we validate it.