### PR TITLE
r/aws_gamelift_game_server_group: fix crash reading group with nil ASG ARN

### DIFF
--- a/.changelog/39022.txt
+++ b/.changelog/39022.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_gamelift_game_server_group: Fix crash while reading server group with a nil auto scaling group ARN
+```


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The read operation assumed a non-`nil` value for the `AutoScalingGroupArn` field in the Describe API response. This field may be `nil` if the scaling group cannot be created or is deleted out of band. Previously, when a `nil` value was returned, the provider attempted to split the result to retrieve the name of the auto scaling group from the full ARN, resulting in an `index out of range` panic when referencing the second item of the split function.

The read operation now ensures the `AutoScalingGroupArn` field is not `nil` and can be split into the appropriate number of parts before attempting to complete subsequent read operations on the auto scaling group. When `nil`, these read operations are skipped entirely.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29759



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->



```console
% make testacc PKG=gamelift TESTS=TestAccGameLiftGameServerGroup_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/gamelift/... -v -count 1 -parallel 20 -run='TestAccGameLiftGameServerGroup_'  -timeout 360m

--- PASS: TestAccGameLiftGameServerGroup_InstanceDefinition (211.70s)
--- PASS: TestAccGameLiftGameServerGroup_InstanceDefinition_WeightedCapacity (223.88s)
--- PASS: TestAccGameLiftGameServerGroup_LaunchTemplate_Id (246.89s)
--- PASS: TestAccGameLiftGameServerGroup_AutoScalingPolicy_EstimatedInstanceWarmup (248.01s)
--- PASS: TestAccGameLiftGameServerGroup_GameServerProtectionPolicy (274.38s)
--- PASS: TestAccGameLiftGameServerGroup_BalancingStrategy (277.45s)
--- PASS: TestAccGameLiftGameServerGroup_basic (279.24s)
--- PASS: TestAccGameLiftGameServerGroup_LaunchTemplate_Version (282.54s)
--- PASS: TestAccGameLiftGameServerGroup_roleARN (287.50s)
--- PASS: TestAccGameLiftGameServerGroup_LaunchTemplate_Name (293.63s)
--- PASS: TestAccGameLiftGameServerGroup_AutoScalingPolicy (333.94s)
--- PASS: TestAccGameLiftGameServerGroup_MinSize (362.83s)
--- PASS: TestAccGameLiftGameServerGroup_vpcSubnets (402.18s)
--- PASS: TestAccGameLiftGameServerGroup_GameServerGroupName (465.44s)
--- PASS: TestAccGameLiftGameServerGroup_MaxSize (676.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/gamelift   682.783s
```
