### PR TITLE
b/aws_lakeformation_permissions: properly remove data cells filters

### DIFF
--- a/internal/service/lakeformation/permissions.go
+++ b/internal/service/lakeformation/permissions.go
@@ -756,6 +756,10 @@ func resourcePermissionsDelete(ctx context.Context, d *schema.ResourceData, meta
 		input.Resource.Catalog = ExpandCatalogResource()
 	}
 
+	if v, ok := d.GetOk("data_cells_filter"); ok {
+		input.Resource.DataCellsFilter = ExpandDataCellsFilter(v.([]interface{}))
+	}
+
 	if v, ok := d.GetOk("data_location"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 		input.Resource.DataLocation = ExpandDataLocationResource(v.([]interface{})[0].(map[string]interface{}))
 	}
@@ -814,6 +818,10 @@ func resourcePermissionsDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "cannot grant/revoke permission on non-existent column") {
+		return diags
+	}
+
+	if errs.IsAErrorMessageContains[*awstypes.InvalidInputException](err, "Cell Filter not found") {
 		return diags
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Resource did not properly delete when removed from config, for example, with a block comment.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:


--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccLakeFormation_serial/PermissionsBasic/dataCellsFilter" PKG=lakeformation

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/lakeformation/... -v -count 1 -parallel 20  -run=TestAccLakeFormation_serial/PermissionsBasic/dataCellsFilter -timeout 360m
--- PASS: TestAccLakeFormation_serial (17.81s)
    --- PASS: TestAccLakeFormation_serial/PermissionsBasic (17.81s)
        --- PASS: TestAccLakeFormation_serial/PermissionsBasic/dataCellsFilter (17.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	23.899s
```
