### PR TITLE
r/aws_osis_pipeline: add `vpc_attachment_options` and `vpc_endpoint_management` options

### DIFF
--- a/.changelog/39030.txt
+++ b/.changelog/39030.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_osis_pipeline: add `vpc_attachment_options` and `vpc_endpoint_management` options
+```

--- a/internal/service/osis/pipeline.go
+++ b/internal/service/osis/pipeline.go
@@ -527,6 +527,13 @@ type cloudWatchLogDestinationModel struct {
 }
 
 type vpcOptionsModel struct {
-	SecurityGroupIDs fwtypes.SetValueOf[types.String] `tfsdk:"security_group_ids"`
-	SubnetIDs        fwtypes.SetValueOf[types.String] `tfsdk:"subnet_ids"`
+	SecurityGroupIDs      fwtypes.SetValueOf[types.String]                           `tfsdk:"security_group_ids"`
+	SubnetIDs             fwtypes.SetValueOf[types.String]                           `tfsdk:"subnet_ids"`
+	VpcAttachmentOptions  fwtypes.ListNestedObjectValueOf[vpcAttachmentOptionsModel] `tfsdk:"vpc_attachment_options"`
+	VpcEndpointManagement types.String                                               `tfsdk:"vpc_endpoint_management"`
+}
+
+type vpcAttachmentOptionsModel struct {
+	AttachToVpc types.Bool   `tfsdk:"attach_to_vpc"`
+	CidrBlock   types.String `tfsdk:"cidr_block"`
 }

--- a/internal/service/osis/pipeline_test.go
+++ b/internal/service/osis/pipeline_test.go
@@ -230,6 +230,9 @@ func TestAccOpenSearchIngestionPipeline_vpc(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_options.0.security_group_ids.0"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_options.0.subnet_ids.#", acctest.Ct1),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_options.0.subnet_ids.0"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_options.0.vpc_attachment_options.#", acctest.Ct1),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_options.0.vpc_attachment_options.0"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_options.0.vpc_endpoint_management", "CUSTOMER"),
 				),
 			},
 			{
@@ -725,6 +728,11 @@ resource "aws_osis_pipeline" "test" {
   vpc_options {
     security_group_ids = [aws_security_group.test.id]
     subnet_ids         = [aws_subnet.test.id]
+	vpc_attachment_options = {
+		attach_to_vpc = false
+		cidr_block = "10.0.1.0/24"
+	}
+	vpc_endpoint_management = "CUSTOMER"
   }
 }
 `, rName)

--- a/internal/service/osis/pipeline_test.go
+++ b/internal/service/osis/pipeline_test.go
@@ -728,11 +728,11 @@ resource "aws_osis_pipeline" "test" {
   vpc_options {
     security_group_ids = [aws_security_group.test.id]
     subnet_ids         = [aws_subnet.test.id]
-	vpc_attachment_options = {
+    vpc_attachment_options = {
 		attach_to_vpc = false
 		cidr_block = "10.0.1.0/24"
 	}
-	vpc_endpoint_management = "CUSTOMER"
+    vpc_endpoint_management = "CUSTOMER"
   }
 }
 `, rName)

--- a/internal/service/osis/pipeline_test.go
+++ b/internal/service/osis/pipeline_test.go
@@ -729,8 +729,8 @@ resource "aws_osis_pipeline" "test" {
     security_group_ids = [aws_security_group.test.id]
     subnet_ids         = [aws_subnet.test.id]
     vpc_attachment_options = {
-		attach_to_vpc = false
-		cidr_block = "10.0.1.0/24"
+        attach_to_vpc = false
+        cidr_block = "10.0.1.0/24"
 	}
     vpc_endpoint_management = "CUSTOMER"
   }

--- a/internal/service/osis/pipeline_test.go
+++ b/internal/service/osis/pipeline_test.go
@@ -731,7 +731,7 @@ resource "aws_osis_pipeline" "test" {
     vpc_attachment_options = {
         attach_to_vpc = false
         cidr_block = "10.0.1.0/24"
-	}
+    }
     vpc_endpoint_management = "CUSTOMER"
   }
 }

--- a/website/docs/cdktf/python/r/osis_pipeline.html.markdown
+++ b/website/docs/cdktf/python/r/osis_pipeline.html.markdown
@@ -116,6 +116,8 @@ The following arguments are optional:
 
 * `subnet_ids` - (Required) A list of subnet IDs associated with the VPC endpoint.
 * `security_group_ids` - (Optional) A list of security groups associated with the VPC endpoint.
+* `vpc_attachment_options` - (Optional) Options for attaching a VPC to a pipeline.
+* `vpc_endpoint_management` - (Optional) Defines whether you or Amazon OpenSearch Ingestion service create and manage the VPC endpoint configured for the pipeline. Allowed values: `CUSTOMER | SERVICE`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- Added the missing configs to `aws_osis_pipeline` as described in https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-osis-pipeline-vpcoptions.html


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38962


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
