### PR TITLE
docs: add missing types for keyword_input in auditmanager control

### DIFF
--- a/website/docs/r/auditmanager_control.html.markdown
+++ b/website/docs/r/auditmanager_control.html.markdown
@@ -60,7 +60,7 @@ The following arguments are optional:
 
 The following arguments are required:
 
-* `keyword_input_type` - (Required) Input method for the keyword. Valid values are `SELECT_FROM_LIST`.
+* `keyword_input_type` - (Required) Input method for the keyword. Valid values are `INPUT_TEXT`, `SELECT_FROM_LIST`, or `UPLOAD_FILE`.
 * `keyword_value` - (Required) The value of the keyword that's used when mapping a control data source. For example, this can be a CloudTrail event name, a rule name for Config, a Security Hub control, or the name of an Amazon Web Services API call. See the [Audit Manager supported control data sources documentation](https://docs.aws.amazon.com/audit-manager/latest/userguide/control-data-sources.html) for more information.
 
 ## Attribute Reference


### PR DESCRIPTION
### Description

Add two missing values for the attribute `keyword_input_type` of resource `auditmanager`.

### Relations

Closes #39020 

### References

- [Audit Manager API Reference](https://docs.aws.amazon.com/audit-manager/latest/APIReference/API_SourceKeyword.html#API_SourceKeyword_Contents)  
showing the three supported values for `keywordInputType`

- [Definition of `KeywordInputType` in AWS SDK Go v2](https://github.com/aws/aws-sdk-go-v2/blob/84ca95e16adf482b8a80069d5ffa85814c7f61a2/service/auditmanager/types/types.go#L1636)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.