### PR TITLE
r/aws_elbv2_listener: fix crash reading forward action

### DIFF
--- a/.changelog/39039.txt
+++ b/.changelog/39039.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elbv2_listener: Fix crash when reading forward actions not configured in state
+```

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -1020,7 +1020,7 @@ func flattenLbForwardAction(d *schema.ResourceData, attrName string, i int, awsA
 	}
 
 	if rawState := d.GetRawState(); rawState.IsKnown() && !rawState.IsNull() {
-		if defaultActions := rawState.GetAttr(attrName); defaultActions.LengthInt() > 0 {
+		if defaultActions := rawState.GetAttr(attrName); defaultActions.IsKnown() && !defaultActions.IsNull() && defaultActions.LengthInt() > 0 {
 			flattenLbForwardActionOneOf(defaultActions, i, awsAction, actionMap)
 			return
 		}


### PR DESCRIPTION




<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds a check to the `flattenLbForwardAction` function to verify the default actions attribute is known and not null before checking the length. Previously the length was checked without verifying the attribute was known, potentially resulting in a crash during read operations.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39031


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elbv2 TESTS=TestAccELBV2Listener_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2Listener_'  -timeout 360m

--- PASS: TestAccELBV2Listener_mutualAuthenticationPassthrough (227.28s)
=== CONT  TestAccELBV2Listener_ActionForward_ForwardBlock_AddStickiness
--- PASS: TestAccELBV2Listener_mutualAuthentication (229.83s)
=== CONT  TestAccELBV2Listener_forwardTargetARNAndBlock
--- PASS: TestAccELBV2Listener_oidc (241.32s)
=== CONT  TestAccELBV2Listener_forwardWeighted
--- PASS: TestAccELBV2Listener_ActionForward_TargetGroupARNToForwardBlock_WeightAndStickiness (244.97s)
=== CONT  TestAccELBV2Listener_updateForwardBasic
--- PASS: TestAccELBV2Listener_ActionForward_ForwardBlockToTargetGroupARN_NoChanges (246.47s)
=== CONT  TestAccELBV2Listener_disappears
--- PASS: TestAccELBV2Listener_tags_DefaultTags_nullOverlappingResourceTag (249.45s)
=== CONT  TestAccELBV2Listener_Gateway_basic
--- PASS: TestAccELBV2Listener_tags_DefaultTags_emptyProviderOnlyTag (252.40s)
=== CONT  TestAccELBV2Listener_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccELBV2Listener_DefaultAction_specifyOrder (253.34s)
=== CONT  TestAccELBV2Listener_Application_basic
--- PASS: TestAccELBV2Listener_Protocol_upd (255.67s)
=== CONT  TestAccELBV2Listener_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccELBV2Listener_backwardsCompatibility (256.87s)
=== CONT  TestAccELBV2Listener_tags_ComputedTag_OnCreate
--- PASS: TestAccELBV2Listener_ActionForward_ForwardBlockToTargetGroupARN_WeightAndStickiness (258.95s)
=== CONT  TestAccELBV2Listener_DefaultAction_defaultOrder
--- PASS: TestAccELBV2Listener_ActionForward_ForwardBlock_RemoveStickiness (262.88s)
=== CONT  TestAccELBV2Listener_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccELBV2Listener_DefaultAction_actionDisappears (266.71s)
=== CONT  TestAccELBV2Listener_ActionForward_IgnoreFields
--- PASS: TestAccELBV2Listener_ActionForward_TargetGroupARNToForwardBlock_NoChanges (270.91s)
=== CONT  TestAccELBV2Listener_redirect
--- PASS: TestAccELBV2Listener_Network_basic (272.20s)
=== CONT  TestAccELBV2Listener_cognito
--- PASS: TestAccELBV2Listener_ActionForward_ForwardBlock_RemoveAction (274.75s)
=== CONT  TestAccELBV2Listener_fixedResponse
--- PASS: TestAccELBV2Listener_tags (275.54s)
=== CONT  TestAccELBV2Listener_tags_DefaultTags_providerOnly
--- PASS: TestAccELBV2Listener_Protocol_https (280.82s)
=== CONT  TestAccELBV2Listener_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccELBV2Listener_ActionForward_ForwardBlock_AddAction (297.53s)
=== CONT  TestAccELBV2Listener_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccELBV2Listener_redirectWithTargetGroupARN (325.95s)
=== CONT  TestAccELBV2Listener_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccELBV2Listener_forwardTargetARNAndBlock (192.93s)
=== CONT  TestAccELBV2Listener_tags_DefaultTags_overlapping
--- PASS: TestAccELBV2Listener_Gateway_basic (189.50s)
=== CONT  TestAccELBV2Listener_tags_DefaultTags_nonOverlapping
--- PASS: TestAccELBV2Listener_ActionForward_ForwardBlock_AddStickiness (222.54s)
=== CONT  TestAccELBV2Listener_Protocol_tls
--- PASS: TestAccELBV2Listener_tags_ComputedTag_OnCreate (201.74s)
=== CONT  TestAccELBV2Listener_tags_EmptyTag_OnCreate
--- PASS: TestAccELBV2Listener_Application_basic (207.93s)
=== CONT  TestAccELBV2Listener_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccELBV2Listener_updateForwardBasic (220.31s)
=== CONT  TestAccELBV2Listener_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccELBV2Listener_disappears (224.12s)
=== CONT  TestAccELBV2Listener_tags_AddOnUpdate
--- PASS: TestAccELBV2Listener_tags_DefaultTags_nullNonOverlappingResourceTag (210.19s)
=== CONT  TestAccELBV2Listener_tags_null
--- PASS: TestAccELBV2Listener_DefaultAction_defaultOrder (217.43s)
=== CONT  TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer
--- PASS: TestAccELBV2Listener_tags_ComputedTag_OnUpdate_Add (230.66s)
=== CONT  TestAccELBV2Listener_EmptyDefaultAction/authenticate-cognito
--- PASS: TestAccELBV2Listener_tags_ComputedTag_OnUpdate_Replace (228.55s)
=== CONT  TestAccELBV2Listener_EmptyDefaultAction/authenticate-oidc
=== CONT  TestAccELBV2Listener_EmptyDefaultAction/forward
=== CONT  TestAccELBV2Listener_EmptyDefaultAction/fixed-response
=== CONT  TestAccELBV2Listener_EmptyDefaultAction/redirect
--- PASS: TestAccELBV2Listener_EmptyDefaultAction (0.00s)
    --- PASS: TestAccELBV2Listener_EmptyDefaultAction/authenticate-cognito (1.63s)
    --- PASS: TestAccELBV2Listener_EmptyDefaultAction/authenticate-oidc (1.87s)
    --- PASS: TestAccELBV2Listener_EmptyDefaultAction/forward (1.70s)
    --- PASS: TestAccELBV2Listener_EmptyDefaultAction/fixed-response (1.68s)
    --- PASS: TestAccELBV2Listener_EmptyDefaultAction/redirect (1.61s)
--- PASS: TestAccELBV2Listener_ActionForward_IgnoreFields (221.61s)
--- PASS: TestAccELBV2Listener_redirect (221.82s)
--- PASS: TestAccELBV2Listener_fixedResponse (218.53s)
--- PASS: TestAccELBV2Listener_cognito (227.62s)
--- PASS: TestAccELBV2Listener_forwardWeighted (259.11s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_emptyResourceTag (221.82s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_updateToResourceOnly (257.67s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_updateToProviderOnly (255.03s)
--- PASS: TestAccELBV2Listener_LoadBalancerARN_gatewayLoadBalancer (155.57s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_providerOnly (367.38s)
--- PASS: TestAccELBV2Listener_tags_null (204.67s)
--- PASS: TestAccELBV2Listener_tags_EmptyTag_OnUpdate_Replace (220.60s)
--- PASS: TestAccELBV2Listener_tags_EmptyTag_OnCreate (233.93s)
--- PASS: TestAccELBV2Listener_tags_AddOnUpdate (224.94s)
--- PASS: TestAccELBV2Listener_tags_EmptyTag_OnUpdate_Add (240.76s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_overlapping (307.22s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_nonOverlapping (310.24s)
--- PASS: TestAccELBV2Listener_Protocol_tls (426.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      884.767s
```
