### PR TITLE
r/aws_amplify_app: fix crash updating `auto_branch_creation_config`

### DIFF
--- a/.changelog/39041.txt
+++ b/.changelog/39041.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_amplify_app: Fix crash updating `auto_branch_creation_config`
+```

--- a/internal/service/amplify/app.go
+++ b/internal/service/amplify/app.go
@@ -456,11 +456,13 @@ func resourceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 
 		if d.HasChange("auto_branch_creation_config") {
-			input.AutoBranchCreationConfig = expandAutoBranchCreationConfig(d.Get("auto_branch_creation_config").([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.Get("auto_branch_creation_config").([]interface{}); ok && len(v) > 0 && v[0] != nil {
+				input.AutoBranchCreationConfig = expandAutoBranchCreationConfig(v[0].(map[string]interface{}))
 
-			if d.HasChange("auto_branch_creation_config.0.environment_variables") {
-				if v := d.Get("auto_branch_creation_config.0.environment_variables").(map[string]interface{}); len(v) == 0 {
-					input.AutoBranchCreationConfig.EnvironmentVariables = map[string]string{"": ""}
+				if d.HasChange("auto_branch_creation_config.0.environment_variables") {
+					if v, ok := d.Get("auto_branch_creation_config.0.environment_variables").(map[string]interface{}); ok && len(v) == 0 {
+						input.AutoBranchCreationConfig.EnvironmentVariables = map[string]string{"": ""}
+					}
 				}
 			}
 		}


### PR DESCRIPTION





<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The update operation was missing the appropriate checks to ensure nil values were not passed into the expander function.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29691


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=amplify TESTS=TestAccAmplify_serial/App
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/amplify/... -v -count 1 -parallel 20 -run='TestAccAmplify_serial/App'  -timeout 360m

--- FAIL: TestAccAmplify_serial (7326.08s)
    --- FAIL: TestAccAmplify_serial/App (7326.08s)
        --- PASS: TestAccAmplify_serial/App/tags (5258.13s)
            --- PASS: TestAccAmplify_serial/App/tags/EmptyTag_OnCreate (292.74s)
            --- PASS: TestAccAmplify_serial/App/tags/DefaultTags_providerOnly (311.60s)
            --- PASS: TestAccAmplify_serial/App/tags/DefaultTags_nonOverlapping (302.30s)
            --- PASS: TestAccAmplify_serial/App/tags/DefaultTags_nullOverlappingResourceTag (282.80s)
            --- PASS: TestAccAmplify_serial/App/tags/basic (310.23s)
            --- PASS: TestAccAmplify_serial/App/tags/EmptyTag_OnUpdate_Add (299.40s)
            --- PASS: TestAccAmplify_serial/App/tags/EmptyTag_OnUpdate_Replace (289.53s)
            --- PASS: TestAccAmplify_serial/App/tags/DefaultTags_overlapping (303.28s)
            --- PASS: TestAccAmplify_serial/App/tags/DefaultTags_updateToProviderOnly (290.14s)
            --- PASS: TestAccAmplify_serial/App/tags/DefaultTags_emptyResourceTag (282.28s)
            --- PASS: TestAccAmplify_serial/App/tags/DefaultTags_nullNonOverlappingResourceTag (283.03s)
            --- PASS: TestAccAmplify_serial/App/tags/ComputedTag_OnCreate (293.87s)
            --- PASS: TestAccAmplify_serial/App/tags/null (284.63s)
            --- PASS: TestAccAmplify_serial/App/tags/ComputedTag_OnUpdate_Replace (292.53s)
            --- PASS: TestAccAmplify_serial/App/tags/ComputedTag_OnUpdate_Add (291.90s)
            --- PASS: TestAccAmplify_serial/App/tags/DefaultTags_updateToResourceOnly (288.73s)
            --- PASS: TestAccAmplify_serial/App/tags/AddOnUpdate (289.13s)
        --- FAIL: TestAccAmplify_serial/App/AutoBranchCreationConfig (14.44s)
        --- FAIL: TestAccAmplify_serial/App/BasicAuthCredentials (6.04s)
        --- FAIL: TestAccAmplify_serial/App/EnvironmentVariables (19.97s)
        --- SKIP: TestAccAmplify_serial/App/Repository (0.00s)
        --- PASS: TestAccAmplify_serial/App/basic (280.71s)
        --- PASS: TestAccAmplify_serial/App/BuildSpec (292.99s)
        --- PASS: TestAccAmplify_serial/App/CustomRules (295.51s)
        --- PASS: TestAccAmplify_serial/App/Description (294.85s)
        --- PASS: TestAccAmplify_serial/App/IamServiceRole (296.00s)
        --- PASS: TestAccAmplify_serial/App/Name (287.57s)
        --- PASS: TestAccAmplify_serial/App/disappears (279.85s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/amplify    7332.066s
```

Test failures are pre-existing and present in CI, not a related to this change.