### PR TITLE
r/aws_glue_catalog_table_optimizer: add disappears test

### DIFF
--- a/internal/service/glue/catalog_table_optimizer.go
+++ b/internal/service/glue/catalog_table_optimizer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
@@ -173,6 +174,12 @@ func (r *resourceCatalogTableOptimizer) Read(ctx context.Context, request resour
 	}
 
 	output, err := findCatalogTableOptimizer(ctx, conn, data.CatalogID.ValueString(), data.DatabaseName.ValueString(), data.TableName.ValueString(), data.Type.ValueString())
+
+	if tfresource.NotFound(err) {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+		return
+	}
 
 	if err != nil {
 		id, _ := flex.FlattenResourceId([]string{

--- a/internal/service/glue/catalog_table_optimizer_test.go
+++ b/internal/service/glue/catalog_table_optimizer_test.go
@@ -97,6 +97,32 @@ func testAccCatalogTableOptimizer_update(t *testing.T) {
 	})
 }
 
+func testAccCatalogTableOptimizer_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var catalogTableOptimizer glue.GetTableOptimizerOutput
+
+	resourceName := "aws_glue_catalog_table_optimizer.test"
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckCatalogTableOptimizerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTableOptimizerConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCatalogTableOptimizerExists(ctx, resourceName, &catalogTableOptimizer),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfglue.ResourceCatalogTableOptimizer, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCatalogTableOptimizerStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/internal/service/glue/glue_test.go
+++ b/internal/service/glue/glue_test.go
@@ -14,8 +14,9 @@ func TestAccGlue_serial(t *testing.T) {
 
 	testCases := map[string]map[string]func(t *testing.T){
 		"CatalogTableOptimizer": {
-			acctest.CtBasic: testAccCatalogTableOptimizer_basic,
-			"update":        testAccCatalogTableOptimizer_update,
+			acctest.CtBasic:      testAccCatalogTableOptimizer_basic,
+			"update":             testAccCatalogTableOptimizer_update,
+			acctest.CtDisappears: testAccCatalogTableOptimizer_disappears,
 		},
 		"DataCatalogEncryptionSettings": {
 			acctest.CtBasic: testAccDataCatalogEncryptionSettings_basic,

--- a/internal/service/glue/glue_test.go
+++ b/internal/service/glue/glue_test.go
@@ -15,8 +15,8 @@ func TestAccGlue_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"CatalogTableOptimizer": {
 			acctest.CtBasic:      testAccCatalogTableOptimizer_basic,
-			"update":             testAccCatalogTableOptimizer_update,
 			acctest.CtDisappears: testAccCatalogTableOptimizer_disappears,
+			"update":             testAccCatalogTableOptimizer_update,
 		},
 		"DataCatalogEncryptionSettings": {
 			acctest.CtBasic: testAccDataCatalogEncryptionSettings_basic,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:


--->

Relates #38052

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccGlue_serial/CatalogTableOptimizer/' PKG=glue

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/glue/... -v -count 1 -parallel 20  -run=TestAccGlue_serial/CatalogTableOptimizer/ -timeout 360m
=== RUN   TestAccGlue_serial
=== PAUSE TestAccGlue_serial
=== CONT  TestAccGlue_serial
=== RUN   TestAccGlue_serial/CatalogTableOptimizer
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/disappears
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/basic
=== RUN   TestAccGlue_serial/CatalogTableOptimizer/update
=== PAUSE TestAccGlue_serial/CatalogTableOptimizer/update
=== CONT  TestAccGlue_serial/CatalogTableOptimizer/update
--- PASS: TestAccGlue_serial (92.40s)
    --- PASS: TestAccGlue_serial/CatalogTableOptimizer (55.91s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/disappears (27.29s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/basic (28.62s)
        --- PASS: TestAccGlue_serial/CatalogTableOptimizer/update (36.49s)
PASS
```
