### PR TITLE
feat: Add password_policy.password_history_size arg for aws_cognito_user_pool

### DIFF
--- a/.changelog/39043.txt
+++ b/.changelog/39043.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_user_pool: Add `password_policy.password_history_size` argument 
+```

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -386,6 +386,11 @@ func resourceUserPool() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(6, 99),
 						},
+						"password_history_size": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 24),
+						},
 						"require_lowercase": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -405,6 +410,7 @@ func resourceUserPool() *schema.Resource {
 						"temporary_password_validity_days": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.IntBetween(0, 365),
 						},
 					},
@@ -1589,6 +1595,10 @@ func expandPasswordPolicyType(tfMap map[string]interface{}) *awstypes.PasswordPo
 		apiObject.MinimumLength = aws.Int32(int32(v.(int)))
 	}
 
+	if v, ok := tfMap["password_history_size"]; ok {
+		apiObject.PasswordHistorySize = aws.Int32(int32(v.(int)))
+	}
+
 	if v, ok := tfMap["require_lowercase"]; ok {
 		apiObject.RequireLowercase = v.(bool)
 	}
@@ -1884,6 +1894,10 @@ func flattenPasswordPolicyType(apiObject *awstypes.PasswordPolicyType) []interfa
 
 	if apiObject.MinimumLength != nil {
 		tfMap["minimum_length"] = aws.ToInt32(apiObject.MinimumLength)
+	}
+
+	if apiObject.PasswordHistorySize != nil {
+		tfMap["password_history_size"] = aws.ToInt32(apiObject.PasswordHistorySize)
 	}
 
 	if len(tfMap) > 0 {

--- a/website/docs/r/cognito_user_pool.html.markdown
+++ b/website/docs/r/cognito_user_pool.html.markdown
@@ -158,6 +158,9 @@ The following arguments are optional:
 ### password_policy
 
 * `minimum_length` - (Optional) Minimum length of the password policy that you have set.
+* `password_history_size` - (Optional) Number of previous passwords that you want Amazon Cognito to restrict each user from reusing. Users can't set a password that matches any of number of previous passwords specified by this argument. A value of 0 means that password history is not enforced. Valid values are between 0 and 24.
+
+  **Note:** This argument requires advanced security features to be active in the user pool.
 * `require_lowercase` - (Optional) Whether you have required users to use at least one lowercase letter in their password.
 * `require_numbers` - (Optional) Whether you have required users to use at least one number in their password.
 * `require_symbols` - (Optional) Whether you have required users to use at least one symbol in their password.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add a new argument `password_history_size` to the `password_policy` configuration block for the `aws_cognito_user_pool` to implement the [Password reuse prevention](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-advanced-security-password-reuse.html) feature.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39016

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [PasswordPolicyType](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_PasswordPolicyType.html#CognitoUserPools-Type-PasswordPolicyType-PasswordHistorySize) for specs and wordings for documentation.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS"=TestAccCognitoIDPUserPool_passwordHistorySize|TestAccCognitoIDPUserPool_basic|TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy" PKG=cognitoidp
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPool_passwordHistorySize|TestAccCognitoIDPUserPool_basic|TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy'  -timeout 360m
=== RUN   TestAccCognitoIDPUserPool_basic
=== PAUSE TestAccCognitoIDPUserPool_basic
=== RUN   TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== PAUSE TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== CONT  TestAccCognitoIDPUserPool_passwordHistorySize
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy     
--- PASS: TestAccCognitoIDPUserPool_basic (20.55s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy (20.55s)
--- PASS: TestAccCognitoIDPUserPool_passwordHistorySize (31.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 31.320s

$
```
