### PR TITLE
r/aws_route53_query_log: Fix sweeper in US GovCloud

### DIFF
--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -18,6 +18,10 @@ func SkipSweepError(err error) bool {
 		return dnsErr.IsNotFound
 	}
 
+	// Example: AccessDenied: The operation ListQueryLoggingConfigs is not available for the current AWS account ...
+	if tfawserr.ErrMessageContains(err, "AccessDenied", "is not available for the current AWS account") {
+		return true
+	}
 	// GovCloud has endpoints that respond with (no message provided):
 	// AccessDeniedException:
 	// Since acceptance test sweepers are best effort and this response is very common,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes:

```
2024/08/27 08:38:49 [ERROR] Error running Sweeper (aws_route53_query_log) in region (us-gov-east-1): listing Route 53 Query Logging Configs (us-gov-east-1): operation error Route 53: ListQueryLoggingConfigs, https response error StatusCode: 403, RequestID: 0330c9f1-27f4-4049-8e6e-49b8878f6470, api error AccessDenied: The operation ListQueryLoggingConfigs is not available for the current AWS account 123456789012.
```