### PR TITLE
docs: update node for route53_health_check

### DIFF
--- a/website/docs/r/route53_health_check.html.markdown
+++ b/website/docs/r/route53_health_check.html.markdown
@@ -83,7 +83,7 @@ resource "aws_route53_health_check" "foo" {
 
 This resource supports the following arguments:
 
-~> **Note:** At least one of either `fqdn` or `ip_address` must be specified.
+~> **Note:** At least one of either `fqdn` or `ip_address` must be specified for endpoint checks.
 
 * `reference_name` - (Optional) This is a reference name used in Caller Reference
     (helpful for identifying single health_check set amongst others)


### PR DESCRIPTION
### Description

The resource `aws_route53_health_check` contains a note that states

> At least one of either fqdn or ip_address must be specified.


The Route53 Health check supports different check types as described [here](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/health-checks-types.html). In short, 

- endpoint
- calculated
- cloudwatch metric/ alarm

Only for endpoint checks it is required to specify IP address or FQDN. For the other types this is not applicable or even possible.

### Relations

Closes #39013 

### References

Links to the implementation in the AWS SDK GO v2 as we validate in the AWS provider code base against types defined there

```golang
names.AttrType: {
				Type:             schema.TypeString,
				Required:         true,
				ForceNew:         true,
				ValidateDiagFunc: enum.Validate[awstypes.HealthCheckType](),
				StateFunc: func(val interface{}) string {
					return strings.ToUpper(val.(string))
				},
			},
``` 


- [AWS SDK Go v2 HealthCheckConfig](https://github.com/aws/aws-sdk-go-v2/blob/a6e48aca89f21791c465cb8cf1136d72a28da31b/service/route53/types/types.go#L861)
- [AWS SDK Go v2 HealthCheckTypes](https://github.com/aws/aws-sdk-go-v2/blob/a6e48aca89f21791c465cb8cf1136d72a28da31b/service/route53/types/enums.go#L250)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.