### PR TITLE
docs: `db_instance_role_association`: add `replace_triggered_by` to example config

### DIFF
--- a/website/docs/r/db_instance_role_association.html.markdown
+++ b/website/docs/r/db_instance_role_association.html.markdown
@@ -22,6 +22,13 @@ resource "aws_db_instance_role_association" "example" {
   db_instance_identifier = aws_db_instance.example.identifier
   feature_name           = "S3_INTEGRATION"
   role_arn               = aws_iam_role.example.arn
+
+  # Only necessary where the instance identifier is a known string value; ensuring recreation when the instance is replaced.
+  lifecycle {
+    replace_triggered_by = [
+      aws_db_instance.example.id
+    ]
+  }
 }
 ```
 

--- a/website/docs/r/db_instance_role_association.html.markdown
+++ b/website/docs/r/db_instance_role_association.html.markdown
@@ -23,7 +23,7 @@ resource "aws_db_instance_role_association" "example" {
   feature_name           = "S3_INTEGRATION"
   role_arn               = aws_iam_role.example.arn
 
-  # Only necessary where the instance identifier is a known string value; ensuring recreation when the instance is replaced.
+  # Only necessary where the instance identifier is a known string value; ensuring recreation when the instance is replaced. Requires Terraform 1.2 or later.
   lifecycle {
     replace_triggered_by = [
       aws_db_instance.example.id


### PR DESCRIPTION
### Description

I wrote quite a [long comment](https://github.com/hashicorp/terraform-provider-aws/issues/38765#issuecomment-2313008183) on the referenced issue that gives more detail as to what's going on here. The tl;dr is:

- You can use a known, static string for `aws_db_instance.example.identifier`
- Since it's known, if `aws_db_instance.example` is recreated, Terraform has no reason to recreate the `aws_db_instance_role_association`, since the `db_instance_identifier` is unchanged
- On a second apply, the drift is detected/corrected

I didn't dig too far into when this became necessary, but I suspect it may have been when the `id` / `identifier` / `resource_id` changes happened ("Schema notes" in references).

I'm a bit on the fence on exactly how to document this. It's not required in all cases (using `identifier_prefix` or omitting both of those arguments negates the need), but it also might not be immediately clear that this is necessary, or exactly what is necessary (I got the "solution" wrong at first, for example). Adding the `lifecycle` block with a note to the example config seemed like a decent compromise.

### Relations

Closes #38765

### References

- [Schema notes](https://github.com/hashicorp/terraform-provider-aws/blob/8d8407e7ae0356cace0234d6accaf30f14a0cedf/internal/service/rds/instance.go#L41-L50) 

### Output from Acceptance Testing

n/a, docs
