### PR TITLE
Use ServiceRecord instead of `names` for `skaff`

### DIFF
--- a/names/data/read.go
+++ b/names/data/read.go
@@ -5,6 +5,7 @@ package data
 
 import (
 	_ "embed"
+	"fmt"
 	"log"
 	"strings"
 
@@ -137,6 +138,14 @@ func (sr ServiceRecord) DocPrefix() []string {
 
 func (sr ServiceRecord) HumanFriendly() string {
 	return sr[colHumanFriendly]
+}
+
+func (sr ServiceRecord) FullHumanFriendly() string {
+	if sr.Brand() == "" {
+		return sr.HumanFriendly()
+	}
+
+	return fmt.Sprintf("%s %s", sr.Brand(), sr.HumanFriendly())
 }
 
 func (sr ServiceRecord) Brand() string {

--- a/skaff/datasource/datasource.go
+++ b/skaff/datasource/datasource.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-provider-aws/names"
+	"github.com/hashicorp/terraform-provider-aws/names/data"
 	"github.com/hashicorp/terraform-provider-aws/skaff/convert"
 )
 
@@ -69,32 +69,22 @@ func Create(dsName, snakeName string, comments, force, v2, pluginFramework, tags
 
 	snakeName = convert.ToSnakeCase(dsName, snakeName)
 
-	s, err := names.ProviderNameUpper(servicePackage)
+	service, err := data.LookupService(servicePackage)
 	if err != nil {
-		return fmt.Errorf("error getting service connection name: %w", err)
-	}
-
-	sn, err := names.FullHumanFriendly(servicePackage)
-	if err != nil {
-		return fmt.Errorf("error getting AWS service name: %w", err)
-	}
-
-	hf, err := names.HumanFriendly(servicePackage)
-	if err != nil {
-		return fmt.Errorf("error getting human-friendly name: %w", err)
+		return fmt.Errorf("error looking up service package data for %q: %w", servicePackage, err)
 	}
 
 	templateData := TemplateData{
 		DataSource:           dsName,
 		DataSourceLower:      strings.ToLower(dsName),
 		DataSourceSnake:      snakeName,
-		HumanFriendlyService: hf,
+		HumanFriendlyService: service.HumanFriendly(),
 		IncludeComments:      comments,
 		IncludeTags:          tags,
 		ServicePackage:       servicePackage,
-		Service:              s,
-		ServiceLower:         strings.ToLower(s),
-		AWSServiceName:       sn,
+		Service:              service.ProviderNameUpper(),
+		ServiceLower:         strings.ToLower(service.ProviderNameUpper()),
+		AWSServiceName:       service.FullHumanFriendly(),
 		AWSGoSDKV2:           v2,
 		PluginFramework:      pluginFramework,
 		HumanDataSourceName:  convert.ToHumanResName(dsName),

--- a/skaff/function/function.go
+++ b/skaff/function/function.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-provider-aws/skaff/convert"
 )
 
@@ -26,8 +25,6 @@ var functionTestTmpl string
 
 //go:embed websitedoc.tmpl
 var websiteTmpl string
-
-var snakeCaseRegex = regexache.MustCompile(`[a-z0-9_]*`)
 
 type TemplateData struct {
 	Function        string

--- a/skaff/resource/resource.go
+++ b/skaff/resource/resource.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/terraform-provider-aws/names"
+	"github.com/hashicorp/terraform-provider-aws/names/data"
 	"github.com/hashicorp/terraform-provider-aws/skaff/convert"
 )
 
@@ -69,32 +69,22 @@ func Create(resName, snakeName string, comments, force, v2, pluginFramework, tag
 
 	snakeName = convert.ToSnakeCase(resName, snakeName)
 
-	s, err := names.ProviderNameUpper(servicePackage)
+	service, err := data.LookupService(servicePackage)
 	if err != nil {
-		return fmt.Errorf("error getting service connection name: %w", err)
-	}
-
-	sn, err := names.FullHumanFriendly(servicePackage)
-	if err != nil {
-		return fmt.Errorf("error getting AWS service name: %w", err)
-	}
-
-	hf, err := names.HumanFriendly(servicePackage)
-	if err != nil {
-		return fmt.Errorf("error getting human-friendly name: %w", err)
+		return fmt.Errorf("error looking up service package data for %q: %w", servicePackage, err)
 	}
 
 	templateData := TemplateData{
 		Resource:             resName,
 		ResourceLower:        strings.ToLower(resName),
 		ResourceSnake:        snakeName,
-		HumanFriendlyService: hf,
+		HumanFriendlyService: service.HumanFriendly(),
 		IncludeComments:      comments,
 		IncludeTags:          tags,
 		ServicePackage:       servicePackage,
-		Service:              s,
-		ServiceLower:         strings.ToLower(s),
-		AWSServiceName:       sn,
+		Service:              service.ProviderNameUpper(),
+		ServiceLower:         strings.ToLower(service.ProviderNameUpper()),
+		AWSServiceName:       service.FullHumanFriendly(),
 		AWSGoSDKV2:           v2,
 		PluginFramework:      pluginFramework,
 		HumanResourceName:    convert.ToHumanResName(resName),


### PR DESCRIPTION
### Description

Uses ServiceRecord data instead of `names` for `skaff`
