### PR TITLE
fix: configure_at_launch -> configured_at_launch

### DIFF
--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -2229,7 +2229,7 @@ TASK_DEFINITION
 
   volume {
     name                = "vol1"
-    configure_at_launch = true
+    configured_at_launch = true
   }
 }
 

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -298,7 +298,7 @@ func resourceTaskDefinition() *schema.Resource {
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"configure_at_launch": {
+						"configured_at_launch": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Computed: true,
@@ -951,7 +951,7 @@ func expandVolumes(configured []interface{}) []awstypes.Volume {
 			}
 		}
 
-		if v, ok := data["configure_at_launch"].(bool); ok {
+		if v, ok := data["configured_at_launch"].(bool); ok {
 			l.ConfiguredAtLaunch = aws.Bool(v)
 		}
 
@@ -1088,7 +1088,7 @@ func flattenVolumes(list []awstypes.Volume) []map[string]interface{} {
 		}
 
 		if volume.ConfiguredAtLaunch != nil {
-			l["configure_at_launch"] = aws.ToBool(volume.ConfiguredAtLaunch)
+			l["configured_at_launch"] = aws.ToBool(volume.ConfiguredAtLaunch)
 		}
 
 		if volume.DockerVolumeConfiguration != nil {

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -178,7 +178,7 @@ func TestAccECSTaskDefinition_configuredAtLaunch(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
 					resource.TestCheckResourceAttr(resourceName, "volume.#", acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.configure_at_launch", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.configured_at_launch", acctest.CtTrue),
 				),
 			},
 			{

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -260,7 +260,7 @@ The following arguments are optional:
 * `efs_volume_configuration` - (Optional) Configuration block for an [EFS volume](#efs_volume_configuration). Detailed below.
 * `fsx_windows_file_server_volume_configuration` - (Optional) Configuration block for an [FSX Windows File Server volume](#fsx_windows_file_server_volume_configuration). Detailed below.
 * `host_path` - (Optional) Path on the host container instance that is presented to the container. If not set, ECS will create a nonpersistent data volume that starts empty and is deleted after the task has finished.
-* `configure_at_launch` - (Optional) Whether the volume should be configured at launch time. This is used to create Amazon EBS volumes for standalone tasks or tasks created as part of a service. Each task definition revision may only have one volume configured at launch in the volume configuration.
+* `configured_at_launch` - (Optional) Whether the volume should be configured at launch time. This is used to create Amazon EBS volumes for standalone tasks or tasks created as part of a service. Each task definition revision may only have one volume configured at launch in the volume configuration.
 * `name` - (Required) Name of the volume. This name is referenced in the `sourceVolume`
 parameter of container definition in the `mountPoints` section.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fixes typo in `configure_at_launch`. it should be `configured_at_launch`. All downstream sdks that generate based off of terraform's are broken b/c of this.

### Relations
https://github.com/hashicorp/terraform-provider-aws/issues/38153
https://github.com/pulumi/pulumi-aws/issues/4413
