### PR TITLE
Update instance.html.markdown

### DIFF
--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -60,6 +60,7 @@ data "aws_ami" "this" {
 resource "aws_instance" "this" {
   ami = data.aws_ami.this.id
   instance_market_options {
+    market_type = "spot"
     spot_options {
       max_price = 0.0031
     }


### PR DESCRIPTION
As per documentation if we are creating spot instance with spot_options parameter , market_type need to be specified. Or else spot instance creation fails with error

│ Error: creating EC2 Instance: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: 82006487-bd8c-4d4a-b9ab-36bd0b51fc7f, api error MissingParameter: The request must contain the parameter MarketType. │
│   with aws_instance.this,
│   on resource.tf line 14, in resource "aws_instance" "this":
│   14: resource "aws_instance" "this" {
│

updated the example with market_type and tested it .After adding market_type under instance_market_options , spot insatance created  successfully.

Closes https://github.com/hashicorp/terraform-provider-aws/issues/38588

Documentation Referred :
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#market-options
![Error](https://github.com/user-attachments/assets/731241ba-f29d-411f-b0dd-e598933a2037)
![Output](https://github.com/user-attachments/assets/de738723-4d91-4168-9b8e-9f1bd1d4db89)
