### PR TITLE
resource/aws_quicksight_refresh_schedule: Prevent Value Conversion Error for unknown values

### DIFF
--- a/internal/errs/fwdiag/validatordiag.go
+++ b/internal/errs/fwdiag/validatordiag.go
@@ -1,0 +1,38 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwdiag
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// NewAttributeRequiredWhenError returns an error diagnostic indicating that the attribute at neededPath is required when the
+// attribute at otherPath has the given value.
+func NewAttributeRequiredWhenError(neededPath, otherPath path.Path, value string) diag.Diagnostic {
+	return validatordiag.InvalidAttributeCombinationDiagnostic(
+		otherPath,
+		fmt.Sprintf("Attribute %q must be specified when %q is %q.",
+			neededPath.String(),
+			otherPath.String(),
+			value,
+		),
+	)
+}
+
+// NewAttributeConflictsWhenError returns an error diagnostic indicating that the attribute at the given path cannot be
+// specified when the attribute at otherPath has the given value.
+func NewAttributeConflictsWhenError(path, otherPath path.Path, otherValue string) diag.Diagnostic {
+	return validatordiag.InvalidAttributeCombinationDiagnostic(
+		path,
+		fmt.Sprintf("Attribute %q cannot be specified when %q is %q.",
+			path.String(),
+			otherPath.String(),
+			otherValue,
+		),
+	)
+}

--- a/internal/errs/fwdiag/validatordiag_testing.go
+++ b/internal/errs/fwdiag/validatordiag_testing.go
@@ -1,0 +1,28 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwdiag
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/YakDriver/regexache"
+)
+
+func ExpectAttributeRequiredWhenError(neededPath, otherPath, value string) *regexp.Regexp {
+	return regexache.MustCompile(strings.ReplaceAll(fmt.Sprintf(`Attribute "%s" must be specified when "%s" is "%s".`,
+		regexp.QuoteMeta(neededPath),
+		regexp.QuoteMeta(otherPath),
+		value,
+	), " ", `(\n?\s+)`))
+}
+
+func ExpectAttributeConflictsWhenError(path, otherPath, value string) *regexp.Regexp {
+	return regexache.MustCompile(strings.ReplaceAll(fmt.Sprintf(`Attribute "%s" cannot be specified when "%s" is "%s".`,
+		regexp.QuoteMeta(path),
+		regexp.QuoteMeta(otherPath),
+		value,
+	), " ", `(\n?\s+)`))
+}


### PR DESCRIPTION
### Description

The `ValidateConfig` function can be called with unknown values, which was failing

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39051

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=quicksight TESTS=TestAccQuickSightRefreshSchedule_

--- PASS: TestAccQuickSightRefreshSchedule_invalidMonthlyRefresh (2.64s)
--- PASS: TestAccQuickSightRefreshSchedule_invalidWeeklyRefresh (2.80s)
--- PASS: TestAccQuickSightRefreshSchedule_invalidRefreshInterval (4.08s)
--- PASS: TestAccQuickSightRefreshSchedule_disappears (21.70s)
--- PASS: TestAccQuickSightRefreshSchedule_basic (23.33s)
--- PASS: TestAccQuickSightRefreshSchedule_monthlyRefresh (23.50s)
--- PASS: TestAccQuickSightRefreshSchedule_weeklyRefresh (23.89s)
```
