### PR TITLE
Add maximum_length to the user_settings set within aws_appstream_stack

### DIFF
--- a/.changelog/39078.txt
+++ b/.changelog/39078.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_appstream_stack: Add user_settings.maximum_length argument.
+resource/aws_appstream_stack: Add `user_settings.maximum_length` argument.
 ```

--- a/.changelog/39078.txt
+++ b/.changelog/39078.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appstream_stack: Add user_settings.maximum_length argument.
+```

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -199,6 +199,7 @@ func ResourceStack() *schema.Resource {
 						"maximum_length": {
 							Type:         nullable.TypeNullableInt,
 							Optional:     true,
+							Default:      "",
 							ValidateFunc: nullable.ValidateTypeStringNullableIntBetween(1, 20971520),
 						},
 						"permission": {

--- a/internal/service/appstream/stack_test.go
+++ b/internal/service/appstream/stack_test.go
@@ -118,6 +118,7 @@ func TestAccAppStreamStack_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "redirect_url", ""),
 					resource.TestCheckResourceAttr(resourceName, "storage_connectors.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "user_settings.#", "7"),
+					resource.TestCheckResourceAttr(resourceName, "user_settings.1.maximum_length", "32"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct0),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsAllPercent, acctest.Ct0),
 				),
@@ -427,8 +428,9 @@ resource "aws_appstream_stack" "test" {
     permission = "ENABLED"
   }
   user_settings {
-    action     = "CLIPBOARD_COPY_TO_LOCAL_DEVICE"
-    permission = "ENABLED"
+    action         = "CLIPBOARD_COPY_TO_LOCAL_DEVICE"
+	maximum_length = 32
+    permission     = "ENABLED"
   }
   user_settings {
     action     = "DOMAIN_PASSWORD_SIGNIN"

--- a/internal/service/appstream/stack_test.go
+++ b/internal/service/appstream/stack_test.go
@@ -429,7 +429,7 @@ resource "aws_appstream_stack" "test" {
   }
   user_settings {
     action         = "CLIPBOARD_COPY_TO_LOCAL_DEVICE"
-	maximum_length = 32
+    maximum_length = 32
     permission     = "ENABLED"
   }
   user_settings {

--- a/website/docs/r/appstream_stack.html.markdown
+++ b/website/docs/r/appstream_stack.html.markdown
@@ -25,12 +25,14 @@ resource "aws_appstream_stack" "example" {
   }
 
   user_settings {
-    action     = "CLIPBOARD_COPY_FROM_LOCAL_DEVICE"
-    permission = "ENABLED"
+    action         = "CLIPBOARD_COPY_FROM_LOCAL_DEVICE"
+    maximum_length = 256
+    permission     = "ENABLED"
   }
   user_settings {
-    action     = "CLIPBOARD_COPY_TO_LOCAL_DEVICE"
-    permission = "ENABLED"
+    action         = "CLIPBOARD_COPY_TO_LOCAL_DEVICE"
+    maximum_length = 256
+    permission     = "ENABLED"
   }
   user_settings {
     action     = "DOMAIN_PASSWORD_SIGNIN"
@@ -115,6 +117,7 @@ The following arguments are optional:
   Valid values are `CLIPBOARD_COPY_FROM_LOCAL_DEVICE`,  `CLIPBOARD_COPY_TO_LOCAL_DEVICE`, `FILE_UPLOAD`, `FILE_DOWNLOAD`, `PRINTING_TO_LOCAL_DEVICE`, `DOMAIN_PASSWORD_SIGNIN`, or `DOMAIN_SMART_CARD_SIGNIN`.
 * `permission` - (Required) Whether the action is enabled or disabled.
   Valid values are `ENABLED` or `DISABLED`.
+* `maximum_length` - (Optional) Specifies the number of characters that can be copied by end users from the local device to the remote session, and to the local device from the remote session. The value can be between 1 and 20,971,520 (20 MB)
 
 ### `streaming_experience_settings`
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Allowing for the setting of maximum_length in user_settings for AppStream stacks.

### Relations

N/A

### References

https://aws.amazon.com/about-aws/whats-new/2024/02/amazon-appstream-2-0-controls-limiting-clipboard/

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appstream-stack-usersetting.html#aws-properties-appstream-stack-usersetting-properties

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
➜  terraform-provider-aws git:(f-aws_appstream_stack-clipboard_maximum_length) ✗ make testacc TESTS=TestAccAppStreamStack PKG=appstream
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/appstream/... -v -count 1 -parallel 20 -run='TestAccAppStreamStack'  -timeout 360m
=== RUN   TestAccAppStreamStack_basic
=== PAUSE TestAccAppStreamStack_basic
=== RUN   TestAccAppStreamStack_disappears
=== PAUSE TestAccAppStreamStack_disappears
=== RUN   TestAccAppStreamStack_complete
=== PAUSE TestAccAppStreamStack_complete
=== RUN   TestAccAppStreamStack_applicationSettings_basic
=== PAUSE TestAccAppStreamStack_applicationSettings_basic
=== RUN   TestAccAppStreamStack_applicationSettings_removeFromEnabled
=== PAUSE TestAccAppStreamStack_applicationSettings_removeFromEnabled
=== RUN   TestAccAppStreamStack_applicationSettings_removeFromDisabled
=== PAUSE TestAccAppStreamStack_applicationSettings_removeFromDisabled
=== RUN   TestAccAppStreamStack_withTags
=== PAUSE TestAccAppStreamStack_withTags
=== RUN   TestAccAppStreamStack_streamingExperienceSettings_basic
=== PAUSE TestAccAppStreamStack_streamingExperienceSettings_basic
=== CONT  TestAccAppStreamStack_basic
=== CONT  TestAccAppStreamStack_applicationSettings_removeFromEnabled
=== CONT  TestAccAppStreamStack_complete
=== CONT  TestAccAppStreamStack_withTags
=== CONT  TestAccAppStreamStack_disappears
=== CONT  TestAccAppStreamStack_streamingExperienceSettings_basic
=== CONT  TestAccAppStreamStack_applicationSettings_removeFromDisabled
=== CONT  TestAccAppStreamStack_applicationSettings_basic
--- PASS: TestAccAppStreamStack_basic (30.94s)
--- PASS: TestAccAppStreamStack_complete (44.58s)
--- PASS: TestAccAppStreamStack_disappears (46.18s)
--- PASS: TestAccAppStreamStack_applicationSettings_removeFromDisabled (48.62s)
--- PASS: TestAccAppStreamStack_streamingExperienceSettings_basic (50.11s)
--- PASS: TestAccAppStreamStack_withTags (66.71s)
--- PASS: TestAccAppStreamStack_applicationSettings_basic (71.05s)
--- PASS: TestAccAppStreamStack_applicationSettings_removeFromEnabled (74.68s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appstream  79.146s
...
```

<!-- gk-ai-analysis-start:6c357303c4b654e98209fd559e8327ab3cdf0815 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiQWRkIGBtYXhpbXVtX2xlbmd0aGAgdG8gdGhlIGB1c2VyX3NldHRpbmdzYCBibG9jayBpbiB0aGUgYGF3c19hcHBzdHJlYW1fc3RhY2tgIHJlc291cmNlIHRvIGxpbWl0IGNsaXBib2FyZCBsZW5ndGguIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiQWRkZWQgbWF4aW11bV9sZW5ndGggdG8gdXNlcl9zZXR0aW5ncyIsImRlc2NyaXB0aW9uIjoiSW50cm9kdWNlZCB0aGUgYG1heGltdW1fbGVuZ3RoYCBwYXJhbWV0ZXIgdG8gdGhlIGB1c2VyX3NldHRpbmdzYCBibG9jaywgdXNpbmcgYG51bGxhYmxlLlR5cGVOdWxsYWJsZUludGAgdG8gY29ycmVjdGx5IGhhbmRsZSBlbXB0eSBzdGF0ZXMgd2hpbGUgcGFzc2luZyBhbiBpbnRlZ2VyIHRvIHRoZSBBV1MgQVBJLiIsInNldmVyaXR5IjoibWVkaXVtIiwiZmlsZVBhdGgiOiJpbnRlcm5hbC9zZXJ2aWNlL2FwcHN0cmVhbS9zdGFjay5nbyIsImxpbmVTdGFydCI6MTk5fSx7InRpdGxlIjoiVHlwbyBmaXggaW4gc3RyZWFtaW5nIGV4cGVyaWVuY2UgZnVuY3Rpb25zIiwiZGVzY3JpcHRpb24iOiJSZW5hbWVkIGBmbGF0dGVuU3RyZWFtaW5FeHBlcmllbmNlU2V0dGluZyhzKWAgdG8gYGZsYXR0ZW5TdHJlYW1pbmdFeHBlcmllbmNlU2V0dGluZyhzKWAgdG8gZml4IGEgdHlwbyBpbiB0aGUgZnVuY3Rpb24gbmFtZS4iLCJzZXZlcml0eSI6ImxvdyIsImZpbGVQYXRoIjoiaW50ZXJuYWwvc2VydmljZS9hcHBzdHJlYW0vc3RhY2suZ28iLCJsaW5lU3RhcnQiOjU5OX1dLCJpc3N1ZXMiOlt7InRpdGxlIjoiRGVmYXVsdCB2YWx1ZSBpbiBuZXN0ZWQgYmxvY2sgc2NoZW1hIiwiZGVzY3JpcHRpb24iOiJUaGUgYERlZmF1bHQ6IFwiXCJgIHByb3BlcnR5IGlzIHNldCBvbiB0aGUgYG1heGltdW1fbGVuZ3RoYCBhdHRyaWJ1dGUgaW5zaWRlIHdoYXQgYXBwZWFycyB0byBiZSBhIGBUeXBlU2V0YCBvciBgVHlwZUxpc3RgIChgdXNlcl9zZXR0aW5nc2ApLiBUZXJyYWZvcm0gUGx1Z2luIFNESyB2MiBkb2VzIG5vdCBzdXBwb3J0IGBEZWZhdWx0YCBvbiBuZXN0ZWQgYmxvY2sgZWxlbWVudHM7IGl0IGlzIGVpdGhlciBpZ25vcmVkIG9yIGNhbiBjYXVzZSB1bmV4cGVjdGVkIHNjaGVtYSB2YWxpZGF0aW9uIGVycm9ycy4gQ29uc2lkZXIgcmVtb3ZpbmcgaXQuIiwic2V2ZXJpdHkiOiJoaWdoIiwiZmlsZVBhdGgiOiJpbnRlcm5hbC9zZXJ2aWNlL2FwcHN0cmVhbS9zdGFjay5nbyIsImxpbmVTdGFydCI6MjAyfV0sInN1Z2dlc3Rpb25zIjpbXSwic2VjdXJpdHkiOltdfQ== -->
<!-- gk-ai-analysis-end:6c357303c4b654e98209fd559e8327ab3cdf0815 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/hashicorp/terraform-provider-aws/pull/39078?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->