### PR TITLE
Increase endpointInServiceTimeout from 10m to 60m

### DIFF
--- a/.changelog/39090.txt
+++ b/.changelog/39090.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_endpoint: Increase Create and Update `InService` timeouts to 60 minutes
+```

--- a/internal/service/sagemaker/wait.go
+++ b/internal/service/sagemaker/wait.go
@@ -25,7 +25,7 @@ const (
 	imageCreatedTimeout                = 10 * time.Minute
 	imageDeletedTimeout                = 10 * time.Minute
 	endpointDeletedTimeout             = 10 * time.Minute
-	endpointInServiceTimeout           = 10 * time.Minute
+	endpointInServiceTimeout           = 60 * time.Minute
 	imageVersionCreatedTimeout         = 10 * time.Minute
 	imageVersionDeletedTimeout         = 10 * time.Minute
 	domainInServiceTimeout             = 20 * time.Minute


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

SageMaker endpoints are now taking a little over 10 minutes to become InService. This aligns the hardcoded endpoint timeout to 60 minutes.

This primarily effects SageMaker serverless endpoints. As an example, a test endpoint that deploys in >10m is using an xgboost model and associated container.

i.e.

```
...
module.tf_modules_sagemaker.module.endpoint.aws_sagemaker_endpoint.sagemaker_endpoint[0]: Still creating... [9m40s elapsed]
module.tf_modules_sagemaker.module.endpoint.aws_sagemaker_endpoint.sagemaker_endpoint[0]: Still creating... [9m50s elapsed]
module.tf_modules_sagemaker.module.endpoint.aws_sagemaker_endpoint.sagemaker_endpoint[0]: Still creating... [10m0s elapsed]
╷
│ Error: waiting for SageMaker Endpoint (ep-demo-sample-svrless) to be in service: timeout while waiting for state to become 'InService' (last state: 'Creating', timeout: 10m0s)
│ 
│   with module.tf_modules_sagemaker.module.endpoint.aws_sagemaker_endpoint.sagemaker_endpoint[0],
│   on .terraform/modules/tf_modules_sagemaker/modules/endpoint/main.tf line 55, in resource "aws_sagemaker_endpoint" "sagemaker_endpoint":
│   55: resource "aws_sagemaker_endpoint" "sagemaker_endpoint" {
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
