### PR TITLE
fix: Increase endpointInServiceTimeout to 20 min

### DIFF
--- a/.changelog/39093.txt
+++ b/.changelog/39093.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_endpoint: Increase connection in-service status wait timeout to 20 minutes for create and update
+```

--- a/internal/service/sagemaker/wait.go
+++ b/internal/service/sagemaker/wait.go
@@ -25,7 +25,7 @@ const (
 	imageCreatedTimeout                = 10 * time.Minute
 	imageDeletedTimeout                = 10 * time.Minute
 	endpointDeletedTimeout             = 10 * time.Minute
-	endpointInServiceTimeout           = 10 * time.Minute
+	endpointInServiceTimeout           = 20 * time.Minute
 	imageVersionCreatedTimeout         = 10 * time.Minute
 	imageVersionDeletedTimeout         = 10 * time.Minute
 	domainInServiceTimeout             = 20 * time.Minute


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to increase the wait timeout for a SageMaker endpoint to become InService from 10 min to 20 min for the `aws_sagemaker_endpoint` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39040

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
$ make testacc TESTS="TestAccSageMakerEndpoint_" PKG=sagemaker
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerEndpoint_'  -timeout 360m
=== RUN   TestAccSageMakerEndpoint_basic
=== PAUSE TestAccSageMakerEndpoint_basic
=== RUN   TestAccSageMakerEndpoint_endpointName
=== PAUSE TestAccSageMakerEndpoint_endpointName
=== RUN   TestAccSageMakerEndpoint_tags
=== PAUSE TestAccSageMakerEndpoint_tags
=== RUN   TestAccSageMakerEndpoint_deploymentConfig
=== PAUSE TestAccSageMakerEndpoint_deploymentConfig
=== RUN   TestAccSageMakerEndpoint_deploymentConfig_blueGreen
=== PAUSE TestAccSageMakerEndpoint_deploymentConfig_blueGreen
=== RUN   TestAccSageMakerEndpoint_deploymentConfig_rolling
=== PAUSE TestAccSageMakerEndpoint_deploymentConfig_rolling
=== RUN   TestAccSageMakerEndpoint_disappears
=== PAUSE TestAccSageMakerEndpoint_disappears
=== CONT  TestAccSageMakerEndpoint_basic
=== CONT  TestAccSageMakerEndpoint_deploymentConfig_blueGreen
=== CONT  TestAccSageMakerEndpoint_tags
=== CONT  TestAccSageMakerEndpoint_deploymentConfig_rolling
=== CONT  TestAccSageMakerEndpoint_deploymentConfig
=== CONT  TestAccSageMakerEndpoint_endpointName
=== CONT  TestAccSageMakerEndpoint_disappears
--- PASS: TestAccSageMakerEndpoint_basic (193.10s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig_rolling (196.20s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig (198.22s)
--- PASS: TestAccSageMakerEndpoint_deploymentConfig_blueGreen (201.12s)
--- PASS: TestAccSageMakerEndpoint_tags (226.51s)
--- PASS: TestAccSageMakerEndpoint_disappears (305.60s)
--- PASS: TestAccSageMakerEndpoint_endpointName (439.28s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  439.521s

$
```
