### PR TITLE
Improve aws_wafv2_web_acl (rate_based_statement limit now manage values from 10)

### DIFF
--- a/.changelog/39107.txt
+++ b/.changelog/39107.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Reduce `rate_based_statement.limit` minimum from `100` to `10`
+```
+
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Reduce `rate_based_statement.limit` minimum from `100` to `10`
+```

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -1159,7 +1159,7 @@ func rateBasedStatementSchema(level int) *schema.Schema {
 				"limit": {
 					Type:         schema.TypeInt,
 					Required:     true,
-					ValidateFunc: validation.IntBetween(100, 2000000000),
+					ValidateFunc: validation.IntBetween(10, 2000000000),
 				},
 				"scope_down_statement": scopeDownStatementSchema(level - 1),
 			},


### PR DESCRIPTION
### Description
AWS recently announced the ability to have lower rate limits 

### Relations
Closes #39106

### References
https://aws.amazon.com/fr/about-aws/whats-new/2024/08/aws-waf-rate-based-rules-lower-rate-limits/
