### PR TITLE
docs: update example code

### DIFF
--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -17,7 +17,7 @@ resources.
 data "aws_ami" "example" {
   executable_users = ["self"]
   most_recent      = true
-  name_regex       = "^myami-\\d{3}"
+  name_regex       = "^myami-[0-9]{3}"
   owners           = ["self"]
 
   filter {


### PR DESCRIPTION
### Description

As described in #39109  the generation of the Python and TypeScript code snippets for the Terraform AWS provider documentation fails. The cause for this is an issue when parsing the regex existing in current example (`^myami-\d{3}`).

This PR replaces the used regex with another one that still makes  in context of the provided filter

```hcl
filter {
    name   = "name"
    values = ["myami-*"]
  }
```

The generation of the code snippets using the new regex was tested by running

```shell
cdktf-registry-docs convert  --files='d/ami.html.markdown' --languages='python' --parallel-file-conversions=1 --parallel-conversions-per-document=3  --provider-from-registry="hashicorp/aws"
```

respective

```shell
cdktf-registry-docs convert  --files='d/ami.html.markdown' --languages='typescript' --parallel-file-conversions=1 --parallel-conversions-per-document=3  --provider-from-registry="hashicorp/aws"
```

The Python code snippet is rendered as below

```python
# DO NOT EDIT. Code generated by 'cdktf convert' - Please report bugs at https://cdk.tf/bug
from constructs import Construct
from cdktf import TerraformStack
#
# Provider bindings are generated by running `cdktf get`.
# See https://cdk.tf/provider-generation for more details.
#
from imports.aws.data_aws_ami import DataAwsAmi
class MyConvertedCode(TerraformStack):
    def __init__(self, scope, name):
        super().__init__(scope, name)
        DataAwsAmi(self, "example",
            executable_users=["self"],
            filter=[DataAwsAmiFilter(
                name="name",
                values=["myami-*"]
            ), DataAwsAmiFilter(
                name="root-device-type",
                values=["ebs"]
            ), DataAwsAmiFilter(
                name="virtualization-type",
                values=["hvm"]
            )
            ],
            most_recent=True,
            name_regex="^myami-[0-9]{3}",
            owners=["self"]
        )
```

and the Typescript one as

```typescript
// DO NOT EDIT. Code generated by 'cdktf convert' - Please report bugs at https://cdk.tf/bug
import { Construct } from "constructs";
import { TerraformStack } from "cdktf";
/*
 * Provider bindings are generated by running `cdktf get`.
 * See https://cdk.tf/provider-generation for more details.
 */
import { DataAwsAmi } from "./.gen/providers/aws/data-aws-ami";
class MyConvertedCode extends TerraformStack {
  constructor(scope: Construct, name: string) {
    super(scope, name);
    new DataAwsAmi(this, "example", {
      executableUsers: ["self"],
      filter: [
        {
          name: "name",
          values: ["myami-*"],
        },
        {
          name: "root-device-type",
          values: ["ebs"],
        },
        {
          name: "virtualization-type",
          values: ["hvm"],
        },
      ],
      mostRecent: true,
      nameRegex: "^myami-[0-9]{3}",
      owners: ["self"],
    });
  }
}
```

If you have a suggestion for a different regex, happy to update the PR.

### Relations

Closes #39109 

### References


### Output from Acceptance Testing

Not applicable. Only documentation is updated.