### PR TITLE
r/aws_lexmodelsv2_slot_type: fix `slot_type_values` validator

### DIFF
--- a/.changelog/39126.txt
+++ b/.changelog/39126.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lexv2models_slot_type: Fix `slot_type_values` validator which limited configurations to 1 element
+```

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -164,9 +164,6 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 				},
 			},
 			"slot_type_values": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
 				CustomType: fwtypes.NewListNestedObjectTypeOf[SlotTypeValues](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{

--- a/internal/service/lexv2models/slot_type_test.go
+++ b/internal/service/lexv2models/slot_type_test.go
@@ -268,6 +268,11 @@ resource "aws_lexv2models_slot_type" "test" {
       value = "testval"
     }
   }
+  slot_type_values {
+    sample_value {
+      value = "testval2"
+    }
+  }
 }
 `, rName))
 }


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously the `slot_type_values` validator limited the configuration to a maximum of 1 block. The corresponding AWS API accepts a minimum of 1 and maximum of 10000 items. This changes removes provider validation entirely, relying on the AWS API instead.

Before:

```console
% make testacc PKG=lexv2models TESTS=TestAccLexV2ModelsSlotType_values
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsSlotType_values'  -timeout 360m

    slot_type_test.go:70: Step 1/2 error: Error running pre-apply plan: exit status 1

        Error: Invalid Attribute Value

          with aws_lexv2models_slot_type.test,
          on terraform_plugin_test.tf line 62, in resource "aws_lexv2models_slot_type" "test":
          62: resource "aws_lexv2models_slot_type" "test" {

        Attribute slot_type_values list must contain at most 1 elements, got: 2
--- FAIL: TestAccLexV2ModelsSlotType_values (1.66s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        7.841s
FAIL
```

After:

```console
% make testacc PKG=lexv2models TESTS=TestAccLexV2ModelsSlotType_values
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsSlotType_values'  -timeout 360m

--- PASS: TestAccLexV2ModelsSlotType_values (41.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        47.033s
```




### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/lexv2/latest/APIReference/API_CreateSlotType.html#lexv2-CreateSlotType-request-slotTypeValues

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lexv2models TESTS=TestAccLexV2ModelsSlotType_

--- PASS: TestAccLexV2ModelsSlotType_disappears (37.01s)
--- PASS: TestAccLexV2ModelsSlotType_values (37.93s)
--- PASS: TestAccLexV2ModelsSlotType_basic (38.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        44.856s
```
