### PR TITLE
Use Go 1.23 `slices.Chunk` as a replacement for `internal/slices.Chunks`

### DIFF
--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -8,6 +8,7 @@ import ( // nosemgrep:ci.semgrep.aws.multiple-service-imports
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -34,7 +35,6 @@ import ( // nosemgrep:ci.semgrep.aws.multiple-service-imports
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types/nullable"
-	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -959,8 +959,7 @@ func resourceGroup() *schema.Resource {
 
 func instanceMaintenancePolicyDiffSupress(k, old, new string, d *schema.ResourceData) bool {
 	o, n := d.GetChange("instance_maintenance_policy")
-	oList := o.([]interface{})
-	nList := n.([]interface{})
+	oList, nList := o.([]interface{}), n.([]interface{})
 
 	if len(oList) == 0 && len(nList) != 0 {
 		tfMap := nList[0].(map[string]interface{})
@@ -968,6 +967,7 @@ func instanceMaintenancePolicyDiffSupress(k, old, new string, d *schema.Resource
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -1500,22 +1500,17 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if d.HasChange("traffic_source") {
 		o, n := d.GetChange("traffic_source")
-		if o == nil {
-			o = new(schema.Set)
-		}
-		if n == nil {
-			n = new(schema.Set)
-		}
-		os := o.(*schema.Set)
-		ns := n.(*schema.Set)
+		os, ns := o.(*schema.Set), n.(*schema.Set)
 
 		// API only supports adding or removing 10 at a time.
 		batchSize := 10
-		for _, chunk := range tfslices.Chunks(expandTrafficSourceIdentifiers(os.Difference(ns).List()), batchSize) {
-			_, err := conn.DetachTrafficSources(ctx, &autoscaling.DetachTrafficSourcesInput{
+		for chunk := range slices.Chunk(expandTrafficSourceIdentifiers(os.Difference(ns).List()), batchSize) {
+			input := &autoscaling.DetachTrafficSourcesInput{
 				AutoScalingGroupName: aws.String(d.Id()),
 				TrafficSources:       chunk,
-			})
+			}
+
+			_, err := conn.DetachTrafficSources(ctx, input)
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "detaching Auto Scaling Group (%s) traffic sources: %s", d.Id(), err)
@@ -1526,11 +1521,13 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			}
 		}
 
-		for _, chunk := range tfslices.Chunks(expandTrafficSourceIdentifiers(ns.Difference(os).List()), batchSize) {
-			_, err := conn.AttachTrafficSources(ctx, &autoscaling.AttachTrafficSourcesInput{
+		for chunk := range slices.Chunk(expandTrafficSourceIdentifiers(ns.Difference(os).List()), batchSize) {
+			input := &autoscaling.AttachTrafficSourcesInput{
 				AutoScalingGroupName: aws.String(d.Id()),
 				TrafficSources:       chunk,
-			})
+			}
+
+			_, err := conn.AttachTrafficSources(ctx, input)
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "attaching Auto Scaling Group (%s) traffic sources: %s", d.Id(), err)
@@ -1544,22 +1541,17 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if d.HasChange("load_balancers") {
 		o, n := d.GetChange("load_balancers")
-		if o == nil {
-			o = new(schema.Set)
-		}
-		if n == nil {
-			n = new(schema.Set)
-		}
-		os := o.(*schema.Set)
-		ns := n.(*schema.Set)
+		os, ns := o.(*schema.Set), n.(*schema.Set)
 
 		// API only supports adding or removing 10 at a time.
 		batchSize := 10
-		for _, chunk := range tfslices.Chunks(flex.ExpandStringValueSet(os.Difference(ns)), batchSize) {
-			_, err := conn.DetachLoadBalancers(ctx, &autoscaling.DetachLoadBalancersInput{
+		for chunk := range slices.Chunk(flex.ExpandStringValueSet(os.Difference(ns)), batchSize) {
+			input := &autoscaling.DetachLoadBalancersInput{
 				AutoScalingGroupName: aws.String(d.Id()),
 				LoadBalancerNames:    chunk,
-			})
+			}
+
+			_, err := conn.DetachLoadBalancers(ctx, input)
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "detaching Auto Scaling Group (%s) load balancers: %s", d.Id(), err)
@@ -1570,11 +1562,13 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			}
 		}
 
-		for _, chunk := range tfslices.Chunks(flex.ExpandStringValueSet(ns.Difference(os)), batchSize) {
-			_, err := conn.AttachLoadBalancers(ctx, &autoscaling.AttachLoadBalancersInput{
+		for chunk := range slices.Chunk(flex.ExpandStringValueSet(ns.Difference(os)), batchSize) {
+			input := &autoscaling.AttachLoadBalancersInput{
 				AutoScalingGroupName: aws.String(d.Id()),
 				LoadBalancerNames:    chunk,
-			})
+			}
+
+			_, err := conn.AttachLoadBalancers(ctx, input)
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "attaching Auto Scaling Group (%s) load balancers: %s", d.Id(), err)
@@ -1588,22 +1582,17 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if d.HasChange("target_group_arns") {
 		o, n := d.GetChange("target_group_arns")
-		if o == nil {
-			o = new(schema.Set)
-		}
-		if n == nil {
-			n = new(schema.Set)
-		}
-		os := o.(*schema.Set)
-		ns := n.(*schema.Set)
+		os, ns := o.(*schema.Set), n.(*schema.Set)
 
 		// API only supports adding or removing 10 at a time.
 		batchSize := 10
-		for _, chunk := range tfslices.Chunks(flex.ExpandStringValueSet(os.Difference(ns)), batchSize) {
-			_, err := conn.DetachLoadBalancerTargetGroups(ctx, &autoscaling.DetachLoadBalancerTargetGroupsInput{
+		for chunk := range slices.Chunk(flex.ExpandStringValueSet(os.Difference(ns)), batchSize) {
+			input := &autoscaling.DetachLoadBalancerTargetGroupsInput{
 				AutoScalingGroupName: aws.String(d.Id()),
 				TargetGroupARNs:      chunk,
-			})
+			}
+
+			_, err := conn.DetachLoadBalancerTargetGroups(ctx, input)
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "detaching Auto Scaling Group (%s) target groups: %s", d.Id(), err)
@@ -1614,11 +1603,13 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			}
 		}
 
-		for _, chunk := range tfslices.Chunks(flex.ExpandStringValueSet(ns.Difference(os)), batchSize) {
-			_, err := conn.AttachLoadBalancerTargetGroups(ctx, &autoscaling.AttachLoadBalancerTargetGroupsInput{
+		for chunk := range slices.Chunk(flex.ExpandStringValueSet(ns.Difference(os)), batchSize) {
+			input := &autoscaling.AttachLoadBalancerTargetGroupsInput{
 				AutoScalingGroupName: aws.String(d.Id()),
 				TargetGroupARNs:      chunk,
-			})
+			}
+
+			_, err := conn.AttachLoadBalancerTargetGroups(ctx, input)
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "attaching Auto Scaling Group (%s) target groups: %s", d.Id(), err)
@@ -1717,14 +1708,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if d.HasChange("enabled_metrics") {
 		o, n := d.GetChange("enabled_metrics")
-		if o == nil {
-			o = new(schema.Set)
-		}
-		if n == nil {
-			n = new(schema.Set)
-		}
-		os := o.(*schema.Set)
-		ns := n.(*schema.Set)
+		os, ns := o.(*schema.Set), n.(*schema.Set)
 
 		if disableMetrics := os.Difference(ns); disableMetrics.Len() != 0 {
 			input := &autoscaling.DisableMetricsCollectionInput{
@@ -1756,14 +1740,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if d.HasChange("suspended_processes") {
 		o, n := d.GetChange("suspended_processes")
-		if o == nil {
-			o = new(schema.Set)
-		}
-		if n == nil {
-			n = new(schema.Set)
-		}
-		os := o.(*schema.Set)
-		ns := n.(*schema.Set)
+		os, ns := o.(*schema.Set), n.(*schema.Set)
 
 		if resumeProcesses := os.Difference(ns); resumeProcesses.Len() != 0 {
 			input := &autoscaling.ResumeProcessesInput{
@@ -1887,7 +1864,7 @@ func drainGroup(ctx context.Context, conn *autoscaling.Client, name string, inst
 		}
 	}
 	const batchSize = 50 // API limit.
-	for _, chunk := range tfslices.Chunks(instanceIDs, batchSize) {
+	for chunk := range slices.Chunk(instanceIDs, batchSize) {
 		input := &autoscaling.SetInstanceProtectionInput{
 			AutoScalingGroupName: aws.String(name),
 			InstanceIds:          chunk,

--- a/internal/service/connect/routing_profile.go
+++ b/internal/service/connect/routing_profile.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -361,8 +361,7 @@ func updateRoutingProfileQueueAssociations(ctx context.Context, conn *connect.Cl
 	// the respective queues based on the diff detected
 
 	// disassociate first since Queue and channel type combination cannot be duplicated
-	chunks := tfslices.Chunks(del, routingProfileQueueAssociationChunkSize)
-	for _, chunk := range chunks {
+	for chunk := range slices.Chunk(del, routingProfileQueueAssociationChunkSize) {
 		var queueReferences []awstypes.RoutingProfileQueueReference
 		for _, v := range chunk {
 			if v := v.QueueReference; v != nil {
@@ -385,8 +384,7 @@ func updateRoutingProfileQueueAssociations(ctx context.Context, conn *connect.Cl
 		}
 	}
 
-	chunks = tfslices.Chunks(add, routingProfileQueueAssociationChunkSize)
-	for _, chunk := range chunks {
+	for chunk := range slices.Chunk(add, routingProfileQueueAssociationChunkSize) {
 		input := &connect.AssociateRoutingProfileQueuesInput{
 			InstanceId:       aws.String(instanceID),
 			QueueConfigs:     chunk,

--- a/internal/service/docdb/cluster_parameter_group.go
+++ b/internal/service/docdb/cluster_parameter_group.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -226,7 +226,7 @@ func modifyClusterParameterGroupParameters(ctx context.Context, conn *docdb.Clie
 		clusterParameterGroupMaxParamsBulkEdit = 20
 	)
 	// We can only modify 20 parameters at a time, so chunk them until we've got them all.
-	for _, chunk := range tfslices.Chunks(parameters, clusterParameterGroupMaxParamsBulkEdit) {
+	for chunk := range slices.Chunk(parameters, clusterParameterGroupMaxParamsBulkEdit) {
 		input := &docdb.ModifyDBClusterParameterGroupInput{
 			DBClusterParameterGroupName: aws.String(name),
 			Parameters:                  chunk,

--- a/internal/service/kafka/scram_secret_association.go
+++ b/internal/service/kafka/scram_secret_association.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
-	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
@@ -163,7 +163,7 @@ func findSCRAMSecretsByClusterARN(ctx context.Context, conn *kafka.Client, clust
 }
 
 func associateSRAMSecrets(ctx context.Context, conn *kafka.Client, clusterARN string, secretARNs []string) error {
-	for _, chunk := range tfslices.Chunks(secretARNs, scramSecretBatchSize) {
+	for chunk := range slices.Chunk(secretARNs, scramSecretBatchSize) {
 		input := &kafka.BatchAssociateScramSecretInput{
 			ClusterArn:    aws.String(clusterARN),
 			SecretArnList: chunk,
@@ -184,7 +184,7 @@ func associateSRAMSecrets(ctx context.Context, conn *kafka.Client, clusterARN st
 }
 
 func disassociateSRAMSecrets(ctx context.Context, conn *kafka.Client, clusterARN string, secretARNs []string) error {
-	for _, chunk := range tfslices.Chunks(secretARNs, scramSecretBatchSize) {
+	for chunk := range slices.Chunk(secretARNs, scramSecretBatchSize) {
 		input := &kafka.BatchDisassociateScramSecretInput{
 			ClusterArn:    aws.String(clusterARN),
 			SecretArnList: chunk,

--- a/internal/service/lakeformation/exports_test.go
+++ b/internal/service/lakeformation/exports_test.go
@@ -10,4 +10,5 @@ var (
 
 	FindDataCellsFilterByID = findDataCellsFilterByID
 	FindResourceLFTagByID   = findResourceLFTagByID
+	LFTagParseResourceID    = lfTagParseResourceID
 )

--- a/internal/service/lakeformation/lf_tag.go
+++ b/internal/service/lakeformation/lf_tag.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 
 	"github.com/YakDriver/regexache"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
-	"github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -74,45 +74,46 @@ func resourceLFTagCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	tagKey := d.Get(names.AttrKey).(string)
 	tagValues := d.Get(names.AttrValues).(*schema.Set)
-
 	var catalogID string
 	if v, ok := d.GetOk(names.AttrCatalogID); ok {
 		catalogID = v.(string)
 	} else {
 		catalogID = meta.(*conns.AWSClient).AccountID
 	}
+	id := lfTagCreateResourceID(catalogID, tagKey)
 
-	tagValueChunks := slices.Chunks(tagValues.List(), lfTagsValuesMaxBatchSize)
+	i := 0
+	for chunk := range slices.Chunk(tagValues.List(), lfTagsValuesMaxBatchSize) {
+		if i == 0 {
+			input := &lakeformation.CreateLFTagInput{
+				CatalogId: aws.String(catalogID),
+				TagKey:    aws.String(tagKey),
+				TagValues: flex.ExpandStringValueList(chunk),
+			}
 
-	input := &lakeformation.CreateLFTagInput{
-		CatalogId: aws.String(catalogID),
-		TagKey:    aws.String(tagKey),
-		TagValues: flex.ExpandStringValueList(tagValueChunks[0]),
-	}
+			_, err := conn.CreateLFTag(ctx, input)
 
-	_, err := conn.CreateLFTag(ctx, input)
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Lake Formation LF-Tag: %s", err)
-	}
-
-	if len(tagValueChunks) > 1 {
-		tagValueChunks = tagValueChunks[1:]
-
-		for _, v := range tagValueChunks {
-			in := &lakeformation.UpdateLFTagInput{
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "creating Lake Formation LF-Tag (%s): %s", id, err)
+			}
+		} else {
+			input := &lakeformation.UpdateLFTagInput{
 				CatalogId:      aws.String(catalogID),
 				TagKey:         aws.String(tagKey),
-				TagValuesToAdd: flex.ExpandStringValueList(v),
+				TagValuesToAdd: flex.ExpandStringValueList(chunk),
 			}
 
-			_, err := conn.UpdateLFTag(ctx, in)
+			_, err := conn.UpdateLFTag(ctx, input)
+
 			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "creating Lake Formation LF-Tag: %s", err)
+				return sdkdiag.AppendErrorf(diags, "updating Lake Formation LF-Tag (%s): %s", id, err)
 			}
 		}
+
+		i++
 	}
 
-	d.SetId(fmt.Sprintf("%s:%s", catalogID, tagKey))
+	d.SetId(id)
 
 	return append(diags, resourceLFTagRead(ctx, d, meta)...)
 }
@@ -121,9 +122,9 @@ func resourceLFTagRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
-	catalogID, tagKey, err := ReadLFTagID(d.Id())
+	catalogID, tagKey, err := lfTagParseResourceID(d.Id())
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading Lake Formation LF-Tag (%s): %s", d.Id(), err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &lakeformation.GetLFTagInput{
@@ -155,9 +156,9 @@ func resourceLFTagUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
-	catalogID, tagKey, err := ReadLFTagID(d.Id())
+	catalogID, tagKey, err := lfTagParseResourceID(d.Id())
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating Lake Formation LF-Tag (%s): %s", d.Id(), err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	o, n := d.GetChange(names.AttrValues)
@@ -168,11 +169,11 @@ func resourceLFTagUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	var toAddChunks, toDeleteChunks [][]interface{}
 	if len(toAdd.List()) > 0 {
-		toAddChunks = slices.Chunks(toAdd.List(), lfTagsValuesMaxBatchSize)
+		toAddChunks = slices.Collect(slices.Chunk(toAdd.List(), lfTagsValuesMaxBatchSize))
 	}
 
 	if len(toDelete.List()) > 0 {
-		toDeleteChunks = slices.Chunks(toDelete.List(), lfTagsValuesMaxBatchSize)
+		toDeleteChunks = slices.Collect(slices.Chunk(toDelete.List(), lfTagsValuesMaxBatchSize))
 	}
 
 	for {
@@ -212,9 +213,9 @@ func resourceLFTagDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LakeFormationClient(ctx)
 
-	catalogID, tagKey, err := ReadLFTagID(d.Id())
+	catalogID, tagKey, err := lfTagParseResourceID(d.Id())
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting Lake Formation LF-Tag (%s): %s", d.Id(), err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &lakeformation.DeleteLFTagInput{
@@ -235,11 +236,20 @@ func resourceLFTagDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func ReadLFTagID(id string) (string, string, error) {
-	catalogID, tagKey, found := strings.Cut(id, ":")
+const lfTagResourceIDSeparator = ":"
+
+func lfTagCreateResourceID(catalogID, tagKey string) string {
+	parts := []string{catalogID, tagKey}
+	id := strings.Join(parts, lfTagResourceIDSeparator)
+
+	return id
+}
+
+func lfTagParseResourceID(id string) (string, string, error) {
+	catalogID, tagKey, found := strings.Cut(id, lfTagResourceIDSeparator)
 
 	if !found {
-		return "", "", fmt.Errorf("unexpected format of ID (%q), expected CATALOG-ID:TAG-KEY", id)
+		return "", "", fmt.Errorf("unexpected format of ID (%[1]s), expected CATALOG-ID%[2]sTAG-KEY", id, lfTagResourceIDSeparator)
 	}
 
 	return catalogID, tagKey, nil

--- a/internal/service/lakeformation/lf_tag_test.go
+++ b/internal/service/lakeformation/lf_tag_test.go
@@ -59,7 +59,7 @@ func TestReadLFTagID(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			catalogID, tagKey, err := tflakeformation.ReadLFTagID(test.val)
+			catalogID, tagKey, err := tflakeformation.LFTagParseResourceID(test.val)
 
 			if err == nil && test.expectError {
 				t.Fatal("expected error")
@@ -253,7 +253,7 @@ func testAccCheckLFTagsDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			catalogID, tagKey, err := tflakeformation.ReadLFTagID(rs.Primary.ID)
+			catalogID, tagKey, err := tflakeformation.LFTagParseResourceID(rs.Primary.ID)
 			if err != nil {
 				return err
 			}
@@ -288,7 +288,7 @@ func testAccCheckLFTagExists(ctx context.Context, name string) resource.TestChec
 			return fmt.Errorf("no ID is set")
 		}
 
-		catalogID, tagKey, err := tflakeformation.ReadLFTagID(rs.Primary.ID)
+		catalogID, tagKey, err := tflakeformation.LFTagParseResourceID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -316,7 +316,7 @@ func testAccCheckLFTagValuesLen(ctx context.Context, name string, expectedLength
 			return fmt.Errorf("no ID is set")
 		}
 
-		catalogID, tagKey, err := tflakeformation.ReadLFTagID(rs.Primary.ID)
+		catalogID, tagKey, err := tflakeformation.LFTagParseResourceID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/service/neptune/cluster_parameter_group.go
+++ b/internal/service/neptune/cluster_parameter_group.go
@@ -242,7 +242,7 @@ func modifyClusterParameterGroupParameters(ctx context.Context, conn *neptune.Cl
 		clusterParameterGroupMaxParamsBulkEdit = 20
 	)
 	// We can only modify 20 parameters at a time, so chunk them until we've got them all.
-	for _, chunk := range tfslices.Chunks(parameters, clusterParameterGroupMaxParamsBulkEdit) {
+	for chunk := range slices.Chunk(parameters, clusterParameterGroupMaxParamsBulkEdit) {
 		input := &neptune.ModifyDBClusterParameterGroupInput{
 			DBClusterParameterGroupName: aws.String(name),
 			Parameters:                  chunk,

--- a/internal/service/neptune/parameter_group.go
+++ b/internal/service/neptune/parameter_group.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -226,7 +226,7 @@ func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, m
 }
 
 func addDBParameterGroupParameters(ctx context.Context, conn *neptune.Client, name string, parameters []awstypes.Parameter) error { // We can only modify 20 parameters at a time, so chunk them until we've got them all.
-	for _, chunk := range tfslices.Chunks(parameters, dbParameterGroupMaxParamsBulkEdit) {
+	for chunk := range slices.Chunk(parameters, dbParameterGroupMaxParamsBulkEdit) {
 		input := &neptune.ModifyDBParameterGroupInput{
 			DBParameterGroupName: aws.String(name),
 			Parameters:           chunk,
@@ -243,7 +243,7 @@ func addDBParameterGroupParameters(ctx context.Context, conn *neptune.Client, na
 }
 
 func delDBParameterGroupParameters(ctx context.Context, conn *neptune.Client, name string, parameters []awstypes.Parameter) error { // We can only modify 20 parameters at a time, so chunk them until we've got them all.
-	for _, chunk := range tfslices.Chunks(parameters, dbParameterGroupMaxParamsBulkEdit) {
+	for chunk := range slices.Chunk(parameters, dbParameterGroupMaxParamsBulkEdit) {
 		input := &neptune.ResetDBParameterGroupInput{
 			DBParameterGroupName: aws.String(name),
 			Parameters:           chunk,

--- a/internal/service/rds/cluster_parameter_group.go
+++ b/internal/service/rds/cluster_parameter_group.go
@@ -208,7 +208,7 @@ func resourceClusterParameterGroupUpdate(ctx context.Context, d *schema.Resource
 		o, n := d.GetChange(names.AttrParameter)
 		os, ns := o.(*schema.Set), n.(*schema.Set)
 
-		for _, chunk := range tfslices.Chunks(expandParameters(ns.Difference(os).List()), maxParamModifyChunk) {
+		for chunk := range slices.Chunk(expandParameters(ns.Difference(os).List()), maxParamModifyChunk) {
 			input := &rds.ModifyDBClusterParameterGroupInput{
 				DBClusterParameterGroupName: aws.String(d.Id()),
 				Parameters:                  chunk,
@@ -236,7 +236,7 @@ func resourceClusterParameterGroupUpdate(ctx context.Context, d *schema.Resource
 		}
 
 		// Reset parameters that have been removed.
-		for _, chunk := range tfslices.Chunks(maps.Values(toRemove), maxParamModifyChunk) {
+		for chunk := range slices.Chunk(maps.Values(toRemove), maxParamModifyChunk) {
 			input := &rds.ResetDBClusterParameterGroupInput{
 				DBClusterParameterGroupName: aws.String(d.Id()),
 				Parameters:                  chunk,

--- a/internal/service/route53/zone.go
+++ b/internal/service/route53/zone.go
@@ -383,8 +383,7 @@ func deleteAllResourceRecordsFromHostedZone(ctx context.Context, conn *route53.C
 	const (
 		chunkSize = 100
 	)
-	chunks := tfslices.Chunks(resourceRecordSets, chunkSize)
-	for _, chunk := range chunks {
+	for chunk := range slices.Chunk(resourceRecordSets, chunkSize) {
 		changes := tfslices.ApplyToAll(chunk, func(v awstypes.ResourceRecordSet) awstypes.Change {
 			return awstypes.Change{
 				Action:            awstypes.ChangeActionDelete,

--- a/internal/service/ssm/document.go
+++ b/internal/service/ssm/document.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
-	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -290,9 +290,7 @@ func resourceDocumentCreate(ctx context.Context, d *schema.ResourceData, meta in
 		tfMap := flex.ExpandStringValueMap(v.(map[string]interface{}))
 
 		if v, ok := tfMap["account_ids"]; ok && v != "" {
-			chunks := tfslices.Chunks(strings.Split(v, ","), documentPermissionsBatchLimit)
-
-			for _, chunk := range chunks {
+			for chunk := range slices.Chunk(strings.Split(v, ","), documentPermissionsBatchLimit) {
 				input := &ssm.ModifyDocumentPermissionInput{
 					AccountIdsToAdd: chunk,
 					Name:            aws.String(d.Id()),
@@ -426,7 +424,7 @@ func resourceDocumentUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			}
 		}
 
-		for _, chunk := range tfslices.Chunks(newAccountIDs.Difference(oldAccountIDs), documentPermissionsBatchLimit) {
+		for chunk := range slices.Chunk(newAccountIDs.Difference(oldAccountIDs), documentPermissionsBatchLimit) {
 			input := &ssm.ModifyDocumentPermissionInput{
 				AccountIdsToAdd: chunk,
 				Name:            aws.String(d.Id()),
@@ -440,7 +438,7 @@ func resourceDocumentUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			}
 		}
 
-		for _, chunk := range tfslices.Chunks(oldAccountIDs.Difference(newAccountIDs), documentPermissionsBatchLimit) {
+		for chunk := range slices.Chunk(oldAccountIDs.Difference(newAccountIDs), documentPermissionsBatchLimit) {
 			input := &ssm.ModifyDocumentPermissionInput{
 				AccountIdsToRemove: chunk,
 				Name:               aws.String(d.Id()),
@@ -517,9 +515,7 @@ func resourceDocumentDelete(ctx context.Context, d *schema.ResourceData, meta in
 		tfMap := flex.ExpandStringValueMap(v.(map[string]interface{}))
 
 		if v, ok := tfMap["account_ids"]; ok && v != "" {
-			chunks := tfslices.Chunks(strings.Split(v, ","), documentPermissionsBatchLimit)
-
-			for _, chunk := range chunks {
+			for chunk := range slices.Chunk(strings.Split(v, ","), documentPermissionsBatchLimit) {
 				input := &ssm.ModifyDocumentPermissionInput{
 					AccountIdsToRemove: chunk,
 					Name:               aws.String(d.Id()),

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -100,23 +100,6 @@ func Any[S ~[]E, E any](s S, f Predicate[E]) bool {
 	return false
 }
 
-// Chunks returns a slice of S, each of the specified size (or less).
-func Chunks[S ~[]E, E any](s S, size int) []S {
-	chunks := make([]S, 0)
-
-	for i := 0; i < len(s); i += size {
-		end := i + size
-
-		if end > len(s) {
-			end = len(s)
-		}
-
-		chunks = append(chunks, s[i:end])
-	}
-
-	return chunks
-}
-
 // AppendUnique appends unique (not already in the slice) values to a slice.
 func AppendUnique[S ~[]E, E comparable](s S, vs ...E) S {
 	for _, v := range vs {

--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -153,45 +153,6 @@ func TestApplyToAll(t *testing.T) {
 	}
 }
 
-func TestChunk(t *testing.T) {
-	t.Parallel()
-
-	type testCase struct {
-		input    []string
-		expected [][]string
-	}
-	tests := map[string]testCase{
-		"three elements": {
-			input:    []string{"one", "two", "3"},
-			expected: [][]string{{"one", "two"}, {"3"}},
-		},
-		"two elements": {
-			input:    []string{"aa", "bb"},
-			expected: [][]string{{"aa", "bb"}},
-		},
-		"one element": {
-			input:    []string{"1"},
-			expected: [][]string{{"1"}},
-		},
-		"zero elements": {
-			input:    []string{},
-			expected: [][]string{},
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			got := Chunks(test.input, 2)
-
-			if diff := cmp.Diff(got, test.expected); diff != "" {
-				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
-			}
-		})
-	}
-}
-
 func TestFilter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use the new Go 1.23 [`slices.Chunk`](https://go.dev/pkg/slices#Chunk) function as a replacement for our `internal/slices.Chunks`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/38999.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccLakeFormation_serial/^LFTags$$' PKG=lakeformation
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/lakeformation/... -v -count 1 -parallel 20  -run=TestAccLakeFormation_serial/^LFTags$ -timeout 360m
=== RUN   TestAccLakeFormation_serial
=== PAUSE TestAccLakeFormation_serial
=== CONT  TestAccLakeFormation_serial
=== RUN   TestAccLakeFormation_serial/LFTags
=== RUN   TestAccLakeFormation_serial/LFTags/values
=== RUN   TestAccLakeFormation_serial/LFTags/valuesOverFifty
=== RUN   TestAccLakeFormation_serial/LFTags/basic
=== RUN   TestAccLakeFormation_serial/LFTags/disappears
=== RUN   TestAccLakeFormation_serial/LFTags/tagKeyComplex
--- PASS: TestAccLakeFormation_serial (78.55s)
    --- PASS: TestAccLakeFormation_serial/LFTags (78.55s)
        --- PASS: TestAccLakeFormation_serial/LFTags/values (20.60s)
        --- PASS: TestAccLakeFormation_serial/LFTags/valuesOverFifty (25.66s)
        --- PASS: TestAccLakeFormation_serial/LFTags/basic (12.05s)
        --- PASS: TestAccLakeFormation_serial/LFTags/disappears (10.33s)
        --- PASS: TestAccLakeFormation_serial/LFTags/tagKeyComplex (9.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	83.418s
```
```console
% make testacc TESTARGS='-run=TestAccAutoScalingGroup_basic\|TestAccAutoScalingGroup_withTrafficSourcesELBs\|TestAccAutoScalingGroup_loadBalancers\|TestAccAutoScalingGroup_targetGroups' PKG=autoscaling ACCTEST_PARALLELISM=2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/autoscaling/... -v -count 1 -parallel 2  -run=TestAccAutoScalingGroup_basic\|TestAccAutoScalingGroup_withTrafficSourcesELBs\|TestAccAutoScalingGroup_loadBalancers\|TestAccAutoScalingGroup_targetGroups -timeout 360m
=== RUN   TestAccAutoScalingGroup_basic
=== PAUSE TestAccAutoScalingGroup_basic
=== RUN   TestAccAutoScalingGroup_withTrafficSourcesELBs
=== PAUSE TestAccAutoScalingGroup_withTrafficSourcesELBs
=== RUN   TestAccAutoScalingGroup_loadBalancers
=== PAUSE TestAccAutoScalingGroup_loadBalancers
=== RUN   TestAccAutoScalingGroup_targetGroups
=== PAUSE TestAccAutoScalingGroup_targetGroups
=== CONT  TestAccAutoScalingGroup_basic
=== CONT  TestAccAutoScalingGroup_loadBalancers
--- PASS: TestAccAutoScalingGroup_basic (66.57s)
=== CONT  TestAccAutoScalingGroup_targetGroups
--- PASS: TestAccAutoScalingGroup_targetGroups (167.58s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourcesELBs
--- PASS: TestAccAutoScalingGroup_loadBalancers (329.49s)
--- PASS: TestAccAutoScalingGroup_withTrafficSourcesELBs (238.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	477.936s
```
