### PR TITLE
Clean up uses of `aws-sdk-go-base/v2/awsv1shim/v2/tfawserr`

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -44,7 +44,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	tfawserr_sdkv1 "github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	tfawserr_sdkv2 "github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
@@ -1821,31 +1822,31 @@ func PreCheckSkipError(err error) bool {
 	// GovCloud has endpoints that respond with (no message provided after the error code):
 	// AccessDeniedException:
 	// Ignore these API endpoints that exist but are not officially enabled
-	if tfawserr.ErrCodeEquals(err, "AccessDeniedException") {
+	if tfawserr_sdkv1.ErrCodeEquals(err, "AccessDeniedException") || tfawserr_sdkv2.ErrCodeEquals(err, "AccessDeniedException") {
 		return true
 	}
 	// Ignore missing API endpoints
-	if tfawserr.ErrMessageContains(err, "RequestError", "send request failed") {
+	if tfawserr_sdkv1.ErrMessageContains(err, "RequestError", "send request failed") || tfawserr_sdkv2.ErrMessageContains(err, "RequestError", "send request failed") {
 		return true
 	}
 	// Ignore unsupported API calls
-	if tfawserr.ErrCodeEquals(err, "UnknownOperationException") {
+	if tfawserr_sdkv1.ErrCodeEquals(err, "UnknownOperationException") || tfawserr_sdkv2.ErrCodeEquals(err, "UnknownOperationException") {
 		return true
 	}
-	if tfawserr.ErrCodeEquals(err, "UnsupportedOperation") {
+	if tfawserr_sdkv1.ErrCodeEquals(err, "UnsupportedOperation") || tfawserr_sdkv2.ErrCodeEquals(err, "UnsupportedOperation") {
 		return true
 	}
-	if tfawserr.ErrMessageContains(err, "InvalidInputException", "Unknown operation") {
+	if tfawserr_sdkv1.ErrMessageContains(err, "InvalidInputException", "Unknown operation") || tfawserr_sdkv2.ErrMessageContains(err, "InvalidInputException", "Unknown operation") {
 		return true
 	}
-	if tfawserr.ErrMessageContains(err, "InvalidAction", "is not valid") {
+	if tfawserr_sdkv1.ErrMessageContains(err, "InvalidAction", "is not valid") || tfawserr_sdkv2.ErrMessageContains(err, "InvalidAction", "is not valid") {
 		return true
 	}
-	if tfawserr.ErrMessageContains(err, "InvalidAction", "Unavailable Operation") {
+	if tfawserr_sdkv1.ErrMessageContains(err, "InvalidAction", "Unavailable Operation") || tfawserr_sdkv2.ErrMessageContains(err, "InvalidAction", "Unavailable Operation") {
 		return true
 	}
 	// ignore when not authorized to call API from account
-	if tfawserr.ErrCodeEquals(err, "ForbiddenException") {
+	if tfawserr_sdkv1.ErrCodeEquals(err, "ForbiddenException") || tfawserr_sdkv2.ErrCodeEquals(err, "ForbiddenException") {
 		return true
 	}
 	// Ignore missing API endpoints

--- a/internal/errs/unsupported.go
+++ b/internal/errs/unsupported.go
@@ -4,7 +4,7 @@
 package errs
 
 import (
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	tfawserr_sdkv1 "github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	tfawserr_sdkv2 "github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -106,9 +106,9 @@ func IsUnsupportedOperationInPartitionError(partition string, err error) bool {
 }
 
 func errCodeContains(err error, code string) bool {
-	return tfawserr.ErrCodeContains(err, code) || tfawserr_sdkv2.ErrCodeContains(err, code)
+	return tfawserr_sdkv1.ErrCodeContains(err, code) || tfawserr_sdkv2.ErrCodeContains(err, code)
 }
 
 func errMessageContains(err error, code, message string) bool {
-	return tfawserr.ErrMessageContains(err, code, message) || tfawserr_sdkv2.ErrMessageContains(err, code, message)
+	return tfawserr_sdkv1.ErrMessageContains(err, code, message) || tfawserr_sdkv2.ErrMessageContains(err, code, message)
 }

--- a/internal/service/dax/cluster_test.go
+++ b/internal/service/dax/cluster_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dax"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/dax/types"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -355,6 +355,7 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 	input := &dax.DescribeClustersInput{}
 
 	_, err := conn.DescribeClusters(ctx, input)
+
 	if acctest.PreCheckSkipError(err) || tfawserr.ErrMessageContains(err, "InvalidParameterValueException", "Access Denied to API Version: DAX_V3") {
 		t.Skipf("skipping acceptance testing: %s", err)
 	}

--- a/internal/service/mwaa/environment.go
+++ b/internal/service/mwaa/environment.go
@@ -35,7 +35,7 @@ const (
 
 // @SDKResource("aws_mwaa_environment", name="Environment")
 // @Tags(identifierAttribute="arn")
-func ResourceEnvironment() *schema.Resource {
+func resourceEnvironment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEnvironmentCreate,
 		ReadWithoutTimeout:   resourceEnvironmentRead,
@@ -441,7 +441,7 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	conn := meta.(*conns.AWSClient).MWAAClient(ctx)
 
-	environment, err := FindEnvironmentByName(ctx, conn, d.Id())
+	environment, err := findEnvironmentByName(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] MWAA Environment %s not found, removing from state", d.Id())
@@ -661,7 +661,7 @@ func environmentModuleLoggingConfigurationSchema() *schema.Resource {
 	}
 }
 
-func FindEnvironmentByName(ctx context.Context, conn *mwaa.Client, name string) (*awstypes.Environment, error) {
+func findEnvironmentByName(ctx context.Context, conn *mwaa.Client, name string) (*awstypes.Environment, error) {
 	input := &mwaa.GetEnvironmentInput{
 		Name: aws.String(name),
 	}
@@ -688,7 +688,7 @@ func FindEnvironmentByName(ctx context.Context, conn *mwaa.Client, name string) 
 
 func statusEnvironment(ctx context.Context, conn *mwaa.Client, name string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		environment, err := FindEnvironmentByName(ctx, conn, name)
+		environment, err := findEnvironmentByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/mwaa/exports_test.go
+++ b/internal/service/mwaa/exports_test.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package mwaa
+
+// Exports for use in tests only.
+var (
+	ResourceEnvironment = resourceEnvironment
+
+	FindEnvironmentByName = findEnvironmentByName
+)

--- a/internal/service/mwaa/service_package_gen.go
+++ b/internal/service/mwaa/service_package_gen.go
@@ -29,7 +29,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
 		{
-			Factory:  ResourceEnvironment,
+			Factory:  resourceEnvironment,
 			TypeName: "aws_mwaa_environment",
 			Name:     "Environment",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/mwaa/sweep.go
+++ b/internal/service/mwaa/sweep.go
@@ -8,8 +8,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/mwaa"
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
@@ -28,34 +27,37 @@ func sweepEnvironment(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
+	input := &mwaa.ListEnvironmentsInput{}
 	conn := client.MWAAClient(ctx)
-
 	sweepResources := make([]sweep.Sweepable, 0)
-	var sweeperErrs *multierror.Error
 
-	pages := mwaa.NewListEnvironmentsPaginator(conn, &mwaa.ListEnvironmentsInput{})
+	pages := mwaa.NewListEnvironmentsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-		if err != nil {
-			if awsv2.SkipSweepError(err) || tfawserr.ErrCodeEquals(err, "InternalFailure") {
-				log.Printf("[WARN] Skipping MWAA Environment sweep for %s: %s", region, err)
-				return nil
-			}
-			return fmt.Errorf("error retrieving MWAA Environment: %s", err)
+
+		if awsv2.SkipSweepError(err) || tfawserr.ErrCodeEquals(err, "InternalFailure") {
+			log.Printf("[WARN] Skipping MWAA Environment sweep for %s: %s", region, err)
+			return nil
 		}
 
-		for _, name := range page.Environments {
+		if err != nil {
+			return fmt.Errorf("error listing MWAA Environments (%s): %w", region, err)
+		}
+
+		for _, v := range page.Environments {
 			r := ResourceEnvironment()
 			d := r.Data(nil)
-			d.SetId(name)
+			d.SetId(v)
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
 	}
 
-	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping MWAA Environment: %w", err))
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping MWAA Environments (%s): %w", region, err)
 	}
 
-	return sweeperErrs.ErrorOrNil()
+	return nil
 }

--- a/internal/service/mwaa/sweep.go
+++ b/internal/service/mwaa/sweep.go
@@ -45,7 +45,7 @@ func sweepEnvironment(region string) error {
 		}
 
 		for _, v := range page.Environments {
-			r := ResourceEnvironment()
+			r := resourceEnvironment()
 			d := r.Data(nil)
 			d.SetId(v)
 

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
+	tfawserr_sdkv1 "github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
 	tfawserr_sdkv2 "github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -96,7 +96,7 @@ func RetryGWhen[T any](ctx context.Context, timeout time.Duration, f func() (T, 
 // RetryWhenAWSErrCodeEquals retries the specified function when it returns one of the specified AWS error codes.
 func RetryWhenAWSErrCodeEquals(ctx context.Context, timeout time.Duration, f func() (interface{}, error), codes ...string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if tfawserr.ErrCodeEquals(err, codes...) || tfawserr_sdkv2.ErrCodeEquals(err, codes...) {
+		if tfawserr_sdkv1.ErrCodeEquals(err, codes...) || tfawserr_sdkv2.ErrCodeEquals(err, codes...) {
 			return true, err
 		}
 
@@ -107,7 +107,7 @@ func RetryWhenAWSErrCodeEquals(ctx context.Context, timeout time.Duration, f fun
 // RetryWhenAWSErrCodeContains retries the specified function when it returns an AWS error containing the specified code.
 func RetryWhenAWSErrCodeContains(ctx context.Context, timeout time.Duration, f func() (interface{}, error), code string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if tfawserr.ErrCodeContains(err, code) || tfawserr_sdkv2.ErrCodeContains(err, code) {
+		if tfawserr_sdkv1.ErrCodeContains(err, code) || tfawserr_sdkv2.ErrCodeContains(err, code) {
 			return true, err
 		}
 
@@ -118,7 +118,7 @@ func RetryWhenAWSErrCodeContains(ctx context.Context, timeout time.Duration, f f
 // RetryWhenAWSErrMessageContains retries the specified function when it returns an AWS error containing the specified message.
 func RetryWhenAWSErrMessageContains(ctx context.Context, timeout time.Duration, f func() (interface{}, error), code, message string) (interface{}, error) { // nosemgrep:ci.aws-in-func-name
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if tfawserr.ErrMessageContains(err, code, message) || tfawserr_sdkv2.ErrMessageContains(err, code, message) {
+		if tfawserr_sdkv1.ErrMessageContains(err, code, message) || tfawserr_sdkv2.ErrMessageContains(err, code, message) {
 			return true, err
 		}
 
@@ -130,7 +130,7 @@ func RetryWhenAWSErrMessageContains(ctx context.Context, timeout time.Duration, 
 func RetryWhenMessageContains(ctx context.Context, timeout time.Duration, f func() (interface{}, error), codes []string, messages []string) (interface{}, error) {
 	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
 		for i, message := range messages {
-			if tfawserr.ErrMessageContains(err, codes[i], message) || tfawserr_sdkv2.ErrMessageContains(err, codes[i], message) {
+			if tfawserr_sdkv1.ErrMessageContains(err, codes[i], message) || tfawserr_sdkv2.ErrMessageContains(err, codes[i], message) {
 				return true, err
 			}
 		}
@@ -143,7 +143,7 @@ func RetryWhenMessageContains(ctx context.Context, timeout time.Duration, f func
 func RetryGWhenMessageContains[T any](ctx context.Context, timeout time.Duration, f func() (T, error), codes []string, messages []string) (T, error) {
 	return RetryGWhen(ctx, timeout, f, func(err error) (bool, error) {
 		for i, message := range messages {
-			if tfawserr.ErrMessageContains(err, codes[i], message) || tfawserr_sdkv2.ErrMessageContains(err, codes[i], message) {
+			if tfawserr_sdkv1.ErrMessageContains(err, codes[i], message) || tfawserr_sdkv2.ErrMessageContains(err, codes[i], message) {
 				return true, err
 			}
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

With the near completion of the migration to AWS SDK for Go v2 (https://github.com/hashicorp/terraform-provider-aws/issues/32976), cleanup any errant uses of `aws-sdk-go-base/v2/awsv1shim/v2/tfawserr` (which checks only AWS SDK for Go v1 errors).

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SWEEPERS=aws_mwaa_environment make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.23.0 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run='aws_mwaa_environment' -timeout 360m
2024/09/04 15:35:05 [DEBUG] Running Sweepers for region (us-west-2):
2024/09/04 15:35:05 [DEBUG] Running Sweeper (aws_mwaa_environment) in region (us-west-2)
2024/09/04 15:35:05 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2
2024-09-04T15:35:05.404-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-2
2024-09-04T15:35:05.405-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2
2024-09-04T15:35:05.405-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-2
2024-09-04T15:35:05.405-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-2 tf_aws.credentials_source=EnvConfigCredentials
2024-09-04T15:35:05.405-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2
2024/09/04 15:35:05 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-west-2
2024/09/04 15:35:05 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-2
2024-09-04T15:35:05.405-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-2
2024-09-04T15:35:05.799-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-2
2024/09/04 15:35:06 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2
2024/09/04 15:35:06 [DEBUG] Completed Sweeper (aws_mwaa_environment) in region (us-west-2) in 910.904542ms
2024/09/04 15:35:06 Completed Sweepers for region (us-west-2) in 911.083583ms
2024/09/04 15:35:06 Sweeper Tests for region (us-west-2) ran successfully:
2024/09/04 15:35:06 	- aws_mwaa_environment
2024/09/04 15:35:06 [DEBUG] Running Sweepers for region (us-east-1):
2024/09/04 15:35:06 [DEBUG] Running Sweeper (aws_mwaa_environment) in region (us-east-1)
2024/09/04 15:35:06 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-1
2024-09-04T15:35:06.315-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-1
2024-09-04T15:35:06.315-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1
2024-09-04T15:35:06.315-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-1
2024-09-04T15:35:06.316-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-1 tf_aws.credentials_source=EnvConfigCredentials
2024-09-04T15:35:06.316-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1
2024/09/04 15:35:06 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-east-1
2024/09/04 15:35:06 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-1
2024-09-04T15:35:06.316-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-1
2024-09-04T15:35:06.440-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-1
2024/09/04 15:35:06 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1
2024/09/04 15:35:06 [DEBUG] Completed Sweeper (aws_mwaa_environment) in region (us-east-1) in 277.47925ms
2024/09/04 15:35:06 Completed Sweepers for region (us-east-1) in 277.50975ms
2024/09/04 15:35:06 Sweeper Tests for region (us-east-1) ran successfully:
2024/09/04 15:35:06 	- aws_mwaa_environment
2024/09/04 15:35:06 [DEBUG] Running Sweepers for region (us-east-2):
2024/09/04 15:35:06 [DEBUG] Running Sweeper (aws_mwaa_environment) in region (us-east-2)
2024/09/04 15:35:06 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-2
2024-09-04T15:35:06.593-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-2
2024-09-04T15:35:06.593-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2
2024-09-04T15:35:06.593-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-2
2024-09-04T15:35:06.593-0400 [INFO]  sweeper.aws-base: Retrieved credentials: tf_aws.credentials_source=EnvConfigCredentials sweeper_region=us-east-2
2024-09-04T15:35:06.593-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2
2024/09/04 15:35:06 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-east-2
2024/09/04 15:35:06 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-2
2024-09-04T15:35:06.594-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-2
2024-09-04T15:35:06.773-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-2
2024/09/04 15:35:07 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2
2024/09/04 15:35:07 [DEBUG] Completed Sweeper (aws_mwaa_environment) in region (us-east-2) in 557.609834ms
2024/09/04 15:35:07 Completed Sweepers for region (us-east-2) in 557.731375ms
2024/09/04 15:35:07 Sweeper Tests for region (us-east-2) ran successfully:
2024/09/04 15:35:07 	- aws_mwaa_environment
2024/09/04 15:35:07 [DEBUG] Running Sweepers for region (us-west-1):
2024/09/04 15:35:07 [DEBUG] Running Sweeper (aws_mwaa_environment) in region (us-west-1)
2024/09/04 15:35:07 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-1
2024-09-04T15:35:07.151-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-1
2024-09-04T15:35:07.151-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1
2024-09-04T15:35:07.151-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-1
2024-09-04T15:35:07.151-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-1 tf_aws.credentials_source=EnvConfigCredentials
2024-09-04T15:35:07.151-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1
2024/09/04 15:35:07 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-west-1
2024/09/04 15:35:07 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-1
2024-09-04T15:35:07.152-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-1
2024-09-04T15:35:07.528-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-1
2024/09/04 15:35:07 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-1
2024/09/04 15:35:07 [DEBUG] Completed Sweeper (aws_mwaa_environment) in region (us-west-1) in 830.39925ms
2024/09/04 15:35:07 Completed Sweepers for region (us-west-1) in 830.483542ms
2024/09/04 15:35:07 Sweeper Tests for region (us-west-1) ran successfully:
2024/09/04 15:35:07 	- aws_mwaa_environment
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	7.583s
```
