### PR TITLE
Fix Redis Engine Version Parsing for 6.x

### DIFF
--- a/internal/service/elasticache/engine_version_test.go
+++ b/internal/service/elasticache/engine_version_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/go-version"
+	gversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -908,6 +909,64 @@ func TestParamGroupNameRequiresMajorVersionUpgrade(t *testing.T) {
 				if !testcase.expectError.MatchString(err.Error()) {
 					t.Fatalf("unexpected error: %q", err.Error())
 				}
+			}
+		})
+	}
+}
+
+func TestDetermineAttrEngineVersionRedis(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		configVersion string // state file value
+		engineVersion string // aws value
+		expected      string
+	}{
+		{
+			configVersion: "5.4.3",
+			engineVersion: "5.4.3",
+			expected:      "5.4.3",
+		},
+		{
+			configVersion: "5.4.3",
+			engineVersion: "7.1",
+			expected:      "7.1",
+		},
+		{
+			configVersion: "6.x",
+			engineVersion: "6.2.6",
+			expected:      "6.x",
+		},
+		{
+			configVersion: "6.2.6",
+			engineVersion: "7.1",
+			expected:      "7.1",
+		},
+		{
+			configVersion: "7.0",
+			engineVersion: "7.1",
+			expected:      "7.1",
+		},
+		{
+			configVersion: "6.x",
+			engineVersion: "7.1",
+			expected:      "7.1",
+		},
+	}
+
+	for _, testcase := range testcases {
+		testcase := testcase
+		t.Run(testcase.engineVersion, func(t *testing.T) {
+			t.Parallel()
+			engineVersion, _ := gversion.NewVersion(testcase.engineVersion)
+			attrEngineVersion, err := tfelasticache.DetermineAttrEngineVersionRedis(testcase.configVersion, engineVersion)
+
+			if err != nil {
+				t.Errorf("expected no error, got %s", err)
+			}
+
+			if testcase.expected != attrEngineVersion {
+				t.Errorf("expected %s, got %s", testcase.expected, attrEngineVersion)
 			}
 		})
 	}

--- a/internal/service/elasticache/exports_test.go
+++ b/internal/service/elasticache/exports_test.go
@@ -31,6 +31,7 @@ var (
 	WaitReplicationGroupAvailable        = waitReplicationGroupAvailable
 
 	DeleteCacheCluster                        = deleteCacheCluster
+	DetermineAttrEngineVersionRedis           = determineAttrEngineVersionRedis
 	DiffVersion                               = diffVersion
 	EmptyDescription                          = emptyDescription
 	EngineMemcached                           = engineMemcached


### PR DESCRIPTION
### Description
If a redis cluster was configured in terraform using version `6.x` and manually updated in the AWS console to version `7.0` or `7.1`, during the planning phase we'll get the following error: `parsing old engine_version: Malformed version: 7.x:`

We should only try to us `6.x` if the cluster is using redis6.

### Relations

Closes #36605

### References
We discovered that this issue started with aws provider v5.3.0. v5.2.0 did not have any problems.

#### Reproduction
1. Create a redis cluster with version 6.2.6 in terraform
1. Manually upgrade to 7.1.0 in the console
1. Run terraform plan and see that it throws the following error: │ Error: parsing old engine_version: Malformed version: 7.x
1. In v4.x to v5.2 we'd see that it tries to propose `engine_version = 7.x`:
```
 # module.poc.module.redis-instance.aws_elasticache_replication_group.redis must be replaced
-/+ resource "aws_elasticache_replication_group" "redis" {
      ...
      ~ engine_version                 = "7.x" -> "7.1" # forces replacement
      ~ engine_version_actual          = "7.1.0" -> (known after apply)
      ...
      ~ parameter_group_name           = "default.redis7" -> (known after apply)
      ...
```

We think the error occurs [here](https://github.com/hashicorp/terraform-provider-aws/blob/524df2d6dc78ccfc2256ee2a0951afeb24a0c3b7/internal/service/elasticache/engine_version.go#L177)
**`engineVersion, err := gversion.NewVersion(aws.ToString(version))`**
- The engine version that gets passed in here is what is retrieved from AWS engine_version.go:setEngineVersionRedis() called by global_replication_group.go:resourceGlobalReplicationGroupRead()
- resourceGlobalReplicationGroupRead is reading the resource from AWS
- Since we upgraded the cluster manually, the version passed to this function 7.1

**`configVersion := d.Get(names.AttrEngineVersion).(string)`**
* d the schema, populated by the terraform plan. In this case, d.engine_version is 6.x.
![image](https://github.com/user-attachments/assets/b9640778-e5fa-40b2-a218-f18676db95a3)
* Since we're in this code block, it then tries to set/update the schema. It parses the value in **`engineVersion.Segments()[0]`**
* However, engineVersion is actually passed in as 7.1
* It also assumes that it only needs to update part of the string! **`fmt.Sprintf("%d.x"`** and that's why we're seeing 7.x

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
❯ make testacc TESTS=TestDetermineAttrEngineVersionRedis PKG=elasticache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestDetermineAttrEngineVersionRedis'  -timeout 360m
=== RUN   TestDetermineAttrEngineVersionRedis
=== PAUSE TestDetermineAttrEngineVersionRedis
=== CONT  TestDetermineAttrEngineVersionRedis
=== RUN   TestDetermineAttrEngineVersionRedis/5.4.3
=== PAUSE TestDetermineAttrEngineVersionRedis/5.4.3
=== RUN   TestDetermineAttrEngineVersionRedis/7.1
=== PAUSE TestDetermineAttrEngineVersionRedis/7.1
=== RUN   TestDetermineAttrEngineVersionRedis/6.2.6
=== PAUSE TestDetermineAttrEngineVersionRedis/6.2.6
=== RUN   TestDetermineAttrEngineVersionRedis/7.1#01
=== PAUSE TestDetermineAttrEngineVersionRedis/7.1#01
=== RUN   TestDetermineAttrEngineVersionRedis/7.1#02
=== PAUSE TestDetermineAttrEngineVersionRedis/7.1#02
=== RUN   TestDetermineAttrEngineVersionRedis/7.1#03
=== PAUSE TestDetermineAttrEngineVersionRedis/7.1#03
=== CONT  TestDetermineAttrEngineVersionRedis/5.4.3
=== CONT  TestDetermineAttrEngineVersionRedis/7.1#01
=== CONT  TestDetermineAttrEngineVersionRedis/7.1#02
=== CONT  TestDetermineAttrEngineVersionRedis/7.1
=== CONT  TestDetermineAttrEngineVersionRedis/7.1#03
=== CONT  TestDetermineAttrEngineVersionRedis/6.2.6
--- PASS: TestDetermineAttrEngineVersionRedis (0.00s)
    --- PASS: TestDetermineAttrEngineVersionRedis/5.4.3 (0.00s)
    --- PASS: TestDetermineAttrEngineVersionRedis/7.1#01 (0.00s)
    --- PASS: TestDetermineAttrEngineVersionRedis/7.1#02 (0.00s)
    --- PASS: TestDetermineAttrEngineVersionRedis/7.1 (0.00s)
    --- PASS: TestDetermineAttrEngineVersionRedis/7.1#03 (0.00s)
    --- PASS: TestDetermineAttrEngineVersionRedis/6.2.6 (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        5.760s
```
