### PR TITLE
Check for update in-progress upon deletion

### DIFF
--- a/internal/service/sagemaker/endpoint.go
+++ b/internal/service/sagemaker/endpoint.go
@@ -380,10 +380,6 @@ func findEndpointByName(ctx context.Context, conn *sagemaker.Client, name string
 		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	if output.EndpointStatus == awstypes.EndpointStatusDeleting {
-		return nil, tfresource.NewEmptyResultError(input)
-	}
-
 	return output, nil
 }
 

--- a/internal/service/sagemaker/endpoint.go
+++ b/internal/service/sagemaker/endpoint.go
@@ -339,6 +339,10 @@ func resourceEndpointDelete(ctx context.Context, d *schema.ResourceData, meta in
 
 	_, err := conn.DeleteEndpoint(ctx, deleteEndpointOpts)
 
+	if tfawserr.ErrMessageContains(err, ErrCodeValidationException, "Cannot update in-progress endpoint") {
+		return sdkdiag.AppendErrorf(diags, "deleting SageMaker Endpoint (%s): %s", d.Id(), err)
+	}
+
 	if tfawserr.ErrCodeEquals(err, ErrCodeValidationException) {
 		return diags
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This change will check for an in-progress endpoint update during an attempted deletion. This prevents a failure that invalidates tf state, the invalid state occurs because deleteEndpoint returns an incorrect success removing it from the state file.

e.g.
* create a sagemaker serverless endpoint
* wait until it times out (currently 10m, soon to be 60m #39090)
* re-run terraform apply
* note the correct call to replace endpoint
* note destruction succeeds in 0s
* note creation fails because endpoint already exists

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
