### PR TITLE
Add support for appsync MERGED api type

### DIFF
--- a/.changelog/39159.txt
+++ b/.changelog/39159.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appsync_graphql_api: Add `api_type` and `merged_api_execution_role_arn` arguments
+```

--- a/internal/service/appsync/appsync_test.go
+++ b/internal/service/appsync/appsync_test.go
@@ -39,6 +39,7 @@ func TestAccAppSync_serial(t *testing.T) {
 			acctest.CtDisappears:        testAccGraphQLAPI_disappears,
 			"tags":                      testAccGraphQLAPI_tags,
 			"schema":                    testAccGraphQLAPI_schema,
+			"apiType":                   testAccGraphQLAPI_apiType,
 			"authenticationType":        testAccGraphQLAPI_authenticationType,
 			"AuthenticationType_apiKey": testAccGraphQLAPI_AuthenticationType_apiKey,
 			"AuthenticationType_awsIAM": testAccGraphQLAPI_AuthenticationType_iam,

--- a/internal/service/appsync/graphql_api.go
+++ b/internal/service/appsync/graphql_api.go
@@ -135,6 +135,12 @@ func resourceGraphQLAPI() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"api_type": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.GraphQLApiType](),
+				ForceNew:         true,
+			},
 			"authentication_type": {
 				Type:             schema.TypeString,
 				Required:         true,
@@ -216,6 +222,10 @@ func resourceGraphQLAPI() *schema.Resource {
 						},
 					},
 				},
+			},
+			"merged_api_execution_role_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			names.AttrName: {
 				Type:         schema.TypeString,
@@ -329,6 +339,10 @@ func resourceGraphQLAPICreate(ctx context.Context, d *schema.ResourceData, meta 
 		input.AdditionalAuthenticationProviders = expandAdditionalAuthenticationProviders(v.([]interface{}), meta.(*conns.AWSClient).Region)
 	}
 
+	if v, ok := d.GetOk("api_type"); ok {
+		input.ApiType = awstypes.GraphQLApiType(v.(string))
+	}
+
 	if v, ok := d.GetOk("enhanced_metrics_config"); ok {
 		input.EnhancedMetricsConfig = expandEnhancedMetricsConfig(v.([]interface{}))
 	}
@@ -343,6 +357,10 @@ func resourceGraphQLAPICreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	if v, ok := d.GetOk("log_config"); ok {
 		input.LogConfig = expandLogConfig(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("merged_api_execution_role_arn"); ok {
+		input.MergedApiExecutionRoleArn = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("openid_connect_config"); ok {
@@ -405,6 +423,7 @@ func resourceGraphQLAPIRead(ctx context.Context, d *schema.ResourceData, meta in
 	if err := d.Set("additional_authentication_provider", flattenAdditionalAuthenticationProviders(api.AdditionalAuthenticationProviders)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting additional_authentication_provider: %s", err)
 	}
+	d.Set("api_type", api.ApiType)
 	d.Set(names.AttrARN, api.Arn)
 	d.Set("authentication_type", api.AuthenticationType)
 	if err := d.Set("enhanced_metrics_config", flattenEnhancedMetricsConfig(api.EnhancedMetricsConfig)); err != nil {
@@ -417,6 +436,7 @@ func resourceGraphQLAPIRead(ctx context.Context, d *schema.ResourceData, meta in
 	if err := d.Set("log_config", flattenLogConfig(api.LogConfig)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting log_config: %s", err)
 	}
+	d.Set("merged_api_execution_role_arn", api.MergedApiExecutionRoleArn)
 	d.Set(names.AttrName, api.Name)
 	if err := d.Set("openid_connect_config", flattenOpenIDConnectConfig(api.OpenIDConnectConfig)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting openid_connect_config: %s", err)
@@ -464,6 +484,10 @@ func resourceGraphQLAPIUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		if v, ok := d.GetOk("log_config"); ok {
 			input.LogConfig = expandLogConfig(v.([]interface{}))
+		}
+
+		if v, ok := d.GetOk("merged_api_execution_role_arn"); ok {
+			input.MergedApiExecutionRoleArn = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk("openid_connect_config"); ok {

--- a/internal/service/appsync/graphql_api.go
+++ b/internal/service/appsync/graphql_api.go
@@ -131,15 +131,16 @@ func resourceGraphQLAPI() *schema.Resource {
 					},
 				},
 			},
-			names.AttrARN: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"api_type": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: enum.Validate[awstypes.GraphQLApiType](),
 				ForceNew:         true,
+				Default:          awstypes.GraphQLApiTypeGraphql,
+			},
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"authentication_type": {
 				Type:             schema.TypeString,

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -1416,11 +1416,11 @@ func testAccGraphQLAPI_apiType(t *testing.T) {
 		CheckDestroy:             testAccCheckGraphQLAPIDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGraphQLAPIConfig_apiType(rName, "MERGED"),
+				Config: testAccGraphQLAPIConfig_apiType(rName, string(awstypes.GraphQLApiTypeMerged)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGraphQLAPIExists(ctx, resourceName, &api1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(resourceName, "api_type", "MERGED"),
+					resource.TestCheckResourceAttr(resourceName, "api_type", string(awstypes.GraphQLApiTypeMerged)),
 				),
 			},
 			{

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -1403,6 +1403,35 @@ func testAccCheckGraphQLAPITypeExists(ctx context.Context, n, typeName string) r
 	}
 }
 
+func testAccGraphQLAPI_apiType(t *testing.T) {
+	ctx := acctest.Context(t)
+	var api1 awstypes.GraphqlApi
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_appsync_graphql_api.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.AppSyncEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppSyncServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGraphQLAPIDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGraphQLAPIConfig_apiType(rName, "MERGED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGraphQLAPIExists(ctx, resourceName, &api1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "api_type", "MERGED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccGraphQLAPIConfig_authenticationType(rName, authenticationType string) string {
 	return fmt.Sprintf(`
 resource "aws_appsync_graphql_api" "test" {
@@ -1881,4 +1910,47 @@ resource "aws_appsync_graphql_api" "test" {
   resolver_count_limit = %[2]d
 }
 `, rName, resolverCountLimit)
+}
+
+func testAccGraphQLAPIConfig_apiType(rName, apiType string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  assume_role_policy = data.aws_iam_policy_document.test.json
+  name_prefix        = %[1]q
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      identifiers = ["appsync.amazonaws.com"]
+      type        = "Service"
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [data.aws_caller_identity.current.account_id]
+      variable = "aws:SourceAccount"
+    }
+
+    condition {
+      test     = "ArnLike"
+      values   = ["arn:${data.aws_partition.current.partition}:appsync:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}::apis/*"]
+      variable = "aws:SourceArn"
+    }
+  }
+}
+
+resource "aws_appsync_graphql_api" "test" {
+  authentication_type = "API_KEY"
+  name                = %[1]q
+  api_type            = %[2]q
+  merged_api_execution_role_arn = aws_iam_role.test.arn
+}
+`, rName, apiType)
 }

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -1947,9 +1947,9 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_appsync_graphql_api" "test" {
-  authentication_type = "API_KEY"
-  name                = %[1]q
-  api_type            = %[2]q
+  authentication_type           = "API_KEY"
+  name                          = %[1]q
+  api_type                      = %[2]q
   merged_api_execution_role_arn = aws_iam_role.test.arn
 }
 `, rName, apiType)

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -215,17 +215,17 @@ resource "aws_appsync_graphql_api" "example" {
 The following arguments are required:
 
 * `authentication_type` - (Required) Authentication type. Valid values: `API_KEY`, `AWS_IAM`, `AMAZON_COGNITO_USER_POOLS`, `OPENID_CONNECT`, `AWS_LAMBDA`
-* `name` - (Required) User-supplied name for the GraphSQL API.
+* `name` - (Required) User-supplied name for the GraphQL API.
 
 The following arguments are optional:
 
-* `additional_authentication_provider` - (Optional) One or more additional authentication providers for the GraphSQL API. See [`additional_authentication_provider` Block](#additional_authentication_provider-block) for details.
-* `api_type` - (Optional) Set the API Type to `GRAPHQL | MERGED`. `MERGED` API type required `merged_api_execution_role_arn` to bet set.
+* `additional_authentication_provider` - (Optional) One or more additional authentication providers for the GraphQL API. See [`additional_authentication_provider` Block](#additional_authentication_provider-block) for details.
+* `api_type` - (Optional) API type. Valid values are `GRAPHQL` or `MERGED`. A `MERGED` type requires `merged_api_execution_role_arn` to be set.
 * `enhanced_metrics_config` - (Optional) Enables and controls the enhanced metrics feature. See [`enhanced_metrics_config` Block](#enhanced_metrics_config-block) for details.
 * `introspection_config` - (Optional) Sets the value of the GraphQL API to enable (`ENABLED`) or disable (`DISABLED`) introspection. If no value is provided, the introspection configuration will be set to ENABLED by default. This field will produce an error if the operation attempts to use the introspection feature while this field is disabled. For more information about introspection, see [GraphQL introspection](https://graphql.org/learn/introspection/).
 * `lambda_authorizer_config` - (Optional) Nested argument containing Lambda authorizer configuration. See [`lambda_authorizer_config` Block](#lambda_authorizer_config-block) for details.
 * `log_config` - (Optional) Nested argument containing logging configuration. See [`log_config` Block](#log_config-block) for details.
-* `merged_api_execution_role_arn` - (Optional) Sets the ARN of the execution role for `MERGED` API type.
+* `merged_api_execution_role_arn` - (Optional) ARN of the execution role when `api_type` is set to `MERGED`.
 * `openid_connect_config` - (Optional) Nested argument containing OpenID Connect configuration. See [`openid_connect_config` Block](#openid_connect_config-block) for details.
 * `query_depth_limit` - (Optional) The maximum depth a query can have in a single request. Depth refers to the amount of nested levels allowed in the body of query. The default value is `0` (or unspecified), which indicates there's no depth limit. If you set a limit, it can be between `1` and `75` nested levels. This field will produce a limit error if the operation falls out of bounds.
 
@@ -294,7 +294,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `id` - API ID
 * `arn` - ARN
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
-* `uris` - Map of URIs associated with the APIE.g., `uris["GRAPHQL"] = https://ID.appsync-api.REGION.amazonaws.com/graphql`
+* `uris` - Map of URIs associated with the API E.g., `uris["GRAPHQL"] = https://ID.appsync-api.REGION.amazonaws.com/graphql`
 
 ## Import
 

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -220,10 +220,12 @@ The following arguments are required:
 The following arguments are optional:
 
 * `additional_authentication_provider` - (Optional) One or more additional authentication providers for the GraphSQL API. See [`additional_authentication_provider` Block](#additional_authentication_provider-block) for details.
+* `api_type` - (Optional) Set the API Type to `GRAPHQL | MERGED`. `MERGED` API type required `merged_api_execution_role_arn` to bet set.
 * `enhanced_metrics_config` - (Optional) Enables and controls the enhanced metrics feature. See [`enhanced_metrics_config` Block](#enhanced_metrics_config-block) for details.
 * `introspection_config` - (Optional) Sets the value of the GraphQL API to enable (`ENABLED`) or disable (`DISABLED`) introspection. If no value is provided, the introspection configuration will be set to ENABLED by default. This field will produce an error if the operation attempts to use the introspection feature while this field is disabled. For more information about introspection, see [GraphQL introspection](https://graphql.org/learn/introspection/).
 * `lambda_authorizer_config` - (Optional) Nested argument containing Lambda authorizer configuration. See [`lambda_authorizer_config` Block](#lambda_authorizer_config-block) for details.
 * `log_config` - (Optional) Nested argument containing logging configuration. See [`log_config` Block](#log_config-block) for details.
+* `merged_api_execution_role_arn` - (Optional) Sets the ARN of the execution role for `MERGED` API type.
 * `openid_connect_config` - (Optional) Nested argument containing OpenID Connect configuration. See [`openid_connect_config` Block](#openid_connect_config-block) for details.
 * `query_depth_limit` - (Optional) The maximum depth a query can have in a single request. Depth refers to the amount of nested levels allowed in the body of query. The default value is `0` (or unspecified), which indicates there's no depth limit. If you set a limit, it can be between `1` and `75` nested levels. This field will produce a limit error if the operation falls out of bounds.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Add the `api_type` and `merged_api_execution_role_arn` to support MERGED apis

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #33148

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc TESTS=TestAccAppSync_serial/GraphQLAPI PKG=appsync
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/appsync/... -v -count 1 -parallel 20 -run='TestAccAppSync_serial/GraphQLAPI'  -timeout 360m
=== RUN   TestAccAppSync_serial
=== PAUSE TestAccAppSync_serial
=== CONT  TestAccAppSync_serial
=== RUN   TestAccAppSync_serial/GraphQLAPI
=== RUN   TestAccAppSync_serial/GraphQLAPI/basic
=== RUN   TestAccAppSync_serial/GraphQLAPI/OpenIDConnect_issuer
=== RUN   TestAccAppSync_serial/GraphQLAPI/UserPool_awsRegion
=== RUN   TestAccAppSync_serial/GraphQLAPI/xrayEnabled
=== RUN   TestAccAppSync_serial/GraphQLAPI/name
=== RUN   TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_openIDConnect
=== RUN   TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_multiple
=== RUN   TestAccAppSync_serial/GraphQLAPI/visibility
=== RUN   TestAccAppSync_serial/GraphQLAPI/disappears
=== RUN   TestAccAppSync_serial/GraphQLAPI/apiType
=== RUN   TestAccAppSync_serial/GraphQLAPI/enhancedMetricsConfig
=== RUN   TestAccAppSync_serial/GraphQLAPI/OpenIDConnect_clientID
=== RUN   TestAccAppSync_serial/GraphQLAPI/queryDepthLimit
=== RUN   TestAccAppSync_serial/GraphQLAPI/OpenIDConnect_iatTTL
=== RUN   TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_awsIAM
=== RUN   TestAccAppSync_serial/GraphQLAPI/schema
=== RUN   TestAccAppSync_serial/GraphQLAPI/authenticationType
=== RUN   TestAccAppSync_serial/GraphQLAPI/AuthenticationType_apiKey
=== RUN   TestAccAppSync_serial/GraphQLAPI/AuthenticationType_awsIAM
=== RUN   TestAccAppSync_serial/GraphQLAPI/AuthenticationType_awsLambda
=== RUN   TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_cognitoUserPools
=== RUN   TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_awsLambda
=== RUN   TestAccAppSync_serial/GraphQLAPI/introspectionConfig
=== RUN   TestAccAppSync_serial/GraphQLAPI/resolverCountLimit
=== RUN   TestAccAppSync_serial/GraphQLAPI/AuthenticationType_amazonCognitoUserPools
=== RUN   TestAccAppSync_serial/GraphQLAPI/Log_fieldLogLevel
=== RUN   TestAccAppSync_serial/GraphQLAPI/LambdaAuthorizerConfig_authorizerUri
=== RUN   TestAccAppSync_serial/GraphQLAPI/LambdaAuthorizerConfig_authorizerResultTtlInSeconds
=== RUN   TestAccAppSync_serial/GraphQLAPI/tags
=== RUN   TestAccAppSync_serial/GraphQLAPI/Log_excludeVerboseContent
=== RUN   TestAccAppSync_serial/GraphQLAPI/LambdaAuthorizerConfig_identityValidationExpression
=== RUN   TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_apiKey
=== RUN   TestAccAppSync_serial/GraphQLAPI/AuthenticationType_openIDConnect
=== RUN   TestAccAppSync_serial/GraphQLAPI/log
=== RUN   TestAccAppSync_serial/GraphQLAPI/OpenIDConnect_authTTL
=== RUN   TestAccAppSync_serial/GraphQLAPI/UserPool_defaultAction
--- PASS: TestAccAppSync_serial (1117.38s)
    --- PASS: TestAccAppSync_serial/GraphQLAPI (1117.38s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/basic (20.92s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/OpenIDConnect_issuer (31.60s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/UserPool_awsRegion (32.84s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/xrayEnabled (27.47s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/name (28.37s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_openIDConnect (19.53s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_multiple (39.91s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/visibility (19.49s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/disappears (17.18s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/apiType (22.08s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/enhancedMetricsConfig (34.26s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/OpenIDConnect_clientID (28.91s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/queryDepthLimit (19.79s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/OpenIDConnect_iatTTL (31.36s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_awsIAM (18.87s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/schema (41.21s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/authenticationType (28.77s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AuthenticationType_apiKey (19.52s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AuthenticationType_awsIAM (19.88s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AuthenticationType_awsLambda (40.71s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_cognitoUserPools (22.71s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_awsLambda (40.77s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/introspectionConfig (19.52s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/resolverCountLimit (20.57s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AuthenticationType_amazonCognitoUserPools (23.62s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/Log_fieldLogLevel (46.46s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/LambdaAuthorizerConfig_authorizerUri (57.22s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/LambdaAuthorizerConfig_authorizerResultTtlInSeconds (85.62s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/tags (44.61s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/Log_excludeVerboseContent (33.16s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/LambdaAuthorizerConfig_identityValidationExpression (56.33s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AdditionalAuthentication_apiKey (18.65s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/AuthenticationType_openIDConnect (19.24s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/log (19.99s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/OpenIDConnect_authTTL (30.09s)
        --- PASS: TestAccAppSync_serial/GraphQLAPI/UserPool_defaultAction (36.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appsync    1121.319s

```
