### PR TITLE
Integer port number

### DIFF
--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -295,7 +295,7 @@ func resourceListener() *schema.Resource {
 										ValidateFunc: validation.StringLenBetween(1, 128),
 									},
 									names.AttrPort: {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Optional: true,
 										Default:  "#{port}",
 									},


### PR DESCRIPTION
### Description
This should allow the following in Python CDKTF:
```python
LbListener(
    stack,
    'http',
    default_action=[
        LbListenerDefaultAction(
            redirect=LbListenerDefaultActionRedirect(
                port=443, protocol='HTTPS', status_code='HTTP_301'
            ),
            type='redirect',
        ),
    ],
    load_balancer=load_balancer.arn,
    port=80,
    protocol='HTTP',
)
```

Previously `port='443'` was required to avoid
```
TypeError: type of argument port must be one of (str, NoneType); got int instead
```