### PR TITLE
`aws_elasticache_domain`: Update list of valid options for `tls_security_policy`

### DIFF
--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -291,7 +291,7 @@ AWS documentation: [Amazon Cognito Authentication for Kibana](https://docs.aws.a
 * `custom_endpoint_enabled` - (Optional) Whether to enable custom endpoint for the Elasticsearch domain.
 * `custom_endpoint` - (Optional) Fully qualified domain for your custom endpoint.
 * `enforce_https` - (Optional) Whether or not to require HTTPS. Defaults to `true`.
-* `tls_security_policy` - (Optional) Name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values:  `Policy-Min-TLS-1-0-2019-07` and `Policy-Min-TLS-1-2-2019-07`. Terraform will only perform drift detection if a configuration value is provided.
+* `tls_security_policy` - (Optional) Name of the TLS security policy that needs to be applied to the HTTPS endpoint. Valid values:  `Policy-Min-TLS-1-0-2019-07`, `Policy-Min-TLS-1-2-2019-07`, and `Policy-Min-TLS-1-2-PFS-2023-10`. Terraform will only perform drift detection if a configuration value is provided.
 
 ### ebs_options
 


### PR DESCRIPTION
### Description

Updates the list of valid values for `tls_security_policy


### Relations

Closes #39158

### References

- [Schema](https://github.com/hashicorp/terraform-provider-aws/blob/6a28717037912f5b295495f18091cb62c2f658e9/internal/service/elasticsearch/domain.go#L379)
- [`types` reference for `TLSSecurityPolicy`](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/elasticsearchservice@v1.30.7/types#TLSSecurityPolicy)

### Output from Acceptance Testing

N/a, docs
