### PR TITLE
r/aws_quicksight: fix groups sweeper

### DIFF
--- a/internal/service/quicksight/sweep.go
+++ b/internal/service/quicksight/sweep.go
@@ -11,8 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/quicksight"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
@@ -438,12 +438,13 @@ func sweepVPCConnections(region string) error {
 }
 
 func skipSweepError(err error) bool {
-	if errs.IsA[*awstypes.UnsupportedUserEditionException](err) {
+	if tfawserr.ErrCodeContains(err, "UnsupportedUserEditionException") {
 		return true
 	}
-	if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "Directory information for account") ||
-		errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "Account information for account") ||
-		errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "is not signed up with QuickSight") {
+
+	if tfawserr.ErrMessageContains(err, "ResourceNotFoundException", "Directory information for account") ||
+		tfawserr.ErrMessageContains(err, "ResourceNotFoundException", "Account information for account") ||
+		tfawserr.ErrMessageContains(err, "ResourceNotFoundException", "is not signed up with QuickSight") {
 		return true
 	}
 
@@ -451,10 +452,8 @@ func skipSweepError(err error) bool {
 }
 
 func skipSweepUsersError(err error) bool {
-	if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "not signed up with QuickSight") {
-		return true
-	}
-	if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "Namespace default not found in account") {
+	if tfawserr.ErrMessageContains(err, "ResourceNotFoundException", "is not signed up with QuickSight") ||
+		tfawserr.ErrMessageContains(err, "ResourceNotFoundException", "Namespace default not found in account") {
 		return true
 	}
 

--- a/internal/service/quicksight/sweep.go
+++ b/internal/service/quicksight/sweep.go
@@ -441,10 +441,9 @@ func skipSweepError(err error) bool {
 	if errs.IsA[*awstypes.UnsupportedUserEditionException](err) {
 		return true
 	}
-	if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "Directory information for account") {
-		return true
-	}
-	if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "Account information for account") {
+	if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "Directory information for account") ||
+		errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "Account information for account") ||
+		errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "is not signed up with QuickSight") {
 		return true
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add handling for errors indicating the account is not configured with a default namespace. 

```
2024/09/05 13:58:18 [ERROR] Error running Sweeper (aws_quicksight_group) in region (us-west-2): error listing QuickSight Groups (us-west-2): operation error QuickSight: ListGroups, https response error StatusCode: 404, RequestID: 12a908dc-d8d2-4cd5-a146-9a354bcdcb07, ResourceNotFoundException: Account 727561393803 is not signed up with QuickSight with namespace default. AWS account ID: 727561393803, Namespace: default.
```

Also updates skip checks to use `tfawserr` for consistency with the shared sweeper skip checks.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sweep SWEEPARGS=-sweep-run=aws_quicksight
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.23.0 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run=aws_quicksight -timeout 360m
2024/09/05 14:21:36 [DEBUG] Running Sweepers for region (us-west-2):
2024/09/05 14:21:36 [DEBUG] Running Sweeper (aws_quicksight_group) in region (us-west-2)

2024/09/05 14:21:40 [DEBUG] Completed Sweeper (aws_quicksight_data_set) in region (us-west-1) in 2.141625ms
2024/09/05 14:21:40 Completed Sweepers for region (us-west-1) in 419.117708ms
2024/09/05 14:21:40 Sweeper Tests for region (us-west-1) ran successfully:
2024/09/05 14:21:40     - aws_quicksight_data_set
2024/09/05 14:21:40     - aws_quicksight_folder
2024/09/05 14:21:40     - aws_quicksight_template
2024/09/05 14:21:40     - aws_quicksight_data_source
2024/09/05 14:21:40     - aws_quicksight_group
2024/09/05 14:21:40     - aws_quicksight_user
2024/09/05 14:21:40     - aws_quicksight_dashboard
2024/09/05 14:21:40     - aws_quicksight_vpc_connection
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      10.036s
```
