### PR TITLE
r/aws_eks_cluster: Allow unsetting the `bootstrap_cluster_creator_admin_permissions` (from `true` to `null`) without cluster re-creation

### DIFF
--- a/.changelog/38967.txt
+++ b/.changelog/38967.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_cluster: Allow unsetting the `bootstrap_cluster_creator_admin_permissions` (from `true` to `null`) without cluster re-creation.
+```

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -84,6 +84,7 @@ func resourceCluster() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
+							Default:  true,
 						},
 					},
 				},
@@ -445,7 +446,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// bootstrap_cluster_creator_admin_permissions isn't returned from the AWS API.
 	// See https://github.com/aws/containers-roadmap/issues/185#issuecomment-1863025784.
-	var bootstrapClusterCreatorAdminPermissions *bool
+	bootstrapClusterCreatorAdminPermissions := aws.Bool(true)
 	if v, ok := d.GetOk("access_config"); ok {
 		if apiObject := expandCreateAccessConfigRequest(v.([]interface{})); apiObject != nil {
 			bootstrapClusterCreatorAdminPermissions = apiObject.BootstrapClusterCreatorAdminPermissions
@@ -881,9 +882,11 @@ func expandCreateAccessConfigRequest(tfList []interface{}) *types.CreateAccessCo
 		apiObject.AuthenticationMode = types.AuthenticationMode(v)
 	}
 
+	bootstrapClusterCreatorAdminPermissions := aws.Bool(true)
 	if v, ok := tfMap["bootstrap_cluster_creator_admin_permissions"].(bool); ok {
-		apiObject.BootstrapClusterCreatorAdminPermissions = aws.Bool(v)
+		bootstrapClusterCreatorAdminPermissions = aws.Bool(v)
 	}
+	apiObject.BootstrapClusterCreatorAdminPermissions = bootstrapClusterCreatorAdminPermissions
 
 	return apiObject
 }


### PR DESCRIPTION

### Description
- Allow unsetting the `bootstrap_cluster_creator_admin_permissions` (from `true` to `null`) without cluster re-creation

### Relations

Closes #38967

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
