### PR TITLE
fixed iam role in ecr repository

### DIFF
--- a/internal/service/ecr/repository_policy.go
+++ b/internal/service/ecr/repository_policy.go
@@ -77,7 +77,7 @@ func resourceRepositoryPolicyPut(ctx context.Context, d *schema.ResourceData, me
 
 	_, err = tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (interface{}, error) {
 		return conn.SetRepositoryPolicy(ctx, input)
-	}, "Invalid repository policy provided")
+	}, "Principal not found")
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "putting ECR Repository Policy (%s): %s", repositoryName, err)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fixes issue 
```
Invalid parameter at 'PolicyText' failed to satisfy constraint: 'Principal not found'
```

when using newly created IAM role as a principal in ECR repository policy.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39064 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccECRRepositoryPolicy_  PKG=ecr
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRRepositoryPolicy_'  -timeout 360m
=== RUN   TestAccECRRepositoryPolicy_basic
=== PAUSE TestAccECRRepositoryPolicy_basic
=== RUN   TestAccECRRepositoryPolicy_IAM_basic
=== PAUSE TestAccECRRepositoryPolicy_IAM_basic
=== RUN   TestAccECRRepositoryPolicy_IAM_principalOrder
=== PAUSE TestAccECRRepositoryPolicy_IAM_principalOrder
=== RUN   TestAccECRRepositoryPolicy_disappears
=== PAUSE TestAccECRRepositoryPolicy_disappears
=== RUN   TestAccECRRepositoryPolicy_Disappears_repository
=== PAUSE TestAccECRRepositoryPolicy_Disappears_repository
=== CONT  TestAccECRRepositoryPolicy_basic
=== CONT  TestAccECRRepositoryPolicy_disappears
=== CONT  TestAccECRRepositoryPolicy_Disappears_repository
=== CONT  TestAccECRRepositoryPolicy_IAM_principalOrder
=== CONT  TestAccECRRepositoryPolicy_IAM_basic
--- PASS: TestAccECRRepositoryPolicy_Disappears_repository (27.21s)
--- PASS: TestAccECRRepositoryPolicy_disappears (27.46s)
--- PASS: TestAccECRRepositoryPolicy_IAM_basic (39.32s)
--- PASS: TestAccECRRepositoryPolicy_basic (47.27s)
--- PASS: TestAccECRRepositoryPolicy_IAM_principalOrder (55.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ecr        60.406s

```
