### PR TITLE
r/aws_verifiedaccess_endpoint: fix crash when updating `load_balancer_options.subnet_ids`

### DIFF
--- a/.changelog/39196.txt
+++ b/.changelog/39196.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_verifiedaccess_endpoint: fix crash when updating `load_balancer_options.subnet_ids`
+```

--- a/internal/service/ec2/verifiedaccess_endpoint.go
+++ b/internal/service/ec2/verifiedaccess_endpoint.go
@@ -502,8 +502,8 @@ func expandModifyVerifiedAccessEndpointLoadBalancerOptions(tfMap map[string]inte
 		apiObject.Protocol = types.VerifiedAccessEndpointProtocol(v)
 	}
 
-	if v, ok := tfMap[names.AttrSubnetIDs]; ok {
-		apiObject.SubnetIds = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := tfMap[names.AttrSubnetIDs].(*schema.Set); ok && v.Len() > 0 {
+		apiObject.SubnetIds = flex.ExpandStringValueSet(v)
 	}
 
 	return apiObject

--- a/internal/service/ec2/verifiedaccess_endpoint_test.go
+++ b/internal/service/ec2/verifiedaccess_endpoint_test.go
@@ -252,6 +252,54 @@ func testAccVerifiedAccessEndpoint_policyDocument(t *testing.T, semaphore tfsync
 	})
 }
 
+// Verifies load balancer subnet ID's can be updated without a crash
+// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/39186
+func testAccVerifiedAccessEndpoint_subnetIDs(t *testing.T, semaphore tfsync.Semaphore) {
+	ctx := acctest.Context(t)
+	var v types.VerifiedAccessEndpoint
+	resourceName := "aws_verifiedaccess_endpoint.test"
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckVerifiedAccessSynchronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckVerifiedAccess(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVerifiedAccessEndpointDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVerifiedAccessEndpointConfig_subnetIDs(rName, acctest.TLSPEMEscapeNewlines(key), acctest.TLSPEMEscapeNewlines(certificate)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVerifiedAccessEndpointExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.0.subnet_ids.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"endpoint_domain_prefix",
+				},
+			},
+			{
+				Config: testAccVerifiedAccessEndpointConfig_subnetIDsUpdate(rName, acctest.TLSPEMEscapeNewlines(key), acctest.TLSPEMEscapeNewlines(certificate)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVerifiedAccessEndpointExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.0.subnet_ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVerifiedAccessEndpointDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
@@ -298,8 +346,10 @@ func testAccCheckVerifiedAccessEndpointExists(ctx context.Context, n string, v *
 	}
 }
 
-func testAccVerifiedAccessEndpointConfig_base(rName, key, certificate string) string {
-	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+func testAccVerifiedAccessEndpointConfig_base(rName, key, certificate string, subnetCount int) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigVPCWithSubnets(rName, subnetCount),
+		fmt.Sprintf(`
 resource "aws_security_group" "test" {
   name   = %[1]q
   vpc_id = aws_vpc.test.id
@@ -398,8 +448,9 @@ resource "aws_verifiedaccess_group" "test" {
 }
 
 func testAccVerifiedAccessEndpointConfig_basic(rName, key, certificate string) string {
-	return acctest.ConfigCompose(testAccVerifiedAccessEndpointConfig_base(rName, key, certificate), fmt.Sprintf(`
-
+	return acctest.ConfigCompose(
+		testAccVerifiedAccessEndpointConfig_base(rName, key, certificate, 1),
+		fmt.Sprintf(`
 resource "aws_verifiedaccess_endpoint" "test" {
   application_domain     = "example.com"
   attachment_type        = "vpc"
@@ -427,8 +478,9 @@ resource "aws_verifiedaccess_endpoint" "test" {
 }
 
 func testAccVerifiedAccessEndpointConfig_networkInterface(rName, key, certificate string) string {
-	return acctest.ConfigCompose(testAccVerifiedAccessEndpointConfig_base(rName, key, certificate), fmt.Sprintf(`
-
+	return acctest.ConfigCompose(
+		testAccVerifiedAccessEndpointConfig_base(rName, key, certificate, 1),
+		fmt.Sprintf(`
 resource "aws_verifiedaccess_endpoint" "test" {
   application_domain     = "example.com"
   attachment_type        = "vpc"
@@ -454,8 +506,9 @@ resource "aws_verifiedaccess_endpoint" "test" {
 }
 
 func testAccVerifiedAccessEndpointConfig_tags1(rName, key, certificate, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(testAccVerifiedAccessEndpointConfig_base(rName, key, certificate), fmt.Sprintf(`
-
+	return acctest.ConfigCompose(
+		testAccVerifiedAccessEndpointConfig_base(rName, key, certificate, 1),
+		fmt.Sprintf(`
 resource "aws_verifiedaccess_endpoint" "test" {
   application_domain     = "example.com"
   attachment_type        = "vpc"
@@ -481,9 +534,9 @@ resource "aws_verifiedaccess_endpoint" "test" {
 }
 
 func testAccVerifiedAccessEndpointConfig_tags2(rName, key, certificate, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccVerifiedAccessEndpointConfig_base(rName, key, certificate), fmt.Sprintf(`
-
-
+	return acctest.ConfigCompose(
+		testAccVerifiedAccessEndpointConfig_base(rName, key, certificate, 1),
+		fmt.Sprintf(`
 resource "aws_verifiedaccess_endpoint" "test" {
   application_domain     = "example.com"
   attachment_type        = "vpc"
@@ -508,7 +561,9 @@ resource "aws_verifiedaccess_endpoint" "test" {
 }
 
 func testAccVerifiedAccessEndpointConfig_policyBase(rName, key, certificate string) string {
-	return acctest.ConfigCompose(testAccVerifiedAccessEndpointConfig_base(rName, key, certificate), `
+	return acctest.ConfigCompose(
+		testAccVerifiedAccessEndpointConfig_base(rName, key, certificate, 1),
+		`
 resource "aws_verifiedaccess_endpoint" "test" {
   application_domain     = "example.com"
   attachment_type        = "vpc"
@@ -528,7 +583,9 @@ resource "aws_verifiedaccess_endpoint" "test" {
 }
 
 func testAccVerifiedAccessEndpointConfig_policyUpdate(rName, key, certificate, policyDocument string) string {
-	return acctest.ConfigCompose(testAccVerifiedAccessEndpointConfig_base(rName, key, certificate), fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccVerifiedAccessEndpointConfig_base(rName, key, certificate, 1),
+		fmt.Sprintf(`
 resource "aws_verifiedaccess_endpoint" "test" {
   application_domain     = "example.com"
   attachment_type        = "vpc"
@@ -546,4 +603,62 @@ resource "aws_verifiedaccess_endpoint" "test" {
   verified_access_group_id = aws_verifiedaccess_group.test.id
 }
 `, rName, key, certificate, policyDocument))
+}
+
+func testAccVerifiedAccessEndpointConfig_subnetIDs(rName, key, certificate string) string {
+	return acctest.ConfigCompose(
+		testAccVerifiedAccessEndpointConfig_base(rName, key, certificate, 2),
+		fmt.Sprintf(`
+resource "aws_verifiedaccess_endpoint" "test" {
+  application_domain     = "example.com"
+  attachment_type        = "vpc"
+  description            = "example"
+  domain_certificate_arn = aws_acm_certificate.test.arn
+  endpoint_domain_prefix = "example"
+  endpoint_type          = "load-balancer"
+  sse_specification {
+    customer_managed_key_enabled = false
+  }
+  load_balancer_options {
+    load_balancer_arn = aws_lb.test.arn
+    port              = 443
+    protocol          = "https"
+    subnet_ids        = [for subnet in slice(aws_subnet.test, 0, 1) : subnet.id]
+  }
+  security_group_ids       = [aws_security_group.test.id]
+  verified_access_group_id = aws_verifiedaccess_group.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, key, certificate))
+}
+
+func testAccVerifiedAccessEndpointConfig_subnetIDsUpdate(rName, key, certificate string) string {
+	return acctest.ConfigCompose(testAccVerifiedAccessEndpointConfig_base(rName, key, certificate, 2), fmt.Sprintf(`
+resource "aws_verifiedaccess_endpoint" "test" {
+  application_domain     = "example.com"
+  attachment_type        = "vpc"
+  description            = "example"
+  domain_certificate_arn = aws_acm_certificate.test.arn
+  endpoint_domain_prefix = "example"
+  endpoint_type          = "load-balancer"
+  sse_specification {
+    customer_managed_key_enabled = false
+  }
+  load_balancer_options {
+    load_balancer_arn = aws_lb.test.arn
+    port              = 443
+    protocol          = "https"
+    subnet_ids        = [for subnet in aws_subnet.test : subnet.id]
+  }
+  security_group_ids       = [aws_security_group.test.id]
+  verified_access_group_id = aws_verifiedaccess_group.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, key, certificate))
 }

--- a/internal/service/ec2/verifiedaccess_endpoint_test.go
+++ b/internal/service/ec2/verifiedaccess_endpoint_test.go
@@ -276,8 +276,8 @@ func testAccVerifiedAccessEndpoint_subnetIDs(t *testing.T, semaphore tfsync.Sema
 				Config: testAccVerifiedAccessEndpointConfig_subnetIDs(rName, acctest.TLSPEMEscapeNewlines(key), acctest.TLSPEMEscapeNewlines(certificate)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVerifiedAccessEndpointExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.0.subnet_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.0.subnet_ids.#", acctest.Ct1),
 				),
 			},
 			{
@@ -292,8 +292,8 @@ func testAccVerifiedAccessEndpoint_subnetIDs(t *testing.T, semaphore tfsync.Sema
 				Config: testAccVerifiedAccessEndpointConfig_subnetIDsUpdate(rName, acctest.TLSPEMEscapeNewlines(key), acctest.TLSPEMEscapeNewlines(certificate)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVerifiedAccessEndpointExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.0.subnet_ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "load_balancer_options.0.subnet_ids.#", acctest.Ct2),
 				),
 			},
 		},

--- a/internal/service/ec2/verifiedaccess_test.go
+++ b/internal/service/ec2/verifiedaccess_test.go
@@ -21,6 +21,7 @@ func TestAccVerifiedAccess_serial(t *testing.T) {
 			"tags":               testAccVerifiedAccessEndpoint_tags,
 			acctest.CtDisappears: testAccVerifiedAccessEndpoint_disappears,
 			"policyDocument":     testAccVerifiedAccessEndpoint_policyDocument,
+			"subnetIDs":          testAccVerifiedAccessEndpoint_subnetIDs,
 		},
 		"Group": {
 			acctest.CtBasic:      testAccVerifiedAccessGroup_basic,


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes an incorrect assertion of a set type to an `[]interface{}`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39186



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS=TestAccVerifiedAccess_serial/Endpoint/basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVerifiedAccess_serial/Endpoint/basic'  -timeout 360m

--- PASS: TestAccVerifiedAccess_serial (0.59s)
    --- PASS: TestAccVerifiedAccess_serial/Endpoint_networkInterface (1115.35s)
    --- PASS: TestAccVerifiedAccess_serial/Endpoint_tags (1278.48s)
    --- PASS: TestAccVerifiedAccess_serial/Endpoint_policyDocument (1289.64s)
    --- PASS: TestAccVerifiedAccess_serial/Endpoint_basic (1371.40s)
    --- PASS: TestAccVerifiedAccess_serial/Endpoint_disappears (1451.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        1458.259s
```
