### PR TITLE
fix: Replace bad .Resource ref with .DataSource in datasourcefw.gtpl

### DIFF
--- a/skaff/datasource/datasourcefw.gtpl
+++ b/skaff/datasource/datasourcefw.gtpl
@@ -201,9 +201,9 @@ func (d *dataSource{{ .DataSource }}) Read(ctx context.Context, req datasource.R
 
 	{{ if .IncludeComments -}}
 	// TIP: -- 4. Set the ID, arguments, and attributes
-	// Using a field name prefix allows mapping fields such as `{{ .Resource }}Id` to `ID`
+	// Using a field name prefix allows mapping fields such as `{{ .DataSource }}Id` to `ID`
 	{{- end }}
-	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data, flex.WithFieldNamePrefix("{{ .Resource }}"))...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data, flex.WithFieldNamePrefix("{{ .DataSource }}"))...)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to replace the invalid variable reference `.Resource` with `.DataSource` in `datasourcefw.gtpl` which prevented `skaff datasource` from being run successfully to generate new data source artifacts.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39207

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ cd internal/service/synthetics
$ skaff datasource -f -n RuntimeVersion

$
```

Source code and documentation are generated successfully.
