### PR TITLE
fix: Update wordings of warning message about GitHub action provider

### DIFF
--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -619,8 +619,8 @@ func pipelineValidateActionProvider(i interface{}, path cty.Path) diag.Diagnosti
 		return diag.Diagnostics{
 			diag.Diagnostic{
 				Severity: diag.Warning,
-				Summary:  "The CodePipeline GitHub version 1 action provider is deprecated.",
-				Detail:   "Use a GitHub version 2 action (with a CodeStar Connection `aws_codestarconnections_connection`) instead. See https://docs.aws.amazon.com/codepipeline/latest/userguide/update-github-action-connections.html",
+				Summary:  "The CodePipeline GitHub version 1 action provider is no longer recommended.",
+				Detail:   "Use a GitHub version 2 action (with a CodeStar Connection `aws_codestarconnections_connection`) as recommended instead. See https://docs.aws.amazon.com/codepipeline/latest/userguide/update-github-action-connections.html",
 			},
 		}
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to clarify the warning messages about GitHub action provider v1 being deprecated, which is it not, in the `aws_codepipeline` resource. The difference is that v1 and v2 are both supported, but v1 is no longer **recommended**.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38412

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [Update a GitHub version 1 source action to a GitHub version 2 source action](https://docs.aws.amazon.com/codepipeline/latest/userguide/update-github-action-connections.html) for wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a - it's just an error message update
