### PR TITLE
feat: Add cache_config arg for aws_amplify_app

### DIFF
--- a/.changelog/39215.txt
+++ b/.changelog/39215.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_amplify_app: Add `cache_config` argument
+```

--- a/internal/service/amplify/amplify_test.go
+++ b/internal/service/amplify/amplify_test.go
@@ -24,6 +24,7 @@ func TestAccAmplify_serial(t *testing.T) {
 			"AutoBranchCreationConfig": testAccApp_AutoBranchCreationConfig,
 			"BasicAuthCredentials":     testAccApp_BasicAuthCredentials,
 			"BuildSpec":                testAccApp_BuildSpec,
+			"CacheConfig":              testAccApp_CacheConfig,
 			"CustomRules":              testAccApp_CustomRules,
 			"Description":              testAccApp_Description,
 			"EnvironmentVariables":     testAccApp_EnvironmentVariables,

--- a/website/docs/r/amplify_app.html.markdown
+++ b/website/docs/r/amplify_app.html.markdown
@@ -166,12 +166,13 @@ This resource supports the following arguments:
 
 * `name` - (Required) Name for an Amplify app.
 * `access_token` - (Optional) Personal access token for a third-party source control system for an Amplify app. This token must have write access to the relevant repo to create a webhook and a read-only deploy key for the Amplify project. The token is not stored, so after applying this attribute can be removed and the setup token deleted.
-* `auto_branch_creation_config` - (Optional) Automated branch creation configuration for an Amplify app. An `auto_branch_creation_config` block is documented below.
+* `auto_branch_creation_config` - (Optional) Automated branch creation configuration for an Amplify app. See [`auto_branch_creation_config` Block](#auto_branch_creation_config-block) for details.
 * `auto_branch_creation_patterns` - (Optional) Automated branch creation glob patterns for an Amplify app.
 * `basic_auth_credentials` - (Optional) Credentials for basic authorization for an Amplify app.
 * `build_spec` - (Optional) The [build specification](https://docs.aws.amazon.com/amplify/latest/userguide/build-settings.html) (build spec) for an Amplify app.
+* `cache_config` - (Optional) Cache configuration for the Amplify app. See [`cache_config` Block](#cache_config-block) for details.
 * `custom_headers` - (Optional) The [custom HTTP headers](https://docs.aws.amazon.com/amplify/latest/userguide/custom-headers.html) for an Amplify app.
-* `custom_rule` - (Optional) Custom rewrite and redirect rules for an Amplify app. A `custom_rule` block is documented below.
+* `custom_rule` - (Optional) Custom rewrite and redirect rules for an Amplify app. See [`custom_rule` Block](#custom_rule-block) for details.
 * `description` - (Optional) Description for an Amplify app.
 * `enable_auto_branch_creation` - (Optional) Enables automated branch creation for an Amplify app.
 * `enable_basic_auth` - (Optional) Enables basic authorization for an Amplify app. This will apply to all branches that are part of this app.
@@ -184,7 +185,9 @@ This resource supports the following arguments:
 * `repository` - (Optional) Repository for an Amplify app.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-An `auto_branch_creation_config` block supports the following arguments:
+### `auto_branch_creation_config` Block
+
+The `auto_branch_creation_config` configuration block supports the following arguments:
 
 * `basic_auth_credentials` - (Optional) Basic authorization credentials for the autocreated branch.
 * `build_spec` - (Optional) Build specification (build spec) for the autocreated branch.
@@ -197,7 +200,15 @@ An `auto_branch_creation_config` block supports the following arguments:
 * `pull_request_environment_name` - (Optional) Amplify environment name for the pull request.
 * `stage` - (Optional) Describes the current stage for the autocreated branch. Valid values: `PRODUCTION`, `BETA`, `DEVELOPMENT`, `EXPERIMENTAL`, `PULL_REQUEST`.
 
-A `custom_rule` block supports the following arguments:
+### `cache_config` Block
+
+The `cache_config` configuration block supports the following arguments:
+
+- `type` - (Required) Type of cache configuration to use for an Amplify app. Valid values: `AMPLIFY_MANAGED`, `AMPLIFY_MANAGED_NO_COOKIES`.
+
+### `custom_rule` Block
+
+The `custom_rule` configuration block supports the following arguments:
 
 * `condition` - (Optional) Condition for a URL rewrite or redirect rule, such as a country code.
 * `source` - (Required) Source pattern for a URL rewrite or redirect rule.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `cache_config` configuration block argument to the `aws_amplify_app` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38864

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateApp](https://docs.aws.amazon.com/amplify/latest/APIReference/API_CreateApp.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccAmplify_serial/App/basic|TestAccAmplify_serial/App/CacheConfig" PKG=amplify
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/amplify/... -v -count 1 -parallel 20 -run='TestAccAmplify_serial/App/basic|TestAccAmplify_serial/App/CacheConfig'  -timeout 360m
=== RUN   TestAccAmplify_serial
=== PAUSE TestAccAmplify_serial
=== CONT  TestAccAmplify_serial
=== RUN   TestAccAmplify_serial/App
=== RUN   TestAccAmplify_serial/App/CacheConfig
=== RUN   TestAccAmplify_serial/App/basic
--- PASS: TestAccAmplify_serial (591.42s)
    --- PASS: TestAccAmplify_serial/App (591.42s)
        --- PASS: TestAccAmplify_serial/App/CacheConfig (301.43s)
        --- PASS: TestAccAmplify_serial/App/basic (289.99s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amplify    591.661s

$
```
