### PR TITLE
Add validation support for QuickSight PRO user roles

### DIFF
--- a/.changelog/39220.txt
+++ b/.changelog/39220.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-resource/aws_quicksight_user: Add validation for `PRO` user roles - `READER_PRO`, `AUTHOR_PRO`, and `ADMIN_PRO`
+resource/aws_quicksight_user: Add `READER_PRO`, `AUTHOR_PRO`, and `ADMIN_PRO` as valid values for the `user_role` argument
 ```

--- a/.changelog/39220.txt
+++ b/.changelog/39220.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_quicksight_user: Add validation for `PRO` user roles - `READER_PRO`, `AUTHOR_PRO`, and `ADMIN_PRO`
+```

--- a/internal/service/quicksight/user.go
+++ b/internal/service/quicksight/user.go
@@ -98,6 +98,9 @@ func resourceUser() *schema.Resource {
 						awstypes.UserRoleReader,
 						awstypes.UserRoleAuthor,
 						awstypes.UserRoleAdmin,
+						awstypes.UserRoleReaderPro,
+						awstypes.UserRoleAuthorPro,
+						awstypes.UserRoleAdminPro,
 					), false),
 				},
 			}

--- a/website/docs/r/quicksight_user.html.markdown
+++ b/website/docs/r/quicksight_user.html.markdown
@@ -29,7 +29,7 @@ This resource supports the following arguments:
 
 * `email` - (Required) The email address of the user that you want to register.
 * `identity_type` - (Required) Amazon QuickSight supports several ways of managing the identity of users. This parameter accepts either  `IAM` or `QUICKSIGHT`. If `IAM` is specified, the `iam_arn` must also be specified.
-* `user_role` - (Required) The Amazon QuickSight role of the user. The user role can be one of the following: `READER`, `AUTHOR`, or `ADMIN`
+* `user_role` - (Required) The Amazon QuickSight role of the user. The user role can be one of the following: `READER`, `AUTHOR`, `ADMIN`, `READER_PRO`, `AUTHOR_PRO` or `ADMIN_PRO`.
 * `user_name` - (Optional) The Amazon QuickSight user name that you want to create for the user you are registering. Only valid for registering a user with `identity_type` set to `QUICKSIGHT`.
 * `aws_account_id` - (Optional) The ID for the AWS account that the user is in. Currently, you use the ID for the AWS account that contains your Amazon QuickSight account.
 * `iam_arn` - (Optional) The ARN of the IAM user or role that you are registering with Amazon QuickSight.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add validation support for the following QuickSight PRO user roles - `READER_PRO`, `AUTHOR_PRO`, and `ADMIN_PRO`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
NA

### References
- Valid `UserRole` in AWS [documentation](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_RegisterUser.html#API_RegisterUser_RequestSyntax)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_REGION=us-east-1 make testacc TESTS=TestAccQuickSightUser PKG=quicksight

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightUser'  -timeout 360m
=== RUN   TestAccQuickSightUserDataSource_basic
=== PAUSE TestAccQuickSightUserDataSource_basic
=== RUN   TestAccQuickSightUser_basic
=== PAUSE TestAccQuickSightUser_basic
=== RUN   TestAccQuickSightUser_withInvalidFormattedEmailStillWorks
=== PAUSE TestAccQuickSightUser_withInvalidFormattedEmailStillWorks
=== RUN   TestAccQuickSightUser_withNamespace
    user_test.go:92: Environment variable QUICKSIGHT_NAMESPACE is not set
--- SKIP: TestAccQuickSightUser_withNamespace (0.00s)
=== RUN   TestAccQuickSightUser_disappears
=== PAUSE TestAccQuickSightUser_disappears
=== CONT  TestAccQuickSightUserDataSource_basic
=== CONT  TestAccQuickSightUser_basic
=== CONT  TestAccQuickSightUser_withInvalidFormattedEmailStillWorks
=== CONT  TestAccQuickSightUser_disappears
--- PASS: TestAccQuickSightUserDataSource_basic (34.58s)
--- PASS: TestAccQuickSightUser_disappears (35.87s)
--- PASS: TestAccQuickSightUser_basic (58.17s)
--- PASS: TestAccQuickSightUser_withInvalidFormattedEmailStillWorks (58.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 63.796s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  0.480s [no tests to run]
```


