### PR TITLE
quicksight: `skipSweepUsersError` -> `skipSweepUsersOrGroupsError`

### DIFF
--- a/internal/service/quicksight/sweep.go
+++ b/internal/service/quicksight/sweep.go
@@ -256,7 +256,7 @@ func sweepGroups(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if skipSweepError(err) {
+		if skipSweepUsersOrGroupsError(err) {
 			log.Printf("[WARN] Skipping QuickSight Group sweep for %s: %s", region, err)
 			return nil
 		}
@@ -352,7 +352,7 @@ func sweepUsers(region string) error {
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
-		if skipSweepUsersError(err) {
+		if skipSweepUsersOrGroupsError(err) {
 			log.Printf("[WARN] Skipping QuickSight User sweep for %s: %s", region, err)
 			return nil
 		}
@@ -451,7 +451,7 @@ func skipSweepError(err error) bool {
 	return awsv2.SkipSweepError(err)
 }
 
-func skipSweepUsersError(err error) bool {
+func skipSweepUsersOrGroupsError(err error) bool {
 	if tfawserr.ErrMessageContains(err, "ResourceNotFoundException", "is not signed up with QuickSight") ||
 		tfawserr.ErrMessageContains(err, "ResourceNotFoundException", "Namespace default not found in account") {
 		return true


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes sweeper error:

```
2024/09/09 08:47:00 [ERROR] Error running Sweeper (aws_quicksight_group) in region (us-east-2): error listing QuickSight Groups (us-east-2): operation error QuickSight: ListGroups, https response error StatusCode: 404, RequestID: c66b43e6-c7d3-48b6-be9c-55b6b994220a, ResourceNotFoundException: Namespace default not found in account 927163995318. AWS account ID: 927163995318, Namespace: default.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/39168.
