### PR TITLE
r/aws_quicksight_vpc_connection: Remove `vpc_connection_id` regex validator

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_vpc_connection: Remove `vpc_connection_id` regular expression validator. This fixes a regression introduced in [v5.66.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5660-september--5-2024)
+```

--- a/.changelog/39220.txt
+++ b/.changelog/39220.txt
@@ -1,3 +1,3 @@
-```release-note:note
+```release-note:enhancement
 resource/aws_quicksight_user: Add `READER_PRO`, `AUTHOR_PRO`, and `ADMIN_PRO` as valid values for the `user_role` argument
 ```

--- a/internal/service/quicksight/vpc_connection.go
+++ b/internal/service/quicksight/vpc_connection.go
@@ -38,6 +38,7 @@ import (
 // @Tags(identifierAttribute="arn")
 func newVPCConnectionResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &vpcConnectionResource{}
+
 	r.SetDefaultCreateTimeout(5 * time.Minute)
 	r.SetDefaultUpdateTimeout(5 * time.Minute)
 	r.SetDefaultDeleteTimeout(5 * time.Minute)
@@ -78,10 +79,7 @@ func (r *vpcConnectionResource) Schema(ctx context.Context, req resource.SchemaR
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.All(
-						stringvalidator.LengthAtMost(1000),
-						stringvalidator.RegexMatches(regexache.MustCompile(`[\\w\\-]+`), ""),
-					),
+					stringvalidator.LengthAtMost(1000),
 				},
 			},
 			names.AttrName: schema.StringAttribute{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes **v5.66.0** regression.
There is nor regular expression validator defined in the API documentation or the QuickSight console, so just removed from the code.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/39228.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
