### PR TITLE
r/`aws_secretsmanager_secret`: Fix removal of all `replica` blocks not being detected as a change

### DIFF
--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -105,7 +105,6 @@ func resourceSecret() *schema.Resource {
 			"replica": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				Set: func(v interface{}) int {
 					var buf bytes.Buffer
 

--- a/internal/service/secretsmanager/secret_test.go
+++ b/internal/service/secretsmanager/secret_test.go
@@ -175,6 +175,38 @@ func TestAccSecretsManagerSecret_basicReplica(t *testing.T) {
 	})
 }
 
+func TestAccSecretsManagerSecret_removeReplica(t *testing.T) {
+	ctx := acctest.Context(t)
+	var secret secretsmanager.DescribeSecretOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_secretsmanager_secret.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t); acctest.PreCheckMultipleRegion(t, 2) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
+		CheckDestroy:             testAccCheckSecretDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretConfig_basicReplica(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecretExists(ctx, resourceName, &secret),
+					resource.TestCheckResourceAttr(resourceName, "force_overwrite_replica_secret", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", acctest.Ct1),
+				),
+			},
+			{
+				Config: testAccSecretConfig_name(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecretExists(ctx, resourceName, &secret),
+					resource.TestCheckResourceAttr(resourceName, "force_overwrite_replica_secret", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "replica.#", acctest.Ct0),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSecretsManagerSecret_overwriteReplica(t *testing.T) {
 	ctx := acctest.Context(t)
 	var secret secretsmanager.DescribeSecretOutput


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fix changing replicas in secret.


### Relations
Closes #23316

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccSecretsManagerSecret_  PKG=secretsmanager
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecret_'  -timeout 360m
=== RUN   TestAccSecretsManagerSecret_tags
=== PAUSE TestAccSecretsManagerSecret_tags
=== RUN   TestAccSecretsManagerSecret_tags_null
=== PAUSE TestAccSecretsManagerSecret_tags_null
=== RUN   TestAccSecretsManagerSecret_tags_AddOnUpdate
=== PAUSE TestAccSecretsManagerSecret_tags_AddOnUpdate
=== RUN   TestAccSecretsManagerSecret_tags_EmptyTag_OnCreate
=== PAUSE TestAccSecretsManagerSecret_tags_EmptyTag_OnCreate
=== RUN   TestAccSecretsManagerSecret_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccSecretsManagerSecret_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccSecretsManagerSecret_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccSecretsManagerSecret_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccSecretsManagerSecret_tags_DefaultTags_providerOnly
=== PAUSE TestAccSecretsManagerSecret_tags_DefaultTags_providerOnly
=== RUN   TestAccSecretsManagerSecret_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccSecretsManagerSecret_tags_DefaultTags_nonOverlapping
=== RUN   TestAccSecretsManagerSecret_tags_DefaultTags_overlapping
=== PAUSE TestAccSecretsManagerSecret_tags_DefaultTags_overlapping
=== RUN   TestAccSecretsManagerSecret_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccSecretsManagerSecret_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccSecretsManagerSecret_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccSecretsManagerSecret_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccSecretsManagerSecret_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccSecretsManagerSecret_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccSecretsManagerSecret_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccSecretsManagerSecret_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccSecretsManagerSecret_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccSecretsManagerSecret_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccSecretsManagerSecret_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccSecretsManagerSecret_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccSecretsManagerSecret_tags_ComputedTag_OnCreate
=== PAUSE TestAccSecretsManagerSecret_tags_ComputedTag_OnCreate
=== RUN   TestAccSecretsManagerSecret_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccSecretsManagerSecret_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccSecretsManagerSecret_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccSecretsManagerSecret_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== RUN   TestAccSecretsManagerSecret_withNamePrefix
=== PAUSE TestAccSecretsManagerSecret_withNamePrefix
=== RUN   TestAccSecretsManagerSecret_disappears
=== PAUSE TestAccSecretsManagerSecret_disappears
=== RUN   TestAccSecretsManagerSecret_description
=== PAUSE TestAccSecretsManagerSecret_description
=== RUN   TestAccSecretsManagerSecret_basicReplica
=== PAUSE TestAccSecretsManagerSecret_basicReplica
=== RUN   TestAccSecretsManagerSecret_removeReplica
=== PAUSE TestAccSecretsManagerSecret_removeReplica
=== RUN   TestAccSecretsManagerSecret_overwriteReplica
=== PAUSE TestAccSecretsManagerSecret_overwriteReplica
=== RUN   TestAccSecretsManagerSecret_kmsKeyID
=== PAUSE TestAccSecretsManagerSecret_kmsKeyID
=== RUN   TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
=== PAUSE TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
=== RUN   TestAccSecretsManagerSecret_policy
=== PAUSE TestAccSecretsManagerSecret_policy
=== CONT  TestAccSecretsManagerSecret_tags
=== CONT  TestAccSecretsManagerSecret_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccSecretsManagerSecret_tags_DefaultTags_nonOverlapping
=== CONT  TestAccSecretsManagerSecret_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccSecretsManagerSecret_description
=== CONT  TestAccSecretsManagerSecret_kmsKeyID
=== CONT  TestAccSecretsManagerSecret_removeReplica
=== CONT  TestAccSecretsManagerSecret_policy
=== CONT  TestAccSecretsManagerSecret_overwriteReplica
=== CONT  TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate
=== CONT  TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_disappears
=== CONT  TestAccSecretsManagerSecret_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccSecretsManagerSecret_withNamePrefix
=== CONT  TestAccSecretsManagerSecret_tags_DefaultTags_providerOnly
=== CONT  TestAccSecretsManagerSecret_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccSecretsManagerSecret_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccSecretsManagerSecret_tags_ComputedTag_OnUpdate_Add
=== CONT  TestAccSecretsManagerSecret_tags_AddOnUpdate
=== CONT  TestAccSecretsManagerSecret_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccSecretsManagerSecret_disappears (42.65s)
=== CONT  TestAccSecretsManagerSecret_tags_EmptyTag_OnCreate
--- PASS: TestAccSecretsManagerSecret_withNamePrefix (48.44s)
=== CONT  TestAccSecretsManagerSecret_tags_ComputedTag_OnCreate
--- PASS: TestAccSecretsManagerSecret_basic (49.55s)
=== CONT  TestAccSecretsManagerSecret_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccSecretsManagerSecret_tags_DefaultTags_nullNonOverlappingResourceTag (53.83s)
=== CONT  TestAccSecretsManagerSecret_basicReplica
--- PASS: TestAccSecretsManagerSecret_tags_DefaultTags_nullOverlappingResourceTag (55.02s)
=== CONT  TestAccSecretsManagerSecret_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccSecretsManagerSecret_tags_DefaultTags_emptyResourceTag (56.46s)
=== CONT  TestAccSecretsManagerSecret_tags_null
--- PASS: TestAccSecretsManagerSecret_description (92.03s)
=== CONT  TestAccSecretsManagerSecret_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccSecretsManagerSecret_kmsKeyID (93.48s)
=== CONT  TestAccSecretsManagerSecret_tags_DefaultTags_overlapping
--- PASS: TestAccSecretsManagerSecret_removeReplica (97.34s)
--- PASS: TestAccSecretsManagerSecret_tags_ComputedTag_OnUpdate_Add (99.33s)
--- PASS: TestAccSecretsManagerSecret_tags_EmptyTag_OnUpdate_Replace (100.14s)
--- PASS: TestAccSecretsManagerSecret_tags_AddOnUpdate (108.67s)
--- PASS: TestAccSecretsManagerSecret_tags_ComputedTag_OnUpdate_Replace (113.40s)
--- PASS: TestAccSecretsManagerSecret_RecoveryWindowInDays_recreate (114.55s)
--- PASS: TestAccSecretsManagerSecret_policy (117.52s)
--- PASS: TestAccSecretsManagerSecret_tags_ComputedTag_OnCreate (76.89s)
--- PASS: TestAccSecretsManagerSecret_basicReplica (79.94s)
--- PASS: TestAccSecretsManagerSecret_tags_EmptyTag_OnUpdate_Add (134.81s)
--- PASS: TestAccSecretsManagerSecret_tags_EmptyTag_OnCreate (100.20s)
--- PASS: TestAccSecretsManagerSecret_tags_DefaultTags_emptyProviderOnlyTag (54.92s)
--- PASS: TestAccSecretsManagerSecret_tags_DefaultTags_updateToProviderOnly (100.73s)
--- PASS: TestAccSecretsManagerSecret_tags_DefaultTags_nonOverlapping (157.13s)
--- PASS: TestAccSecretsManagerSecret_tags_null (103.52s)
--- PASS: TestAccSecretsManagerSecret_tags (172.36s)
--- PASS: TestAccSecretsManagerSecret_tags_DefaultTags_updateToResourceOnly (121.17s)
--- PASS: TestAccSecretsManagerSecret_tags_DefaultTags_providerOnly (176.59s)
--- PASS: TestAccSecretsManagerSecret_overwriteReplica (183.65s)
--- PASS: TestAccSecretsManagerSecret_tags_DefaultTags_overlapping (106.12s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager     204.643s
```
