### PR TITLE
fix cognito user pool data source

### DIFF
--- a/internal/service/cognitoidp/user_pool_data_source.go
+++ b/internal/service/cognitoidp/user_pool_data_source.go
@@ -183,7 +183,7 @@ type userPoolDataSourceModel struct {
 	SMSConfigurationFailure  types.String                                                     `tfsdk:"sms_configuration_failure"`
 	SMSVerificationMessage   types.String                                                     `tfsdk:"sms_verification_message"`
 	UserPoolID               types.String                                                     `tfsdk:"user_pool_id"`
-	UserPoolTags             types.Map                                                        `tfsdk:"user_pool_tags"`
+	UserPoolTags             tftags.Map                                                       `tfsdk:"user_pool_tags"`
 	UsernameAttributes       fwtypes.ListValueOf[types.String]                                `tfsdk:"username_attributes"`
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fix cognito user pool data source


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39183

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%make testacc TESTS=TestAccCognitoIDPUserPoolDataSource_  PKG=cognitoidp
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPoolDataSource_'  -timeout 360m
=== RUN   TestAccCognitoIDPUserPoolDataSource_basic
=== PAUSE TestAccCognitoIDPUserPoolDataSource_basic
=== RUN   TestAccCognitoIDPUserPoolDataSource_schemaAttributes
=== PAUSE TestAccCognitoIDPUserPoolDataSource_schemaAttributes
=== CONT  TestAccCognitoIDPUserPoolDataSource_basic
=== CONT  TestAccCognitoIDPUserPoolDataSource_schemaAttributes
--- PASS: TestAccCognitoIDPUserPoolDataSource_basic (26.77s)
--- PASS: TestAccCognitoIDPUserPoolDataSource_schemaAttributes (26.92s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 31.886s
```
