### PR TITLE
docs: update allowed value for state in ebs_snapshot_block_public_access

### DIFF
--- a/website/docs/r/ebs_snapshot_block_public_access.html.markdown
+++ b/website/docs/r/ebs_snapshot_block_public_access.html.markdown
@@ -24,7 +24,7 @@ resource "aws_ebs_snapshot_block_public_access" "example" {
 
 This resource supports the following arguments:
 
-* `state` - (Required) The mode in which to enable "Block public access for snapshots" for the region. Allowed values are `block-all`, `block-new-sharing`, `unblocked`.
+* `state` - (Required) The mode in which to enable "Block public access for snapshots" for the region. Allowed values are `block-all-sharing`, `block-new-sharing`, `unblocked`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
In the textual description of the resource, one of the mentioned/ allowed values is incomplete:
instead of  `block-all` it should read `block-all-sharing`.

In the refences section I provided a link to the official CF documentation.

### Relations

Closes #39243 

### References
- [CloudFormation documentation ](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-snapshotblockpublicaccess.html)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.