### PR TITLE
r/aws_lexv2models_slot_type: fix `audio_recognition_strategy` argument name

### DIFF
--- a/.changelog/39254.txt
+++ b/.changelog/39254.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+resource/aws_lexv2models_slot_type: Within the `value_selection_setting.advanced_recognition_setting` block, the `audio_recognition_setting` argument has been renamed `audio_recognition_strategy`
+```
+
+```release-note:note
+resource/aws_lexv2models_slot_type: Within the `value_selection_setting.advanced_recognition_setting` block, the `audio_recognition_setting` argument has been renamed `audio_recognition_strategy`. See the [linked pull request](https://github.com/hashicorp/terraform-provider-aws/pull/39254) for additional justification on this change. The previous misnaming effectively made this argument unusable, therefore a breaking change in a minor version was deemed acceptable. 
+```

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -208,7 +208,7 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 							CustomType: fwtypes.NewListNestedObjectTypeOf[AdvancedRecognitionSetting](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
-									"audio_recognition_setting": schema.StringAttribute{
+									"audio_recognition_strategy": schema.StringAttribute{
 										Optional: true,
 										Validators: []validator.String{
 											enum.FrameworkValidate[awstypes.AudioRecognitionStrategy](),
@@ -488,7 +488,7 @@ type SlotTypeValues struct {
 }
 
 type AdvancedRecognitionSetting struct {
-	AudioRecognitionSetting types.String `tfsdk:"audio_recognition_setting"`
+	AudioRecognitionStrategy types.String `tfsdk:"audio_recognition_strategy"`
 }
 
 type RegexFilter struct {

--- a/internal/service/lexv2models/slot_type_test.go
+++ b/internal/service/lexv2models/slot_type_test.go
@@ -130,6 +130,37 @@ func TestAccLexV2ModelsSlotType_disappears(t *testing.T) {
 	})
 }
 
+func TestAccLexV2ModelsSlotType_valueSelectionSetting(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var slottype lexmodelsv2.DescribeSlotTypeOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_slot_type.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSlotTypeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSlotTypeConfig_valueSelectionSetting(rName, string(types.AudioRecognitionStrategyUseSlotValuesAsCustomVocabulary)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSlotTypeExists(ctx, resourceName, &slottype),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "value_selection_setting.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "value_selection_setting.0.advanced_recognition_setting.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "value_selection_setting.0.advanced_recognition_setting.0.audio_recognition_strategy", string(types.AudioRecognitionStrategyUseSlotValuesAsCustomVocabulary)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSlotTypeDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).LexV2ModelsClient(ctx)
@@ -275,4 +306,31 @@ resource "aws_lexv2models_slot_type" "test" {
   }
 }
 `, rName))
+}
+
+func testAccSlotTypeConfig_valueSelectionSetting(rName, audioRecognitionStrategy string) string {
+	return acctest.ConfigCompose(
+		testAccSlotTypeConfig_base(rName, 60, true),
+		fmt.Sprintf(`
+resource "aws_lexv2models_slot_type" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  value_selection_setting {
+    resolution_strategy = "OriginalValue"
+
+    advanced_recognition_setting {
+      audio_recognition_strategy = %[2]q
+    }
+  }
+
+  slot_type_values {
+    sample_value {
+      value = "testval"
+    }
+  }
+}
+`, rName, audioRecognitionStrategy))
 }

--- a/website/docs/r/lexv2models_slot_type.html.markdown
+++ b/website/docs/r/lexv2models_slot_type.html.markdown
@@ -129,22 +129,22 @@ This resource exports the following attributes in addition to the arguments abov
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Slot Type using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lex V2 Models Slot Type using a comma-delimited string concatenating `bot_id`, `bot_version`, `locale_id`, and `slot_type_id`. For example:
 
 ```terraform
 import {
   to = aws_lexv2models_slot_type.example
-  id = "slot_type-id-12345678"
+  id = "bot-1234,DRAFT,en_US,slot_type-id-12345678"
 }
 ```
 
-Using `terraform import`, import Lex V2 Models Slot Type using the `example_id_arg`. For example:
+Using `terraform import`, import Lex V2 Models Slot Type using using a comma-delimited string concatenating `bot_id`, `bot_version`, `locale_id`, and `slot_type_id`. For example:
 
 ```console
 % terraform import aws_lexv2models_slot_type.example bot-1234,DRAFT,en_US,slot_type-id-12345678

--- a/website/docs/r/lexv2models_slot_type.html.markdown
+++ b/website/docs/r/lexv2models_slot_type.html.markdown
@@ -15,42 +15,62 @@ Terraform resource for managing an AWS Lex V2 Models Slot Type.
 ### Basic Usage
 
 ```terraform
-resource "aws_iam_role_policy_attachment" "test" {
-  role       = aws_iam_role.test.name
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonLexFullAccess"
-}
-
-resource "aws_lexv2models_bot" "test" {
-  name                        = "testbot"
+resource "aws_lexv2models_bot" "example" {
+  name                        = "example"
   idle_session_ttl_in_seconds = 60
-  role_arn                    = aws_iam_role.test.arn
+  role_arn                    = aws_iam_role.example.arn
 
   data_privacy {
     child_directed = true
   }
 }
 
-resource "aws_lexv2models_bot_locale" "test" {
+resource "aws_lexv2models_bot_locale" "example" {
   locale_id                        = "en_US"
-  bot_id                           = aws_lexv2models_bot.test.id
+  bot_id                           = aws_lexv2models_bot.example.id
   bot_version                      = "DRAFT"
   n_lu_intent_confidence_threshold = 0.7
 }
 
-resource "aws_lexv2models_bot_version" "test" {
-  bot_id = aws_lexv2models_bot.test.id
+resource "aws_lexv2models_bot_version" "example" {
+  bot_id = aws_lexv2models_bot.example.id
   locale_specification = {
-    (aws_lexv2models_bot_locale.test.locale_id) = {
+    (aws_lexv2models_bot_locale.example.locale_id) = {
       source_bot_version = "DRAFT"
     }
   }
 }
 
-resource "aws_lexv2models_slot_type" "test" {
-  bot_id      = aws_lexv2models_bot.test.id
-  bot_version = aws_lexv2models_bot_locale.test.bot_version
-  name        = "test"
-  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+resource "aws_lexv2models_slot_type" "example" {
+  bot_id      = aws_lexv2models_bot.example.id
+  bot_version = aws_lexv2models_bot_locale.example.bot_version
+  name        = "example"
+  locale_id   = aws_lexv2models_bot_locale.example.locale_id
+}
+```
+
+### `value_selection_setting` Usage
+
+```terraform
+resource "aws_lexv2models_slot_type" "example" {
+  bot_id      = aws_lexv2models_bot.example.id
+  bot_version = aws_lexv2models_bot_locale.example.bot_version
+  name        = "example"
+  locale_id   = aws_lexv2models_bot_locale.example.locale_id
+
+  value_selection_setting {
+    resolution_strategy = "OriginalValue"
+
+    advanced_recognition_setting {
+      audio_recognition_strategy = "UseSlotValuesAsCustomVocabulary"
+    }
+  }
+
+  slot_type_values {
+    sample_value {
+      value = "exampleValue"
+    }
+  }
 }
 ```
 

--- a/website/docs/r/lexv2models_slot_type.html.markdown
+++ b/website/docs/r/lexv2models_slot_type.html.markdown
@@ -45,6 +45,7 @@ resource "aws_lexv2models_bot_version" "test" {
     }
   }
 }
+
 resource "aws_lexv2models_slot_type" "test" {
   bot_id      = aws_lexv2models_bot.test.id
   bot_version = aws_lexv2models_bot_locale.test.bot_version
@@ -59,71 +60,93 @@ The following arguments are required:
 
 * `bot_id` - (Required) Identifier of the bot associated with this slot type.
 * `bot_version` - (Required) Version of the bot associated with this slot type.
-* `locale_id` - (Required) Identifier of the language and locale where this slot type is used. All of the bots, slot types, and slots used by the intent must have the same locale.
-* `name` - (Required) Name of the slot type
+* `locale_id` - (Required) Identifier of the language and locale where this slot type is used.
+All of the bots, slot types, and slots used by the intent must have the same locale.
+* `name` - (Required) Name of the slot type.
 
 The following arguments are optional:
 
 * `description` - (Optional) Description of the slot type.
-* `composite_slot_type_setting` - (Optional) Specifications for a composite slot type. See [`composite_slot_type_setting` argument reference](#composite_slot_type_setting-argument-reference) below.
-* `external_source_setting` - (Optional) Type of external information used to create the slot type. See [`external_source_setting` argument reference](#external_source_setting-argument-reference) below.
-* `parent_slot_type_signature` - (Optional) Built-in slot type used as a parent of this slot type. When you define a parent slot type, the new slot type has the configuration of the parent slot type. Only AMAZON.AlphaNumeric is supported.
-* `slot_type_values` - (Optional) List of SlotTypeValue objects that defines the values that the slot type can take. Each value can have a list of synonyms, additional values that help train the machine learning model about the values that it resolves for a slot. See [`slot_type_values` argument reference](#slot_type_values-argument-reference) below.
-* `value_selection_setting` - (Optional) Determines the strategy that Amazon Lex uses to select a value from the list of possible values. The field can be set to one of the following values: `ORIGINAL_VALUE` returns the value entered by the user, if the user value is similar to the slot value. `TOP_RESOLUTION` if there is a resolution list for the slot, return the first value in the resolution list. If there is no resolution list, return null. If you don't specify the valueSelectionSetting parameter, the default is ORIGINAL_VALUE. See [`value_selection_setting` argument reference](#value_selection_setting-argument-reference) below.
+* `composite_slot_type_setting` - (Optional) Specifications for a composite slot type.
+See [`composite_slot_type_setting` argument reference](#composite_slot_type_setting-argument-reference) below.
+* `external_source_setting` - (Optional) Type of external information used to create the slot type.
+See [`external_source_setting` argument reference](#external_source_setting-argument-reference) below.
+* `parent_slot_type_signature` - (Optional) Built-in slot type used as a parent of this slot type.
+When you define a parent slot type, the new slot type has the configuration of the parent slot type.
+Only `AMAZON.AlphaNumeric` is supported.
+* `slot_type_values` - (Optional) List of SlotTypeValue objects that defines the values that the slot type can take.
+Each value can have a list of synonyms, additional values that help train the machine learning model about the values that it resolves for a slot.
+See [`slot_type_values` argument reference](#slot_type_values-argument-reference) below.
+* `value_selection_setting` - (Optional) Determines the strategy that Amazon Lex uses to select a value from the list of possible values.
+See [`value_selection_setting` argument reference](#value_selection_setting-argument-reference) below.
 
-### `slot_type_values` Argument Reference
+### `composite_slot_type_setting` Argument Reference
 
-* `sample_value` - (Optional) Value of the slot type entry.  See [`sample_value` argument reference](#sample_value-argument-reference) below.
-* `synonyms` - (Optional) Additional values related to the slot type entry. See [`sample_value` argument reference](#sample_value-argument-reference) below.
+* `sub_slots` - (Optional) Sub slots in the composite slot.
+See [`sub_slots` argument reference](#sub_slots-argument-reference) below.
 
-### `sample_value` Argument Reference
+#### `sub_slots` Argument Reference
 
-* `value` - (Required) Value that can be used for a slot type.
+* `name` - (Required) Name of a constituent sub slot inside a composite slot.
+* `slot_type_id` - (Required) Unique identifier assigned to a slot type.
+This refers to either a built-in slot type or the unique `slot_type_id` of a custom slot type.
 
 ### `external_source_setting` Argument Reference
 
-*`grammar_slot_type_setting` - (Optional) Settings required for a slot type based on a grammar that you provide. See [`grammar_slot_type_setting` argument reference](#grammar_slot_type_setting-argument-reference) below.
+*`grammar_slot_type_setting` - (Optional) Settings required for a slot type based on a grammar that you provide.
+See [`grammar_slot_type_setting` argument reference](#grammar_slot_type_setting-argument-reference) below.
 
-### `grammar_slot_type_setting` Argument Reference
+#### `grammar_slot_type_setting` Argument Reference
 
-* `source` - (Optional) Source of the grammar used to create the slot type. See [`grammar_slot_type_source` argument reference](#grammar_slot_type_source-argument-reference) below.
+* `source` - (Optional) Source of the grammar used to create the slot type.
+See [`source` argument reference](#source-argument-reference) below.
 
-### `grammar_slot_type_source` Argument Reference
+##### `source` Argument Reference
 
 * `s3_bucket_name` - (Required) Name of the Amazon S3 bucket that contains the grammar source.
 * `s3_object_key` - (Required) Path to the grammar in the Amazon S3 bucket.
 * `kms_key_arn` - (Optional) KMS key required to decrypt the contents of the grammar, if any.
 
-### `composite_slot_type_setting` Argument Reference
+### `slot_type_values` Argument Reference
 
-* `sub_slots` - (Optional) Subslots in the composite slot. Contains filtered or unexported fields. See [`sub_slot_type_composition` argument reference] below.
+* `sample_value` - (Optional) Value of the slot type entry.
+See [`sample_value` argument reference](#sample_value-argument-reference) below.
+* `synonyms` - (Optional) A list of additional values related to the slot type entry.
+See [`synonyms` argument reference](#synonyms-argument-reference) below.
 
-### `sub_slot_type_composition` Argument Reference
+#### `sample_value` Argument Reference
 
-* `name` - (Required) Name of a constituent sub slot inside a composite slot.
-* `slot_type_id` - (Required) Unique identifier assigned to a slot type. This refers to either a built-in slot type or the unique slotTypeId of a custom slot type.
+* `value` - (Required) Value that can be used for a slot type.
+
+#### `synonyms` Argument Reference
+
+* `value` - (Required) Value that can be used for a slot type.
 
 ### `value_selection_setting` Argument Reference
 
-* `resolution_strategy` - (Required) Determines the slot resolution strategy that Amazon Lex uses to return slot type values. The field can be set to one of the following values: `ORIGINAL_VALUE` - Returns the value entered by the user, if the user value is similar to the slot value. `TOP_RESOLUTION` If there is a resolution list for the slot, return the first value in the resolution list as the slot type value. If there is no resolution list, null is returned. If you don't specify the valueSelectionStrategy , the default is `ORIGINAL_VALUE`. Valid values are `OriginalValue`, `TopResolution`, and `Concatenation`.
-* `advanced_recognition_setting` - (Optional) Provides settings that enable advanced recognition settings for slot values. You can use this to enable using slot values as a custom vocabulary for recognizing user utterances. See [`advanced_recognition_setting` argument reference] below.
-* `regex_filter` - (Optional) Used to validate the value of the slot. See [`regex_filter` argument reference] below.
+* `resolution_strategy` - (Required) Determines the slot resolution strategy that Amazon Lex uses to return slot type values.
+Valid values are `OriginalValue`, `TopResolution`, and `Concatenation`.
+* `advanced_recognition_setting` - (Optional) Provides settings that enable advanced recognition settings for slot values.
+You can use this to enable using slot values as a custom vocabulary for recognizing user utterances.
+See [`advanced_recognition_setting` argument reference](#advanced_recognition_setting-argument-reference) below.
+* `regex_filter` - (Optional) Used to validate the value of the slot.
+See [`regex_filter` argument reference](#regexfilter-argument-reference) below.
 
-### `advanced_recognition_setting` Argument Reference
+#### `advanced_recognition_setting` Argument Reference
 
-* `pattern` - (Required) Used to validate the value of a slot. Use a standard regular expression. Amazon Lex supports the following characters in the regular expression: A-Z, a-z, 0-9, Unicode characters ("\⁠u").
-Represent Unicode characters with four digits, for example "\⁠u0041" or "\⁠u005A". The following regular expression operators are not supported: Infinite repeaters: *, +, or {x,} with no upper bound, wild card (.)
+* `audio_recognition_strategy` - (Optional) Enables using the slot values as a custom vocabulary for recognizing user utterances.
+Valid value is `UseSlotValuesAsCustomVocabulary`.
 
-### `advanced_recognition_setting` Argument Reference
+#### `regex_filter` Argument Reference
 
-* `audio_recognition_strategy` - (Optional) Enables using the slot values as a custom vocabulary for recognizing user utterances. Valid value is `UseSlotValuesAsCustomVocabulary`.
+* `pattern` - (Required) A regular expression used to validate the value of a slot.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
 * `id` - Comma-delimited string concatenating `bot_id`, `bot_version`, `locale_id`, and `slot_type_id`.
-* `slot_id` - Unique identifier for the intent.
+* `slot_type_id` - Unique identifier for the slot type.
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously this nested argument was misnamed `audio_recognition_settings`. If the correct name was provided, Terraform would fail indicating the argument name did not exist.

```
│ Error: Unsupported argument
│
│   on main.tf line 71, in resource "aws_lexv2models_slot_type" "test":
│   71:       audio_recognition_strategy = "UseSlotValuesAsCustomVocabulary"
│
│ An argument named "audio_recognition_strategy" is not expected here.
```

If the incorrect name was provided, creation would fail as AutoFlex would be unable to write the result from the AWS data structure back to the Terraform data structure due to the mismatch in field names.

```
aws_lexv2models_slot_type.test: Creating...
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to aws_lexv2models_slot_type.test, provider "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an unexpected new value:
│ .value_selection_setting[0].advanced_recognition_setting[0].audio_recognition_setting: was cty.StringVal("UseSlotValuesAsCustomVocabulary"), but now null.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

As such, this technically breaking change to the schema definition is deemed acceptable within a minor release.

Also fixes various issues with the registry documentation for `aws_lexv2models_slot_type` and adds a new example.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39246
Closes #39247 (documentation changes incorporated into this PR)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/lexv2/latest/APIReference/API_CreateSlotType.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=lexv2models TESTS=TestAccLexV2ModelsSlotType_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/lexv2models/... -v -count 1 -parallel 20 -run='TestAccLexV2ModelsSlotType_'  -timeout 360m

--- PASS: TestAccLexV2ModelsSlotType_values (42.82s)
--- PASS: TestAccLexV2ModelsSlotType_valueSelectionSetting (44.74s)
--- PASS: TestAccLexV2ModelsSlotType_disappears (45.08s)
--- PASS: TestAccLexV2ModelsSlotType_basic (50.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        56.975s
```
