### PR TITLE
resource/aws_batch_job_queue: Fixes type conversion error in migration function

### DIFF
--- a/.changelog/39257.txt
+++ b/.changelog/39257.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_batch_job_queue: Fixes error in schema migration function.
+```

--- a/internal/service/batch/job_queue_migrate.go
+++ b/internal/service/batch/job_queue_migrate.go
@@ -60,8 +60,8 @@ func upgradeJobQueueResourceStateV0toV1(ctx context.Context, request resource.Up
 		Priority            types.Int64    `tfsdk:"priority"`
 		SchedulingPolicyARN types.String   `tfsdk:"scheduling_policy_arn"`
 		State               types.String   `tfsdk:"state"`
-		Tags                types.Map      `tfsdk:"tags"`     // nosemgrep:ci.semgrep.framework.model-tag-types
-		TagsAll             types.Map      `tfsdk:"tags_all"` // nosemgrep:ci.semgrep.framework.model-tag-types
+		Tags                tftags.Map     `tfsdk:"tags"`
+		TagsAll             tftags.Map     `tfsdk:"tags_all"`
 		Timeouts            timeouts.Value `tfsdk:"timeouts"`
 	}
 
@@ -80,8 +80,8 @@ func upgradeJobQueueResourceStateV0toV1(ctx context.Context, request resource.Up
 		JobStateTimeLimitActions: fwtypes.NewListNestedObjectValueOfNull[jobStateTimeLimitActionModel](ctx),
 		Priority:                 jobQueueDataV0.Priority,
 		State:                    jobQueueDataV0.State,
-		Tags:                     tftags.NewMapFromMapValue(jobQueueDataV0.Tags),
-		TagsAll:                  tftags.NewMapFromMapValue(jobQueueDataV0.TagsAll),
+		Tags:                     jobQueueDataV0.Tags,
+		TagsAll:                  jobQueueDataV0.TagsAll,
 		Timeouts:                 jobQueueDataV0.Timeouts,
 	}
 


### PR DESCRIPTION
### Description

When the `aws_batch_job_queue` schema migration function is called, it returns a type conversion error.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39198

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=batch TESTS=TestAccBatchJobQueue_

--- PASS: TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate (147.38s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_emptyResourceTag (156.46s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_nullNonOverlappingResourceTag (162.39s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_nullOverlappingResourceTag (163.34s)
--- PASS: TestAccBatchJobQueue_tags_ComputedTag_OnCreate (164.75s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_emptyProviderOnlyTag (164.76s)
--- PASS: TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Replace (186.04s)
--- PASS: TestAccBatchJobQueue_tags_AddOnUpdate (188.26s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_updateToProviderOnly (189.70s)
--- PASS: TestAccBatchJobQueue_tags_EmptyTag_OnCreate (196.78s)
--- PASS: TestAccBatchJobQueue_state (201.83s)
--- PASS: TestAccBatchJobQueue_ComputeEnvironmentOrder_multiple (204.34s)
--- PASS: TestAccBatchJobQueue_schedulingPolicy (214.35s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_overlapping (218.19s)
--- PASS: TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Add (218.38s)
--- PASS: TestAccBatchJobQueue_ComputeEnvironments_multiple (223.21s)
--- PASS: TestAccBatchJobQueue_jobStateTimeLimitActionsMultiple (188.64s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_nonOverlapping (227.34s)
--- PASS: TestAccBatchJobQueue_tags (244.08s)
--- PASS: TestAccBatchJobQueue_tags_DefaultTags_providerOnly (244.08s)
--- PASS: TestAccBatchJobQueue_basicCEO (128.61s)
--- PASS: TestAccBatchJobQueue_disappearsCEO (126.99s)
--- PASS: TestAccBatchJobQueue_MigrateFromPluginSDK (132.30s)
--- PASS: TestAccBatchJobQueue_basic (131.71s)
--- PASS: TestAccBatchJobQueue_tags_ComputedTag_OnUpdate_Replace (145.11s)
--- PASS: TestAccBatchJobQueue_disappears (123.59s)
--- PASS: TestAccBatchJobQueue_tags_null (124.22s)
--- PASS: TestAccBatchJobQueue_priority (171.92s)
--- PASS: TestAccBatchJobQueue_tags_ComputedTag_OnUpdate_Add (138.68s)
```
