### PR TITLE
tagging tests: Adds tests for empty and `null` tag maps on data sources

### DIFF
--- a/internal/generate/tagstests/data_source_test.go.gtpl
+++ b/internal/generate/tagstests/data_source_test.go.gtpl
@@ -99,6 +99,8 @@ func {{ template "testname" . }}_tagsSerial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic: {{ template "testname" . }}_tags,
+		"NullMap":       {{ template "testname" . }}_tags_NullMap,
+		"EmptyMap":      {{ template "testname" . }}_tags_EmptyMap,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, {{ if .SerializeDelay }}serializeDelay{{ else }}0{{ end }})
@@ -133,7 +135,7 @@ func {{ template "testname" . }}_tags(t *testing.T) {
 	})
 }
 
-func {{ template "testname" . }}_tags_None(t *testing.T) {
+func {{ template "testname" . }}_tags_NullMap(t *testing.T) {
 	{{- template "Init" . }}
 
 	resource.{{ if .Serialize }}Test{{ else }}ParallelTest{{ end }}(t, resource.TestCase{
@@ -147,6 +149,30 @@ func {{ template "testname" . }}_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{ {{ if .Generator }}
 					acctest.CtRName:        config.StringVariable(rName),{{ end }}
 					acctest.CtResourceTags: nil,
+					{{ template "AdditionalTfVars" . }}
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func {{ template "testname" . }}_tags_EmptyMap(t *testing.T) {
+	{{- template "Init" . }}
+
+	resource.{{ if .Serialize }}Test{{ else }}ParallelTest{{ end }}(t, resource.TestCase{
+		{{ template "TestCaseSetup" . }}
+		Steps: []resource.TestStep{
+			{
+				{{ if .AlternateRegionProvider -}}
+				ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+				{{ end -}}
+				ConfigDirectory: config.StaticDirectory("testdata/{{ .Name }}/data.tags/"),
+				ConfigVariables: config.Variables{ {{ if .Generator }}
+					acctest.CtRName:        config.StringVariable(rName),{{ end }}
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 					{{ template "AdditionalTfVars" . }}
 				},
 				ConfigStateChecks: []statecheck.StateCheck{

--- a/internal/generate/tagstests/data_source_test.go.gtpl
+++ b/internal/generate/tagstests/data_source_test.go.gtpl
@@ -132,3 +132,27 @@ func {{ template "testname" . }}_tags(t *testing.T) {
 		},
 	})
 }
+
+func {{ template "testname" . }}_tags_None(t *testing.T) {
+	{{- template "Init" . }}
+
+	resource.{{ if .Serialize }}Test{{ else }}ParallelTest{{ end }}(t, resource.TestCase{
+		{{ template "TestCaseSetup" . }}
+		Steps: []resource.TestStep{
+			{
+				{{ if .AlternateRegionProvider -}}
+				ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
+				{{ end -}}
+				ConfigDirectory: config.StaticDirectory("testdata/{{ .Name }}/data.tags/"),
+				ConfigVariables: config.Variables{ {{ if .Generator }}
+					acctest.CtRName:        config.StringVariable(rName),{{ end }}
+					acctest.CtResourceTags: nil,
+					{{ template "AdditionalTfVars" . }}
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/acm/certificate_data_source_tags_gen_test.go
+++ b/internal/service/acm/certificate_data_source_tags_gen_test.go
@@ -43,3 +43,29 @@ func TestAccACMCertificateDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccACMCertificateDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_acm_certificate.test"
+	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Certificate/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtResourceTags:   nil,
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/acm/certificate_data_source_tags_gen_test.go
+++ b/internal/service/acm/certificate_data_source_tags_gen_test.go
@@ -44,7 +44,7 @@ func TestAccACMCertificateDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccACMCertificateDataSource_tags_None(t *testing.T) {
+func TestAccACMCertificateDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_acm_certificate.test"
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
@@ -59,6 +59,32 @@ func TestAccACMCertificateDataSource_tags_None(t *testing.T) {
 				ConfigDirectory: config.StaticDirectory("testdata/Certificate/data.tags/"),
 				ConfigVariables: config.Variables{
 					acctest.CtResourceTags:   nil,
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccACMCertificateDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_acm_certificate.test"
+	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Certificate/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtResourceTags:   config.MapVariable(map[string]config.Variable{}),
 					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},

--- a/internal/service/acmpca/certificate_authority_data_source_tags_gen_test.go
+++ b/internal/service/acmpca/certificate_authority_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccACMPCACertificateAuthorityDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccACMPCACertificateAuthorityDataSource_tags_None(t *testing.T) {
+func TestAccACMPCACertificateAuthorityDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_acmpca_certificate_authority.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccACMPCACertificateAuthorityDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccACMPCACertificateAuthorityDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_acmpca_certificate_authority.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/CertificateAuthority/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/acmpca/certificate_authority_data_source_tags_gen_test.go
+++ b/internal/service/acmpca/certificate_authority_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccACMPCACertificateAuthorityDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccACMPCACertificateAuthorityDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_acmpca_certificate_authority.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/CertificateAuthority/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/amp/workspace_data_source_tags_gen_test.go
+++ b/internal/service/amp/workspace_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccAMPWorkspaceDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccAMPWorkspaceDataSource_tags_None(t *testing.T) {
+func TestAccAMPWorkspaceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_prometheus_workspace.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccAMPWorkspaceDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAMPWorkspaceDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_prometheus_workspace.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Workspace/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/amp/workspace_data_source_tags_gen_test.go
+++ b/internal/service/amp/workspace_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccAMPWorkspaceDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAMPWorkspaceDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_prometheus_workspace.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Workspace/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigateway/api_key_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/api_key_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccAPIGatewayAPIKeyDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAPIGatewayAPIKeyDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_api_gateway_api_key.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/APIKey/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigateway/api_key_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/api_key_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccAPIGatewayAPIKeyDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccAPIGatewayAPIKeyDataSource_tags_None(t *testing.T) {
+func TestAccAPIGatewayAPIKeyDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_api_key.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccAPIGatewayAPIKeyDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayAPIKeyDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_api_gateway_api_key.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/APIKey/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/apigateway/domain_name_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/domain_name_data_source_tags_gen_test.go
@@ -45,3 +45,31 @@ func TestAccAPIGatewayDomainNameDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAPIGatewayDomainNameDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_api_gateway_domain_name.test"
+	rName := acctest.RandomSubdomain()
+	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/DomainName/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:          config.StringVariable(rName),
+					acctest.CtResourceTags:   nil,
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigateway/domain_name_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/domain_name_data_source_tags_gen_test.go
@@ -46,7 +46,7 @@ func TestAccAPIGatewayDomainNameDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccAPIGatewayDomainNameDataSource_tags_None(t *testing.T) {
+func TestAccAPIGatewayDomainNameDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_domain_name.test"
 	rName := acctest.RandomSubdomain()
@@ -63,6 +63,34 @@ func TestAccAPIGatewayDomainNameDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:          config.StringVariable(rName),
 					acctest.CtResourceTags:   nil,
+					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
+					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayDomainNameDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_api_gateway_domain_name.test"
+	rName := acctest.RandomSubdomain()
+	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/DomainName/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:          config.StringVariable(rName),
+					acctest.CtResourceTags:   config.MapVariable(map[string]config.Variable{}),
 					acctest.CtCertificatePEM: config.StringVariable(certificatePEM),
 					acctest.CtPrivateKeyPEM:  config.StringVariable(privateKeyPEM),
 				},

--- a/internal/service/apigateway/rest_api_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/rest_api_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccAPIGatewayRESTAPIDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAPIGatewayRESTAPIDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_api_gateway_rest_api.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/RESTAPI/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigateway/rest_api_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/rest_api_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccAPIGatewayRESTAPIDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccAPIGatewayRESTAPIDataSource_tags_None(t *testing.T) {
+func TestAccAPIGatewayRESTAPIDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccAPIGatewayRESTAPIDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayRESTAPIDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_api_gateway_rest_api.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/RESTAPI/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/apigateway/vpc_link_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/vpc_link_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccAPIGatewayVPCLinkDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccAPIGatewayVPCLinkDataSource_tags_None(t *testing.T) {
+func TestAccAPIGatewayVPCLinkDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_vpc_link.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccAPIGatewayVPCLinkDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayVPCLinkDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_api_gateway_vpc_link.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VPCLink/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/apigateway/vpc_link_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/vpc_link_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccAPIGatewayVPCLinkDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAPIGatewayVPCLinkDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_api_gateway_vpc_link.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VPCLink/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigatewayv2/api_data_source_tags_gen_test.go
+++ b/internal/service/apigatewayv2/api_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccAPIGatewayV2APIDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAPIGatewayV2APIDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_apigatewayv2_api.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/API/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigatewayv2/api_data_source_tags_gen_test.go
+++ b/internal/service/apigatewayv2/api_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccAPIGatewayV2APIDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccAPIGatewayV2APIDataSource_tags_None(t *testing.T) {
+func TestAccAPIGatewayV2APIDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_api.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccAPIGatewayV2APIDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayV2APIDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_apigatewayv2_api.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/API/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/apigatewayv2/vpc_link_data_source_tags_gen_test.go
+++ b/internal/service/apigatewayv2/vpc_link_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccAPIGatewayV2VPCLinkDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAPIGatewayV2VPCLinkDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VPCLink/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/apigatewayv2/vpc_link_data_source_tags_gen_test.go
+++ b/internal/service/apigatewayv2/vpc_link_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccAPIGatewayV2VPCLinkDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccAPIGatewayV2VPCLinkDataSource_tags_None(t *testing.T) {
+func TestAccAPIGatewayV2VPCLinkDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccAPIGatewayV2VPCLinkDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayV2VPCLinkDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VPCLink/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/appconfig/configuration_profile_data_source_tags_gen_test.go
+++ b/internal/service/appconfig/configuration_profile_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccAppConfigConfigurationProfileDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAppConfigConfigurationProfileDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appconfig_configuration_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ConfigurationProfile/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appconfig/configuration_profile_data_source_tags_gen_test.go
+++ b/internal/service/appconfig/configuration_profile_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccAppConfigConfigurationProfileDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccAppConfigConfigurationProfileDataSource_tags_None(t *testing.T) {
+func TestAccAppConfigConfigurationProfileDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_configuration_profile.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccAppConfigConfigurationProfileDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAppConfigConfigurationProfileDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appconfig_configuration_profile.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ConfigurationProfile/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/appconfig/environment_data_source_tags_gen_test.go
+++ b/internal/service/appconfig/environment_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccAppConfigEnvironmentDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccAppConfigEnvironmentDataSource_tags_None(t *testing.T) {
+func TestAccAppConfigEnvironmentDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_environment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccAppConfigEnvironmentDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAppConfigEnvironmentDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appconfig_environment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Environment/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/appconfig/environment_data_source_tags_gen_test.go
+++ b/internal/service/appconfig/environment_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccAppConfigEnvironmentDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAppConfigEnvironmentDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appconfig_environment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Environment/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appintegrations/event_integration_data_source_tags_gen_test.go
+++ b/internal/service/appintegrations/event_integration_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccAppIntegrationsEventIntegrationDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAppIntegrationsEventIntegrationDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appintegrations_event_integration.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/EventIntegration/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appintegrations/event_integration_data_source_tags_gen_test.go
+++ b/internal/service/appintegrations/event_integration_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccAppIntegrationsEventIntegrationDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccAppIntegrationsEventIntegrationDataSource_tags_None(t *testing.T) {
+func TestAccAppIntegrationsEventIntegrationDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appintegrations_event_integration.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccAppIntegrationsEventIntegrationDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccAppIntegrationsEventIntegrationDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appintegrations_event_integration.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/EventIntegration/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/appmesh/gateway_route_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/gateway_route_data_source_tags_gen_test.go
@@ -52,3 +52,27 @@ func testAccAppMeshGatewayRouteDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func testAccAppMeshGatewayRouteDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_gateway_route.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/GatewayRoute/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appmesh/gateway_route_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/gateway_route_data_source_tags_gen_test.go
@@ -20,6 +20,8 @@ func testAccAppMeshGatewayRouteDataSource_tagsSerial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic: testAccAppMeshGatewayRouteDataSource_tags,
+		"NullMap":       testAccAppMeshGatewayRouteDataSource_tags_NullMap,
+		"EmptyMap":      testAccAppMeshGatewayRouteDataSource_tags_EmptyMap,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -53,7 +55,7 @@ func testAccAppMeshGatewayRouteDataSource_tags(t *testing.T) {
 	})
 }
 
-func testAccAppMeshGatewayRouteDataSource_tags_None(t *testing.T) {
+func testAccAppMeshGatewayRouteDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_gateway_route.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -68,6 +70,30 @@ func testAccAppMeshGatewayRouteDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func testAccAppMeshGatewayRouteDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_gateway_route.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/GatewayRoute/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/appmesh/mesh_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/mesh_data_source_tags_gen_test.go
@@ -52,3 +52,27 @@ func testAccAppMeshServiceMeshDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func testAccAppMeshServiceMeshDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_mesh.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ServiceMesh/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appmesh/mesh_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/mesh_data_source_tags_gen_test.go
@@ -20,6 +20,8 @@ func testAccAppMeshServiceMeshDataSource_tagsSerial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic: testAccAppMeshServiceMeshDataSource_tags,
+		"NullMap":       testAccAppMeshServiceMeshDataSource_tags_NullMap,
+		"EmptyMap":      testAccAppMeshServiceMeshDataSource_tags_EmptyMap,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -53,7 +55,7 @@ func testAccAppMeshServiceMeshDataSource_tags(t *testing.T) {
 	})
 }
 
-func testAccAppMeshServiceMeshDataSource_tags_None(t *testing.T) {
+func testAccAppMeshServiceMeshDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_mesh.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -68,6 +70,30 @@ func testAccAppMeshServiceMeshDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func testAccAppMeshServiceMeshDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_mesh.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ServiceMesh/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/appmesh/route_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/route_data_source_tags_gen_test.go
@@ -52,3 +52,27 @@ func testAccAppMeshRouteDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func testAccAppMeshRouteDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_route.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Route/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appmesh/route_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/route_data_source_tags_gen_test.go
@@ -20,6 +20,8 @@ func testAccAppMeshRouteDataSource_tagsSerial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic: testAccAppMeshRouteDataSource_tags,
+		"NullMap":       testAccAppMeshRouteDataSource_tags_NullMap,
+		"EmptyMap":      testAccAppMeshRouteDataSource_tags_EmptyMap,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -53,7 +55,7 @@ func testAccAppMeshRouteDataSource_tags(t *testing.T) {
 	})
 }
 
-func testAccAppMeshRouteDataSource_tags_None(t *testing.T) {
+func testAccAppMeshRouteDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_route.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -68,6 +70,30 @@ func testAccAppMeshRouteDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func testAccAppMeshRouteDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_route.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Route/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/appmesh/virtual_gateway_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_gateway_data_source_tags_gen_test.go
@@ -52,3 +52,27 @@ func testAccAppMeshVirtualGatewayDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func testAccAppMeshVirtualGatewayDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_virtual_gateway.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VirtualGateway/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appmesh/virtual_gateway_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_gateway_data_source_tags_gen_test.go
@@ -20,6 +20,8 @@ func testAccAppMeshVirtualGatewayDataSource_tagsSerial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic: testAccAppMeshVirtualGatewayDataSource_tags,
+		"NullMap":       testAccAppMeshVirtualGatewayDataSource_tags_NullMap,
+		"EmptyMap":      testAccAppMeshVirtualGatewayDataSource_tags_EmptyMap,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -53,7 +55,7 @@ func testAccAppMeshVirtualGatewayDataSource_tags(t *testing.T) {
 	})
 }
 
-func testAccAppMeshVirtualGatewayDataSource_tags_None(t *testing.T) {
+func testAccAppMeshVirtualGatewayDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_gateway.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -68,6 +70,30 @@ func testAccAppMeshVirtualGatewayDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func testAccAppMeshVirtualGatewayDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_virtual_gateway.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VirtualGateway/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/appmesh/virtual_node_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_node_data_source_tags_gen_test.go
@@ -20,6 +20,8 @@ func testAccAppMeshVirtualNodeDataSource_tagsSerial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic: testAccAppMeshVirtualNodeDataSource_tags,
+		"NullMap":       testAccAppMeshVirtualNodeDataSource_tags_NullMap,
+		"EmptyMap":      testAccAppMeshVirtualNodeDataSource_tags_EmptyMap,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -53,7 +55,7 @@ func testAccAppMeshVirtualNodeDataSource_tags(t *testing.T) {
 	})
 }
 
-func testAccAppMeshVirtualNodeDataSource_tags_None(t *testing.T) {
+func testAccAppMeshVirtualNodeDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_node.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -68,6 +70,30 @@ func testAccAppMeshVirtualNodeDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func testAccAppMeshVirtualNodeDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_virtual_node.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VirtualNode/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/appmesh/virtual_node_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_node_data_source_tags_gen_test.go
@@ -52,3 +52,27 @@ func testAccAppMeshVirtualNodeDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func testAccAppMeshVirtualNodeDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_virtual_node.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VirtualNode/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appmesh/virtual_router_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_router_data_source_tags_gen_test.go
@@ -52,3 +52,27 @@ func testAccAppMeshVirtualRouterDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func testAccAppMeshVirtualRouterDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_virtual_router.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VirtualRouter/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appmesh/virtual_router_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_router_data_source_tags_gen_test.go
@@ -20,6 +20,8 @@ func testAccAppMeshVirtualRouterDataSource_tagsSerial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic: testAccAppMeshVirtualRouterDataSource_tags,
+		"NullMap":       testAccAppMeshVirtualRouterDataSource_tags_NullMap,
+		"EmptyMap":      testAccAppMeshVirtualRouterDataSource_tags_EmptyMap,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -53,7 +55,7 @@ func testAccAppMeshVirtualRouterDataSource_tags(t *testing.T) {
 	})
 }
 
-func testAccAppMeshVirtualRouterDataSource_tags_None(t *testing.T) {
+func testAccAppMeshVirtualRouterDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_router.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -68,6 +70,30 @@ func testAccAppMeshVirtualRouterDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func testAccAppMeshVirtualRouterDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_virtual_router.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VirtualRouter/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/appmesh/virtual_service_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_service_data_source_tags_gen_test.go
@@ -52,3 +52,27 @@ func testAccAppMeshVirtualServiceDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func testAccAppMeshVirtualServiceDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_virtual_service.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VirtualService/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/appmesh/virtual_service_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_service_data_source_tags_gen_test.go
@@ -20,6 +20,8 @@ func testAccAppMeshVirtualServiceDataSource_tagsSerial(t *testing.T) {
 
 	testCases := map[string]func(t *testing.T){
 		acctest.CtBasic: testAccAppMeshVirtualServiceDataSource_tags,
+		"NullMap":       testAccAppMeshVirtualServiceDataSource_tags_NullMap,
+		"EmptyMap":      testAccAppMeshVirtualServiceDataSource_tags_EmptyMap,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -53,7 +55,7 @@ func testAccAppMeshVirtualServiceDataSource_tags(t *testing.T) {
 	})
 }
 
-func testAccAppMeshVirtualServiceDataSource_tags_None(t *testing.T) {
+func testAccAppMeshVirtualServiceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_service.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -68,6 +70,30 @@ func testAccAppMeshVirtualServiceDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func testAccAppMeshVirtualServiceDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_appmesh_virtual_service.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VirtualService/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/batch/compute_environment_data_source_tags_gen_test.go
+++ b/internal/service/batch/compute_environment_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccBatchComputeEnvironmentDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccBatchComputeEnvironmentDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_batch_compute_environment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ComputeEnvironment/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/batch/compute_environment_data_source_tags_gen_test.go
+++ b/internal/service/batch/compute_environment_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccBatchComputeEnvironmentDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccBatchComputeEnvironmentDataSource_tags_None(t *testing.T) {
+func TestAccBatchComputeEnvironmentDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_compute_environment.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccBatchComputeEnvironmentDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccBatchComputeEnvironmentDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_batch_compute_environment.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/ComputeEnvironment/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/batch/job_definition_data_source_tags_gen_test.go
+++ b/internal/service/batch/job_definition_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccBatchJobDefinitionDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccBatchJobDefinitionDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_batch_job_definition.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/JobDefinition/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/batch/job_definition_data_source_tags_gen_test.go
+++ b/internal/service/batch/job_definition_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccBatchJobDefinitionDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccBatchJobDefinitionDataSource_tags_None(t *testing.T) {
+func TestAccBatchJobDefinitionDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_definition.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccBatchJobDefinitionDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinitionDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_batch_job_definition.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/JobDefinition/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/batch/job_queue_data_source_tags_gen_test.go
+++ b/internal/service/batch/job_queue_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccBatchJobQueueDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccBatchJobQueueDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_batch_job_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/JobQueue/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/batch/job_queue_data_source_tags_gen_test.go
+++ b/internal/service/batch/job_queue_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccBatchJobQueueDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccBatchJobQueueDataSource_tags_None(t *testing.T) {
+func TestAccBatchJobQueueDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_queue.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccBatchJobQueueDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccBatchJobQueueDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_batch_job_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/JobQueue/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/batch/scheduling_policy_data_source_tags_gen_test.go
+++ b/internal/service/batch/scheduling_policy_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccBatchSchedulingPolicyDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccBatchSchedulingPolicyDataSource_tags_None(t *testing.T) {
+func TestAccBatchSchedulingPolicyDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_scheduling_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccBatchSchedulingPolicyDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccBatchSchedulingPolicyDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_batch_scheduling_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SchedulingPolicy/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/batch/scheduling_policy_data_source_tags_gen_test.go
+++ b/internal/service/batch/scheduling_policy_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccBatchSchedulingPolicyDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccBatchSchedulingPolicyDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_batch_scheduling_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SchedulingPolicy/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/cognitoidp/user_pool_data_source_tags_gen_test.go
+++ b/internal/service/cognitoidp/user_pool_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccCognitoIDPUserPoolDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccCognitoIDPUserPoolDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_cognito_user_pool.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/UserPool/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/cognitoidp/user_pool_data_source_tags_gen_test.go
+++ b/internal/service/cognitoidp/user_pool_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccCognitoIDPUserPoolDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccCognitoIDPUserPoolDataSource_tags_None(t *testing.T) {
+func TestAccCognitoIDPUserPoolDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cognito_user_pool.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccCognitoIDPUserPoolDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPUserPoolDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_cognito_user_pool.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/UserPool/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/ec2/ec2_instance_data_source_tags_gen_test.go
+++ b/internal/service/ec2/ec2_instance_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccEC2InstanceDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccEC2InstanceDataSource_tags_None(t *testing.T) {
+func TestAccEC2InstanceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_instance.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccEC2InstanceDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccEC2InstanceDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Instance/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/ec2/ec2_instance_data_source_tags_gen_test.go
+++ b/internal/service/ec2/ec2_instance_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccEC2InstanceDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccEC2InstanceDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Instance/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ec2/vpc_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccVPCVPCDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccVPCVPCDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_vpc.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VPC/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ec2/vpc_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccVPCVPCDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccVPCVPCDataSource_tags_None(t *testing.T) {
+func TestAccVPCVPCDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_vpc.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccVPCVPCDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCVPCDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_vpc.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/VPC/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/ec2/vpc_route_table_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_route_table_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccVPCRouteTableDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccVPCRouteTableDataSource_tags_None(t *testing.T) {
+func TestAccVPCRouteTableDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_route_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccVPCRouteTableDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCRouteTableDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_route_table.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/RouteTable/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/ec2/vpc_route_table_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_route_table_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccVPCRouteTableDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccVPCRouteTableDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_route_table.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/RouteTable/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/ec2/vpc_security_group_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_security_group_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccVPCSecurityGroupDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccVPCSecurityGroupDataSource_tags_None(t *testing.T) {
+func TestAccVPCSecurityGroupDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_security_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccVPCSecurityGroupDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccVPCSecurityGroupDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_security_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SecurityGroup/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/ec2/vpc_security_group_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_security_group_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccVPCSecurityGroupDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccVPCSecurityGroupDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_security_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/SecurityGroup/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/elbv2/listener_data_source_tags_gen_test.go
+++ b/internal/service/elbv2/listener_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccELBV2ListenerDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccELBV2ListenerDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_lb_listener.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Listener/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/elbv2/listener_data_source_tags_gen_test.go
+++ b/internal/service/elbv2/listener_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccELBV2ListenerDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccELBV2ListenerDataSource_tags_None(t *testing.T) {
+func TestAccELBV2ListenerDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccELBV2ListenerDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccELBV2ListenerDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_lb_listener.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Listener/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/elbv2/load_balancer_data_source_tags_gen_test.go
+++ b/internal/service/elbv2/load_balancer_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccELBV2LoadBalancerDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccELBV2LoadBalancerDataSource_tags_None(t *testing.T) {
+func TestAccELBV2LoadBalancerDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccELBV2LoadBalancerDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccELBV2LoadBalancerDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_lb.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/LoadBalancer/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/elbv2/load_balancer_data_source_tags_gen_test.go
+++ b/internal/service/elbv2/load_balancer_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccELBV2LoadBalancerDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccELBV2LoadBalancerDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_lb.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/LoadBalancer/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/elbv2/target_group_data_source_tags_gen_test.go
+++ b/internal/service/elbv2/target_group_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccELBV2TargetGroupDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccELBV2TargetGroupDataSource_tags_None(t *testing.T) {
+func TestAccELBV2TargetGroupDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_target_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccELBV2TargetGroupDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccELBV2TargetGroupDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_lb_target_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/TargetGroup/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/elbv2/target_group_data_source_tags_gen_test.go
+++ b/internal/service/elbv2/target_group_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccELBV2TargetGroupDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccELBV2TargetGroupDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_lb_target_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/TargetGroup/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/iam/openid_connect_provider_data_source_tags_gen_test.go
+++ b/internal/service/iam/openid_connect_provider_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccIAMOIDCProviderDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccIAMOIDCProviderDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_openid_connect_provider.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/OIDCProvider/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/iam/openid_connect_provider_data_source_tags_gen_test.go
+++ b/internal/service/iam/openid_connect_provider_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccIAMOIDCProviderDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccIAMOIDCProviderDataSource_tags_None(t *testing.T) {
+func TestAccIAMOIDCProviderDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_openid_connect_provider.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccIAMOIDCProviderDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMOIDCProviderDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_openid_connect_provider.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/OIDCProvider/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/iam/policy_data_source_tags_gen_test.go
+++ b/internal/service/iam/policy_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccIAMPolicyDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccIAMPolicyDataSource_tags_None(t *testing.T) {
+func TestAccIAMPolicyDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccIAMPolicyDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMPolicyDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Policy/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/iam/policy_data_source_tags_gen_test.go
+++ b/internal/service/iam/policy_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccIAMPolicyDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccIAMPolicyDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_policy.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Policy/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/iam/role_data_source_tags_gen_test.go
+++ b/internal/service/iam/role_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccIAMRoleDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccIAMRoleDataSource_tags_None(t *testing.T) {
+func TestAccIAMRoleDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_role.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccIAMRoleDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMRoleDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_role.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Role/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/iam/role_data_source_tags_gen_test.go
+++ b/internal/service/iam/role_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccIAMRoleDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccIAMRoleDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_role.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Role/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/iam/user_data_source_tags_gen_test.go
+++ b/internal/service/iam/user_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccIAMUserDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccIAMUserDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_user.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/User/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/iam/user_data_source_tags_gen_test.go
+++ b/internal/service/iam/user_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccIAMUserDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccIAMUserDataSource_tags_None(t *testing.T) {
+func TestAccIAMUserDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_user.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccIAMUserDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccIAMUserDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_iam_user.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/User/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/lambda/function_data_source_tags_gen_test.go
+++ b/internal/service/lambda/function_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccLambdaFunctionDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLambdaFunctionDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_lambda_function.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Function/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/lambda/function_data_source_tags_gen_test.go
+++ b/internal/service/lambda/function_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccLambdaFunctionDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccLambdaFunctionDataSource_tags_None(t *testing.T) {
+func TestAccLambdaFunctionDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lambda_function.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccLambdaFunctionDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccLambdaFunctionDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_lambda_function.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Function/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/logs/group_data_source_tags_gen_test.go
+++ b/internal/service/logs/group_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccLogsLogGroupDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLogsLogGroupDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_cloudwatch_log_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/LogGroup/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/logs/group_data_source_tags_gen_test.go
+++ b/internal/service/logs/group_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccLogsLogGroupDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccLogsLogGroupDataSource_tags_None(t *testing.T) {
+func TestAccLogsLogGroupDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cloudwatch_log_group.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccLogsLogGroupDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccLogsLogGroupDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_cloudwatch_log_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/LogGroup/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/medialive/input_data_source_tags_gen_test.go
+++ b/internal/service/medialive/input_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccMediaLiveInputDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccMediaLiveInputDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_medialive_input.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Input/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/medialive/input_data_source_tags_gen_test.go
+++ b/internal/service/medialive/input_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccMediaLiveInputDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccMediaLiveInputDataSource_tags_None(t *testing.T) {
+func TestAccMediaLiveInputDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_medialive_input.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccMediaLiveInputDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccMediaLiveInputDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_medialive_input.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Input/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/rds/instance_data_source_tags_gen_test.go
+++ b/internal/service/rds/instance_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccRDSDBInstanceDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccRDSDBInstanceDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_db_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/DBInstance/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/rds/instance_data_source_tags_gen_test.go
+++ b/internal/service/rds/instance_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccRDSDBInstanceDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccRDSDBInstanceDataSource_tags_None(t *testing.T) {
+func TestAccRDSDBInstanceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_db_instance.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccRDSDBInstanceDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccRDSDBInstanceDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_db_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/DBInstance/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/s3/bucket_object_data_source_tags_gen_test.go
+++ b/internal/service/s3/bucket_object_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccS3BucketObjectDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccS3BucketObjectDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_s3_bucket_object.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/BucketObject/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/s3/bucket_object_data_source_tags_gen_test.go
+++ b/internal/service/s3/bucket_object_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccS3BucketObjectDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccS3BucketObjectDataSource_tags_None(t *testing.T) {
+func TestAccS3BucketObjectDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_bucket_object.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccS3BucketObjectDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccS3BucketObjectDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_s3_bucket_object.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/BucketObject/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/s3/object_data_source_tags_gen_test.go
+++ b/internal/service/s3/object_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccS3ObjectDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccS3ObjectDataSource_tags_None(t *testing.T) {
+func TestAccS3ObjectDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_object.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccS3ObjectDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccS3ObjectDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_s3_object.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Object/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/s3/object_data_source_tags_gen_test.go
+++ b/internal/service/s3/object_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccS3ObjectDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccS3ObjectDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_s3_object.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Object/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/secretsmanager/secret_data_source_tags_gen_test.go
+++ b/internal/service/secretsmanager/secret_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccSecretsManagerSecretDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccSecretsManagerSecretDataSource_tags_None(t *testing.T) {
+func TestAccSecretsManagerSecretDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_secretsmanager_secret.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccSecretsManagerSecretDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSecretsManagerSecretDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_secretsmanager_secret.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Secret/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/secretsmanager/secret_data_source_tags_gen_test.go
+++ b/internal/service/secretsmanager/secret_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccSecretsManagerSecretDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccSecretsManagerSecretDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_secretsmanager_secret.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Secret/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/servicecatalog/portfolio_data_source_tags_gen_test.go
+++ b/internal/service/servicecatalog/portfolio_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccServiceCatalogPortfolioDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccServiceCatalogPortfolioDataSource_tags_None(t *testing.T) {
+func TestAccServiceCatalogPortfolioDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccServiceCatalogPortfolioDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccServiceCatalogPortfolioDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_servicecatalog_portfolio.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Portfolio/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/servicecatalog/portfolio_data_source_tags_gen_test.go
+++ b/internal/service/servicecatalog/portfolio_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccServiceCatalogPortfolioDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccServiceCatalogPortfolioDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_servicecatalog_portfolio.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Portfolio/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/servicecatalog/product_data_source_tags_gen_test.go
+++ b/internal/service/servicecatalog/product_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccServiceCatalogProductDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccServiceCatalogProductDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_servicecatalog_product.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Product/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/servicecatalog/product_data_source_tags_gen_test.go
+++ b/internal/service/servicecatalog/product_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccServiceCatalogProductDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccServiceCatalogProductDataSource_tags_None(t *testing.T) {
+func TestAccServiceCatalogProductDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_product.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccServiceCatalogProductDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccServiceCatalogProductDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_servicecatalog_product.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Product/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/sqs/queue_data_source_tags_gen_test.go
+++ b/internal/service/sqs/queue_data_source_tags_gen_test.go
@@ -43,7 +43,7 @@ func TestAccSQSQueueDataSource_tags(t *testing.T) {
 	})
 }
 
-func TestAccSQSQueueDataSource_tags_None(t *testing.T) {
+func TestAccSQSQueueDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sqs_queue.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -58,6 +58,30 @@ func TestAccSQSQueueDataSource_tags_None(t *testing.T) {
 				ConfigVariables: config.Variables{
 					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSQSQueueDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_sqs_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Queue/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),

--- a/internal/service/sqs/queue_data_source_tags_gen_test.go
+++ b/internal/service/sqs/queue_data_source_tags_gen_test.go
@@ -42,3 +42,27 @@ func TestAccSQSQueueDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccSQSQueueDataSource_tags_None(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_sqs_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Queue/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
### Description

Adds tests for empty and `null` tag maps on data sources
