### PR TITLE
[New Resource]: aws_iot_package_configuration

### DIFF
--- a/internal/service/iot/package_configuration.go
+++ b/internal/service/iot/package_configuration.go
@@ -1,0 +1,198 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iot
+
+import (
+	"context"
+	"errors"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iot"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/iot/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_iot_package_configuration", name="Package Configuration")
+func newResourcePackageConfiguration(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourcePackageConfiguration{}, nil
+}
+
+const (
+	ResNamePackageConfiguration = "Package Configuration"
+)
+
+type resourcePackageConfiguration struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourcePackageConfiguration) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_iot_package_configuration"
+}
+
+func (r *resourcePackageConfiguration) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Blocks: map[string]schema.Block{
+			"version_update_by_jobs": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[versionUpdateByJobsConfig](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrEnabled: schema.BoolAttribute{
+							Required: true,
+						},
+						names.AttrRoleARN: schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *resourcePackageConfiguration) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan resourcePackageConfigurationModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().IoTClient(ctx)
+
+	input := &iot.UpdatePackageConfigurationInput{
+		VersionUpdateByJobsConfig: &awstypes.VersionUpdateByJobsConfig{},
+	}
+	resp.Diagnostics.Append(flex.Expand(ctx, &plan, input)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := conn.UpdatePackageConfiguration(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.IoT, create.ErrActionCreating, ResNamePackageConfiguration, "", err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.IoT, create.ErrActionCreating, ResNamePackageConfiguration, "", nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourcePackageConfiguration) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan resourcePackageConfigurationModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().IoTClient(ctx)
+
+	input := &iot.UpdatePackageConfigurationInput{
+		VersionUpdateByJobsConfig: &awstypes.VersionUpdateByJobsConfig{},
+	}
+	resp.Diagnostics.Append(flex.Expand(ctx, &plan, input)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := conn.UpdatePackageConfiguration(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.IoT, create.ErrActionCreating, ResNamePackageConfiguration, "", err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.IoT, create.ErrActionCreating, ResNamePackageConfiguration, "", nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourcePackageConfiguration) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state resourcePackageConfigurationModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().IoTClient(ctx)
+
+	out, err := conn.GetPackageConfiguration(ctx, &iot.GetPackageConfigurationInput{})
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.IoT, create.ErrActionSetting, ResNamePackageConfiguration, "", err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourcePackageConfiguration) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().IoTClient(ctx)
+
+	input := &iot.UpdatePackageConfigurationInput{
+		VersionUpdateByJobsConfig: &awstypes.VersionUpdateByJobsConfig{
+			Enabled: aws.Bool(false),
+			RoleArn: nil,
+		},
+	}
+
+	_, err := conn.UpdatePackageConfiguration(ctx, input)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.IoT, create.ErrActionDeleting, ResNamePackageConfiguration, "", err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+type resourcePackageConfigurationModel struct {
+	VersionUpdateByJobsConfig fwtypes.ListNestedObjectValueOf[versionUpdateByJobsConfig] `tfsdk:"version_update_by_jobs"`
+}
+
+type versionUpdateByJobsConfig struct {
+	Enabled types.Bool   `tfsdk:"enabled"`
+	RoleARN types.String `tfsdk:"role_arn"`
+}

--- a/internal/service/iot/package_configuration_test.go
+++ b/internal/service/iot/package_configuration_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iot_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccPackageConfiguration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	resourceName := "aws_iot_package_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IoTServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPackageConfiguration_basic,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "version_update_by_jobs.0."+names.AttrEnabled, "true"),
+					resource.TestCheckResourceAttrWith(resourceName, "version_update_by_jobs.0."+names.AttrRoleARN, func(value string) error {
+						if len(value) == 0 {
+							return fmt.Errorf("empty role arn")
+						}
+
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+const testAccPackageConfiguration_basic = `
+resource "aws_iam_role" "test" {
+  name = "test_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "iot.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iot_package_configuration" "test" {
+  version_update_by_jobs {
+    enabled = true
+    role_arn = aws_iam_role.test.arn
+  }
+}
+`

--- a/internal/service/iot/service_package_gen.go
+++ b/internal/service/iot/service_package_gen.go
@@ -19,7 +19,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourcePackageConfiguration,
+			Name:    "Package Configuration",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/website/docs/r/iot_package_configuration.html.markdown
+++ b/website/docs/r/iot_package_configuration.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "IoT Core"
+layout: "aws"
+page_title: "AWS: aws_iot_package_configuration"
+description: |-
+  Terraform resource for managing the AWS IoT Core Package Configuration.
+---
+
+# Resource: aws_iot_package_configuration
+
+Terraform resource for managing the AWS IoT Core Package Configuration.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_iam_role" "example" {
+  name = "example_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "iot.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iot_package_configuration" "example" {
+  version_update_by_jobs {
+    enabled  = true
+    role_arn = aws_iam_role.example.arn
+  }
+}
+```
+
+## Argument Reference
+
+* `version_update_by_jobs` - (Optional) Configuration to manage job's package version reporting. This updates the thing's reserved named shadow that the job targets. Detailed below.
+
+### version_update_by_jobs
+
+* `enabled` - (Required) Whether to enable job's package version reporting.
+* `role_arn` - (Optional) ARN of the IAM role that grants necessary permissions for IoT to update the thing's reserved named shadow.


### PR DESCRIPTION
### Description
This resource will allow practitioners to manage the AWS IoT Core Package Configuration.


### Relations

None

### References

https://docs.aws.amazon.com/iot/latest/apireference/API_GetPackageConfiguration.html
https://docs.aws.amazon.com/iot/latest/apireference/API_UpdatePackageConfiguration.html

### Output from Acceptance Testing

```console
% make testacc TESTARGS="-run=TestAccPackageConfiguration_" PKG=iot
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/iot/... -v -count 1 -parallel 20  -run=TestAccPackageConfiguration_ -timeout 360m
=== RUN   TestAccPackageConfiguration_basic
=== PAUSE TestAccPackageConfiguration_basic
=== CONT  TestAccPackageConfiguration_basic
--- PASS: TestAccPackageConfiguration_basic (23.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iot        23.862s
```
