### PR TITLE
r/aws_synthetics_canary: increase maximum `name` length to 255 characters

### DIFF
--- a/.changelog/39315.txt
+++ b/.changelog/39315.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_synthetics_canary: Increase maximum `name` length to 255 characters
+```

--- a/internal/service/synthetics/canary.go
+++ b/internal/service/synthetics/canary.go
@@ -113,7 +113,7 @@ func ResourceCanary() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 21),
+					validation.StringLenBetween(1, 255),
 					validation.StringMatch(regexache.MustCompile(`^[0-9a-z_\-]+$`), "must contain only lowercase alphanumeric, hyphen, or underscore."),
 				),
 			},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Canary name can now be a maximum of 255 characters.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39313
Depends on #39299 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://github.com/aws/aws-sdk-go-v2/blob/main/CHANGELOG.md#release-2024-09-12

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=synthetics TESTS=TestAccSyntheticsCanary_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/synthetics/... -v -count 1 -parallel 20 -run='TestAccSyntheticsCanary_'  -timeout 360m

--- PASS: TestAccSyntheticsCanary_runtimeVersion (98.95s)
--- PASS: TestAccSyntheticsCanary_artifactEncryption (100.34s)
--- PASS: TestAccSyntheticsCanary_tags (150.84s)
--- PASS: TestAccSyntheticsCanary_runEnvironmentVariables (155.54s)
--- PASS: TestAccSyntheticsCanary_runTracing (239.88s)
--- PASS: TestAccSyntheticsCanary_run (281.66s)
--- PASS: TestAccSyntheticsCanary_startCanary (297.75s)
--- PASS: TestAccSyntheticsCanary_disappears (498.48s)
--- PASS: TestAccSyntheticsCanary_s3 (523.35s)
--- PASS: TestAccSyntheticsCanary_StartCanary_codeChanges (580.49s)
--- PASS: TestAccSyntheticsCanary_basic (615.16s)
--- PASS: TestAccSyntheticsCanary_rate (650.49s)
--- PASS: TestAccSyntheticsCanary_vpc (2172.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/synthetics 2178.691s

```
