### PR TITLE
AutoFlex: Flatten list/set of string enum struct fields

### DIFF
--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -3400,6 +3400,65 @@ func TestExpandSetOfStringEnum(t *testing.T) {
 	runAutoExpandTestCases(t, testCases)
 }
 
+func TestExpandStructListOfStringEnum(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testCases := autoFlexTestCases{
+		"valid value": {
+			Source: &tfListOfStringEnum{
+				Field1: fwtypes.NewListValueOfMust[fwtypes.StringEnum[testEnum]](ctx, []attr.Value{
+					fwtypes.StringEnumValue(testEnumScalar),
+					fwtypes.StringEnumValue(testEnumList),
+				}),
+			},
+			Target: &awsListOfStringEnum{},
+			WantTarget: &awsListOfStringEnum{
+				Field1: []testEnum{testEnumScalar, testEnumList},
+			},
+			expectedLogLines: []map[string]any{
+				infoExpanding(reflect.TypeFor[*tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
+				infoConverting(reflect.TypeFor[tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
+				traceMatchedFields("Field1", reflect.TypeFor[tfListOfStringEnum](), "Field1", reflect.TypeFor[*awsListOfStringEnum]()),
+				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
+				traceExpandingWithElementsAs("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), 2, "Field1", reflect.TypeFor[[]testEnum]()),
+			},
+		},
+		"empty value": {
+			Source: &tfListOfStringEnum{
+				Field1: fwtypes.NewListValueOfMust[fwtypes.StringEnum[testEnum]](ctx, []attr.Value{}),
+			},
+			Target: &awsListOfStringEnum{},
+			WantTarget: &awsListOfStringEnum{
+				Field1: []testEnum{},
+			},
+			expectedLogLines: []map[string]any{
+				infoExpanding(reflect.TypeFor[*tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
+				infoConverting(reflect.TypeFor[tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
+				traceMatchedFields("Field1", reflect.TypeFor[tfListOfStringEnum](), "Field1", reflect.TypeFor[*awsListOfStringEnum]()),
+				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
+				traceExpandingWithElementsAs("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), 0, "Field1", reflect.TypeFor[([]testEnum)]()),
+			},
+		},
+		"null value": {
+			Source: &tfListOfStringEnum{
+				Field1: fwtypes.NewListValueOfNull[fwtypes.StringEnum[testEnum]](ctx),
+			},
+			Target:     &awsListOfStringEnum{},
+			WantTarget: &awsListOfStringEnum{},
+			expectedLogLines: []map[string]any{
+				infoExpanding(reflect.TypeFor[*tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
+				infoConverting(reflect.TypeFor[tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
+				traceMatchedFields("Field1", reflect.TypeFor[tfListOfStringEnum](), "Field1", reflect.TypeFor[*awsListOfStringEnum]()),
+				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
+				traceExpandingNullValue("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
+			},
+		},
+	}
+	runAutoExpandTestCases(t, testCases)
+}
+
 func TestExpandTopLevelListOfNestedObject(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -3413,14 +3413,14 @@ func TestExpandStructListOfStringEnum(t *testing.T) {
 					fwtypes.StringEnumValue(testEnumList),
 				}),
 			},
-			Target: &awsListOfStringEnum{},
-			WantTarget: &awsListOfStringEnum{
+			Target: &awsSliceOfStringEnum{},
+			WantTarget: &awsSliceOfStringEnum{
 				Field1: []testEnum{testEnumScalar, testEnumList},
 			},
 			expectedLogLines: []map[string]any{
-				infoExpanding(reflect.TypeFor[*tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
-				infoConverting(reflect.TypeFor[tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
-				traceMatchedFields("Field1", reflect.TypeFor[tfListOfStringEnum](), "Field1", reflect.TypeFor[*awsListOfStringEnum]()),
+				infoExpanding(reflect.TypeFor[*tfListOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				infoConverting(reflect.TypeFor[tfListOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				traceMatchedFields("Field1", reflect.TypeFor[tfListOfStringEnum](), "Field1", reflect.TypeFor[*awsSliceOfStringEnum]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
 				traceExpandingWithElementsAs("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), 2, "Field1", reflect.TypeFor[[]testEnum]()),
 			},
@@ -3429,14 +3429,14 @@ func TestExpandStructListOfStringEnum(t *testing.T) {
 			Source: &tfListOfStringEnum{
 				Field1: fwtypes.NewListValueOfMust[fwtypes.StringEnum[testEnum]](ctx, []attr.Value{}),
 			},
-			Target: &awsListOfStringEnum{},
-			WantTarget: &awsListOfStringEnum{
+			Target: &awsSliceOfStringEnum{},
+			WantTarget: &awsSliceOfStringEnum{
 				Field1: []testEnum{},
 			},
 			expectedLogLines: []map[string]any{
-				infoExpanding(reflect.TypeFor[*tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
-				infoConverting(reflect.TypeFor[tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
-				traceMatchedFields("Field1", reflect.TypeFor[tfListOfStringEnum](), "Field1", reflect.TypeFor[*awsListOfStringEnum]()),
+				infoExpanding(reflect.TypeFor[*tfListOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				infoConverting(reflect.TypeFor[tfListOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				traceMatchedFields("Field1", reflect.TypeFor[tfListOfStringEnum](), "Field1", reflect.TypeFor[*awsSliceOfStringEnum]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
 				traceExpandingWithElementsAs("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), 0, "Field1", reflect.TypeFor[([]testEnum)]()),
 			},
@@ -3445,14 +3445,73 @@ func TestExpandStructListOfStringEnum(t *testing.T) {
 			Source: &tfListOfStringEnum{
 				Field1: fwtypes.NewListValueOfNull[fwtypes.StringEnum[testEnum]](ctx),
 			},
-			Target:     &awsListOfStringEnum{},
-			WantTarget: &awsListOfStringEnum{},
+			Target:     &awsSliceOfStringEnum{},
+			WantTarget: &awsSliceOfStringEnum{},
 			expectedLogLines: []map[string]any{
-				infoExpanding(reflect.TypeFor[*tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
-				infoConverting(reflect.TypeFor[tfListOfStringEnum](), reflect.TypeFor[*awsListOfStringEnum]()),
-				traceMatchedFields("Field1", reflect.TypeFor[tfListOfStringEnum](), "Field1", reflect.TypeFor[*awsListOfStringEnum]()),
+				infoExpanding(reflect.TypeFor[*tfListOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				infoConverting(reflect.TypeFor[tfListOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				traceMatchedFields("Field1", reflect.TypeFor[tfListOfStringEnum](), "Field1", reflect.TypeFor[*awsSliceOfStringEnum]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
 				traceExpandingNullValue("Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
+			},
+		},
+	}
+	runAutoExpandTestCases(t, testCases)
+}
+
+func TestExpandStructSetOfStringEnum(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testCases := autoFlexTestCases{
+		"valid value": {
+			Source: &tfSetOfStringEnum{
+				Field1: fwtypes.NewSetValueOfMust[fwtypes.StringEnum[testEnum]](ctx, []attr.Value{
+					fwtypes.StringEnumValue(testEnumScalar),
+					fwtypes.StringEnumValue(testEnumList),
+				}),
+			},
+			Target: &awsSliceOfStringEnum{},
+			WantTarget: &awsSliceOfStringEnum{
+				Field1: []testEnum{testEnumScalar, testEnumList},
+			},
+			expectedLogLines: []map[string]any{
+				infoExpanding(reflect.TypeFor[*tfSetOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				infoConverting(reflect.TypeFor[tfSetOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				traceMatchedFields("Field1", reflect.TypeFor[tfSetOfStringEnum](), "Field1", reflect.TypeFor[*awsSliceOfStringEnum]()),
+				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
+				traceExpandingWithElementsAs("Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]](), 2, "Field1", reflect.TypeFor[[]testEnum]()),
+			},
+		},
+		"empty value": {
+			Source: &tfSetOfStringEnum{
+				Field1: fwtypes.NewSetValueOfMust[fwtypes.StringEnum[testEnum]](ctx, []attr.Value{}),
+			},
+			Target: &awsSliceOfStringEnum{},
+			WantTarget: &awsSliceOfStringEnum{
+				Field1: []testEnum{},
+			},
+			expectedLogLines: []map[string]any{
+				infoExpanding(reflect.TypeFor[*tfSetOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				infoConverting(reflect.TypeFor[tfSetOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				traceMatchedFields("Field1", reflect.TypeFor[tfSetOfStringEnum](), "Field1", reflect.TypeFor[*awsSliceOfStringEnum]()),
+				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
+				traceExpandingWithElementsAs("Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]](), 0, "Field1", reflect.TypeFor[([]testEnum)]()),
+			},
+		},
+		"null value": {
+			Source: &tfSetOfStringEnum{
+				Field1: fwtypes.NewSetValueOfNull[fwtypes.StringEnum[testEnum]](ctx),
+			},
+			Target:     &awsSliceOfStringEnum{},
+			WantTarget: &awsSliceOfStringEnum{},
+			expectedLogLines: []map[string]any{
+				infoExpanding(reflect.TypeFor[*tfSetOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				infoConverting(reflect.TypeFor[tfSetOfStringEnum](), reflect.TypeFor[*awsSliceOfStringEnum]()),
+				traceMatchedFields("Field1", reflect.TypeFor[tfSetOfStringEnum](), "Field1", reflect.TypeFor[*awsSliceOfStringEnum]()),
+				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
+				traceExpandingNullValue("Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]](), "Field1", reflect.TypeFor[[]testEnum]()),
 			},
 		},
 	}

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -3321,18 +3321,14 @@ func TestExpandSetOfInt64(t *testing.T) {
 func TestExpandListOfStringEnum(t *testing.T) {
 	t.Parallel()
 
-	type testEnum string
-	var testEnumFoo testEnum = "foo"
-	var testEnumBar testEnum = "bar"
-
 	testCases := autoFlexTestCases{
 		"valid value": {
 			Source: types.ListValueMust(types.StringType, []attr.Value{
-				types.StringValue(string(testEnumFoo)),
-				types.StringValue(string(testEnumBar)),
+				types.StringValue(string(testEnumScalar)),
+				types.StringValue(string(testEnumList)),
 			}),
 			Target:     &[]testEnum{},
-			WantTarget: &[]testEnum{testEnumFoo, testEnumBar},
+			WantTarget: &[]testEnum{testEnumScalar, testEnumList},
 			expectedLogLines: []map[string]any{
 				infoExpanding(reflect.TypeFor[types.List](), reflect.TypeFor[*[]testEnum]()),
 				infoConverting(reflect.TypeFor[types.List](), reflect.TypeFor[[]testEnum]()),
@@ -3366,18 +3362,14 @@ func TestExpandListOfStringEnum(t *testing.T) {
 func TestExpandSetOfStringEnum(t *testing.T) {
 	t.Parallel()
 
-	type testEnum string
-	var testEnumFoo testEnum = "foo"
-	var testEnumBar testEnum = "bar"
-
 	testCases := autoFlexTestCases{
 		"valid value": {
 			Source: types.SetValueMust(types.StringType, []attr.Value{
-				types.StringValue(string(testEnumFoo)),
-				types.StringValue(string(testEnumBar)),
+				types.StringValue(string(testEnumScalar)),
+				types.StringValue(string(testEnumList)),
 			}),
 			Target:     &[]testEnum{},
-			WantTarget: &[]testEnum{testEnumFoo, testEnumBar},
+			WantTarget: &[]testEnum{testEnumScalar, testEnumList},
 			expectedLogLines: []map[string]any{
 				infoExpanding(reflect.TypeFor[types.Set](), reflect.TypeFor[*[]testEnum]()),
 				infoConverting(reflect.TypeFor[types.Set](), reflect.TypeFor[[]testEnum]()),

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -710,19 +710,33 @@ func (flattener autoFlattener) slice(ctx context.Context, sourcePath path.Path, 
 		}
 
 	case reflect.String:
+		var elementType attr.Type = types.StringType
+		attrValueFromReflectValue := newStringValueFromReflectValue
+		if tTo, ok := tTo.(attr.TypeWithElementType); ok {
+			if tElem, ok := tTo.ElementType().(basetypes.StringTypable); ok {
+				//
+				// []stringy -> types.List/Set(OfStringEnum).
+				//
+				elementType = tElem
+				attrValueFromReflectValue = func(val reflect.Value) (attr.Value, diag.Diagnostics) {
+					return tElem.ValueFromString(ctx, types.StringValue(val.String()))
+				}
+			}
+		}
+
 		switch tTo := tTo.(type) {
 		case basetypes.ListTypable:
 			//
 			// []string -> types.List(OfString).
 			//
-			diags.Append(flattener.sliceOfPrimtiveToList(ctx, vFrom, tTo, vTo, types.StringType, newStringValueFromReflectValue, fieldOpts)...)
+			diags.Append(flattener.sliceOfPrimtiveToList(ctx, vFrom, tTo, vTo, elementType, attrValueFromReflectValue, fieldOpts)...)
 			return diags
 
 		case basetypes.SetTypable:
 			//
 			// []string -> types.Set(OfString).
 			//
-			diags.Append(flattener.sliceOfPrimitiveToSet(ctx, vFrom, tTo, vTo, types.StringType, newStringValueFromReflectValue, fieldOpts)...)
+			diags.Append(flattener.sliceOfPrimitiveToSet(ctx, vFrom, tTo, vTo, elementType, attrValueFromReflectValue, fieldOpts)...)
 			return diags
 		}
 
@@ -1249,7 +1263,7 @@ func (flattener autoFlattener) interfaceToNestedObject(ctx context.Context, vFro
 }
 
 // sliceOfPrimtiveToList copies an AWS API slice of primitive (or pointer to primitive) value to a compatible Plugin Framework List value.
-func (flattener autoFlattener) sliceOfPrimtiveToList(ctx context.Context, vFrom reflect.Value, tTo basetypes.ListTypable, vTo reflect.Value, elementType attr.Type, f attrValueFromReflectValueFunc, fieldOpts fieldOpts) diag.Diagnostics {
+func (flattener autoFlattener) sliceOfPrimtiveToList(ctx context.Context, vFrom reflect.Value, tTo basetypes.ListTypable, vTo reflect.Value, elementType attr.Type, attrValueFromReflectValue attrValueFromReflectValueFunc, fieldOpts fieldOpts) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if fieldOpts.legacy {
@@ -1289,7 +1303,13 @@ func (flattener autoFlattener) sliceOfPrimtiveToList(ctx context.Context, vFrom 
 	})
 	elements := make([]attr.Value, vFrom.Len())
 	for i := 0; i < vFrom.Len(); i++ {
-		elements[i] = f(vFrom.Index(i))
+		value, d := attrValueFromReflectValue(vFrom.Index(i))
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+
+		elements[i] = value
 	}
 	list, d := types.ListValue(elementType, elements)
 	diags.Append(d...)
@@ -1308,7 +1328,7 @@ func (flattener autoFlattener) sliceOfPrimtiveToList(ctx context.Context, vFrom 
 }
 
 // sliceOfPrimitiveToSet copies an AWS API slice of primitive (or pointer to primitive) value to a compatible Plugin Framework Set value.
-func (flattener autoFlattener) sliceOfPrimitiveToSet(ctx context.Context, vFrom reflect.Value, tTo basetypes.SetTypable, vTo reflect.Value, elementType attr.Type, f attrValueFromReflectValueFunc, fieldOpts fieldOpts) diag.Diagnostics {
+func (flattener autoFlattener) sliceOfPrimitiveToSet(ctx context.Context, vFrom reflect.Value, tTo basetypes.SetTypable, vTo reflect.Value, elementType attr.Type, attrValueFromReflectValue attrValueFromReflectValueFunc, fieldOpts fieldOpts) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if fieldOpts.legacy {
@@ -1348,7 +1368,13 @@ func (flattener autoFlattener) sliceOfPrimitiveToSet(ctx context.Context, vFrom 
 	})
 	elements := make([]attr.Value, vFrom.Len())
 	for i := 0; i < vFrom.Len(); i++ {
-		elements[i] = f(vFrom.Index(i))
+		value, d := attrValueFromReflectValue(vFrom.Index(i))
+		diags.Append(d...)
+		if diags.HasError() {
+			return diags
+		}
+
+		elements[i] = value
 	}
 	set, d := types.SetValue(elementType, elements)
 	diags.Append(d...)
@@ -1496,27 +1522,31 @@ func setMapBlockKey(ctx context.Context, to any, key reflect.Value) diag.Diagnos
 	return diags
 }
 
-type attrValueFromReflectValueFunc func(reflect.Value) attr.Value
+type attrValueFromReflectValueFunc func(reflect.Value) (attr.Value, diag.Diagnostics)
 
-func newInt64ValueFromReflectValue(v reflect.Value) attr.Value {
-	return types.Int64Value(v.Int())
+func newInt64ValueFromReflectValue(v reflect.Value) (attr.Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	return types.Int64Value(v.Int()), diags
 }
 
-func newInt64ValueFromReflectPointerValue(v reflect.Value) attr.Value {
+func newInt64ValueFromReflectPointerValue(v reflect.Value) (attr.Value, diag.Diagnostics) {
 	if v.IsNil() {
-		return types.Int64Null()
+		var diags diag.Diagnostics
+		return types.Int64Null(), diags
 	}
 
 	return newInt64ValueFromReflectValue(v.Elem())
 }
 
-func newStringValueFromReflectValue(v reflect.Value) attr.Value {
-	return types.StringValue(v.String())
+func newStringValueFromReflectValue(v reflect.Value) (attr.Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	return types.StringValue(v.String()), diags
 }
 
-func newStringValueFromReflectPointerValue(v reflect.Value) attr.Value {
+func newStringValueFromReflectPointerValue(v reflect.Value) (attr.Value, diag.Diagnostics) {
 	if v.IsNil() {
-		return types.StringNull()
+		var diags diag.Diagnostics
+		return types.StringNull(), diags
 	}
 
 	return newStringValueFromReflectValue(v.Elem())

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -5226,6 +5226,142 @@ func TestFlattenFlattener(t *testing.T) {
 	runAutoFlattenTestCases(t, testCases)
 }
 
+func TestFlattenStructListOfStringEnum(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testCases := map[string]autoFlexTestCases{
+		"struct with list of string enum": {
+			"valid value": {
+				Source: awsSliceOfStringEnum{
+					Field1: []testEnum{testEnumScalar, testEnumList},
+				},
+				Target: &tfListOfStringEnum{},
+				WantTarget: &tfListOfStringEnum{
+					Field1: fwtypes.NewListValueOfMust[fwtypes.StringEnum[testEnum]](ctx, []attr.Value{
+						fwtypes.StringEnumValue(testEnumScalar),
+						fwtypes.StringEnumValue(testEnumList),
+					}),
+				},
+				expectedLogLines: []map[string]any{
+					infoFlattening(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfListOfStringEnum]()),
+					infoConverting(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfListOfStringEnum]()),
+					traceMatchedFields("Field1", reflect.TypeFor[awsSliceOfStringEnum](), "Field1", reflect.TypeFor[*tfListOfStringEnum]()),
+					infoConvertingWithPath("Field1", reflect.TypeFor[[]testEnum](), "Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]]()),
+					traceFlatteningWithListValue("Field1", reflect.TypeFor[[]testEnum](), 2, "Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]]()),
+				},
+			},
+			"empty value": {
+				Source: awsSliceOfStringEnum{
+					Field1: []testEnum{},
+				},
+				Target: &tfListOfStringEnum{},
+				WantTarget: &tfListOfStringEnum{
+					Field1: fwtypes.NewListValueOfMust[fwtypes.StringEnum[testEnum]](ctx, []attr.Value{}),
+				},
+				expectedLogLines: []map[string]any{
+					infoFlattening(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfListOfStringEnum]()),
+					infoConverting(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfListOfStringEnum]()),
+					traceMatchedFields("Field1", reflect.TypeFor[awsSliceOfStringEnum](), "Field1", reflect.TypeFor[*tfListOfStringEnum]()),
+					infoConvertingWithPath("Field1", reflect.TypeFor[[]testEnum](), "Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]]()),
+					traceFlatteningWithListValue("Field1", reflect.TypeFor[[]testEnum](), 0, "Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]]()),
+				},
+			},
+			"null value": {
+				Source: awsSliceOfStringEnum{},
+				Target: &tfListOfStringEnum{},
+				WantTarget: &tfListOfStringEnum{
+					Field1: fwtypes.NewListValueOfNull[fwtypes.StringEnum[testEnum]](ctx),
+				},
+				expectedLogLines: []map[string]any{
+					infoFlattening(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfListOfStringEnum]()),
+					infoConverting(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfListOfStringEnum]()),
+					traceMatchedFields("Field1", reflect.TypeFor[awsSliceOfStringEnum](), "Field1", reflect.TypeFor[*tfListOfStringEnum]()),
+					infoConvertingWithPath("Field1", reflect.TypeFor[[]testEnum](), "Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]]()),
+					traceFlatteningWithListNull("Field1", reflect.TypeFor[[]testEnum](), "Field1", reflect.TypeFor[fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]]]()),
+				},
+			},
+		},
+	}
+
+	for testName, cases := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			runAutoFlattenTestCases(t, cases)
+		})
+	}
+}
+
+func TestFlattenStructSetOfStringEnum(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testCases := map[string]autoFlexTestCases{
+		"struct with set of string enum": {
+			"valid value": {
+				Source: awsSliceOfStringEnum{
+					Field1: []testEnum{testEnumScalar, testEnumList},
+				},
+				Target: &tfSetOfStringEnum{},
+				WantTarget: &tfSetOfStringEnum{
+					Field1: fwtypes.NewSetValueOfMust[fwtypes.StringEnum[testEnum]](ctx, []attr.Value{
+						fwtypes.StringEnumValue(testEnumScalar),
+						fwtypes.StringEnumValue(testEnumList),
+					}),
+				},
+				expectedLogLines: []map[string]any{
+					infoFlattening(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfSetOfStringEnum]()),
+					infoConverting(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfSetOfStringEnum]()),
+					traceMatchedFields("Field1", reflect.TypeFor[awsSliceOfStringEnum](), "Field1", reflect.TypeFor[*tfSetOfStringEnum]()),
+					infoConvertingWithPath("Field1", reflect.TypeFor[[]testEnum](), "Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]]()),
+					traceFlatteningWithSetValue("Field1", reflect.TypeFor[[]testEnum](), 2, "Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]]()),
+				},
+			},
+			"empty value": {
+				Source: awsSliceOfStringEnum{
+					Field1: []testEnum{},
+				},
+				Target: &tfSetOfStringEnum{},
+				WantTarget: &tfSetOfStringEnum{
+					Field1: fwtypes.NewSetValueOfMust[fwtypes.StringEnum[testEnum]](ctx, []attr.Value{}),
+				},
+				expectedLogLines: []map[string]any{
+					infoFlattening(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfSetOfStringEnum]()),
+					infoConverting(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfSetOfStringEnum]()),
+					traceMatchedFields("Field1", reflect.TypeFor[awsSliceOfStringEnum](), "Field1", reflect.TypeFor[*tfSetOfStringEnum]()),
+					infoConvertingWithPath("Field1", reflect.TypeFor[[]testEnum](), "Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]]()),
+					traceFlatteningWithSetValue("Field1", reflect.TypeFor[[]testEnum](), 0, "Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]]()),
+				},
+			},
+			"null value": {
+				Source: awsSliceOfStringEnum{},
+				Target: &tfSetOfStringEnum{},
+				WantTarget: &tfSetOfStringEnum{
+					Field1: fwtypes.NewSetValueOfNull[fwtypes.StringEnum[testEnum]](ctx),
+				},
+				expectedLogLines: []map[string]any{
+					infoFlattening(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfSetOfStringEnum]()),
+					infoConverting(reflect.TypeFor[awsSliceOfStringEnum](), reflect.TypeFor[*tfSetOfStringEnum]()),
+					traceMatchedFields("Field1", reflect.TypeFor[awsSliceOfStringEnum](), "Field1", reflect.TypeFor[*tfSetOfStringEnum]()),
+					infoConvertingWithPath("Field1", reflect.TypeFor[[]testEnum](), "Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]]()),
+					traceFlatteningWithSetNull("Field1", reflect.TypeFor[[]testEnum](), "Field1", reflect.TypeFor[fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]]]()),
+				},
+			},
+		},
+	}
+
+	for testName, cases := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			runAutoFlattenTestCases(t, cases)
+		})
+	}
+}
+
 func runAutoFlattenTestCases(t *testing.T, testCases autoFlexTestCases) {
 	t.Helper()
 

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -686,3 +686,11 @@ type awsExpanderStructSlice struct {
 type awsExpanderPtrSlice struct {
 	Field1 []*awsExpander
 }
+
+type tfListOfStringEnum struct {
+	Field1 fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]] `tfsdk:"field1"`
+}
+
+type awsListOfStringEnum struct {
+	Field1 []testEnum
+}

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -691,6 +691,10 @@ type tfListOfStringEnum struct {
 	Field1 fwtypes.ListValueOf[fwtypes.StringEnum[testEnum]] `tfsdk:"field1"`
 }
 
-type awsListOfStringEnum struct {
+type tfSetOfStringEnum struct {
+	Field1 fwtypes.SetValueOf[fwtypes.StringEnum[testEnum]] `tfsdk:"field1"`
+}
+
+type awsSliceOfStringEnum struct {
 	Field1 []testEnum
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds autoflex support for flattening struct fields that are of type slice of Smithy string [enum](https://smithy.io/2.0/spec/simple-types.html#enum) into our `StringEnum` Plugin Framework custom type.

Note that support for slice of string enum pointers was not added as these are not present in the AWS SDK for Go v2.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/39292.

```console
% go test ./internal/framework/flex
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.569s
```