### PR TITLE
r/opensearchserverless_access_policy: policy is not set correctly

### DIFF
--- a/.changelog/39322.txt
+++ b/.changelog/39322.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_opensearchserverless_access_policy: Fix incompatible type error when setting `policy`
+```

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -615,7 +615,7 @@ func (flattener autoFlattener) interface_(ctx context.Context, vFrom reflect.Val
 		//
 		// JSONStringer -> types.String-ish.
 		//
-		if vFrom.Type() == reflect.TypeFor[smithyjson.JSONStringer]() {
+		if vFrom.Type().Implements(reflect.TypeFor[smithyjson.JSONStringer]()) {
 			tflog.SubsystemInfo(ctx, subsystemName, "Source implements json.JSONStringer")
 
 			stringValue := types.StringNull()

--- a/internal/framework/types/smithy_json.go
+++ b/internal/framework/types/smithy_json.go
@@ -86,7 +86,7 @@ func (t SmithyJSONType[T]) ValueFromString(ctx context.Context, in basetypes.Str
 		return SmithyJSONUnknown[T](), diags
 	}
 
-	var data map[string]any
+	var data any
 	if err := json.Unmarshal([]byte(in.ValueString()), &data); err != nil {
 		return SmithyJSONUnknown[T](), diags
 	}

--- a/internal/service/opensearchserverless/access_policy.go
+++ b/internal/service/opensearchserverless/access_policy.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless"
+	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless/document"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
-	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -39,7 +39,7 @@ type resourceAccessPolicyData struct {
 	Description   types.String                                  `tfsdk:"description"`
 	ID            types.String                                  `tfsdk:"id"`
 	Name          types.String                                  `tfsdk:"name"`
-	Policy        jsontypes.Normalized                          `tfsdk:"policy"`
+	Policy        fwtypes.SmithyJSON[document.Interface]        `tfsdk:"policy"`
 	PolicyVersion types.String                                  `tfsdk:"policy_version"`
 	Type          fwtypes.StringEnum[awstypes.AccessPolicyType] `tfsdk:"type"`
 }
@@ -76,7 +76,7 @@ func (r *resourceAccessPolicy) Schema(ctx context.Context, req resource.SchemaRe
 				},
 			},
 			names.AttrPolicy: schema.StringAttribute{
-				CustomType: jsontypes.NormalizedType{},
+				CustomType: fwtypes.NewSmithyJSONType(ctx, document.NewLazyDocument),
 				Required:   true,
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 20480),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Autoflex type check for `Interface` type checks that the interface is implemented

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #39319

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccOpenSearchServerlessAccessPolicy_' PKG=opensearchserverless

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20  -run=TestAccOpenSearchServerlessAccessPolicy_ -timeout 360m
--- PASS: TestAccOpenSearchServerlessAccessPolicy_disappears (13.68s)
--- PASS: TestAccOpenSearchServerlessAccessPolicy_basic (16.03s)
--- PASS: TestAccOpenSearchServerlessAccessPolicy_update (32.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless	38.603s.
```
