### PR TITLE
r/aws_dynamodb: wait for tag propagation

### DIFF
--- a/.changelog/39326.txt
+++ b/.changelog/39326.txt
@@ -1,0 +1,9 @@
+```release-note:bug
+resource/aws_dynamodb_tag: Handle eventual consistency of tag creation and removal
+```
+```release-note:bug
+resource/aws_dynamodb_table: Handle eventual consistency of tag creation and removal
+```
+```release-note:bug
+resource/aws_dynamodb_table_replica: Handle eventual consistency of tag creation and removal
+```

--- a/internal/service/dynamodb/generate.go
+++ b/internal/service/dynamodb/generate.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate go run ../../generate/tagresource/main.go
-//go:generate go run ../../generate/tags/main.go -GetTag -ListTags -ListTagsOp=ListTagsOfResource -ServiceTagsSlice -UpdateTags -ParentNotFoundErrCode=ResourceNotFoundException
+//go:generate go run ../../generate/tags/main.go -GetTag -ListTags -ListTagsOp=ListTagsOfResource -ServiceTagsSlice -UpdateTags -Wait -WaitContinuousOccurence 5 -WaitMinTimeout 1s -WaitTimeout 10m -ParentNotFoundErrCode=ResourceNotFoundException
 //go:generate go run ../../generate/servicepackage/main.go
 //go:generate go run ../../generate/listpages/main.go -ListOps=ListBackups -InputPaginator=ExclusiveStartBackupArn -OutputPaginator=LastEvaluatedBackupArn -- list_backups_pages_gen.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.


### PR DESCRIPTION




<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously the `TagResource` and `UntagResource` API's in the DynamoDB service were strongly consistent. An AWS change in August 2024 made these API's eventually consistent, resulting in failures when the `aws_dynamodb_tag` resource (or other resources which support the `tags` argument) attempted to read back tags at the end of a create or update operation. This change adds waiting logic into the generated `UpdateTags` function, ensuring the tags exist before proceeding with any subsequent read operations.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39275



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dynamodb TESTS=TestAccDynamoDBTag_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTag_'  -timeout 360m

--- PASS: TestAccDynamoDBTag_basic (43.96s)
--- PASS: TestAccDynamoDBTag_disappears (51.42s)
--- PASS: TestAccDynamoDBTag_value (70.05s)
--- PASS: TestAccDynamoDBTag_ResourceARN_tableReplica (214.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   220.704s
```

Additional tests with observed tagging failures prior to this change:

```console
% make testacc PKG=dynamodb TESTS="TestAccDynamoDBTable_Replica_tagsUpdate|TestAccDynamoDBTableReplica_basic|TestAccDynamoDBTableReplica_tableClass|TestAccDynamoDBTableReplica_tags"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_Replica_tagsUpdate|TestAccDynamoDBTableReplica_basic|TestAccDynamoDBTableRepl
ica_tableClass|TestAccDynamoDBTableReplica_tags'  -timeout 360m

--- PASS: TestAccDynamoDBTableReplica_tags (215.54s)
--- PASS: TestAccDynamoDBTableReplica_basic (253.02s)
--- PASS: TestAccDynamoDBTableReplica_tableClass (377.68s)
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (451.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   457.615s
```

