### PR TITLE
provider: Allow empty string in `assume_role.role_arn`

### DIFF
--- a/.changelog/39328.txt
+++ b/.changelog/39328.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Allows `assume_role.role_arn` to be an empty string when there is a single `assume_role` entry.
+```

--- a/internal/provider/provider_config_test.go
+++ b/internal/provider/provider_config_test.go
@@ -439,10 +439,76 @@ func TestProviderConfig_AssumeRole(t *testing.T) { //nolint:paralleltest
 			},
 		},
 
+		// For historical reasons, this is valid
+		"config null string": {
+			Config: map[string]any{
+				"assume_role": []any{
+					map[string]any{
+						"role_arn": nil,
+					},
+				},
+			},
+			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
+			ExpectedDiags: diag.Diagnostics{
+				errs.NewAttributeRequiredWillBeError(cty.GetAttrPath("assume_role").IndexInt(0), "role_arn"),
+			},
+		},
+
+		// For historical reasons, this is valid
+		"config empty string": {
+			Config: map[string]any{
+				"assume_role": []any{
+					map[string]any{
+						"role_arn": "",
+					},
+				},
+			},
+			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
+			ExpectedDiags: diag.Diagnostics{
+				errs.NewAttributeRequiredWillBeError(cty.GetAttrPath("assume_role").IndexInt(0), "role_arn"),
+			},
+		},
+
 		"config multiple first empty": {
 			Config: map[string]any{
 				"assume_role": []any{
 					map[string]any{},
+					map[string]any{
+						"role_arn":     servicemocks.MockStsAssumeRoleArn2,
+						"session_name": servicemocks.MockStsAssumeRoleSessionName2,
+					},
+				},
+			},
+			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
+			ExpectedDiags: diag.Diagnostics{
+				errs.NewAttributeRequiredError(cty.GetAttrPath("assume_role").IndexInt(0), "role_arn"),
+			},
+		},
+
+		"config multiple first null string": {
+			Config: map[string]any{
+				"assume_role": []any{
+					map[string]any{
+						"role_arn": nil,
+					},
+					map[string]any{
+						"role_arn":     servicemocks.MockStsAssumeRoleArn2,
+						"session_name": servicemocks.MockStsAssumeRoleSessionName2,
+					},
+				},
+			},
+			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
+			ExpectedDiags: diag.Diagnostics{
+				errs.NewAttributeRequiredError(cty.GetAttrPath("assume_role").IndexInt(0), "role_arn"),
+			},
+		},
+
+		"config multiple first empty string": {
+			Config: map[string]any{
+				"assume_role": []any{
+					map[string]any{
+						"role_arn": nil,
+					},
 					map[string]any{
 						"role_arn":     servicemocks.MockStsAssumeRoleArn2,
 						"session_name": servicemocks.MockStsAssumeRoleSessionName2,
@@ -463,6 +529,48 @@ func TestProviderConfig_AssumeRole(t *testing.T) { //nolint:paralleltest
 						"session_name": servicemocks.MockStsAssumeRoleSessionName,
 					},
 					map[string]any{},
+				},
+			},
+			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
+			ExpectedDiags: diag.Diagnostics{
+				errs.NewAttributeRequiredError(cty.GetAttrPath("assume_role").IndexInt(1), "role_arn"),
+			},
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpoint,
+			},
+		},
+
+		"config multiple last null string": {
+			Config: map[string]any{
+				"assume_role": []any{
+					map[string]any{
+						"role_arn":     servicemocks.MockStsAssumeRoleArn,
+						"session_name": servicemocks.MockStsAssumeRoleSessionName,
+					},
+					map[string]any{
+						"role_arn": nil,
+					},
+				},
+			},
+			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
+			ExpectedDiags: diag.Diagnostics{
+				errs.NewAttributeRequiredError(cty.GetAttrPath("assume_role").IndexInt(1), "role_arn"),
+			},
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpoint,
+			},
+		},
+
+		"config multiple last empty string": {
+			Config: map[string]any{
+				"assume_role": []any{
+					map[string]any{
+						"role_arn":     servicemocks.MockStsAssumeRoleArn,
+						"session_name": servicemocks.MockStsAssumeRoleSessionName,
+					},
+					map[string]any{
+						"role_arn": "",
+					},
 				},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,


### PR DESCRIPTION
### Description

For backwards compatibility, defining an `assume_role` block with a `null` or empty `role_arn` is supported, and does not attempt to assume a role. The PR #39255 did not check the empty string case.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39296.
Closes #39306.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/39331.
