### PR TITLE
docs: remove unneeded note for load balancer listener

### DIFF
--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -266,8 +266,6 @@ The following arguments are optional:
 * `ssl_policy` - (Optional) Name of the SSL Policy for the listener. Required if `protocol` is `HTTPS` or `TLS`. Default is `ELBSecurityPolicy-2016-08`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-~> **NOTE::** Please note that listeners that are attached to Application Load Balancers must use either `HTTP` or `HTTPS` protocols while listeners that are attached to Network Load Balancers must use the `TCP` protocol.
-
 ### default_action
 
 The following arguments are required:


### PR DESCRIPTION
### Description

The mapping of protocols to listeners (HTTP/HTTPS -> ALB, TCP/UDP -> NLB) is already explained as part of the description for argument `protocol`.

In addition, the details in the note are incomplete as it only mentions TCP and leaves out UDP. This causes additinal confusion.


### Relations

Closes #39316 

### References

 - [Description of AWS LB listener `protocol` argument](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener#protocol)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.