### PR TITLE
td/Add tests to slot_type and fixes

### DIFF
--- a/.changelog/39353.txt
+++ b/.changelog/39353.txt
@@ -1,0 +1,7 @@
+``release-note:breaking-change
+resource/aws_lexv2models_slot_type: Within the `composite_slot_type_setting` block, the `subslots` argument has been renamed `sub_slots`
+```
+
+```release-note:note
+resource/aws_lexv2models_slot_type: Within the `composite_slot_type_setting` block, the `subslots` argument has been renamed `sub_slots`. See the [linked pull request](https://github.com/hashicorp/terraform-provider-aws/pull/39353) for additional justification on this change. The previous misnaming effectively made this argument unusable, therefore a breaking change in a minor version was deemed acceptable. 
+```

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -114,9 +114,6 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 		},
 		Blocks: map[string]schema.Block{
 			"composite_slot_type_setting": schema.ListNestedBlock{
-				// Validators: []validator.List{
-				// 	listvalidator.SizeAtMost(1),
-				// },
 				CustomType: fwtypes.NewListNestedObjectTypeOf[CompositeSlotTypeSetting](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
@@ -125,23 +122,14 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 				},
 			},
 			"external_source_setting": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
 				CustomType: fwtypes.NewListNestedObjectTypeOf[ExternalSourceSetting](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
 						"grammar_slot_type_setting": schema.ListNestedBlock{
-							Validators: []validator.List{
-								listvalidator.SizeAtMost(1),
-							},
 							CustomType: fwtypes.NewListNestedObjectTypeOf[GrammarSlotTypeSetting](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Blocks: map[string]schema.Block{
 									names.AttrSource: schema.ListNestedBlock{
-										Validators: []validator.List{
-											listvalidator.SizeAtMost(1),
-										},
 										CustomType: fwtypes.NewListNestedObjectTypeOf[Source](ctx),
 										NestedObject: schema.NestedBlockObject{
 											Attributes: map[string]schema.Attribute{

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -114,13 +114,13 @@ func (r *resourceSlotType) Schema(ctx context.Context, req resource.SchemaReques
 		},
 		Blocks: map[string]schema.Block{
 			"composite_slot_type_setting": schema.ListNestedBlock{
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
+				// Validators: []validator.List{
+				// 	listvalidator.SizeAtMost(1),
+				// },
 				CustomType: fwtypes.NewListNestedObjectTypeOf[CompositeSlotTypeSetting](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
-						"subslots": subSlotTypeCompositionLNB,
+						"sub_slots": subSlotTypeCompositionLNB,
 					},
 				},
 			},

--- a/internal/service/lexv2models/slot_type.go
+++ b/internal/service/lexv2models/slot_type.go
@@ -456,8 +456,8 @@ type resourceSlotTypeData struct {
 }
 
 type SubSlotTypeComposition struct {
-	Name      types.String `tfsdk:"name"`
-	SubSlotID types.String `tfsdk:"sub_slot_id"`
+	Name       types.String `tfsdk:"name"`
+	SlotTypeID types.String `tfsdk:"slot_type_id"`
 }
 
 type CompositeSlotTypeSetting struct {

--- a/internal/service/lexv2models/slot_type_test.go
+++ b/internal/service/lexv2models/slot_type_test.go
@@ -186,6 +186,7 @@ func TestAccLexV2ModelsSlotType_compositeSlotTypeSetting(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "composite_slot_type_setting.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "composite_slot_type_setting.0.sub_slots.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, "composite_slot_type_setting.0.sub_slots.0.name", "testname"),
+					resource.TestCheckResourceAttr(resourceName, "composite_slot_type_setting.0.sub_slots.0.slot_type_id", "AMAZON.Date"),
 				),
 			},
 		},
@@ -377,13 +378,13 @@ resource "aws_lexv2models_slot_type" "test" {
   locale_id   = aws_lexv2models_bot_locale.test.locale_id
 
   value_selection_setting {
-    resolution_strategy = "OriginalValue"
+    resolution_strategy = "Concatenation"
   }
 
   composite_slot_type_setting {
     sub_slots {
-      name = "testname"
-      slot_type_id = "AMAZON..Date"
+      name         = "testname"
+      slot_type_id = "AMAZON.Date"
     }
   }
 }

--- a/internal/service/lexv2models/slot_type_test.go
+++ b/internal/service/lexv2models/slot_type_test.go
@@ -161,6 +161,37 @@ func TestAccLexV2ModelsSlotType_valueSelectionSetting(t *testing.T) {
 	})
 }
 
+func TestAccLexV2ModelsSlotType_compositeSlotTypeSetting(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var slottype lexmodelsv2.DescribeSlotTypeOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lexv2models_slot_type.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LexV2ModelsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LexV2ModelsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckSlotTypeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSlotTypeConfig_compositeSlotTypeSetting(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSlotTypeExists(ctx, resourceName, &slottype),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "composite_slot_type_setting.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "composite_slot_type_setting.0.sub_slots.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "composite_slot_type_setting.0.sub_slots.0.name", "testname"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSlotTypeDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).LexV2ModelsClient(ctx)
@@ -333,4 +364,28 @@ resource "aws_lexv2models_slot_type" "test" {
   }
 }
 `, rName, audioRecognitionStrategy))
+}
+
+func testAccSlotTypeConfig_compositeSlotTypeSetting(rName string) string {
+	return acctest.ConfigCompose(
+		testAccSlotTypeConfig_base(rName, 60, true),
+		fmt.Sprintf(`
+resource "aws_lexv2models_slot_type" "test" {
+  bot_id      = aws_lexv2models_bot.test.id
+  bot_version = aws_lexv2models_bot_locale.test.bot_version
+  name        = %[1]q
+  locale_id   = aws_lexv2models_bot_locale.test.locale_id
+
+  value_selection_setting {
+    resolution_strategy = "OriginalValue"
+  }
+
+  composite_slot_type_setting {
+    sub_slots {
+      name = "testname"
+      slot_type_id = "AMAZON..Date"
+    }
+  }
+}
+`, rName))
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add tests for `composite_slot_type_setting` as well as various fixes for naming errors and mix match.

Previously the nested argument `sub_slots` was misnamed. There was a discrepancy between between the struct and schema - when the current name in the schema is used this error would occur: 

```
        Error: Unable to Convert Configuration
        
          with aws_lexv2models_slot_type.test,
          on terraform_plugin_test.tf line 62, in resource "aws_lexv2models_slot_type" "test":
          62: resource "aws_lexv2models_slot_type" "test" {
        
        An unexpected error was encountered when converting the configuration from
        the protocol type. This is always an issue in terraform-plugin-framework used
        to implement the provider and should be reported to the provider developers.
        
        Please report this to the provider developer:
        
        Unable to unmarshal DynamicValue:
        AttributeName("composite_slot_type_setting").ElementKeyInt(0): unknown
        attribute "subslots"
```
As such, though technically a break change, it is deemed acceptable within a minor release.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTARGS="-run=TestAccLexV2ModelsSlotType_" PKG=lexv2models
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.6 test ./internal/service/lexv2models/... -v -count 1 -parallel 20  -run=TestAccLexV2ModelsSlotType_ -timeout 360m
=== RUN   TestAccLexV2ModelsSlotType_basic
=== PAUSE TestAccLexV2ModelsSlotType_basic
=== RUN   TestAccLexV2ModelsSlotType_values
=== PAUSE TestAccLexV2ModelsSlotType_values
=== RUN   TestAccLexV2ModelsSlotType_disappears
=== PAUSE TestAccLexV2ModelsSlotType_disappears
=== RUN   TestAccLexV2ModelsSlotType_valueSelectionSetting
=== PAUSE TestAccLexV2ModelsSlotType_valueSelectionSetting
=== RUN   TestAccLexV2ModelsSlotType_compositeSlotTypeSetting
=== PAUSE TestAccLexV2ModelsSlotType_compositeSlotTypeSetting
=== CONT  TestAccLexV2ModelsSlotType_basic
=== CONT  TestAccLexV2ModelsSlotType_valueSelectionSetting
=== CONT  TestAccLexV2ModelsSlotType_compositeSlotTypeSetting
=== CONT  TestAccLexV2ModelsSlotType_values
=== CONT  TestAccLexV2ModelsSlotType_disappears
--- PASS: TestAccLexV2ModelsSlotType_compositeSlotTypeSetting (49.64s)
--- PASS: TestAccLexV2ModelsSlotType_valueSelectionSetting (49.70s)
--- PASS: TestAccLexV2ModelsSlotType_values (51.75s)
--- PASS: TestAccLexV2ModelsSlotType_basic (51.78s)
--- PASS: TestAccLexV2ModelsSlotType_disappears (52.22s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lexv2models        58.422s

...
```
