### PR TITLE
opensearchserveless: Skip sweepers in `us-gov-east-1`

### DIFF
--- a/internal/service/opensearchserverless/sweep.go
+++ b/internal/service/opensearchserverless/sweep.go
@@ -43,7 +43,7 @@ func RegisterSweepers() {
 
 func sweepAccessPolicies(region string) error {
 	ctx := sweep.Context(region)
-	if region == names.USWest1RegionID {
+	if region == names.USWest1RegionID || region == names.USGovEast1RegionID {
 		log.Printf("[WARN] Skipping OpenSearch Serverless Access Policy sweep for region: %s", region)
 		return nil
 	}
@@ -90,7 +90,7 @@ func sweepAccessPolicies(region string) error {
 
 func sweepCollections(region string) error {
 	ctx := sweep.Context(region)
-	if region == names.USWest1RegionID {
+	if region == names.USWest1RegionID || region == names.USGovEast1RegionID {
 		log.Printf("[WARN] Skipping OpenSearch Serverless Collection sweep for region: %s", region)
 		return nil
 	}
@@ -133,7 +133,7 @@ func sweepCollections(region string) error {
 
 func sweepSecurityConfigs(region string) error {
 	ctx := sweep.Context(region)
-	if region == names.USWest1RegionID {
+	if region == names.USWest1RegionID || region == names.USGovEast1RegionID {
 		log.Printf("[WARN] Skipping OpenSearch Serverless Security Config sweep for region: %s", region)
 		return nil
 	}
@@ -178,7 +178,7 @@ func sweepSecurityConfigs(region string) error {
 
 func sweepSecurityPolicies(region string) error {
 	ctx := sweep.Context(region)
-	if region == names.USWest1RegionID {
+	if region == names.USWest1RegionID || region == names.USGovEast1RegionID {
 		log.Printf("[WARN] Skipping OpenSearch Serverless Security Policy sweep for region: %s", region)
 		return nil
 	}
@@ -252,7 +252,7 @@ func sweepSecurityPolicies(region string) error {
 
 func sweepVPCEndpoints(region string) error {
 	ctx := sweep.Context(region)
-	if region == names.USWest1RegionID {
+	if region == names.USWest1RegionID || region == names.USGovEast1RegionID {
 		log.Printf("[WARN] Skipping OpenSearch Serverless Security Policy sweep for region: %s", region)
 		return nil
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

opensearchserverless APIs return HTTP 500s in `us-gov-east-1`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/33592.