### PR TITLE
r/aws_amplify_app: fix removal of `environment_variables`

### DIFF
--- a/.changelog/39397.txt
+++ b/.changelog/39397.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_amplify_app: Fix failure when unsetting the `environment_variables` argument
+```

--- a/internal/service/amplify/app.go
+++ b/internal/service/amplify/app.go
@@ -545,7 +545,10 @@ func resourceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 			if v := d.Get("environment_variables").(map[string]interface{}); len(v) > 0 {
 				input.EnvironmentVariables = flex.ExpandStringValueMap(v)
 			} else {
-				input.EnvironmentVariables = map[string]string{"": ""}
+				// To remove environment variables, set the key to a single space
+				// character and the value to an empty string.
+				// Ref: https://github.com/aws/aws-sdk-go-v2/issues/2788
+				input.EnvironmentVariables = map[string]string{" ": ""}
 			}
 		}
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously existing `environment_variables` were removed by sending a map with an empty key/value pair. The `UpdateApp` API appears to have added restrictions around keys with empty values, so this approach began to fail the corresponding acceptance test. After reporting the issue to the AWS Go SDK V2, the new method for removing environment variables is to pass a key containing a single space character and an empty string value.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39327
Relates https://github.com/aws/aws-sdk-go-v2/issues/2788

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/amplify/latest/APIReference/API_UpdateApp.html#amplify-UpdateApp-request-environmentVariables

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=amplify TESTS=TestAccAmplify_serial/App/EnvironmentVariables
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/amplify/... -v -count 1 -parallel 20 -run='TestAccAmplify_serial/App/EnvironmentVariables'  -timeout 360m

--- PASS: TestAccAmplify_serial (301.10s)
    --- PASS: TestAccAmplify_serial/App (301.10s)
        --- PASS: TestAccAmplify_serial/App/EnvironmentVariables (301.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/amplify    307.329s
```
