### PR TITLE
[enhancement] Add `tags` to`aws_connect_instance ` resource

### DIFF
--- a/.changelog/39402.txt
+++ b/.changelog/39402.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 resource/aws_connect_instance: Add `tags` argument and `tags_all` attribute
 ```
+
+```release-note:enhancement
+data-source/aws_connect_instance: Add `tags` attribute
+```

--- a/.changelog/39402.txt
+++ b/.changelog/39402.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_connect_instance: Add `tags` argument and `tags_all` attribute
+```

--- a/internal/service/connect/connect_test.go
+++ b/internal/service/connect/connect_test.go
@@ -58,6 +58,7 @@ func TestAccConnect_serial(t *testing.T) {
 			"directory":        testAccInstance_directory,
 			"saml":             testAccInstance_saml,
 			"dataSource_basic": testAccInstanceDataSource_basic,
+			"tags":             testAccInstance_tags,
 		},
 		"InstanceStorageConfig": {
 			acctest.CtBasic:                             testAccInstanceStorageConfig_basic,

--- a/internal/service/connect/instance.go
+++ b/internal/service/connect/instance.go
@@ -233,7 +233,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	return diags
+	return append(diags, resourceInstanceRead(ctx, d, meta)...)
 }
 
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/service/connect/instance.go
+++ b/internal/service/connect/instance.go
@@ -45,6 +45,7 @@ var (
 )
 
 // @SDKResource("aws_connect_instance", name="Instance")
+// @Tags(identifierAttribute="arn")
 func resourceInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceInstanceCreate,
@@ -215,11 +216,11 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set(names.AttrServiceRole, instance.ServiceRole)
 	d.Set(names.AttrStatus, instance.InstanceStatus)
 
-	setTagsOut(ctx, instance.Tags)
-
 	if err := readInstanceAttributes(ctx, conn, d); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
+
+	setTagsOut(ctx, instance.Tags)
 
 	return diags
 }

--- a/internal/service/connect/instance_data_source.go
+++ b/internal/service/connect/instance_data_source.go
@@ -17,11 +17,13 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKDataSource("aws_connect_instance", name="Instance")
+// @Tags
 func dataSourceInstance() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceInstanceRead,
@@ -87,6 +89,7 @@ func dataSourceInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrTags: tftags.TagsSchemaComputed(),
 			// "use_custom_tts_voices_enabled": {
 			// 	Type:     schema.TypeBool,
 			// 	Computed: true,
@@ -146,6 +149,8 @@ func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta in
 	if err := readInstanceAttributes(ctx, conn, d); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
+
+	setTagsOut(ctx, matchedInstance.Tags)
 
 	return diags
 }

--- a/internal/service/connect/instance_data_source_test.go
+++ b/internal/service/connect/instance_data_source_test.go
@@ -39,6 +39,7 @@ func testAccInstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "multi_party_conference_enabled", dataSourceName, "multi_party_conference_enabled"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrStatus, dataSourceName, names.AttrStatus),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrServiceRole, dataSourceName, names.AttrServiceRole),
+					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsPercent, dataSourceName, acctest.CtTagsPercent),
 				),
 			},
 			{

--- a/internal/service/connect/instance_test.go
+++ b/internal/service/connect/instance_test.go
@@ -177,7 +177,7 @@ func testAccInstance_tags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtKey2, acctest.CtValue2),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
 			},
 		},

--- a/internal/service/connect/instance_test.go
+++ b/internal/service/connect/instance_test.go
@@ -49,6 +49,7 @@ func testAccInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "outbound_calls_enabled", acctest.CtTrue),
 					acctest.MatchResourceAttrGlobalARN(resourceName, names.AttrServiceRole, "iam", regexache.MustCompile(`role/aws-service-role/connect.amazonaws.com/.+`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, string(awstypes.InstanceStatusActive)),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct0),
 				),
 			},
 			{
@@ -150,7 +151,7 @@ func testAccInstance_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_tags(rName, acctest.CtKey1, acctest.CtValue1),
+				Config: testAccInstanceConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct1),
@@ -163,7 +164,7 @@ func testAccInstance_tags(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInstanceConfig_tags_update(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+				Config: testAccInstanceConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct2),
@@ -172,11 +173,11 @@ func testAccInstance_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfig_tags(rName, acctest.CtKey1, acctest.CtValue1),
+				Config: testAccInstanceConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct1),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtKey2, acctest.CtValue2),
 				),
 			},
 		},
@@ -241,7 +242,7 @@ resource "aws_connect_instance" "test" {
 `, rName)
 }
 
-func testAccInstanceConfig_tags(rName string, tag, value string) string {
+func testAccInstanceConfig_tags1(rName string, tag, value string) string {
 	return fmt.Sprintf(`
 resource "aws_connect_instance" "test" {
   identity_management_type = "CONNECT_MANAGED"
@@ -256,7 +257,7 @@ resource "aws_connect_instance" "test" {
 `, rName, tag, value)
 }
 
-func testAccInstanceConfig_tags_update(rName string, tag1, value1, tag2, value2 string) string {
+func testAccInstanceConfig_tags2(rName string, tag1, value1, tag2, value2 string) string {
 	return fmt.Sprintf(`
 resource "aws_connect_instance" "test" {
   identity_management_type = "CONNECT_MANAGED"

--- a/internal/service/connect/instance_test.go
+++ b/internal/service/connect/instance_test.go
@@ -137,6 +137,35 @@ func testAccInstance_saml(t *testing.T) {
 	})
 }
 
+func testAccInstance_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.Instance
+	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
+	resourceName := "aws_connect_instance.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ConnectServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_tags(rName, acctest.CtKey1, acctest.CtValue1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckInstanceExists(ctx context.Context, n string, v *awstypes.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -193,6 +222,21 @@ resource "aws_connect_instance" "test" {
   outbound_calls_enabled   = true
 }
 `, rName)
+}
+
+func testAccInstanceConfig_tags(rName string, tag, value string) string {
+	return fmt.Sprintf(`
+resource "aws_connect_instance" "test" {
+  identity_management_type = "CONNECT_MANAGED"
+  inbound_calls_enabled    = true
+  instance_alias           = %[1]q
+  outbound_calls_enabled   = true
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tag, value)
 }
 
 func testAccInstanceConfig_basicFlipped(rName string) string {

--- a/internal/service/connect/instance_test.go
+++ b/internal/service/connect/instance_test.go
@@ -162,6 +162,23 @@ func testAccInstance_tags(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccInstanceConfig_tags_update(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+			{
+				Config: testAccInstanceConfig_tags(rName, acctest.CtKey1, acctest.CtValue1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+				),
+			},
 		},
 	})
 }
@@ -237,6 +254,22 @@ resource "aws_connect_instance" "test" {
   }
 }
 `, rName, tag, value)
+}
+
+func testAccInstanceConfig_tags_update(rName string, tag1, value1, tag2, value2 string) string {
+	return fmt.Sprintf(`
+resource "aws_connect_instance" "test" {
+  identity_management_type = "CONNECT_MANAGED"
+  inbound_calls_enabled    = true
+  instance_alias           = %[1]q
+  outbound_calls_enabled   = true
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tag1, value1, tag2, value2)
 }
 
 func testAccInstanceConfig_basicFlipped(rName string) string {

--- a/internal/service/connect/service_package_gen.go
+++ b/internal/service/connect/service_package_gen.go
@@ -51,6 +51,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Factory:  dataSourceInstance,
 			TypeName: "aws_connect_instance",
 			Name:     "Instance",
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  dataSourceInstanceStorageConfig,

--- a/internal/service/connect/service_package_gen.go
+++ b/internal/service/connect/service_package_gen.go
@@ -151,6 +151,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Factory:  resourceInstance,
 			TypeName: "aws_connect_instance",
 			Name:     "Instance",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			},
 		},
 		{
 			Factory:  resourceInstanceStorageConfig,

--- a/website/docs/d/connect_instance.html.markdown
+++ b/website/docs/d/connect_instance.html.markdown
@@ -55,3 +55,4 @@ This data source exports the following attributes in addition to the arguments a
 * `use_custom_tts_voices` - Whether use custom tts voices is enabled.
 * `status` - State of the instance.
 * `service_role` - Service role of the instance.
+* `tags` - A map of tags to assigned to the instance.

--- a/website/docs/r/connect_instance.html.markdown
+++ b/website/docs/r/connect_instance.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Provides an Amazon Connect instance resource. For more information see
 [Amazon Connect: Getting Started](https://docs.aws.amazon.com/connect/latest/adminguide/amazon-connect-get-started.html)
 
-!> **WARN:** Amazon Connect enforces a limit of [100 combined instance creation and deletions every 30 days](https://docs.aws.amazon.com/connect/latest/adminguide/amazon-connect-service-limits.html#feature-limits).  For example, if you create 80 instances and delete 20 of them, you must wait 30 days to create or delete another instance.  Use care when creating or deleting instances.
+!> **WARN:** Amazon Connect enforces a limit of [100 combined instance creation and deletions every 30 days](https://docs.aws.amazon.com/connect/latest/adminguide/amazon-connect-service-limits.html#feature-limits). For example, if you create 80 instances and delete 20 of them, you must wait 30 days to create or delete another instance. Use care when creating or deleting instances.
 
 ## Example Usage
 
@@ -21,6 +21,10 @@ resource "aws_connect_instance" "test" {
   inbound_calls_enabled    = true
   instance_alias           = "friendly-name-connect"
   outbound_calls_enabled   = true
+
+  tags = {
+    "hello" = "world"
+  }
 }
 ```
 
@@ -51,34 +55,36 @@ resource "aws_connect_instance" "test" {
 
 This resource supports the following arguments:
 
-* `auto_resolve_best_voices_enabled` - (Optional) Specifies whether auto resolve best voices is enabled. Defaults to `true`.
-* `contact_flow_logs_enabled` - (Optional) Specifies whether contact flow logs are enabled. Defaults to `false`.
-* `contact_lens_enabled` - (Optional) Specifies whether contact lens is enabled. Defaults to `true`.
-* `directory_id` - (Optional) The identifier for the directory if identity_management_type is `EXISTING_DIRECTORY`.
-* `early_media_enabled` - (Optional) Specifies whether early media for outbound calls is enabled . Defaults to `true` if outbound calls is enabled.
-* `identity_management_type` - (Required) Specifies the identity management type attached to the instance. Allowed Values are: `SAML`, `CONNECT_MANAGED`, `EXISTING_DIRECTORY`.
-* `inbound_calls_enabled` - (Required) Specifies whether inbound calls are enabled.
-* `instance_alias` - (Optional) Specifies the name of the instance. Required if `directory_id` not specified.
-* `multi_party_conference_enabled` - (Optional) Specifies whether multi-party calls/conference is enabled. Defaults to `false`.
-* `outbound_calls_enabled` - (Required) Specifies whether outbound calls are enabled.
+- `auto_resolve_best_voices_enabled` - (Optional) Specifies whether auto resolve best voices is enabled. Defaults to `true`.
+- `contact_flow_logs_enabled` - (Optional) Specifies whether contact flow logs are enabled. Defaults to `false`.
+- `contact_lens_enabled` - (Optional) Specifies whether contact lens is enabled. Defaults to `true`.
+- `directory_id` - (Optional) The identifier for the directory if identity_management_type is `EXISTING_DIRECTORY`.
+- `early_media_enabled` - (Optional) Specifies whether early media for outbound calls is enabled . Defaults to `true` if outbound calls is enabled.
+- `identity_management_type` - (Required) Specifies the identity management type attached to the instance. Allowed Values are: `SAML`, `CONNECT_MANAGED`, `EXISTING_DIRECTORY`.
+- `inbound_calls_enabled` - (Required) Specifies whether inbound calls are enabled.
+- `instance_alias` - (Optional) Specifies the name of the instance. Required if `directory_id` not specified.
+- `multi_party_conference_enabled` - (Optional) Specifies whether multi-party calls/conference is enabled. Defaults to `false`.
+- `outbound_calls_enabled` - (Required) Specifies whether outbound calls are enabled.
+- `tags` - (Optional) Tags to apply to the Instance. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 <!-- * `use_custom_tts_voices` - (Optional) Whether use custom tts voices is enabled. Defaults to `false` -->
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The identifier of the instance.
-* `arn` - Amazon Resource Name (ARN) of the instance.
-* `created_time` - When the instance was created.
-* `service_role` - The service role of the instance.
-* `status` - The state of the instance.
+- `id` - The identifier of the instance.
+- `arn` - Amazon Resource Name (ARN) of the instance.
+- `created_time` - When the instance was created.
+- `service_role` - The service role of the instance.
+- `status` - The state of the instance.
+- `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `5m`)
-* `delete` - (Default `5m`)
+- `create` - (Default `5m`)
+- `delete` - (Default `5m`)
 
 ## Import
 

--- a/website/docs/r/connect_instance.html.markdown
+++ b/website/docs/r/connect_instance.html.markdown
@@ -55,36 +55,36 @@ resource "aws_connect_instance" "test" {
 
 This resource supports the following arguments:
 
-- `auto_resolve_best_voices_enabled` - (Optional) Specifies whether auto resolve best voices is enabled. Defaults to `true`.
-- `contact_flow_logs_enabled` - (Optional) Specifies whether contact flow logs are enabled. Defaults to `false`.
-- `contact_lens_enabled` - (Optional) Specifies whether contact lens is enabled. Defaults to `true`.
-- `directory_id` - (Optional) The identifier for the directory if identity_management_type is `EXISTING_DIRECTORY`.
-- `early_media_enabled` - (Optional) Specifies whether early media for outbound calls is enabled . Defaults to `true` if outbound calls is enabled.
-- `identity_management_type` - (Required) Specifies the identity management type attached to the instance. Allowed Values are: `SAML`, `CONNECT_MANAGED`, `EXISTING_DIRECTORY`.
-- `inbound_calls_enabled` - (Required) Specifies whether inbound calls are enabled.
-- `instance_alias` - (Optional) Specifies the name of the instance. Required if `directory_id` not specified.
-- `multi_party_conference_enabled` - (Optional) Specifies whether multi-party calls/conference is enabled. Defaults to `false`.
-- `outbound_calls_enabled` - (Required) Specifies whether outbound calls are enabled.
-- `tags` - (Optional) Tags to apply to the Instance. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `auto_resolve_best_voices_enabled` - (Optional) Specifies whether auto resolve best voices is enabled. Defaults to `true`.
+* `contact_flow_logs_enabled` - (Optional) Specifies whether contact flow logs are enabled. Defaults to `false`.
+* `contact_lens_enabled` - (Optional) Specifies whether contact lens is enabled. Defaults to `true`.
+* `directory_id` - (Optional) The identifier for the directory if identity_management_type is `EXISTING_DIRECTORY`.
+* `early_media_enabled` - (Optional) Specifies whether early media for outbound calls is enabled . Defaults to `true` if outbound calls is enabled.
+* `identity_management_type` - (Required) Specifies the identity management type attached to the instance. Allowed Values are: `SAML`, `CONNECT_MANAGED`, `EXISTING_DIRECTORY`.
+* `inbound_calls_enabled` - (Required) Specifies whether inbound calls are enabled.
+* `instance_alias` - (Optional) Specifies the name of the instance. Required if `directory_id` not specified.
+* `multi_party_conference_enabled` - (Optional) Specifies whether multi-party calls/conference is enabled. Defaults to `false`.
+* `outbound_calls_enabled` - (Required) Specifies whether outbound calls are enabled.
+* `tags` - (Optional) Tags to apply to the Instance. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 <!-- * `use_custom_tts_voices` - (Optional) Whether use custom tts voices is enabled. Defaults to `false` -->
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-- `id` - The identifier of the instance.
-- `arn` - Amazon Resource Name (ARN) of the instance.
-- `created_time` - When the instance was created.
-- `service_role` - The service role of the instance.
-- `status` - The state of the instance.
-- `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `id` - The identifier of the instance.
+* `arn` - Amazon Resource Name (ARN) of the instance.
+* `created_time` - When the instance was created.
+* `service_role` - The service role of the instance.
+* `status` - The state of the instance.
+* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-- `create` - (Default `5m`)
-- `delete` - (Default `5m`)
+* `create` - (Default `5m`)
+* `delete` - (Default `5m`)
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This adds `tag` support to the already existing `aws_connect_instance ` resource

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38849 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccConnect_serial PKG=connect
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnect_serial'  -timeout 360m
=== RUN   TestAccConnect_serial
=== PAUSE TestAccConnect_serial
=== CONT  TestAccConnect_serial
=== RUN   TestAccConnect_serial/Instance
=== RUN   TestAccConnect_serial/Instance/tags
--- PASS: TestAccConnect_serial (131.62s)
    --- PASS: TestAccConnect_serial/Instance (131.62s)
        --- PASS: TestAccConnect_serial/Instance/tags (131.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    137.401s
```
