### PR TITLE
Include all services in backup_region_settings documentation

### DIFF
--- a/website/docs/r/backup_region_settings.html.markdown
+++ b/website/docs/r/backup_region_settings.html.markdown
@@ -15,17 +15,21 @@ Provides an AWS Backup Region Settings resource.
 ```terraform
 resource "aws_backup_region_settings" "test" {
   resource_type_opt_in_preference = {
-    "Aurora"          = true
-    "DocumentDB"      = true
-    "DynamoDB"        = true
-    "EBS"             = true
-    "EC2"             = true
-    "EFS"             = true
-    "FSx"             = true
-    "Neptune"         = true
-    "RDS"             = true
-    "Storage Gateway" = true
-    "VirtualMachine"  = true
+    "Aurora"                 = true
+    "DocumentDB"             = true
+    "DynamoDB"               = true
+    "EBS"                    = true
+    "EC2"                    = true
+    "EFS"                    = true
+    "FSx"                    = true
+    "Neptune"                = true
+    "RDS"                    = true
+    "Storage Gateway"        = true
+    "VirtualMachine"         = true
+    "CloudFormation"         = true
+    "Redshift"               = true
+    "S3"                     = true
+    "SAP HANA on Amazon EC2" = true
   }
 
   resource_type_management_preference = {


### PR DESCRIPTION
### Description
Include newly-supported services in documentation for AWS resource backup_region_settings.

### References
https://docs.aws.amazon.com/aws-backup/latest/devguide/backup-feature-availability.html#features-by-resource

