### PR TITLE
linting: Fixes to acceptance test linting

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -3,3 +3,4 @@
 -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-22.04
 -P linux=ghcr.io/catthehacker/ubuntu:act-22.04
 -P custom-linux-medium=ghcr.io/catthehacker/ubuntu:act-22.04
+-P custom-linux-xl=ghcr.io/catthehacker/ubuntu:act-22.04

--- a/.ci/.tflint.hcl
+++ b/.ci/.tflint.hcl
@@ -4,6 +4,14 @@ plugin "aws" {
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 
+rule "terraform_required_providers" {
+  enabled = false
+}
+
+rule "terraform_required_version" {
+  enabled = false
+}
+
 rule "aws_acm_certificate_lifecycle" {
   enabled = false
 }

--- a/.ci/.tflint.hcl
+++ b/.ci/.tflint.hcl
@@ -1,7 +1,14 @@
 plugin "aws" {
   enabled = true
-  version = "0.23.1"
+  version = "0.33.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+# Terraform Rules
+# https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/README.md
+
+rule "terraform_comment_syntax" {
+  enabled = true
 }
 
 rule "terraform_required_providers" {
@@ -12,6 +19,15 @@ rule "terraform_required_version" {
   enabled = false
 }
 
+# AWS Rules
+# https://github.com/terraform-linters/tflint-ruleset-aws/blob/master/docs/rules/README.md
+
 rule "aws_acm_certificate_lifecycle" {
+  enabled = false
+}
+
+# The provider supports a number of undocumented connection types
+# https://github.com/hashicorp/terraform-provider-aws/pull/37731
+rule "aws_glue_connection_invalid_connection_type" {
   enabled = false
 }

--- a/.ci/scripts/validate-terraform-file.sh
+++ b/.ci/scripts/validate-terraform-file.sh
@@ -20,27 +20,27 @@ block_number=0
 
 while IFS= read -r block ; do
     ((block_number+=1))
-    start_line=$(echo "$block" | jq '.start_line')
-    end_line=$(echo "$block" | jq '.end_line')
-    text=$(echo "$block" | jq --raw-output '.text')
+    start_line=$(echo "${block}" | jq '.start_line')
+    end_line=$(echo "${block}" | jq '.end_line')
+    text=$(echo "${block}" | jq --raw-output '.text')
 
     td=$(mktemp -d)
-    tf="$td/main.tf"
+    tf="${td}/main.tf"
 
-    echo "$text" > "$tf"
+    echo "${text}" > "${tf}"
 
     # We need to capture the output and error code here. We don't want to exit on the first error
     set +e
-    tflint_output=$(tflint --config .ci/.tflint.hcl --filter=$tf "${rules[@]}" 2>&1)
+    tflint_output=$(tflint --config .ci/.tflint.hcl --filter="${tf}" "${rules[@]}" 2>&1)
     tflint_exitcode=$?
     set -e
 
-    if [ $tflint_exitcode -ne 0 ]; then
-        echo "ERROR: File \"$filename\", block #$block_number (lines $start_line-$end_line):"
-        echo "$tflint_output"
+    if [[ ${tflint_exitcode} -ne 0 ]]; then
+        echo "ERROR: File \"${filename}\", block #${block_number} (lines ${start_line}-${end_line}):"
+        echo "${tflint_output}"
         echo
         exit_code=1
     fi
-done < <( terrafmt blocks --json "$filename" | jq --compact-output '.blocks[]?' )
+done < <( terrafmt blocks --json "${filename}" | jq --compact-output '.blocks[]?' )
 
-exit $exit_code
+exit "${exit_code}"

--- a/.ci/scripts/validate-terraform-file.sh
+++ b/.ci/scripts/validate-terraform-file.sh
@@ -16,6 +16,9 @@ rules=( "$@" )
 
 exit_code=0
 
+# tflint always resolves config flies relative to the working directory when using --recursive
+TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
+
 block_number=0
 
 while IFS= read -r block ; do
@@ -31,7 +34,7 @@ while IFS= read -r block ; do
 
     # We need to capture the output and error code here. We don't want to exit on the first error
     set +e
-    tflint_output=$(tflint --config .ci/.tflint.hcl --filter="${tf}" "${rules[@]}" 2>&1)
+    tflint_output=$(tflint --config "${TFLINT_CONFIG}" --chdir="${td}" "${rules[@]}" 2>&1)
     tflint_exitcode=$?
     set -e
 

--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -7,8 +7,8 @@ set -eo pipefail
 # find ./website/docs -type f \( -name '*.md' -o -name '*.markdown' \) \
 #   | ./.ci/scripts/validate-terraform.sh
 
-if [ -z "${TERRAFMT_CMD}" ]; then TERRAFMT_CMD="terrafmt"; fi
-if [ -z "${TFLINT_CMD}" ]; then TFLINT_CMD="tflint"; fi
+if [[ -z "${TERRAFMT_CMD}" ]]; then TERRAFMT_CMD="terrafmt"; fi
+if [[ -z "${TFLINT_CMD}" ]]; then TFLINT_CMD="tflint"; fi
 
 exit_code=0
 
@@ -32,28 +32,28 @@ while read -r filename ; do
 
     while IFS= read -r block ; do
         ((block_number+=1))
-        start_line=$(echo "$block" | jq '.start_line')
-        end_line=$(echo "$block" | jq '.end_line')
-        text=$(echo "$block" | jq --raw-output '.text')
+        start_line=$(echo "${block}" | jq '.start_line')
+        end_line=$(echo "${block}" | jq '.end_line')
+        text=$(echo "${block}" | jq --raw-output '.text')
 
         td=$(mktemp -d)
-        tf="$td/main.tf"
+        tf="${td}/main.tf"
 
-        echo "$text" > "$tf"
+        echo "${text}" > "${tf}"
 
         # We need to capture the output and error code here. We don't want to exit on the first error
         set +e
-        tflint_output=$(${TFLINT_CMD} --config .ci/.tflint.hcl --filter=$tf "${rules[@]}" 2>&1)
+        tflint_output=$(${TFLINT_CMD} --config .ci/.tflint.hcl --filter="${tf}" "${rules[@]}" 2>&1)
         tflint_exitcode=$?
         set -e
 
-        if [ $tflint_exitcode -ne 0 ]; then
-            echo "ERROR: File \"$filename\", block #$block_number (lines $start_line-$end_line):"
-            echo "$tflint_output"
+        if [[ ${tflint_exitcode} -ne 0 ]]; then
+            echo "ERROR: File \"${filename}\", block #${block_number} (lines ${start_line}-${end_line}):"
+            echo "${tflint_output}"
             echo
             exit_code=1
         fi
-    done < <( $TERRAFMT_CMD blocks --fmtcompat --json "$filename" | jq --compact-output '.blocks[]?' )
+    done < <( ${TERRAFMT_CMD} blocks --fmtcompat --json "${filename}" | jq --compact-output '.blocks[]?' )
 done
 
-exit $exit_code
+exit "${exit_code}"

--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -12,12 +12,17 @@ if [[ -z "${TFLINT_CMD}" ]]; then TFLINT_CMD="tflint"; fi
 
 exit_code=0
 
+# tflint always resolves config flies relative to the working directory when using --recursive
+TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
+
 # Configure the rules for tflint.
 rules=(
     # Syntax checks
     "--only=terraform_comment_syntax"
     "--only=terraform_deprecated_index"
     "--only=terraform_deprecated_interpolation"
+    "--only=terraform_deprecated_lookup"
+    "--only=terraform_empty_list_equality"
     # Ensure valid instance types
     "--only=aws_db_instance_invalid_type"
     # Ensure modern instance types
@@ -43,7 +48,7 @@ while read -r filename ; do
 
         # We need to capture the output and error code here. We don't want to exit on the first error
         set +e
-        tflint_output=$(${TFLINT_CMD} --config .ci/.tflint.hcl --filter="${tf}" "${rules[@]}" 2>&1)
+        tflint_output=$(${TFLINT_CMD} --config "${TFLINT_CONFIG}" --chdir="${td}" "${rules[@]}" 2>&1)
         tflint_exitcode=$?
         set -e
 

--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -58,7 +58,7 @@ while read -r filename ; do
             echo
             exit_code=1
         fi
-    done < <( ${TERRAFMT_CMD} blocks --fmtcompat --json "${filename}" | jq --compact-output '.blocks[]?' )
+    done < <( "${TERRAFMT_CMD}" blocks --fmtcompat --json "${filename}" | jq --compact-output '.blocks[]?' )
 done
 
 exit "${exit_code}"

--- a/.ci/scripts/validate-terraform.sh
+++ b/.ci/scripts/validate-terraform.sh
@@ -58,7 +58,7 @@ while read -r filename ; do
             echo
             exit_code=1
         fi
-    done < <( "${TERRAFMT_CMD}" blocks --fmtcompat --json "${filename}" | jq --compact-output '.blocks[]?' )
+    done < <( ${TERRAFMT_CMD} blocks --fmtcompat --json "${filename}" | jq --compact-output '.blocks[]?' )
 done
 
 exit "${exit_code}"

--- a/.github/workflows/acctest-terraform-embedded-lint.yml
+++ b/.github/workflows/acctest-terraform-embedded-lint.yml
@@ -6,11 +6,12 @@ on:
       - "release/**"
   pull_request:
     paths:
-      - .github/workflows/acctest-terraform-lint.yml
+      - .github/workflows/acctest-terraform-embedded-lint.yml
       - .ci/.tflint.hcl
+      - .ci/scripts/validate-terraform.sh
       - .ci/tools/go.mod
       - go.sum
-      - 'internal/service/**/*.tf'
+      - 'internal/service/**/*_test.go'
 
 ## NOTE: !!!
 ## When changing these workflows, ensure that the following is updated:
@@ -32,13 +33,22 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
 
-      - run: terraform fmt -recursive -check
+      - run: cd .ci/tools && go install github.com/katbyte/terrafmt
+
+      - run: |
+          find ./internal/service -type f -name '*_test.go' \
+            | sort -u \
+            | xargs -I {} terrafmt diff --check --fmtcompat {}
 
   tflint:
     name: Validate Acceptance Test Terraform
-    runs-on: ubuntu-latest
+    runs-on: custom-linux-xl
+    strategy:
+      matrix:
+        path: ['[a-f]', '[g-z]']
+    env:
+      TEST_FILES_PARTITION: '\./internal/service/${{ matrix.path }}.*/.*_test\.go'
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -59,11 +69,12 @@ jobs:
           path: ~/.tflint.d/plugins
           key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
 
+      - run: cd .ci/tools && go install github.com/katbyte/terrafmt
       - run: cd .ci/tools && go install github.com/terraform-linters/tflint
 
       - run: tflint --config .ci/.tflint.hcl --init
 
+      - run: echo -n "File count $( find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION }} | wc -l | xargs )"
       - run: |
-          # tflint always resolves config flies relative to the working directory when using --recursive
-          TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
-          tflint --config  "${TFLINT_CONFIG}" --chdir=./internal/service --recursive
+          find ./internal -type f -regextype egrep -regex ${{ env.TEST_FILES_PARTITION }} \
+            | .ci/scripts/validate-terraform.sh

--- a/.github/workflows/acctest-terraform-embedded-lint.yml
+++ b/.github/workflows/acctest-terraform-embedded-lint.yml
@@ -1,4 +1,4 @@
-name: Acceptance Test Linting
+name: Acceptance Test Embedded Configuration Linting
 on:
   push:
     branches:

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -1,4 +1,4 @@
-name: Acceptance Test Linting
+name: Acceptance Test Directory Linting
 on:
   push:
     branches:

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -41,8 +41,40 @@ jobs:
             | sort -u \
             | xargs -I {} terrafmt diff --check --fmtcompat {}
 
-  tflint:
-    name: Validate Acceptance Tests
+  tflint-dir:
+    name: Validate Acceptance Test Terraform Directories
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        name: Cache plugin dir
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/.tflint.d/plugins
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.ci/.tflint.hcl') }}
+
+      - run: cd .ci/tools && go install github.com/terraform-linters/tflint
+
+      - run: tflint --config .ci/.tflint.hcl --init
+
+      - run: |
+          # tflint always resolves config flies relative to the working directory when using --recursive
+          TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
+          tflint --config  "${TFLINT_CONFIG}" --chdir=./internal/service --recursive
+
+  tflint-embedded:
+    name: Validate Embedded Acceptance Test Terraform
     runs-on: custom-linux-xl
     strategy:
       matrix:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -48,19 +48,13 @@ jobs:
 
       - name: tflint
         run: |
-          exit_code=0
           TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
-          for DIR in $(find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u); do
-            pushd "$DIR"
-            tflint --config="$TFLINT_CONFIG" \
-              --enable-rule=terraform_comment_syntax \
-              --enable-rule=terraform_deprecated_index \
-              --enable-rule=terraform_deprecated_interpolation \
-              --disable-rule=terraform_typed_variables \
-              || exit_code=1
-            popd
-          done
-          exit $exit_code
+          cd ./examples
+          tflint --config="$TFLINT_CONFIG" --recursive \
+            --enable-rule=terraform_deprecated_index \
+            --enable-rule=terraform_deprecated_interpolation \
+            --enable-rule=terraform_required_version \
+            --disable-rule=terraform_typed_variables
 
   validate-terraform:
     runs-on: custom-linux-large

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -49,11 +49,7 @@ jobs:
       - name: tflint
         run: |
           TFLINT_CONFIG="$(pwd -P)/.ci/.tflint.hcl"
-          cd ./examples
-          tflint --config="$TFLINT_CONFIG" --recursive \
-            --enable-rule=terraform_deprecated_index \
-            --enable-rule=terraform_deprecated_interpolation \
-            --enable-rule=terraform_required_version \
+          tflint --config="${TFLINT_CONFIG}" --chdir=./examples --recursive \
             --disable-rule=terraform_typed_variables
 
   validate-terraform:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -56,8 +56,6 @@ jobs:
               --enable-rule=terraform_comment_syntax \
               --enable-rule=terraform_deprecated_index \
               --enable-rule=terraform_deprecated_interpolation \
-              --enable-rule=terraform_required_version \
-              --disable-rule=terraform_required_providers \
               --disable-rule=terraform_typed_variables \
               || exit_code=1
             popd

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -66,7 +66,7 @@ jobs:
           verbose: "yes"
           config: ".ci/.markdownlinkcheck.json"
           directory: "website/docs"
-          # Don't check CDKTF translated guides, e.g. website/docs/cdktf/typescript/guides/version-4-upgrade.html.md.
+          # Don't check CDKTF translated guides, e.g. website/docs/cdktf/typescript/guides/version-4-upgrade.html.markdown.
           depth: 2
           extension: ".md"
           # Checking only modified files in the PR does not respect 'mex-depth'.
@@ -150,7 +150,6 @@ jobs:
           # Do not disable *_invalid_name rules, since these are good checks for e.g. "%s" formatting verbs
           # being carried over from test cases.
           shared_rules=(
-              "--enable-rule=terraform_comment_syntax"
               "--disable-rule=aws_cloudwatch_event_target_invalid_arn"
               "--disable-rule=aws_db_instance_default_parameter_group"
               "--disable-rule=aws_elasticache_cluster_default_parameter_group"
@@ -172,15 +171,15 @@ jobs:
           )
           while read -r filename; do
             rules=("${shared_rules[@]}")
-            if [[ "$filename" == "./website/docs/guides/version-2-upgrade.html.md" ]]; then
-                # ./website/docs/guides/version-2-upgrade.html.md should still include pre-0.12 syntax,
+            if [[ "$filename" == "./website/docs/guides/version-2-upgrade.html.markdown" ]]; then
+                # ./website/docs/guides/version-2-upgrade.html.markdown should still include pre-0.12 syntax,
                 # since v1.0 does not support Terraform 0.12.
                 rules+=(
                 "--disable-rule=terraform_deprecated_index"
                 "--disable-rule=terraform_deprecated_interpolation"
                 )
-            elif [[ "$filename" == "./website/docs/guides/version-3-upgrade.html.md" ]]; then
-                # ./website/docs/guides/version-3-upgrade.html.md has one example showing migration from
+            elif [[ "$filename" == "./website/docs/guides/version-3-upgrade.html.markdown" ]]; then
+                # ./website/docs/guides/version-3-upgrade.html.markdown has one example showing migration from
                 # pre-0.12 syntax to 0.12 syntax. We can't customize rules per block, and adding a
                 # tflint-ignore directive to documentation is not ideal.
                 rules+=(
@@ -198,6 +197,6 @@ jobs:
             set +e
             ./.ci/scripts/validate-terraform-file.sh "$filename" "${rules[@]}" || exit_code=1
             set -e
-          done < <(find ./website/docs -type f \( -name '*.md' -o -name '*.markdown' \) | sort -u)
+          done < <(find ./website/docs -not \( -path ./website/docs/cdktf -prune \) -type f -name '*.markdown' | sort -u)
 
           exit $exit_code

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -167,7 +167,6 @@ jobs:
               "--disable-rule=aws_servicecatalog_portfolio_share_invalid_type"
               "--disable-rule=aws_transfer_ssh_key_invalid_body"
               "--disable-rule=aws_worklink_website_certificate_authority_association_invalid_certificate"
-              "--disable-rule=terraform_required_providers"
               "--disable-rule=terraform_unused_declarations"
               "--disable-rule=terraform_typed_variables"
           )

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -648,6 +648,12 @@ testacc-tflint-dir: tflint-init ## Run tflint on Terraform directories
 	@tflint_config="$(PWD)/.ci/.tflint.hcl" ; \
 	tflint --config  "$$tflint_config" --chdir=./internal/service --recursive
 
+testacc-tflint-dir-fix: tflint-init ## fix Terraform directory linter findings
+	@echo "make: Acceptance Test Linting (standalone) / tflint..."
+	@# tflint always resolves config flies relative to the working directory when using --recursive
+	@tflint_config="$(PWD)/.ci/.tflint.hcl" ; \
+	tflint --config  "$$tflint_config" --chdir=./internal/service --recursive --fix
+
 testacc-tflint-embedded: tflint-init ## Run tflint on embedded Terraform configs
 	@echo "make: Acceptance Test Linting (embedded) / tflint..."
 	@find $(SVC_DIR) -type f -name '*_test.go' \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -243,20 +243,13 @@ docs-misspell: ## [CI] Documentation Checks / misspell
 examples-tflint: ## [CI] Examples Checks / tflint
 	@echo "make: Examples Checks / tflint..."
 	@tflint --config .ci/.tflint.hcl --init
-	@exit_code=0 ; \
-	TFLINT_CONFIG="`pwd -P`/.ci/.tflint.hcl" ; \
-	for DIR in `find ./examples -type f -name '*.tf' -exec dirname {} \; | sort -u`; do \
-		pushd "$$DIR" ; \
-		tflint --config="$$TFLINT_CONFIG" \
-			--enable-rule=terraform_comment_syntax \
-			--enable-rule=terraform_deprecated_index \
-			--enable-rule=terraform_deprecated_interpolation \
-			--enable-rule=terraform_required_version \
-			--disable-rule=terraform_typed_variables \
-			|| exit_code=1 ; \
-		popd ; \
-	done ; \
-	exit $$exit_code
+	TFLINT_CONFIG="$(PWD)/.ci/.tflint.hcl" ; \
+	cd ./examples; \
+	tflint --config="$$TFLINT_CONFIG" --recursive \
+		--enable-rule=terraform_deprecated_index \
+		--enable-rule=terraform_deprecated_interpolation \
+		--enable-rule=terraform_required_version \
+		--disable-rule=terraform_typed_variables
 
 fix-constants: semgrep-constants fmt ## Use Semgrep to fix constants
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -769,7 +769,6 @@ website-tflint: ## [CI] Website Checks / tflint
 	@tflint --config .ci/.tflint.hcl --init
 	@exit_code=0 ; \
 	shared_rules=( \
-		"--enable-rule=terraform_comment_syntax" \
 		"--disable-rule=aws_cloudwatch_event_target_invalid_arn" \
 		"--disable-rule=aws_db_instance_default_parameter_group" \
 		"--disable-rule=aws_elasticache_cluster_default_parameter_group" \
@@ -791,12 +790,12 @@ website-tflint: ## [CI] Website Checks / tflint
 	) ; \
 	while read -r filename; do \
 		rules=("$${shared_rules[@]}") ; \
-		if [[ "$$filename" == "./website/docs/guides/version-2-upgrade.html.md" ]] ; then \
+		if [[ "$$filename" == "./website/docs/guides/version-2-upgrade.html.markdown" ]] ; then \
 			rules+=( \
 			"--disable-rule=terraform_deprecated_index" \
 			"--disable-rule=terraform_deprecated_interpolation" \
 			) ; \
-		elif [[ "$$filename" == "./website/docs/guides/version-3-upgrade.html.md" ]]; then \
+		elif [[ "$$filename" == "./website/docs/guides/version-3-upgrade.html.markdown" ]]; then \
 			rules+=( \
 			"--enable-rule=terraform_deprecated_index" \
 			"--disable-rule=terraform_deprecated_interpolation" \
@@ -810,7 +809,7 @@ website-tflint: ## [CI] Website Checks / tflint
 		set +e ; \
 		./.ci/scripts/validate-terraform-file.sh "$$filename" "$${rules[@]}" || exit_code=1 ; \
 		set -e ; \
-	done < <(find ./website/docs -type f \( -name '*.md' -o -name '*.markdown' \) | sort -u) ; \
+	done < <(find ./website/docs -not \( -path ./website/docs/cdktf -prune \) -type f -name '*.markdown' | sort -u) ; \
 	exit $$exit_code
 
 yamllint: ## [CI] YAML Linting / yamllint

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -252,7 +252,6 @@ examples-tflint: ## [CI] Examples Checks / tflint
 			--enable-rule=terraform_deprecated_index \
 			--enable-rule=terraform_deprecated_interpolation \
 			--enable-rule=terraform_required_version \
-			--disable-rule=terraform_required_providers \
 			--disable-rule=terraform_typed_variables \
 			|| exit_code=1 ; \
 		popd ; \
@@ -794,7 +793,6 @@ website-tflint: ## [CI] Website Checks / tflint
 		"--disable-rule=aws_servicecatalog_portfolio_share_invalid_type" \
 		"--disable-rule=aws_transfer_ssh_key_invalid_body" \
 		"--disable-rule=aws_worklink_website_certificate_authority_association_invalid_certificate" \
-		"--disable-rule=terraform_required_providers" \
 		"--disable-rule=terraform_unused_declarations" \
 		"--disable-rule=terraform_typed_variables" \
 	) ; \

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -116,6 +116,18 @@ Use the `testacc-tflint` target to run only the `tflint` test. This is useful if
 make testacc-tflint
 ```
 
+To run `tflint` only against acceptance test configurations in `.tf` files, use the `testacc-tflint-dir` target:
+
+```console
+make testacc-tflint-dir
+```
+
+To run `tflint` only against embedded configurations, use the `testacc-tflint-embedded` target:
+
+```console
+make testacc-tflint-embedded
+```
+
 ### Copyright Checks / add headers check
 
 This CI check simply checks to make sure after running the tool, no files have been modified. No modifications signifies that everything already has the proper header.

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -163,6 +163,9 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `testacc-lint-fix` | Fix acceptance test linter findings |  |  | `K`, `PKG`, `SVC_DIR` |
 | `testacc-short`<sup>D</sup> | Run acceptace tests with the -short flag |  |  | `ACCTEST_PARALLELISM`, `ACCTEST_TIMEOUT`, `GO_VER`, `K`, `PKG`, `PKG_NAME`, `RUNARGS`, `TEST_COUNT`, `TESTARGS` |
 | `testacc-tflint` | Acceptance Test Linting / tflint | ✔️ |  | `K`, `PKG`, `SVC_DIR` |
+| `testacc-tflint-dir` | Run `tflint` on Terraform acceptance test directories | ✔️ |  | `K`, `PKG`, `SVC_DIR` |
+| `testacc-tflint-dir-fix` | Fix `tflint` issues in Terraform acceptance test directories | ✔️ |  | `K`, `PKG`, `SVC_DIR` |
+| `testacc-tflint-embedded` | Run `tflint` on embedded Terraform configurations | ✔️ |  | `K`, `PKG`, `SVC_DIR` |
 | `tfproviderdocs`<sup>D</sup> | Provider Checks / tfproviderdocs | ✔️ |  |  |
 | `tfsdk2fw`<sup>D</sup> | Install tfsdk2fw |  |  | `GO_VER` |
 | `tools`<sup>D</sup> | Install tools |  |  | `GO_VER` |

--- a/examples/api-gateway-websocket-chat-app/main.tf
+++ b/examples/api-gateway-websocket-chat-app/main.tf
@@ -178,7 +178,7 @@ resource "aws_lambda_function" "OnConnectFunction" {
   function_name = "OnConnectFunction"
   role          = aws_iam_role.OnConnectRole.arn
   handler       = "app.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   memory_size   = 256
 
   environment {
@@ -262,7 +262,7 @@ resource "aws_lambda_function" "OnDisconnectFunction" {
   function_name = "OnDisconnectFunction"
   role          = aws_iam_role.OnDisconnectRole.arn
   handler       = "app.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   memory_size   = 256
 
   environment {
@@ -346,7 +346,7 @@ resource "aws_lambda_function" "SendMessageFunction" {
   function_name = "SendMessageFunction"
   role          = aws_iam_role.SendMessageRole.arn
   handler       = "app.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   memory_size   = 256
 
   environment {

--- a/examples/cognito-user-pool/main.tf
+++ b/examples/cognito-user-pool/main.tf
@@ -34,7 +34,7 @@ resource "aws_lambda_function" "main" {
   function_name = "terraform-example"
   role          = aws_iam_role.main.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_iam_role" "cidp" {

--- a/examples/ivschat/main.tf
+++ b/examples/ivschat/main.tf
@@ -38,7 +38,7 @@ resource "aws_lambda_function" "example" {
   function_name    = "tf-ivschat-message-handler"
   role             = aws_iam_role.example.arn
   source_code_hash = data.archive_file.message_review_handler.output_base64sha256
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   handler          = "index.handler"
 }
 

--- a/examples/lambda-file-systems/main.tf
+++ b/examples/lambda-file-systems/main.tf
@@ -138,7 +138,7 @@ resource "aws_lambda_function" "example_lambda" {
 
   role    = aws_iam_role.iam_role_for_lambda.arn
   handler = "hello_lambda.lambda_handler"
-  runtime = "python3.7"
+  runtime = "python3.12"
 
   timeout = 60
 

--- a/internal/generate/tagstests/test.tf.gtpl
+++ b/internal/generate/tagstests/test.tf.gtpl
@@ -47,8 +47,9 @@ provider "null" {}
 
 {{ end -}}
 
-{{ if eq .Tags "data.tags" }}
-{{- template "data_source" }}
+{{ if eq .Tags "data.tags" -}}
+# tflint-ignore: terraform_unused_declarations
+{{ template "data_source" }}
 {{ end }}
 
 {{- block "body" .Tags }}

--- a/internal/service/acm/testdata/Certificate/data.tags/main_gen.tf
+++ b/internal/service/acm/testdata/Certificate/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_acm_certificate" "test" {
   domain = aws_acm_certificate.test.domain_name
 }

--- a/internal/service/acmpca/testdata/CertificateAuthority/data.tags/main_gen.tf
+++ b/internal/service/acmpca/testdata/CertificateAuthority/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_acmpca_certificate_authority" "test" {
   arn = aws_acmpca_certificate_authority.test.arn
 }

--- a/internal/service/amp/scraper_test.go
+++ b/internal/service/amp/scraper_test.go
@@ -336,7 +336,7 @@ resource "aws_eks_cluster" "test" {
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
-    subnet_ids = aws_subnet.test.*.id
+    subnet_ids = aws_subnet.test[*].id
   }
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]

--- a/internal/service/amp/scraper_test.go
+++ b/internal/service/amp/scraper_test.go
@@ -336,7 +336,7 @@ resource "aws_eks_cluster" "test" {
   role_arn = aws_iam_role.test.arn
 
   vpc_config {
-    subnet_ids = aws_subnet.test[*].id
+    subnet_ids = aws_subnet.test.*.id
   }
 
   depends_on = [aws_iam_role_policy_attachment.test-AmazonEKSClusterPolicy]

--- a/internal/service/amp/testdata/Scraper/tags/main_gen.tf
+++ b/internal/service/amp/testdata/Scraper/tags/main_gen.tf
@@ -107,7 +107,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }
@@ -123,7 +123,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }

--- a/internal/service/amp/testdata/Scraper/tags/main_gen.tf
+++ b/internal/service/amp/testdata/Scraper/tags/main_gen.tf
@@ -62,7 +62,7 @@ CONFIG
   source {
     eks {
       cluster_arn = aws_eks_cluster.test.arn
-      subnet_ids  = aws_subnet.test[*].id
+      subnet_ids  = aws_subnet.test.*.id
     }
   }
 

--- a/internal/service/amp/testdata/Scraper/tags/main_gen.tf
+++ b/internal/service/amp/testdata/Scraper/tags/main_gen.tf
@@ -62,7 +62,7 @@ CONFIG
   source {
     eks {
       cluster_arn = aws_eks_cluster.test.arn
-      subnet_ids  = aws_subnet.test.*.id
+      subnet_ids  = aws_subnet.test[*].id
     }
   }
 

--- a/internal/service/amp/testdata/Scraper/tagsComputed1/main_gen.tf
+++ b/internal/service/amp/testdata/Scraper/tagsComputed1/main_gen.tf
@@ -111,7 +111,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }
@@ -127,7 +127,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }

--- a/internal/service/amp/testdata/Scraper/tagsComputed2/main_gen.tf
+++ b/internal/service/amp/testdata/Scraper/tagsComputed2/main_gen.tf
@@ -112,7 +112,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }
@@ -128,7 +128,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }

--- a/internal/service/amp/testdata/Scraper/tags_defaults/main_gen.tf
+++ b/internal/service/amp/testdata/Scraper/tags_defaults/main_gen.tf
@@ -113,7 +113,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }
@@ -129,7 +129,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }

--- a/internal/service/amp/testdata/Scraper/tags_ignore/main_gen.tf
+++ b/internal/service/amp/testdata/Scraper/tags_ignore/main_gen.tf
@@ -116,7 +116,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }
@@ -132,7 +132,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }

--- a/internal/service/amp/testdata/Workspace/data.tags/main_gen.tf
+++ b/internal/service/amp/testdata/Workspace/data.tags/main_gen.tf
@@ -11,12 +11,6 @@ resource "aws_prometheus_workspace" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/amp/testdata/Workspace/data.tags/main_gen.tf
+++ b/internal/service/amp/testdata/Workspace/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_prometheus_workspace" "test" {
   workspace_id = aws_prometheus_workspace.test.id
 }

--- a/internal/service/amp/testdata/Workspace/tags/main_gen.tf
+++ b/internal/service/amp/testdata/Workspace/tags/main_gen.tf
@@ -6,12 +6,6 @@ resource "aws_prometheus_workspace" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/amp/testdata/Workspace/tagsComputed1/main_gen.tf
+++ b/internal/service/amp/testdata/Workspace/tagsComputed1/main_gen.tf
@@ -12,12 +12,6 @@ resource "aws_prometheus_workspace" "test" {
 
 resource "null_resource" "test" {}
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "unknownTagKey" {
   type     = string
   nullable = false

--- a/internal/service/amp/testdata/Workspace/tagsComputed2/main_gen.tf
+++ b/internal/service/amp/testdata/Workspace/tagsComputed2/main_gen.tf
@@ -13,12 +13,6 @@ resource "aws_prometheus_workspace" "test" {
 
 resource "null_resource" "test" {}
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "unknownTagKey" {
   type     = string
   nullable = false

--- a/internal/service/amp/testdata/Workspace/tags_defaults/main_gen.tf
+++ b/internal/service/amp/testdata/Workspace/tags_defaults/main_gen.tf
@@ -12,12 +12,6 @@ resource "aws_prometheus_workspace" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/amp/testdata/Workspace/tags_ignore/main_gen.tf
+++ b/internal/service/amp/testdata/Workspace/tags_ignore/main_gen.tf
@@ -15,12 +15,6 @@ resource "aws_prometheus_workspace" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/amp/testdata/tmpl/scraper_tags.gtpl
+++ b/internal/service/amp/testdata/tmpl/scraper_tags.gtpl
@@ -103,7 +103,7 @@ resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }
@@ -119,7 +119,7 @@ resource "aws_subnet" "test" {
   assign_ipv6_address_on_creation = true
 
   tags = {
-    Name                          = var.rName
+    Name                                 = var.rName
     "kubernetes.io/cluster/${var.rName}" = "shared"
   }
 }

--- a/internal/service/amp/workspace.go
+++ b/internal/service/amp/workspace.go
@@ -29,6 +29,7 @@ import (
 // @SDKResource("aws_prometheus_workspace", name="Workspace")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/amp/types;types.WorkspaceDescription")
+// @Testing(generator=false)
 func resourceWorkspace() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceWorkspaceCreate,

--- a/internal/service/amp/workspace_data_source.go
+++ b/internal/service/amp/workspace_data_source.go
@@ -17,6 +17,7 @@ import (
 
 // @SDKDataSource("aws_prometheus_workspace", name="Workspace")
 // @Tags
+// @Testing(generator=false)
 func dataSourceWorkspace() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceWorkspaceRead,

--- a/internal/service/amp/workspace_data_source_tags_gen_test.go
+++ b/internal/service/amp/workspace_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,7 +17,6 @@ import (
 func TestAccAMPWorkspaceDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -28,7 +26,6 @@ func TestAccAMPWorkspaceDataSource_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -46,7 +43,6 @@ func TestAccAMPWorkspaceDataSource_tags(t *testing.T) {
 func TestAccAMPWorkspaceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -56,7 +52,6 @@ func TestAccAMPWorkspaceDataSource_tags_NullMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -70,7 +65,6 @@ func TestAccAMPWorkspaceDataSource_tags_NullMap(t *testing.T) {
 func TestAccAMPWorkspaceDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -80,7 +74,6 @@ func TestAccAMPWorkspaceDataSource_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{

--- a/internal/service/amp/workspace_tags_gen_test.go
+++ b/internal/service/amp/workspace_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/amp/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,7 +20,6 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -32,7 +30,6 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -63,7 +60,6 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -75,7 +71,6 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -111,7 +106,6 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -124,7 +118,6 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -155,7 +148,6 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -167,7 +159,6 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -188,7 +179,6 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -203,7 +193,6 @@ func TestAccAMPWorkspace_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -214,7 +203,6 @@ func TestAccAMPWorkspace_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -238,7 +226,6 @@ func TestAccAMPWorkspace_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -250,7 +237,6 @@ func TestAccAMPWorkspace_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				PlanOnly:           true,
@@ -264,7 +250,6 @@ func TestAccAMPWorkspace_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -275,7 +260,6 @@ func TestAccAMPWorkspace_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -297,7 +281,6 @@ func TestAccAMPWorkspace_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ResourceName:      resourceName,
@@ -307,7 +290,6 @@ func TestAccAMPWorkspace_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				PlanOnly:           true,
@@ -321,7 +303,6 @@ func TestAccAMPWorkspace_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -332,7 +313,6 @@ func TestAccAMPWorkspace_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -354,7 +334,6 @@ func TestAccAMPWorkspace_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -385,7 +364,6 @@ func TestAccAMPWorkspace_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -402,7 +380,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -413,7 +390,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -443,7 +419,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -455,7 +430,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -476,7 +450,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -491,7 +464,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -502,7 +474,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -533,7 +504,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -567,7 +537,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -580,7 +549,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -611,7 +579,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -628,7 +595,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -639,7 +605,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -670,7 +635,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -700,7 +664,6 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -717,7 +680,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -728,7 +690,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -757,7 +718,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -771,7 +731,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -803,7 +762,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -818,7 +776,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -847,7 +804,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -861,7 +817,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -883,7 +838,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -898,7 +852,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -909,7 +862,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -946,7 +898,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -962,7 +913,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable("providervalue1updated"),
 					}),
@@ -1004,7 +954,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable("providervalue1updated"),
 					}),
@@ -1021,7 +970,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1043,7 +991,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -1058,7 +1005,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1069,7 +1015,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1104,7 +1049,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1120,7 +1064,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1161,7 +1104,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1179,7 +1121,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1214,7 +1155,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1234,7 +1174,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1245,7 +1184,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1277,7 +1215,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1306,7 +1243,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1324,7 +1260,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1335,7 +1270,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1364,7 +1298,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1396,7 +1329,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1413,7 +1345,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1424,7 +1355,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1458,7 +1388,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1478,7 +1407,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1489,7 +1417,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1517,7 +1444,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1535,7 +1461,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nullOverlappingResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1546,7 +1471,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nullOverlappingResourceTag(t *testing.
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1577,7 +1501,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nullOverlappingResourceTag(t *testing.
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1597,7 +1520,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nullNonOverlappingResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1608,7 +1530,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nullNonOverlappingResourceTag(t *testi
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1639,7 +1560,6 @@ func TestAccAMPWorkspace_tags_DefaultTags_nullNonOverlappingResourceTag(t *testi
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1659,7 +1579,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1670,7 +1589,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnCreate(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1699,7 +1617,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnCreate(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				ResourceName:      resourceName,
@@ -1714,7 +1631,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1725,7 +1641,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1757,7 +1672,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1794,7 +1708,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1811,7 +1724,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1822,7 +1734,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1854,7 +1765,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1883,7 +1793,6 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Workspace/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				ResourceName:      resourceName,

--- a/internal/service/apigateway/authorizer_test.go
+++ b/internal/service/apigateway/authorizer_test.go
@@ -448,7 +448,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 `, rName)
 }

--- a/internal/service/apigateway/deployment_test.go
+++ b/internal/service/apigateway/deployment_test.go
@@ -605,7 +605,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName))
 }

--- a/internal/service/apigateway/method_test.go
+++ b/internal/service/apigateway/method_test.go
@@ -376,7 +376,7 @@ resource "aws_lambda_function" "authorizer" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 
 resource "aws_api_gateway_authorizer" "test" {

--- a/internal/service/apigateway/testdata/APIKey/data.tags/main_gen.tf
+++ b/internal/service/apigateway/testdata/APIKey/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_api_gateway_api_key" "test" {
   id = aws_api_gateway_api_key.test.id
 }

--- a/internal/service/apigateway/testdata/DomainName/data.tags/main_gen.tf
+++ b/internal/service/apigateway/testdata/DomainName/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_api_gateway_domain_name" "test" {
   domain_name = aws_api_gateway_domain_name.test.domain_name
 }

--- a/internal/service/apigateway/testdata/RESTAPI/data.tags/main_gen.tf
+++ b/internal/service/apigateway/testdata/RESTAPI/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_api_gateway_rest_api" "test" {
   name = aws_api_gateway_rest_api.test.name
 }

--- a/internal/service/apigateway/testdata/VPCLink/data.tags/main_gen.tf
+++ b/internal/service/apigateway/testdata/VPCLink/data.tags/main_gen.tf
@@ -20,7 +20,7 @@ resource "aws_lb" "test" {
   subnets            = aws_subnet.test[*].id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 1)
+# acctest.ConfigVPCWithSubnets(rName, 1)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -37,7 +37,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigateway/testdata/VPCLink/data.tags/main_gen.tf
+++ b/internal/service/apigateway/testdata/VPCLink/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_api_gateway_vpc_link" "test" {
   name = aws_api_gateway_vpc_link.test.name
 }

--- a/internal/service/apigateway/testdata/VPCLink/tags/main_gen.tf
+++ b/internal/service/apigateway/testdata/VPCLink/tags/main_gen.tf
@@ -15,7 +15,7 @@ resource "aws_lb" "test" {
   subnets            = aws_subnet.test[*].id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 1)
+# acctest.ConfigVPCWithSubnets(rName, 1)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -32,7 +32,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigateway/testdata/VPCLink/tagsComputed1/main_gen.tf
+++ b/internal/service/apigateway/testdata/VPCLink/tagsComputed1/main_gen.tf
@@ -19,7 +19,7 @@ resource "aws_lb" "test" {
   subnets            = aws_subnet.test[*].id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 1)
+# acctest.ConfigVPCWithSubnets(rName, 1)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -36,7 +36,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigateway/testdata/VPCLink/tagsComputed2/main_gen.tf
+++ b/internal/service/apigateway/testdata/VPCLink/tagsComputed2/main_gen.tf
@@ -20,7 +20,7 @@ resource "aws_lb" "test" {
   subnets            = aws_subnet.test[*].id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 1)
+# acctest.ConfigVPCWithSubnets(rName, 1)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -37,7 +37,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigateway/testdata/VPCLink/tags_defaults/main_gen.tf
+++ b/internal/service/apigateway/testdata/VPCLink/tags_defaults/main_gen.tf
@@ -21,7 +21,7 @@ resource "aws_lb" "test" {
   subnets            = aws_subnet.test[*].id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 1)
+# acctest.ConfigVPCWithSubnets(rName, 1)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -38,7 +38,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigateway/testdata/VPCLink/tags_ignore/main_gen.tf
+++ b/internal/service/apigateway/testdata/VPCLink/tags_ignore/main_gen.tf
@@ -24,7 +24,7 @@ resource "aws_lb" "test" {
   subnets            = aws_subnet.test[*].id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 1)
+# acctest.ConfigVPCWithSubnets(rName, 1)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -41,7 +41,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigateway/testdata/tmpl/vpc_link_tags.gtpl
+++ b/internal/service/apigateway/testdata/tmpl/vpc_link_tags.gtpl
@@ -12,7 +12,7 @@ resource "aws_lb" "test" {
   subnets            = aws_subnet.test[*].id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 1)
+# acctest.ConfigVPCWithSubnets(rName, 1)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 
@@ -29,7 +29,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigatewayv2/testdata/API/data.tags/main_gen.tf
+++ b/internal/service/apigatewayv2/testdata/API/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_apigatewayv2_api" "test" {
   api_id = aws_apigatewayv2_api.test.id
 }

--- a/internal/service/apigatewayv2/testdata/VPCLink/data.tags/main_gen.tf
+++ b/internal/service/apigatewayv2/testdata/VPCLink/data.tags/main_gen.tf
@@ -19,7 +19,7 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 2)
+# acctest.ConfigVPCWithSubnets(rName, 2)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -32,7 +32,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigatewayv2/testdata/VPCLink/data.tags/main_gen.tf
+++ b/internal/service/apigatewayv2/testdata/VPCLink/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_apigatewayv2_vpc_link" "test" {
   vpc_link_id = aws_apigatewayv2_vpc_link.test.id
 }

--- a/internal/service/apigatewayv2/testdata/VPCLink/tags/main_gen.tf
+++ b/internal/service/apigatewayv2/testdata/VPCLink/tags/main_gen.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 2)
+# acctest.ConfigVPCWithSubnets(rName, 2)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -27,7 +27,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigatewayv2/testdata/VPCLink/tagsComputed1/main_gen.tf
+++ b/internal/service/apigatewayv2/testdata/VPCLink/tagsComputed1/main_gen.tf
@@ -18,7 +18,7 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 2)
+# acctest.ConfigVPCWithSubnets(rName, 2)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -31,7 +31,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigatewayv2/testdata/VPCLink/tagsComputed2/main_gen.tf
+++ b/internal/service/apigatewayv2/testdata/VPCLink/tagsComputed2/main_gen.tf
@@ -19,7 +19,7 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 2)
+# acctest.ConfigVPCWithSubnets(rName, 2)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -32,7 +32,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigatewayv2/testdata/VPCLink/tags_defaults/main_gen.tf
+++ b/internal/service/apigatewayv2/testdata/VPCLink/tags_defaults/main_gen.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 2)
+# acctest.ConfigVPCWithSubnets(rName, 2)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -33,7 +33,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigatewayv2/testdata/VPCLink/tags_ignore/main_gen.tf
+++ b/internal/service/apigatewayv2/testdata/VPCLink/tags_ignore/main_gen.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 2)
+# acctest.ConfigVPCWithSubnets(rName, 2)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -36,7 +36,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/apigatewayv2/testdata/tmpl/vpc_link_tags.gtpl
+++ b/internal/service/apigatewayv2/testdata/tmpl/vpc_link_tags.gtpl
@@ -11,7 +11,7 @@ resource "aws_security_group" "test" {
   vpc_id = aws_vpc.test.id
 }
 
-// acctest.ConfigVPCWithSubnets(rName, 2)
+# acctest.ConfigVPCWithSubnets(rName, 2)
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
 }
@@ -24,7 +24,7 @@ resource "aws_subnet" "test" {
   cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
 }
 
-// acctest.ConfigAvailableAZsNoOptInDefaultExclude()
+# acctest.ConfigAvailableAZsNoOptInDefaultExclude()
 data "aws_availability_zones" "available" {
   exclude_zone_ids = local.default_exclude_zone_ids
   state            = "available"

--- a/internal/service/appconfig/configuration_profile_test.go
+++ b/internal/service/appconfig/configuration_profile_test.go
@@ -503,7 +503,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName)
 }

--- a/internal/service/appconfig/testdata/ConfigurationProfile/data.tags/main_gen.tf
+++ b/internal/service/appconfig/testdata/ConfigurationProfile/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_appconfig_configuration_profile" "test" {
   application_id           = aws_appconfig_application.test.id
   configuration_profile_id = aws_appconfig_configuration_profile.test.configuration_profile_id

--- a/internal/service/appconfig/testdata/Deployment/tags/main_gen.tf
+++ b/internal/service/appconfig/testdata/Deployment/tags/main_gen.tf
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-resource "aws_appconfig_deployment" "test"{
+resource "aws_appconfig_deployment" "test" {
   application_id           = aws_appconfig_application.test.id
   configuration_profile_id = aws_appconfig_configuration_profile.test.configuration_profile_id
   configuration_version    = aws_appconfig_hosted_configuration_version.test.version_number

--- a/internal/service/appconfig/testdata/Deployment/tagsComputed1/main_gen.tf
+++ b/internal/service/appconfig/testdata/Deployment/tagsComputed1/main_gen.tf
@@ -3,7 +3,7 @@
 
 provider "null" {}
 
-resource "aws_appconfig_deployment" "test"{
+resource "aws_appconfig_deployment" "test" {
   application_id           = aws_appconfig_application.test.id
   configuration_profile_id = aws_appconfig_configuration_profile.test.configuration_profile_id
   configuration_version    = aws_appconfig_hosted_configuration_version.test.version_number

--- a/internal/service/appconfig/testdata/Deployment/tagsComputed2/main_gen.tf
+++ b/internal/service/appconfig/testdata/Deployment/tagsComputed2/main_gen.tf
@@ -3,7 +3,7 @@
 
 provider "null" {}
 
-resource "aws_appconfig_deployment" "test"{
+resource "aws_appconfig_deployment" "test" {
   application_id           = aws_appconfig_application.test.id
   configuration_profile_id = aws_appconfig_configuration_profile.test.configuration_profile_id
   configuration_version    = aws_appconfig_hosted_configuration_version.test.version_number

--- a/internal/service/appconfig/testdata/Deployment/tags_defaults/main_gen.tf
+++ b/internal/service/appconfig/testdata/Deployment/tags_defaults/main_gen.tf
@@ -7,7 +7,7 @@ provider "aws" {
   }
 }
 
-resource "aws_appconfig_deployment" "test"{
+resource "aws_appconfig_deployment" "test" {
   application_id           = aws_appconfig_application.test.id
   configuration_profile_id = aws_appconfig_configuration_profile.test.configuration_profile_id
   configuration_version    = aws_appconfig_hosted_configuration_version.test.version_number

--- a/internal/service/appconfig/testdata/Deployment/tags_ignore/main_gen.tf
+++ b/internal/service/appconfig/testdata/Deployment/tags_ignore/main_gen.tf
@@ -10,7 +10,7 @@ provider "aws" {
   }
 }
 
-resource "aws_appconfig_deployment" "test"{
+resource "aws_appconfig_deployment" "test" {
   application_id           = aws_appconfig_application.test.id
   configuration_profile_id = aws_appconfig_configuration_profile.test.configuration_profile_id
   configuration_version    = aws_appconfig_hosted_configuration_version.test.version_number

--- a/internal/service/appconfig/testdata/Environment/data.tags/main_gen.tf
+++ b/internal/service/appconfig/testdata/Environment/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_appconfig_environment" "test" {
   application_id = aws_appconfig_application.test.id
   environment_id = aws_appconfig_environment.test.environment_id

--- a/internal/service/appconfig/testdata/Extension/tags/main_gen.tf
+++ b/internal/service/appconfig/testdata/Extension/tags/main_gen.tf
@@ -16,7 +16,7 @@ resource "aws_appconfig_extension" "test" {
 }
 
 resource "aws_sns_topic" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 data "aws_iam_policy_document" "test" {

--- a/internal/service/appconfig/testdata/Extension/tagsComputed1/main_gen.tf
+++ b/internal/service/appconfig/testdata/Extension/tagsComputed1/main_gen.tf
@@ -20,7 +20,7 @@ resource "aws_appconfig_extension" "test" {
 }
 
 resource "aws_sns_topic" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 data "aws_iam_policy_document" "test" {

--- a/internal/service/appconfig/testdata/Extension/tagsComputed2/main_gen.tf
+++ b/internal/service/appconfig/testdata/Extension/tagsComputed2/main_gen.tf
@@ -21,7 +21,7 @@ resource "aws_appconfig_extension" "test" {
 }
 
 resource "aws_sns_topic" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 data "aws_iam_policy_document" "test" {

--- a/internal/service/appconfig/testdata/Extension/tags_defaults/main_gen.tf
+++ b/internal/service/appconfig/testdata/Extension/tags_defaults/main_gen.tf
@@ -22,7 +22,7 @@ resource "aws_appconfig_extension" "test" {
 }
 
 resource "aws_sns_topic" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 data "aws_iam_policy_document" "test" {

--- a/internal/service/appconfig/testdata/Extension/tags_ignore/main_gen.tf
+++ b/internal/service/appconfig/testdata/Extension/tags_ignore/main_gen.tf
@@ -25,7 +25,7 @@ resource "aws_appconfig_extension" "test" {
 }
 
 resource "aws_sns_topic" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 data "aws_iam_policy_document" "test" {

--- a/internal/service/appconfig/testdata/tmpl/deployment_tags.gtpl
+++ b/internal/service/appconfig/testdata/tmpl/deployment_tags.gtpl
@@ -1,4 +1,4 @@
-resource "aws_appconfig_deployment" "test"{
+resource "aws_appconfig_deployment" "test" {
   application_id           = aws_appconfig_application.test.id
   configuration_profile_id = aws_appconfig_configuration_profile.test.configuration_profile_id
   configuration_version    = aws_appconfig_hosted_configuration_version.test.version_number

--- a/internal/service/appconfig/testdata/tmpl/extension_tags.gtpl
+++ b/internal/service/appconfig/testdata/tmpl/extension_tags.gtpl
@@ -13,7 +13,7 @@ resource "aws_appconfig_extension" "test" {
 }
 
 resource "aws_sns_topic" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 data "aws_iam_policy_document" "test" {

--- a/internal/service/appintegrations/testdata/EventIntegration/data.tags/main_gen.tf
+++ b/internal/service/appintegrations/testdata/EventIntegration/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_appintegrations_event_integration" "test" {
   name = aws_appintegrations_event_integration.test.name
 }

--- a/internal/service/appmesh/testdata/GatewayRoute/data.tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/GatewayRoute/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_appmesh_gateway_route" "test" {
   name                 = aws_appmesh_gateway_route.test.name
   mesh_name            = aws_appmesh_gateway_route.test.mesh_name

--- a/internal/service/appmesh/testdata/Route/data.tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/Route/data.tags/main_gen.tf
@@ -57,7 +57,7 @@ resource "aws_appmesh_virtual_node" "test1" {
     listener {
       port_mapping {
         port     = 8080
-        protocol ="http"
+        protocol = "http"
       }
     }
 

--- a/internal/service/appmesh/testdata/Route/data.tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/Route/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_appmesh_route" "test" {
   name                = aws_appmesh_route.test.name
   mesh_name           = aws_appmesh_route.test.mesh_name

--- a/internal/service/appmesh/testdata/Route/tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/Route/tags/main_gen.tf
@@ -50,7 +50,7 @@ resource "aws_appmesh_virtual_node" "test1" {
     listener {
       port_mapping {
         port     = 8080
-        protocol ="http"
+        protocol = "http"
       }
     }
 

--- a/internal/service/appmesh/testdata/Route/tagsComputed1/main_gen.tf
+++ b/internal/service/appmesh/testdata/Route/tagsComputed1/main_gen.tf
@@ -54,7 +54,7 @@ resource "aws_appmesh_virtual_node" "test1" {
     listener {
       port_mapping {
         port     = 8080
-        protocol ="http"
+        protocol = "http"
       }
     }
 

--- a/internal/service/appmesh/testdata/Route/tagsComputed2/main_gen.tf
+++ b/internal/service/appmesh/testdata/Route/tagsComputed2/main_gen.tf
@@ -55,7 +55,7 @@ resource "aws_appmesh_virtual_node" "test1" {
     listener {
       port_mapping {
         port     = 8080
-        protocol ="http"
+        protocol = "http"
       }
     }
 

--- a/internal/service/appmesh/testdata/Route/tags_defaults/main_gen.tf
+++ b/internal/service/appmesh/testdata/Route/tags_defaults/main_gen.tf
@@ -56,7 +56,7 @@ resource "aws_appmesh_virtual_node" "test1" {
     listener {
       port_mapping {
         port     = 8080
-        protocol ="http"
+        protocol = "http"
       }
     }
 

--- a/internal/service/appmesh/testdata/Route/tags_ignore/main_gen.tf
+++ b/internal/service/appmesh/testdata/Route/tags_ignore/main_gen.tf
@@ -59,7 +59,7 @@ resource "aws_appmesh_virtual_node" "test1" {
     listener {
       port_mapping {
         port     = 8080
-        protocol ="http"
+        protocol = "http"
       }
     }
 

--- a/internal/service/appmesh/testdata/ServiceMesh/data.tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/ServiceMesh/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_appmesh_mesh" "test" {
   name = aws_appmesh_mesh.test.name
 }

--- a/internal/service/appmesh/testdata/VirtualGateway/data.tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/VirtualGateway/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_appmesh_virtual_gateway" "test" {
   name      = aws_appmesh_virtual_gateway.test.name
   mesh_name = aws_appmesh_mesh.test.name

--- a/internal/service/appmesh/testdata/VirtualNode/data.tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/VirtualNode/data.tags/main_gen.tf
@@ -17,7 +17,7 @@ resource "aws_appmesh_virtual_node" "test" {
 }
 
 resource "aws_appmesh_mesh" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 variable "rName" {

--- a/internal/service/appmesh/testdata/VirtualNode/data.tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/VirtualNode/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_appmesh_virtual_node" "test" {
   name      = aws_appmesh_virtual_node.test.name
   mesh_name = aws_appmesh_mesh.test.name

--- a/internal/service/appmesh/testdata/VirtualNode/tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/VirtualNode/tags/main_gen.tf
@@ -11,7 +11,7 @@ resource "aws_appmesh_virtual_node" "test" {
 }
 
 resource "aws_appmesh_mesh" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 variable "rName" {

--- a/internal/service/appmesh/testdata/VirtualNode/tagsComputed1/main_gen.tf
+++ b/internal/service/appmesh/testdata/VirtualNode/tagsComputed1/main_gen.tf
@@ -15,7 +15,7 @@ resource "aws_appmesh_virtual_node" "test" {
 }
 
 resource "aws_appmesh_mesh" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 resource "null_resource" "test" {}

--- a/internal/service/appmesh/testdata/VirtualNode/tagsComputed2/main_gen.tf
+++ b/internal/service/appmesh/testdata/VirtualNode/tagsComputed2/main_gen.tf
@@ -16,7 +16,7 @@ resource "aws_appmesh_virtual_node" "test" {
 }
 
 resource "aws_appmesh_mesh" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 resource "null_resource" "test" {}

--- a/internal/service/appmesh/testdata/VirtualNode/tags_defaults/main_gen.tf
+++ b/internal/service/appmesh/testdata/VirtualNode/tags_defaults/main_gen.tf
@@ -17,7 +17,7 @@ resource "aws_appmesh_virtual_node" "test" {
 }
 
 resource "aws_appmesh_mesh" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 variable "rName" {

--- a/internal/service/appmesh/testdata/VirtualNode/tags_ignore/main_gen.tf
+++ b/internal/service/appmesh/testdata/VirtualNode/tags_ignore/main_gen.tf
@@ -20,7 +20,7 @@ resource "aws_appmesh_virtual_node" "test" {
 }
 
 resource "aws_appmesh_mesh" "test" {
-  name =var.rName
+  name = var.rName
 }
 
 variable "rName" {

--- a/internal/service/appmesh/testdata/VirtualRouter/data.tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/VirtualRouter/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_appmesh_virtual_router" "test" {
   name      = aws_appmesh_virtual_router.test.name
   mesh_name = aws_appmesh_mesh.test.name

--- a/internal/service/appmesh/testdata/VirtualService/data.tags/main_gen.tf
+++ b/internal/service/appmesh/testdata/VirtualService/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_appmesh_virtual_service" "test" {
   name      = aws_appmesh_virtual_service.test.name
   mesh_name = aws_appmesh_mesh.test.name

--- a/internal/service/appmesh/testdata/tmpl/route_tags.gtpl
+++ b/internal/service/appmesh/testdata/tmpl/route_tags.gtpl
@@ -47,7 +47,7 @@ resource "aws_appmesh_virtual_node" "test1" {
     listener {
       port_mapping {
         port     = 8080
-        protocol ="http"
+        protocol = "http"
       }
     }
 

--- a/internal/service/appmesh/testdata/tmpl/virtual_node_tags.gtpl
+++ b/internal/service/appmesh/testdata/tmpl/virtual_node_tags.gtpl
@@ -8,5 +8,5 @@ resource "aws_appmesh_virtual_node" "test" {
 }
 
 resource "aws_appmesh_mesh" "test" {
-  name =var.rName
+  name = var.rName
 }

--- a/internal/service/appsync/datasource_test.go
+++ b/internal/service/appsync/datasource_test.go
@@ -846,7 +846,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.test"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/backup/vault_policy_test.go
+++ b/internal/service/backup/vault_policy_test.go
@@ -362,7 +362,7 @@ resource "aws_backup_vault_policy" "test" {
       Sid    = "default"
       Effect = "Allow"
       Principal = {
-        AWS = "${aws_iam_role.test.arn}"
+        AWS = aws_iam_role.test.arn
       }
       Action = [
         "backup:DescribeBackupVault",

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -1267,7 +1267,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   environment {
     variables = {

--- a/internal/service/batch/testdata/ComputeEnvironment/data.tags/main_gen.tf
+++ b/internal/service/batch/testdata/ComputeEnvironment/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_batch_compute_environment" "test" {
   compute_environment_name = aws_batch_compute_environment.test.compute_environment_name
 }

--- a/internal/service/batch/testdata/JobDefinition/data.tags/main_gen.tf
+++ b/internal/service/batch/testdata/JobDefinition/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_batch_job_definition" "test" {
   arn = aws_batch_job_definition.test.arn
 }

--- a/internal/service/batch/testdata/JobQueue/data.tags/main_gen.tf
+++ b/internal/service/batch/testdata/JobQueue/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_batch_job_queue" "test" {
   name = aws_batch_job_queue.test.name
 }

--- a/internal/service/batch/testdata/SchedulingPolicy/data.tags/main_gen.tf
+++ b/internal/service/batch/testdata/SchedulingPolicy/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_batch_scheduling_policy" "test" {
   arn = aws_batch_scheduling_policy.test.arn
 }

--- a/internal/service/bedrock/custom_model_test.go
+++ b/internal/service/bedrock/custom_model_test.go
@@ -426,9 +426,9 @@ resource "aws_iam_policy" "training" {
         "s3:ListBucket"
       ],
       "Resource" : [
-        "${aws_s3_bucket.training.arn}",
+        aws_s3_bucket.training.arn,
         "${aws_s3_bucket.training.arn}/*",
-        "${aws_s3_bucket.validation.arn}",
+        aws_s3_bucket.validation.arn,
         "${aws_s3_bucket.validation.arn}/*"
       ]
     }]
@@ -448,7 +448,7 @@ resource "aws_iam_policy" "output" {
         "s3:ListBucket"
       ],
       "Resource" : [
-        "${aws_s3_bucket.output.arn}",
+        aws_s3_bucket.output.arn,
         "${aws_s3_bucket.output.arn}/*"
       ]
     }]

--- a/internal/service/chimesdkvoice/sip_media_application_test.go
+++ b/internal/service/chimesdkvoice/sip_media_application_test.go
@@ -262,7 +262,7 @@ resource "aws_lambda_function" "test" {
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   handler          = "index.handler"
 }
 `, rName)

--- a/internal/service/chimesdkvoice/sip_rule_test.go
+++ b/internal/service/chimesdkvoice/sip_rule_test.go
@@ -216,7 +216,7 @@ resource "aws_lambda_function" "test" {
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   handler          = "index.handler"
 }
 

--- a/internal/service/cloudtrail/trail_test.go
+++ b/internal/service/cloudtrail/trail_test.go
@@ -1337,7 +1337,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName))
 }

--- a/internal/service/cognitoidp/testdata/UserPool/data.tags/main_gen.tf
+++ b/internal/service/cognitoidp/testdata/UserPool/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_cognito_user_pool" "test" {
   user_pool_id = aws_cognito_user_pool.test.id
 }

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -2399,7 +2399,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_kms_key" "test" {
@@ -2455,7 +2455,7 @@ resource "aws_lambda_function" "second" {
   function_name = "%[1]s_second"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -2501,7 +2501,7 @@ resource "aws_lambda_function" "second" {
   function_name = "%[1]s_second"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -2555,7 +2555,7 @@ resource "aws_lambda_function" "second" {
   function_name = "%[1]s_second"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_cognito_user_pool" "test" {
@@ -2611,7 +2611,7 @@ resource "aws_lambda_function" "second" {
   function_name = "%[1]s_second"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_cognito_user_pool" "test" {

--- a/internal/service/configservice/organization_custom_rule_test.go
+++ b/internal/service/configservice/organization_custom_rule_test.go
@@ -572,7 +572,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_lambda_permission" "test" {
@@ -637,7 +637,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_organizations_organization" "test" {
@@ -716,7 +716,7 @@ resource "aws_lambda_function" "test2" {
   function_name = "%[1]s2"
   role          = aws_iam_role.lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_lambda_permission" "test2" {

--- a/internal/service/datazone/glossary_term_test.go
+++ b/internal/service/datazone/glossary_term_test.go
@@ -278,8 +278,8 @@ resource "aws_datazone_glossary_term" "test" {
   short_description   = "short_desc"
   status              = "ENABLED"
   term_relations {
-    classifies = ["${aws_datazone_glossary_term.second.id}"]
-    is_a       = ["${aws_datazone_glossary_term.second.id}"]
+    classifies = [aws_datazone_glossary_term.second.id]
+    is_a       = [aws_datazone_glossary_term.second.id]
   }
 }
 `, rName, gName))

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -45,6 +45,7 @@ import (
 // @Tags(identifierAttribute="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/ec2/types;awstypes;awstypes.Instance")
 // @Testing(importIgnore="user_data_replace_on_change")
+// @Testing(generator=false)
 func resourceInstance() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{

--- a/internal/service/ec2/ec2_instance_data_source.go
+++ b/internal/service/ec2/ec2_instance_data_source.go
@@ -27,6 +27,7 @@ import (
 
 // @SDKDataSource("aws_instance", name="Instance")
 // @Tags
+// @Testing(generator=false)
 func dataSourceInstance() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceInstanceRead,

--- a/internal/service/ec2/ec2_instance_data_source_tags_gen_test.go
+++ b/internal/service/ec2/ec2_instance_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,7 +17,6 @@ import (
 func TestAccEC2InstanceDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -28,7 +26,6 @@ func TestAccEC2InstanceDataSource_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -46,7 +43,6 @@ func TestAccEC2InstanceDataSource_tags(t *testing.T) {
 func TestAccEC2InstanceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -56,7 +52,6 @@ func TestAccEC2InstanceDataSource_tags_NullMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -70,7 +65,6 @@ func TestAccEC2InstanceDataSource_tags_NullMap(t *testing.T) {
 func TestAccEC2InstanceDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -80,7 +74,6 @@ func TestAccEC2InstanceDataSource_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{

--- a/internal/service/ec2/ec2_instance_tags_gen_test.go
+++ b/internal/service/ec2/ec2_instance_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,7 +20,6 @@ func TestAccEC2Instance_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -32,7 +30,6 @@ func TestAccEC2Instance_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -63,7 +60,6 @@ func TestAccEC2Instance_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -78,7 +74,6 @@ func TestAccEC2Instance_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -114,7 +109,6 @@ func TestAccEC2Instance_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -130,7 +124,6 @@ func TestAccEC2Instance_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -161,7 +154,6 @@ func TestAccEC2Instance_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -176,7 +168,6 @@ func TestAccEC2Instance_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -197,7 +188,6 @@ func TestAccEC2Instance_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -215,7 +205,6 @@ func TestAccEC2Instance_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -226,7 +215,6 @@ func TestAccEC2Instance_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -250,7 +238,6 @@ func TestAccEC2Instance_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -265,7 +252,6 @@ func TestAccEC2Instance_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				PlanOnly:           true,
@@ -279,7 +265,6 @@ func TestAccEC2Instance_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -290,7 +275,6 @@ func TestAccEC2Instance_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -312,7 +296,6 @@ func TestAccEC2Instance_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ResourceName:      resourceName,
@@ -325,7 +308,6 @@ func TestAccEC2Instance_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				PlanOnly:           true,
@@ -339,7 +321,6 @@ func TestAccEC2Instance_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -350,7 +331,6 @@ func TestAccEC2Instance_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -372,7 +352,6 @@ func TestAccEC2Instance_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -403,7 +382,6 @@ func TestAccEC2Instance_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -423,7 +401,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -434,7 +411,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -464,7 +440,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -479,7 +454,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -500,7 +474,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -518,7 +491,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -529,7 +501,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -560,7 +531,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -594,7 +564,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -610,7 +579,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -641,7 +609,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -661,7 +628,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -672,7 +638,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -703,7 +668,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -733,7 +697,6 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -753,7 +716,6 @@ func TestAccEC2Instance_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -764,7 +726,6 @@ func TestAccEC2Instance_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -793,7 +754,6 @@ func TestAccEC2Instance_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -810,7 +770,6 @@ func TestAccEC2Instance_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -842,7 +801,6 @@ func TestAccEC2Instance_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -860,7 +818,6 @@ func TestAccEC2Instance_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -889,7 +846,6 @@ func TestAccEC2Instance_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -906,7 +862,6 @@ func TestAccEC2Instance_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -928,7 +883,6 @@ func TestAccEC2Instance_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -946,7 +900,6 @@ func TestAccEC2Instance_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -957,7 +910,6 @@ func TestAccEC2Instance_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -994,7 +946,6 @@ func TestAccEC2Instance_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1013,7 +964,6 @@ func TestAccEC2Instance_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable("providervalue1updated"),
 					}),
@@ -1055,7 +1005,6 @@ func TestAccEC2Instance_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable("providervalue1updated"),
 					}),
@@ -1075,7 +1024,6 @@ func TestAccEC2Instance_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1097,7 +1045,6 @@ func TestAccEC2Instance_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -1115,7 +1062,6 @@ func TestAccEC2Instance_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1126,7 +1072,6 @@ func TestAccEC2Instance_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1161,7 +1106,6 @@ func TestAccEC2Instance_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1180,7 +1124,6 @@ func TestAccEC2Instance_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1221,7 +1164,6 @@ func TestAccEC2Instance_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1242,7 +1184,6 @@ func TestAccEC2Instance_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1277,7 +1218,6 @@ func TestAccEC2Instance_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1300,7 +1240,6 @@ func TestAccEC2Instance_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1311,7 +1250,6 @@ func TestAccEC2Instance_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1343,7 +1281,6 @@ func TestAccEC2Instance_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1372,7 +1309,6 @@ func TestAccEC2Instance_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1393,7 +1329,6 @@ func TestAccEC2Instance_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1404,7 +1339,6 @@ func TestAccEC2Instance_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1433,7 +1367,6 @@ func TestAccEC2Instance_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1465,7 +1398,6 @@ func TestAccEC2Instance_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1485,7 +1417,6 @@ func TestAccEC2Instance_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1496,7 +1427,6 @@ func TestAccEC2Instance_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1530,7 +1460,6 @@ func TestAccEC2Instance_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1553,7 +1482,6 @@ func TestAccEC2Instance_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1564,7 +1492,6 @@ func TestAccEC2Instance_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1592,7 +1519,6 @@ func TestAccEC2Instance_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1613,7 +1539,6 @@ func TestAccEC2Instance_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1624,7 +1549,6 @@ func TestAccEC2Instance_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1655,7 +1579,6 @@ func TestAccEC2Instance_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1678,7 +1601,6 @@ func TestAccEC2Instance_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1689,7 +1611,6 @@ func TestAccEC2Instance_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1720,7 +1641,6 @@ func TestAccEC2Instance_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1743,7 +1663,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1754,7 +1673,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnCreate(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1783,7 +1701,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnCreate(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				ResourceName:      resourceName,
@@ -1801,7 +1718,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1812,7 +1728,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1844,7 +1759,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1881,7 +1795,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1901,7 +1814,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1912,7 +1824,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1944,7 +1855,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1973,7 +1883,6 @@ func TestAccEC2Instance_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Instance/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				ResourceName:      resourceName,

--- a/internal/service/ec2/testdata/Instance/data.tags/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/data.tags/main_gen.tf
@@ -34,12 +34,6 @@ data "aws_ami" "amzn2-ami-minimal-hvm-ebs-arm64" {
   }
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/Instance/data.tags/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_instance" "test" {
   instance_id = aws_instance.test.id
 }

--- a/internal/service/ec2/testdata/Instance/tags/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/tags/main_gen.tf
@@ -29,12 +29,6 @@ data "aws_ami" "amzn2-ami-minimal-hvm-ebs-arm64" {
   }
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/Instance/tagsComputed1/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/tagsComputed1/main_gen.tf
@@ -35,12 +35,6 @@ data "aws_ami" "amzn2-ami-minimal-hvm-ebs-arm64" {
 
 resource "null_resource" "test" {}
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "unknownTagKey" {
   type     = string
   nullable = false

--- a/internal/service/ec2/testdata/Instance/tagsComputed2/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/tagsComputed2/main_gen.tf
@@ -36,12 +36,6 @@ data "aws_ami" "amzn2-ami-minimal-hvm-ebs-arm64" {
 
 resource "null_resource" "test" {}
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "unknownTagKey" {
   type     = string
   nullable = false

--- a/internal/service/ec2/testdata/Instance/tags_defaults/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/tags_defaults/main_gen.tf
@@ -35,12 +35,6 @@ data "aws_ami" "amzn2-ami-minimal-hvm-ebs-arm64" {
   }
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/Instance/tags_ignore/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/tags_ignore/main_gen.tf
@@ -38,12 +38,6 @@ data "aws_ami" "amzn2-ami-minimal-hvm-ebs-arm64" {
   }
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/RouteTable/data.tags/main_gen.tf
+++ b/internal/service/ec2/testdata/RouteTable/data.tags/main_gen.tf
@@ -16,12 +16,6 @@ resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/RouteTable/data.tags/main_gen.tf
+++ b/internal/service/ec2/testdata/RouteTable/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_route_table" "test" {
   route_table_id = aws_route_table.test.id
 }

--- a/internal/service/ec2/testdata/SecurityGroup/data.tags/main_gen.tf
+++ b/internal/service/ec2/testdata/SecurityGroup/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_security_group" "test" {
   id = aws_security_group.test.id
 }

--- a/internal/service/ec2/testdata/Subnet/tags/main_gen.tf
+++ b/internal/service/ec2/testdata/Subnet/tags/main_gen.tf
@@ -12,12 +12,6 @@ resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/Subnet/tagsComputed1/main_gen.tf
+++ b/internal/service/ec2/testdata/Subnet/tagsComputed1/main_gen.tf
@@ -18,12 +18,6 @@ resource "aws_vpc" "test" {
 
 resource "null_resource" "test" {}
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "unknownTagKey" {
   type     = string
   nullable = false

--- a/internal/service/ec2/testdata/Subnet/tagsComputed2/main_gen.tf
+++ b/internal/service/ec2/testdata/Subnet/tagsComputed2/main_gen.tf
@@ -19,12 +19,6 @@ resource "aws_vpc" "test" {
 
 resource "null_resource" "test" {}
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "unknownTagKey" {
   type     = string
   nullable = false

--- a/internal/service/ec2/testdata/Subnet/tags_defaults/main_gen.tf
+++ b/internal/service/ec2/testdata/Subnet/tags_defaults/main_gen.tf
@@ -18,12 +18,6 @@ resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/Subnet/tags_ignore/main_gen.tf
+++ b/internal/service/ec2/testdata/Subnet/tags_ignore/main_gen.tf
@@ -21,12 +21,6 @@ resource "aws_vpc" "test" {
   cidr_block = "10.1.0.0/16"
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/VPC/data.tags/main_gen.tf
+++ b/internal/service/ec2/testdata/VPC/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_vpc" "test" {
   id = aws_vpc.test.id
 }

--- a/internal/service/ec2/testdata/VPC/data.tags/main_gen.tf
+++ b/internal/service/ec2/testdata/VPC/data.tags/main_gen.tf
@@ -12,12 +12,6 @@ resource "aws_vpc" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/VPC/tags/main_gen.tf
+++ b/internal/service/ec2/testdata/VPC/tags/main_gen.tf
@@ -7,12 +7,6 @@ resource "aws_vpc" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/VPC/tagsComputed1/main_gen.tf
+++ b/internal/service/ec2/testdata/VPC/tagsComputed1/main_gen.tf
@@ -13,12 +13,6 @@ resource "aws_vpc" "test" {
 
 resource "null_resource" "test" {}
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "unknownTagKey" {
   type     = string
   nullable = false

--- a/internal/service/ec2/testdata/VPC/tagsComputed2/main_gen.tf
+++ b/internal/service/ec2/testdata/VPC/tagsComputed2/main_gen.tf
@@ -14,12 +14,6 @@ resource "aws_vpc" "test" {
 
 resource "null_resource" "test" {}
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "unknownTagKey" {
   type     = string
   nullable = false

--- a/internal/service/ec2/testdata/VPC/tags_defaults/main_gen.tf
+++ b/internal/service/ec2/testdata/VPC/tags_defaults/main_gen.tf
@@ -13,12 +13,6 @@ resource "aws_vpc" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/testdata/VPC/tags_ignore/main_gen.tf
+++ b/internal/service/ec2/testdata/VPC/tags_ignore/main_gen.tf
@@ -16,12 +16,6 @@ resource "aws_vpc" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -52,6 +52,7 @@ var (
 // @SDKResource("aws_vpc", name="VPC")
 // @Tags(identifierAttribute="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/ec2/types;awstypes;awstypes.Vpc")
+// @Testing(generator=false)
 func resourceVPC() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{

--- a/internal/service/ec2/vpc_data_source.go
+++ b/internal/service/ec2/vpc_data_source.go
@@ -23,6 +23,7 @@ import (
 
 // @SDKDataSource("aws_vpc", name="VPC")
 // @Tags
+// @Testing(generator=false)
 func dataSourceVPC() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceVPCRead,

--- a/internal/service/ec2/vpc_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,7 +17,6 @@ import (
 func TestAccVPCVPCDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -28,7 +26,6 @@ func TestAccVPCVPCDataSource_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -46,7 +43,6 @@ func TestAccVPCVPCDataSource_tags(t *testing.T) {
 func TestAccVPCVPCDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -56,7 +52,6 @@ func TestAccVPCVPCDataSource_tags_NullMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -70,7 +65,6 @@ func TestAccVPCVPCDataSource_tags_NullMap(t *testing.T) {
 func TestAccVPCVPCDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -80,7 +74,6 @@ func TestAccVPCVPCDataSource_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{

--- a/internal/service/ec2/vpc_route_table_data_source.go
+++ b/internal/service/ec2/vpc_route_table_data_source.go
@@ -24,6 +24,7 @@ import (
 
 // @SDKDataSource("aws_route_table", name="Route Table")
 // @Testing(tagsTest=true)
+// @Testing(generator=false)
 func dataSourceRouteTable() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceRouteTableRead,

--- a/internal/service/ec2/vpc_route_table_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_route_table_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,7 +17,6 @@ import (
 func TestAccVPCRouteTableDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_route_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -28,7 +26,6 @@ func TestAccVPCRouteTableDataSource_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/RouteTable/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -46,7 +43,6 @@ func TestAccVPCRouteTableDataSource_tags(t *testing.T) {
 func TestAccVPCRouteTableDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_route_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -56,7 +52,6 @@ func TestAccVPCRouteTableDataSource_tags_NullMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/RouteTable/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -70,7 +65,6 @@ func TestAccVPCRouteTableDataSource_tags_NullMap(t *testing.T) {
 func TestAccVPCRouteTableDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_route_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -80,7 +74,6 @@ func TestAccVPCRouteTableDataSource_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/RouteTable/data.tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ConfigStateChecks: []statecheck.StateCheck{

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -30,6 +30,7 @@ import (
 // @SDKResource("aws_subnet", name="Subnet")
 // @Tags(identifierAttribute="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/ec2/types;types.Subnet")
+// @Testing(generator=false)
 func resourceSubnet() *schema.Resource {
 	//lintignore:R011
 	return &schema.Resource{

--- a/internal/service/ec2/vpc_subnet_tags_gen_test.go
+++ b/internal/service/ec2/vpc_subnet_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,7 +20,6 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -32,7 +30,6 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -63,7 +60,6 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -75,7 +71,6 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -111,7 +106,6 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -124,7 +118,6 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -155,7 +148,6 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -167,7 +159,6 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -188,7 +179,6 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -203,7 +193,6 @@ func TestAccVPCSubnet_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -214,7 +203,6 @@ func TestAccVPCSubnet_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -238,7 +226,6 @@ func TestAccVPCSubnet_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -250,7 +237,6 @@ func TestAccVPCSubnet_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				PlanOnly:           true,
@@ -264,7 +250,6 @@ func TestAccVPCSubnet_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -275,7 +260,6 @@ func TestAccVPCSubnet_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -297,7 +281,6 @@ func TestAccVPCSubnet_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ResourceName:      resourceName,
@@ -307,7 +290,6 @@ func TestAccVPCSubnet_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				PlanOnly:           true,
@@ -321,7 +303,6 @@ func TestAccVPCSubnet_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -332,7 +313,6 @@ func TestAccVPCSubnet_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -354,7 +334,6 @@ func TestAccVPCSubnet_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -385,7 +364,6 @@ func TestAccVPCSubnet_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -402,7 +380,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -413,7 +390,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -443,7 +419,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -455,7 +430,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -476,7 +450,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -491,7 +464,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -502,7 +474,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -533,7 +504,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -567,7 +537,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -580,7 +549,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -611,7 +579,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -628,7 +595,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -639,7 +605,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -670,7 +635,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -700,7 +664,6 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -717,7 +680,6 @@ func TestAccVPCSubnet_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -728,7 +690,6 @@ func TestAccVPCSubnet_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -757,7 +718,6 @@ func TestAccVPCSubnet_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -771,7 +731,6 @@ func TestAccVPCSubnet_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -803,7 +762,6 @@ func TestAccVPCSubnet_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -818,7 +776,6 @@ func TestAccVPCSubnet_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -847,7 +804,6 @@ func TestAccVPCSubnet_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -861,7 +817,6 @@ func TestAccVPCSubnet_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -883,7 +838,6 @@ func TestAccVPCSubnet_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -898,7 +852,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -909,7 +862,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -946,7 +898,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -962,7 +913,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable("providervalue1updated"),
 					}),
@@ -1004,7 +954,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable("providervalue1updated"),
 					}),
@@ -1021,7 +970,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1043,7 +991,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -1058,7 +1005,6 @@ func TestAccVPCSubnet_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1069,7 +1015,6 @@ func TestAccVPCSubnet_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1104,7 +1049,6 @@ func TestAccVPCSubnet_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1120,7 +1064,6 @@ func TestAccVPCSubnet_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1161,7 +1104,6 @@ func TestAccVPCSubnet_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1179,7 +1121,6 @@ func TestAccVPCSubnet_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1214,7 +1155,6 @@ func TestAccVPCSubnet_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1234,7 +1174,6 @@ func TestAccVPCSubnet_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1245,7 +1184,6 @@ func TestAccVPCSubnet_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1277,7 +1215,6 @@ func TestAccVPCSubnet_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1306,7 +1243,6 @@ func TestAccVPCSubnet_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1324,7 +1260,6 @@ func TestAccVPCSubnet_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1335,7 +1270,6 @@ func TestAccVPCSubnet_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1364,7 +1298,6 @@ func TestAccVPCSubnet_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1396,7 +1329,6 @@ func TestAccVPCSubnet_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1413,7 +1345,6 @@ func TestAccVPCSubnet_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1424,7 +1355,6 @@ func TestAccVPCSubnet_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1458,7 +1388,6 @@ func TestAccVPCSubnet_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1478,7 +1407,6 @@ func TestAccVPCSubnet_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1489,7 +1417,6 @@ func TestAccVPCSubnet_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1517,7 +1444,6 @@ func TestAccVPCSubnet_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1535,7 +1461,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1546,7 +1471,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1577,7 +1501,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1597,7 +1520,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1608,7 +1530,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1639,7 +1560,6 @@ func TestAccVPCSubnet_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1659,7 +1579,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1670,7 +1589,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnCreate(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1699,7 +1617,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnCreate(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				ResourceName:      resourceName,
@@ -1714,7 +1631,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1725,7 +1641,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1757,7 +1672,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1794,7 +1708,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1811,7 +1724,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1822,7 +1734,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1854,7 +1765,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1883,7 +1793,6 @@ func TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/Subnet/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				ResourceName:      resourceName,

--- a/internal/service/ec2/vpc_tags_gen_test.go
+++ b/internal/service/ec2/vpc_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,7 +20,6 @@ func TestAccVPCVPC_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -32,7 +30,6 @@ func TestAccVPCVPC_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -63,7 +60,6 @@ func TestAccVPCVPC_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -75,7 +71,6 @@ func TestAccVPCVPC_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -111,7 +106,6 @@ func TestAccVPCVPC_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -124,7 +118,6 @@ func TestAccVPCVPC_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -155,7 +148,6 @@ func TestAccVPCVPC_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -167,7 +159,6 @@ func TestAccVPCVPC_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -188,7 +179,6 @@ func TestAccVPCVPC_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -203,7 +193,6 @@ func TestAccVPCVPC_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -214,7 +203,6 @@ func TestAccVPCVPC_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -238,7 +226,6 @@ func TestAccVPCVPC_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -250,7 +237,6 @@ func TestAccVPCVPC_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				PlanOnly:           true,
@@ -264,7 +250,6 @@ func TestAccVPCVPC_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -275,7 +260,6 @@ func TestAccVPCVPC_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -297,7 +281,6 @@ func TestAccVPCVPC_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ResourceName:      resourceName,
@@ -307,7 +290,6 @@ func TestAccVPCVPC_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				PlanOnly:           true,
@@ -321,7 +303,6 @@ func TestAccVPCVPC_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -332,7 +313,6 @@ func TestAccVPCVPC_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -354,7 +334,6 @@ func TestAccVPCVPC_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -385,7 +364,6 @@ func TestAccVPCVPC_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -402,7 +380,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -413,7 +390,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -443,7 +419,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -455,7 +430,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -476,7 +450,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -491,7 +464,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -502,7 +474,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -533,7 +504,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -567,7 +537,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -580,7 +549,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -611,7 +579,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -628,7 +595,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -639,7 +605,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -670,7 +635,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -700,7 +664,6 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -717,7 +680,6 @@ func TestAccVPCVPC_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -728,7 +690,6 @@ func TestAccVPCVPC_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -757,7 +718,6 @@ func TestAccVPCVPC_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -771,7 +731,6 @@ func TestAccVPCVPC_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -803,7 +762,6 @@ func TestAccVPCVPC_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -818,7 +776,6 @@ func TestAccVPCVPC_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -847,7 +804,6 @@ func TestAccVPCVPC_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -861,7 +817,6 @@ func TestAccVPCVPC_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -883,7 +838,6 @@ func TestAccVPCVPC_tags_DefaultTags_providerOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -898,7 +852,6 @@ func TestAccVPCVPC_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -909,7 +862,6 @@ func TestAccVPCVPC_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -946,7 +898,6 @@ func TestAccVPCVPC_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -962,7 +913,6 @@ func TestAccVPCVPC_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable("providervalue1updated"),
 					}),
@@ -1004,7 +954,6 @@ func TestAccVPCVPC_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable("providervalue1updated"),
 					}),
@@ -1021,7 +970,6 @@ func TestAccVPCVPC_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1043,7 +991,6 @@ func TestAccVPCVPC_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -1058,7 +1005,6 @@ func TestAccVPCVPC_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1069,7 +1015,6 @@ func TestAccVPCVPC_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1104,7 +1049,6 @@ func TestAccVPCVPC_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1120,7 +1064,6 @@ func TestAccVPCVPC_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1161,7 +1104,6 @@ func TestAccVPCVPC_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1179,7 +1121,6 @@ func TestAccVPCVPC_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1214,7 +1155,6 @@ func TestAccVPCVPC_tags_DefaultTags_overlapping(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1234,7 +1174,6 @@ func TestAccVPCVPC_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1245,7 +1184,6 @@ func TestAccVPCVPC_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1277,7 +1215,6 @@ func TestAccVPCVPC_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1306,7 +1243,6 @@ func TestAccVPCVPC_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1324,7 +1260,6 @@ func TestAccVPCVPC_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1335,7 +1270,6 @@ func TestAccVPCVPC_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1364,7 +1298,6 @@ func TestAccVPCVPC_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1396,7 +1329,6 @@ func TestAccVPCVPC_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1413,7 +1345,6 @@ func TestAccVPCVPC_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1424,7 +1355,6 @@ func TestAccVPCVPC_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1458,7 +1388,6 @@ func TestAccVPCVPC_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1478,7 +1407,6 @@ func TestAccVPCVPC_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1489,7 +1417,6 @@ func TestAccVPCVPC_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1517,7 +1444,6 @@ func TestAccVPCVPC_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1535,7 +1461,6 @@ func TestAccVPCVPC_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1546,7 +1471,6 @@ func TestAccVPCVPC_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1577,7 +1501,6 @@ func TestAccVPCVPC_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1597,7 +1520,6 @@ func TestAccVPCVPC_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1608,7 +1530,6 @@ func TestAccVPCVPC_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1639,7 +1560,6 @@ func TestAccVPCVPC_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1659,7 +1579,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1670,7 +1589,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnCreate(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1699,7 +1617,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnCreate(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				ResourceName:      resourceName,
@@ -1714,7 +1631,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1725,7 +1641,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1757,7 +1672,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1794,7 +1708,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1811,7 +1724,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1822,7 +1734,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1854,7 +1765,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1883,7 +1793,6 @@ func TestAccVPCVPC_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/VPC/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				ResourceName:      resourceName,

--- a/internal/service/elbv2/testdata/Listener/data.tags/main_gen.tf
+++ b/internal/service/elbv2/testdata/Listener/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_lb_listener" "test" {
   arn = aws_lb_listener.test.arn
 }

--- a/internal/service/elbv2/testdata/LoadBalancer/data.tags/main_gen.tf
+++ b/internal/service/elbv2/testdata/LoadBalancer/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_lb" "test" {
   arn = aws_lb.test.arn
 }

--- a/internal/service/elbv2/testdata/TargetGroup/data.tags/main_gen.tf
+++ b/internal/service/elbv2/testdata/TargetGroup/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_lb_target_group" "test" {
   arn = aws_lb_target_group.test.arn
 }

--- a/internal/service/events/target_test.go
+++ b/internal/service/events/target_test.go
@@ -2574,7 +2574,7 @@ resource "aws_lambda_function" "test" {
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   role             = aws_iam_role.test.arn
   handler          = "exports.example"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -2687,7 +2687,7 @@ resource "aws_lambda_function" "lambda_function_test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName)
 }

--- a/internal/service/guardduty/malware_protection_plan_test.go
+++ b/internal/service/guardduty/malware_protection_plan_test.go
@@ -491,10 +491,10 @@ data "aws_iam_policy_document" "test" {
   statement {
     sid = "AllowPostScanTag"
     actions = [
-      // Customer bucket is versioned
+      # Customer bucket is versioned
       "s3:PutObjectTagging",
       "s3:GetObjectTagging",
-      // Customer bucket is not versioned
+      # Customer bucket is not versioned
       "s3:PutObjectVersionTagging",
       "s3:GetObjectVersionTagging"
     ]
@@ -541,9 +541,9 @@ data "aws_iam_policy_document" "test" {
   statement {
     sid = "AllowMalwareScan"
     actions = [
-      // Customer bucket is versioned
+      # Customer bucket is versioned
       "s3:GetObject",
-      // Customer bucket is not versioned
+      # Customer bucket is not versioned
       "s3:GetObjectVersion"
     ]
     effect = "Allow"
@@ -687,10 +687,10 @@ data "aws_iam_policy_document" "test2" {
   statement {
     sid = "AllowPostScanTag"
     actions = [
-      // Customer bucket is versioned
+      # Customer bucket is versioned
       "s3:PutObjectTagging",
       "s3:GetObjectTagging",
-      // Customer bucket is not versioned
+      # Customer bucket is not versioned
       "s3:PutObjectVersionTagging",
       "s3:GetObjectVersionTagging"
     ]
@@ -737,9 +737,9 @@ data "aws_iam_policy_document" "test2" {
   statement {
     sid = "AllowMalwareScan"
     actions = [
-      // Customer bucket is versioned
+      # Customer bucket is versioned
       "s3:GetObject",
-      // Customer bucket is not versioned
+      # Customer bucket is not versioned
       "s3:GetObjectVersion"
     ]
     effect = "Allow"

--- a/internal/service/iam/testdata/OIDCProvider/data.tags/main_gen.tf
+++ b/internal/service/iam/testdata/OIDCProvider/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_iam_openid_connect_provider" "test" {
   arn = aws_iam_openid_connect_provider.test.arn
 }

--- a/internal/service/iam/testdata/Policy/data.tags/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_iam_policy" "test" {
   name = aws_iam_policy.test.name
 }

--- a/internal/service/iam/testdata/Role/data.tags/main_gen.tf
+++ b/internal/service/iam/testdata/Role/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_iam_role" "test" {
   name = aws_iam_role.test.name
 }

--- a/internal/service/iam/testdata/User/data.tags/main_gen.tf
+++ b/internal/service/iam/testdata/User/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_iam_user" "test" {
   user_name = aws_iam_user.test.name
 }

--- a/internal/service/ivschat/room_test.go
+++ b/internal/service/ivschat/room_test.go
@@ -386,7 +386,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   handler          = "index.handler"
 }
 

--- a/internal/service/kafka/replicator_test.go
+++ b/internal/service/kafka/replicator_test.go
@@ -369,7 +369,7 @@ resource "aws_iam_role" "source" {
         "Action" : "sts:AssumeRole",
         "Condition" : {
           "StringEquals" : {
-            "aws:SourceAccount" : "${data.aws_caller_identity.current.account_id}"
+            "aws:SourceAccount" : data.aws_caller_identity.current.account_id
           }
         }
       }

--- a/internal/service/kendra/data_source_test.go
+++ b/internal/service/kendra/data_source_test.go
@@ -2088,7 +2088,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[3]q
   role          = aws_iam_role.test_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_iam_role" "test_extraction_hook" {
@@ -3358,7 +3358,7 @@ resource "aws_lambda_function" "test2" {
   function_name = %[1]q
   role          = aws_iam_role.test_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_kendra_data_source" "test" {

--- a/internal/service/kinesisanalytics/application_test.go
+++ b/internal/service/kinesisanalytics/application_test.go
@@ -2052,7 +2052,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s_${count.index}"
   handler       = "exports.example"
   role          = aws_iam_role.test[0].arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {

--- a/internal/service/kinesisanalyticsv2/application_test.go
+++ b/internal/service/kinesisanalyticsv2/application_test.go
@@ -4433,7 +4433,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s_${count.index}"
   handler       = "exports.example"
   role          = aws_iam_role.test[0].arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {

--- a/internal/service/lambda/alias_data_source_test.go
+++ b/internal/service/lambda/alias_data_source_test.go
@@ -100,7 +100,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = true
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_lambda_alias" "test" {

--- a/internal/service/lambda/alias_test.go
+++ b/internal/service/lambda/alias_test.go
@@ -387,7 +387,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   publish          = "true"
 }
@@ -410,7 +410,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   publish          = "true"
 }
@@ -433,7 +433,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   source_code_hash = filebase64sha256("test-fixtures/lambdatest_modified.zip")
   publish          = "true"
 }

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -1438,7 +1438,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName)
 }
@@ -1490,7 +1490,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName)
 }
@@ -1553,7 +1553,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName)
 }
@@ -1698,7 +1698,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName))
 }
@@ -1756,7 +1756,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_security_group" "test" {
@@ -1859,7 +1859,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_mq_broker" "test" {
@@ -1960,7 +1960,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_docdb_subnet_group" "test" {
@@ -2159,7 +2159,7 @@ resource "aws_lambda_function" "test_update" {
   function_name = "%[1]s-update"
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_lambda_event_source_mapping" "test" {
@@ -2228,7 +2228,7 @@ resource "aws_lambda_function" "test_update" {
   function_name = "%[1]s-update"
   role          = aws_iam_role.test_update.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_lambda_event_source_mapping" "test" {

--- a/internal/service/lambda/function_data_source_test.go
+++ b/internal/service/lambda/function_data_source_test.go
@@ -442,7 +442,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -459,7 +459,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = true
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -477,7 +477,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = true
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -494,7 +494,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = false
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -511,7 +511,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   publish       = true
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_lambda_alias" "test" {
@@ -532,7 +532,7 @@ func testAccFunctionDataSourceConfig_layers(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs16.x"]
+  compatible_runtimes = ["nodejs20.x"]
 }
 
 resource "aws_lambda_function" "test" {
@@ -541,7 +541,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   layers        = [aws_lambda_layer_version.test.arn]
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 data "aws_lambda_function" "test" {
@@ -583,7 +583,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   vpc_config {
     security_group_ids = [aws_security_group.test.id]
@@ -604,7 +604,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   environment {
     variables = {
@@ -683,7 +683,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "lambdatest.handler"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   vpc_config {
     security_group_ids = [aws_security_group.test.id]
@@ -731,7 +731,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   architectures = ["arm64"]
 }
 
@@ -748,7 +748,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   ephemeral_storage {
     size = 1024
@@ -768,7 +768,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   logging_config {
     log_format            = "JSON"
@@ -790,7 +790,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   logging_config {
     log_format = "Text"

--- a/internal/service/lambda/function_event_invoke_config_test.go
+++ b/internal/service/lambda/function_event_invoke_config_test.go
@@ -583,7 +583,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.test.arn
   handler       = "lambdapinpoint.handler"
   publish       = true
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   depends_on = [
     aws_iam_role_policy_attachment.test,

--- a/internal/service/lambda/function_recursion_config_test.go
+++ b/internal/service/lambda/function_recursion_config_test.go
@@ -231,7 +231,7 @@ resource "aws_lambda_function" "test" {
   source_code_hash = filebase64sha256("test-fixtures/lambdatest.zip")
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   handler          = "index.handler"
 }
 `, rName)

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -2546,7 +2546,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, funcName))
 }
@@ -2593,7 +2593,7 @@ resource "aws_lambda_function" "test" {
   publish       = false
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, fileName, rName))
 }
@@ -2676,7 +2676,7 @@ resource "aws_lambda_function" "test" {
   function_name           = %[1]q
   role                    = aws_iam_role.iam_for_lambda.arn
   handler                 = "exports.example"
-  runtime                 = "nodejs16.x"
+  runtime                 = "nodejs20.x"
   code_signing_config_arn = aws_lambda_code_signing_config.code_signing_config_1.arn
 }
 `, rName))
@@ -2691,7 +2691,7 @@ resource "aws_lambda_function" "test" {
   function_name           = %[1]q
   role                    = aws_iam_role.iam_for_lambda.arn
   handler                 = "exports.example"
-  runtime                 = "nodejs16.x"
+  runtime                 = "nodejs20.x"
   code_signing_config_arn = aws_lambda_code_signing_config.code_signing_config_2.arn
 }
 `, rName))
@@ -2706,7 +2706,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName))
 }
@@ -2720,7 +2720,7 @@ resource "aws_lambda_function" "test" {
   function_name                  = %[1]q
   role                           = aws_iam_role.iam_for_lambda.arn
   handler                        = "exports.example"
-  runtime                        = "nodejs16.x"
+  runtime                        = "nodejs20.x"
   reserved_concurrent_executions = 111
 }
 `, rName))
@@ -2735,7 +2735,7 @@ resource "aws_lambda_function" "test" {
   function_name                  = %[1]q
   role                           = aws_iam_role.iam_for_lambda.arn
   handler                        = "exports.example"
-  runtime                        = "nodejs16.x"
+  runtime                        = "nodejs20.x"
   reserved_concurrent_executions = 222
 }
 `, rName))
@@ -2749,7 +2749,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName))
 }
@@ -2763,7 +2763,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   environment {
     variables = {
@@ -2783,7 +2783,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   environment {
     variables = {}
@@ -2801,7 +2801,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   environment {
     variables = {
@@ -2822,7 +2822,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName))
 }
@@ -2836,7 +2836,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.iam_for_lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   environment {
     variables = {
@@ -2901,7 +2901,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   kms_key_arn   = aws_kms_key.test1.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   environment {
     variables = {
@@ -2946,7 +2946,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   kms_key_arn   = aws_kms_key.test2.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   environment {
     variables = {
@@ -2967,7 +2967,7 @@ resource "aws_lambda_function" "test" {
   publish       = %[3]t
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, fileName, rName, publish))
 }
@@ -2996,7 +2996,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   dead_letter_config {
     target_arn = aws_sns_topic.test[0].arn
@@ -3020,7 +3020,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   dead_letter_config {
     target_arn = aws_sns_topic.test[1].arn
@@ -3044,7 +3044,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   dead_letter_config {
     target_arn = ""
@@ -3093,7 +3093,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda.id]
@@ -3150,7 +3150,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda_az2.id]
@@ -3224,7 +3224,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   architectures = ["arm64"]
 }
 `, rName))
@@ -3239,7 +3239,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   architectures = ["x86_64"]
 }
 `, rName))
@@ -3252,7 +3252,7 @@ func testAccFunctionConfig_architecturesARM64Layer(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename                 = "test-fixtures/lambdatest.zip"
   layer_name               = %[1]q
-  compatible_runtimes      = ["nodejs16.x"]
+  compatible_runtimes      = ["nodejs20.x"]
   compatible_architectures = ["arm64", "x86_64"]
 }
 
@@ -3261,7 +3261,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   architectures = ["arm64"]
   layers        = [aws_lambda_layer_version.test.arn]
 }
@@ -3275,7 +3275,7 @@ func testAccFunctionConfig_architecturesUpdateLayer(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename                 = "test-fixtures/lambdatest.zip"
   layer_name               = %[1]q
-  compatible_runtimes      = ["nodejs16.x"]
+  compatible_runtimes      = ["nodejs20.x"]
   compatible_architectures = ["arm64", "x86_64"]
 }
 
@@ -3284,7 +3284,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   architectures = ["x86_64"]
   layers        = [aws_lambda_layer_version.test.arn]
 }
@@ -3300,7 +3300,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   ephemeral_storage {
     size = 1024
@@ -3318,7 +3318,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   ephemeral_storage {
     size = 2048
@@ -3336,7 +3336,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   logging_config {
     log_format = "Text"
@@ -3355,7 +3355,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   logging_config {
     application_log_level = "TRACE"
@@ -3375,7 +3375,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   logging_config {
     log_format = "JSON"
@@ -3393,7 +3393,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   tracing_config {
     mode = "Active"
@@ -3411,7 +3411,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   tracing_config {
     mode = "PassThrough"
@@ -3453,7 +3453,7 @@ resource "aws_lambda_function" "test" {
   handler       = "exports.example"
   kms_key_arn   = aws_kms_key.test.arn
   role          = aws_iam_role.iam_for_lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName))
 }
@@ -3467,7 +3467,7 @@ resource "aws_lambda_layer_version" "test" {
 
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = "%[1]s-${count.index}"
-  compatible_runtimes = ["nodejs16.x"]
+  compatible_runtimes = ["nodejs20.x"]
 }
 
 resource "aws_lambda_function" "test" {
@@ -3475,7 +3475,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   layers        = [aws_lambda_layer_version.test[0].arn]
 }
 `, rName))
@@ -3490,7 +3490,7 @@ resource "aws_lambda_layer_version" "test" {
 
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = "%[1]s-${count.index}"
-  compatible_runtimes = ["nodejs16.x"]
+  compatible_runtimes = ["nodejs20.x"]
 }
 
 resource "aws_lambda_function" "test" {
@@ -3498,7 +3498,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   layers        = aws_lambda_layer_version.test[*].arn
 }
 `, rName))
@@ -3513,7 +3513,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda.id]
@@ -3532,7 +3532,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda.id, aws_subnet.subnet_for_lambda_az2.id]
@@ -3571,7 +3571,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   publish       = true
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda.id]
@@ -3590,7 +3590,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   publish       = true
   vpc_config {
     security_group_ids = []
@@ -3609,7 +3609,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.test.id]
@@ -3630,7 +3630,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   replace_security_groups_on_destroy = true
 
@@ -3660,7 +3660,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   replace_security_groups_on_destroy = true
   replacement_security_group_ids     = [aws_security_group.test_replacement.id]
@@ -3682,7 +3682,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   vpc_config {
     subnet_ids         = []
@@ -3730,7 +3730,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName)
 }
@@ -3763,7 +3763,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[2]q
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "exports.example"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 `, filePath, rName)
 }
@@ -3795,7 +3795,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[2]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, filePath, rName)
 }
@@ -3851,7 +3851,7 @@ resource "aws_lambda_function" "test" {
   function_name     = %[3]q
   role              = aws_iam_role.iam_for_lambda.arn
   handler           = "exports.example"
-  runtime           = "nodejs16.x"
+  runtime           = "nodejs20.x"
 }
 `, key, path, rName)
 }
@@ -3896,7 +3896,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName, key, path)
 }
@@ -3923,7 +3923,7 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName))
 }
@@ -3950,7 +3950,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   vpc_config {
     subnet_ids         = [aws_subnet.subnet_for_lambda.id]
@@ -3969,7 +3969,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   vpc_config {
     ipv6_allowed_for_dual_stack = true
@@ -3987,7 +3987,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   skip_destroy  = true
 }
 `, rName))

--- a/internal/service/lambda/invocation_data_source_test.go
+++ b/internal/service/lambda/invocation_data_source_test.go
@@ -137,7 +137,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "%s"
   role          = aws_iam_role.lambda_role.arn
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   environment {
     variables = {
@@ -168,7 +168,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "%s"
   role          = aws_iam_role.lambda_role.arn
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   publish       = true
 
   environment {
@@ -201,7 +201,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "%s"
   role          = aws_iam_role.lambda_role.arn
   handler       = "lambda_invocation.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   publish       = true
 
   environment {

--- a/internal/service/lambda/layer_version_data_source_test.go
+++ b/internal/service/lambda/layer_version_data_source_test.go
@@ -138,7 +138,7 @@ func testAccLayerVersionDataSourceConfig_basic(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs16.x"]
+  compatible_runtimes = ["nodejs20.x"]
 }
 
 data "aws_lambda_layer_version" "test" {
@@ -152,13 +152,13 @@ func testAccLayerVersionDataSourceConfig_version(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs16.x"]
+  compatible_runtimes = ["nodejs20.x"]
 }
 
 resource "aws_lambda_layer_version" "test_two" {
   filename            = "test-fixtures/lambdatest_modified.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs16.x"]
+  compatible_runtimes = ["nodejs20.x"]
 }
 
 data "aws_lambda_layer_version" "test" {
@@ -173,18 +173,18 @@ func testAccLayerVersionDataSourceConfig_runtimes(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["go1.x"]
+  compatible_runtimes = ["python3.12"]
 }
 
 resource "aws_lambda_layer_version" "test_two" {
   filename            = "test-fixtures/lambdatest_modified.zip"
   layer_name          = aws_lambda_layer_version.test.layer_name
-  compatible_runtimes = ["nodejs16.x"]
+  compatible_runtimes = ["nodejs20.x"]
 }
 
 data "aws_lambda_layer_version" "test" {
   layer_name         = aws_lambda_layer_version.test_two.layer_name
-  compatible_runtime = "go1.x"
+  compatible_runtime = "python3.12"
 }
 `, rName)
 }
@@ -194,7 +194,7 @@ func testAccLayerVersionDataSourceConfig_architecturesX86(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename                 = "test-fixtures/lambdatest.zip"
   layer_name               = %[1]q
-  compatible_runtimes      = ["nodejs16.x"]
+  compatible_runtimes      = ["nodejs20.x"]
   compatible_architectures = ["x86_64"]
 }
 
@@ -211,7 +211,7 @@ func testAccLayerVersionDataSourceConfig_architecturesARM(rName string) string {
 resource "aws_lambda_layer_version" "test" {
   filename                 = "test-fixtures/lambdatest.zip"
   layer_name               = %[1]q
-  compatible_runtimes      = ["nodejs16.x"]
+  compatible_runtimes      = ["nodejs20.x"]
   compatible_architectures = ["arm64"]
 }
 
@@ -227,7 +227,7 @@ func testAccLayerVersionDataSourceConfig_architecturesX86ARM(rName string) strin
 resource "aws_lambda_layer_version" "test" {
   filename                 = "test-fixtures/lambdatest.zip"
   layer_name               = %[1]q
-  compatible_runtimes      = ["nodejs16.x"]
+  compatible_runtimes      = ["nodejs20.x"]
   compatible_architectures = ["x86_64", "arm64"]
 }
 
@@ -243,7 +243,7 @@ func testAccLayerVersionDataSourceConfig_architecturesNone(rName string) string 
 resource "aws_lambda_layer_version" "test" {
   filename            = "test-fixtures/lambdatest.zip"
   layer_name          = %[1]q
-  compatible_runtimes = ["nodejs16.x"]
+  compatible_runtimes = ["nodejs20.x"]
 }
 
 data "aws_lambda_layer_version" "test" {

--- a/internal/service/lambda/permission_test.go
+++ b/internal/service/lambda/permission_test.go
@@ -781,7 +781,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_iam_role" "test" {
@@ -903,7 +903,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%s"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {

--- a/internal/service/lambda/provisioned_concurrency_config_test.go
+++ b/internal/service/lambda/provisioned_concurrency_config_test.go
@@ -399,7 +399,7 @@ resource "aws_lambda_function" "test" {
   role          = aws_iam_role.test.arn
   handler       = "lambdapinpoint.handler"
   publish       = true
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   depends_on = [aws_iam_role_policy_attachment.test]
 }

--- a/internal/service/lambda/testdata/Function/data.tags/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/data.tags/main_gen.tf
@@ -11,7 +11,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   tags = var.resource_tags
 }

--- a/internal/service/lambda/testdata/Function/data.tags/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_lambda_function" "test" {
   function_name = aws_lambda_function.test.function_name
 }

--- a/internal/service/lambda/testdata/Function/tags/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/tags/main_gen.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   tags = var.resource_tags
 }

--- a/internal/service/lambda/testdata/Function/tagsComputed1/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/tagsComputed1/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   tags = {
     (var.unknownTagKey) = null_resource.test.id

--- a/internal/service/lambda/testdata/Function/tagsComputed2/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/tagsComputed2/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   tags = {
     (var.unknownTagKey) = null_resource.test.id

--- a/internal/service/lambda/testdata/Function/tags_defaults/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/tags_defaults/main_gen.tf
@@ -12,7 +12,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   tags = var.resource_tags
 }

--- a/internal/service/lambda/testdata/Function/tags_ignore/main_gen.tf
+++ b/internal/service/lambda/testdata/Function/tags_ignore/main_gen.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
   tags = var.resource_tags
 }

--- a/internal/service/lambda/testdata/tmpl/function_tags.gtpl
+++ b/internal/service/lambda/testdata/tmpl/function_tags.gtpl
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "test" {
   function_name = var.rName
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 
 {{- template "tags" . }}
 }

--- a/internal/service/lexmodels/intent_test.go
+++ b/internal/service/lexmodels/intent_test.go
@@ -839,7 +839,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s"
   handler       = "lambdatest.handler"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, rName)
 }

--- a/internal/service/logs/account_policy_test.go
+++ b/internal/service/logs/account_policy_test.go
@@ -294,7 +294,7 @@ resource "aws_cloudwatch_log_account_policy" "test" {
   policy_type = "SUBSCRIPTION_FILTER_POLICY"
 
   policy_document = jsonencode({
-    DestinationArn = "${aws_lambda_function.test.arn}"
+    DestinationArn = aws_lambda_function.test.arn
     FilterPattern  = " "
     Distribution   = "Random"
   })
@@ -309,7 +309,7 @@ resource "aws_cloudwatch_log_account_policy" "test" {
   policy_type = "SUBSCRIPTION_FILTER_POLICY"
 
   policy_document = jsonencode({
-    DestinationArn = "${aws_lambda_function.test.arn}"
+    DestinationArn = aws_lambda_function.test.arn
     FilterPattern  = " "
     Distribution   = "Random"
   })

--- a/internal/service/logs/account_policy_test.go
+++ b/internal/service/logs/account_policy_test.go
@@ -274,7 +274,7 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   handler       = "exports.handler"
 }
 

--- a/internal/service/logs/subscription_filter_test.go
+++ b/internal/service/logs/subscription_filter_test.go
@@ -556,7 +556,7 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = %[1]q
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   handler       = "exports.handler"
 }
 
@@ -609,7 +609,7 @@ resource "aws_lambda_function" "test" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "%[1]s-${count.index}"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   handler       = "exports.handler"
 }
 

--- a/internal/service/logs/testdata/LogGroup/data.tags/main_gen.tf
+++ b/internal/service/logs/testdata/LogGroup/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_cloudwatch_log_group" "test" {
   name = aws_cloudwatch_log_group.test.name
 }

--- a/internal/service/medialive/input_security_group.go
+++ b/internal/service/medialive/input_security_group.go
@@ -28,6 +28,7 @@ import (
 // @SDKResource("aws_medialive_input_security_group", name="Input Security Group")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/medialive;medialive.DescribeInputSecurityGroupOutput")
+// @Testing(generator=false)
 func ResourceInputSecurityGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceInputSecurityGroupCreate,

--- a/internal/service/medialive/input_security_group_tags_gen_test.go
+++ b/internal/service/medialive/input_security_group_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,7 +20,6 @@ func TestAccMediaLiveInputSecurityGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -32,7 +30,6 @@ func TestAccMediaLiveInputSecurityGroup_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -63,7 +60,6 @@ func TestAccMediaLiveInputSecurityGroup_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -75,7 +71,6 @@ func TestAccMediaLiveInputSecurityGroup_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -111,7 +106,6 @@ func TestAccMediaLiveInputSecurityGroup_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -124,7 +118,6 @@ func TestAccMediaLiveInputSecurityGroup_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -155,7 +148,6 @@ func TestAccMediaLiveInputSecurityGroup_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -167,7 +159,6 @@ func TestAccMediaLiveInputSecurityGroup_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -188,7 +179,6 @@ func TestAccMediaLiveInputSecurityGroup_tags(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -203,7 +193,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -214,7 +203,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -238,7 +226,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: nil,
 					}),
@@ -250,7 +237,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_null(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				PlanOnly:           true,
@@ -264,7 +250,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -275,7 +260,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -297,7 +281,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				ResourceName:      resourceName,
@@ -307,7 +290,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyMap(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				PlanOnly:           true,
@@ -321,7 +303,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -332,7 +313,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -354,7 +334,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -385,7 +364,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_AddOnUpdate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -402,7 +380,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -413,7 +390,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -443,7 +419,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -455,7 +430,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -476,7 +450,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -491,7 +464,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -502,7 +474,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -533,7 +504,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -567,7 +537,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 						acctest.CtKey2: config.StringVariable(""),
@@ -580,7 +549,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -611,7 +579,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -628,7 +595,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Replace(t *testin
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -639,7 +605,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Replace(t *testin
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -670,7 +635,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Replace(t *testin
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -700,7 +664,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Replace(t *testin
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -717,7 +680,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_providerOnly(t *testing
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -728,7 +690,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_providerOnly(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -757,7 +718,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_providerOnly(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -771,7 +731,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_providerOnly(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -803,7 +762,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_providerOnly(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1Updated),
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
@@ -818,7 +776,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_providerOnly(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -847,7 +804,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_providerOnly(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey2: config.StringVariable(acctest.CtValue2),
 					}),
@@ -861,7 +817,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_providerOnly(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -883,7 +838,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_providerOnly(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -898,7 +852,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nonOverlapping(t *testi
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -909,7 +862,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nonOverlapping(t *testi
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -946,7 +898,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nonOverlapping(t *testi
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -962,7 +913,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nonOverlapping(t *testi
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable("providervalue1updated"),
 					}),
@@ -1004,7 +954,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nonOverlapping(t *testi
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable("providervalue1updated"),
 					}),
@@ -1021,7 +970,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nonOverlapping(t *testi
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1043,7 +991,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nonOverlapping(t *testi
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName:        config.StringVariable(rName),
 					acctest.CtResourceTags: nil,
 				},
 				ResourceName:      resourceName,
@@ -1058,7 +1005,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_overlapping(t *testing.
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1069,7 +1015,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_overlapping(t *testing.
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1104,7 +1049,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_overlapping(t *testing.
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1120,7 +1064,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_overlapping(t *testing.
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1161,7 +1104,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_overlapping(t *testing.
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 						acctest.CtOverlapKey2: config.StringVariable("providervalue2"),
@@ -1179,7 +1121,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_overlapping(t *testing.
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1214,7 +1155,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_overlapping(t *testing.
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtOverlapKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1234,7 +1174,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_updateToProviderOnly(t 
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1245,7 +1184,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_updateToProviderOnly(t 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1277,7 +1215,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_updateToProviderOnly(t 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1306,7 +1243,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_updateToProviderOnly(t 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1324,7 +1260,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_updateToResourceOnly(t 
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1335,7 +1270,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_updateToResourceOnly(t 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1364,7 +1298,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_updateToResourceOnly(t 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1396,7 +1329,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_updateToResourceOnly(t 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1413,7 +1345,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_emptyResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1424,7 +1355,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_emptyResourceTag(t *tes
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1458,7 +1388,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_emptyResourceTag(t *tes
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1478,7 +1407,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_emptyProviderOnlyTag(t 
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1489,7 +1417,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_emptyProviderOnlyTag(t 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1517,7 +1444,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_emptyProviderOnlyTag(t 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(""),
 					}),
@@ -1535,7 +1461,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nullOverlappingResource
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1546,7 +1471,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nullOverlappingResource
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1577,7 +1501,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nullOverlappingResource
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1597,7 +1520,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nullNonOverlappingResou
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1608,7 +1530,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nullNonOverlappingResou
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1639,7 +1560,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nullNonOverlappingResou
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags_defaults/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtProviderTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtProviderKey1: config.StringVariable(acctest.CtProviderValue1),
 					}),
@@ -1659,7 +1579,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnCreate(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1670,7 +1589,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnCreate(t *testing.T) 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1699,7 +1617,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnCreate(t *testing.T) 
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				ResourceName:      resourceName,
@@ -1714,7 +1631,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnUpdate_Add(t *testing
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1725,7 +1641,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnUpdate_Add(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1757,7 +1672,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnUpdate_Add(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1794,7 +1708,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnUpdate_Add(t *testing
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tagsComputed2/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable("computedkey1"),
 					"knownTagKey":   config.StringVariable(acctest.CtKey1),
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
@@ -1811,7 +1724,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnUpdate_Replace(t *tes
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
@@ -1822,7 +1734,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnUpdate_Replace(t *tes
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tags/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{
 						acctest.CtKey1: config.StringVariable(acctest.CtValue1),
 					}),
@@ -1854,7 +1765,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnUpdate_Replace(t *tes
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1883,7 +1793,6 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnUpdate_Replace(t *tes
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				ConfigDirectory:          config.StaticDirectory("testdata/InputSecurityGroup/tagsComputed1/"),
 				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				ResourceName:      resourceName,

--- a/internal/service/medialive/testdata/Input/data.tags/main_gen.tf
+++ b/internal/service/medialive/testdata/Input/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_medialive_input" "test" {
   id = aws_medialive_input.test.id
 }

--- a/internal/service/medialive/testdata/InputSecurityGroup/tags/main_gen.tf
+++ b/internal/service/medialive/testdata/InputSecurityGroup/tags/main_gen.tf
@@ -9,12 +9,6 @@ resource "aws_medialive_input_security_group" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/medialive/testdata/InputSecurityGroup/tagsComputed1/main_gen.tf
+++ b/internal/service/medialive/testdata/InputSecurityGroup/tagsComputed1/main_gen.tf
@@ -15,12 +15,6 @@ resource "aws_medialive_input_security_group" "test" {
 
 resource "null_resource" "test" {}
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "unknownTagKey" {
   type     = string
   nullable = false

--- a/internal/service/medialive/testdata/InputSecurityGroup/tagsComputed2/main_gen.tf
+++ b/internal/service/medialive/testdata/InputSecurityGroup/tagsComputed2/main_gen.tf
@@ -16,12 +16,6 @@ resource "aws_medialive_input_security_group" "test" {
 
 resource "null_resource" "test" {}
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "unknownTagKey" {
   type     = string
   nullable = false

--- a/internal/service/medialive/testdata/InputSecurityGroup/tags_defaults/main_gen.tf
+++ b/internal/service/medialive/testdata/InputSecurityGroup/tags_defaults/main_gen.tf
@@ -15,12 +15,6 @@ resource "aws_medialive_input_security_group" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/medialive/testdata/InputSecurityGroup/tags_ignore/main_gen.tf
+++ b/internal/service/medialive/testdata/InputSecurityGroup/tags_ignore/main_gen.tf
@@ -18,12 +18,6 @@ resource "aws_medialive_input_security_group" "test" {
   tags = var.resource_tags
 }
 
-variable "rName" {
-  description = "Name for resource"
-  type        = string
-  nullable    = false
-}
-
 variable "resource_tags" {
   description = "Tags to set on resource. To specify no tags, set to `null`"
   # Not setting a default, so that this must explicitly be set to `null` to specify no tags

--- a/internal/service/medialive/testdata/Multiplex/tags/main_gen.tf
+++ b/internal/service/medialive/testdata/Multiplex/tags/main_gen.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/medialive/testdata/Multiplex/tagsComputed1/main_gen.tf
+++ b/internal/service/medialive/testdata/Multiplex/tagsComputed1/main_gen.tf
@@ -4,7 +4,7 @@
 provider "null" {}
 
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/medialive/testdata/Multiplex/tagsComputed2/main_gen.tf
+++ b/internal/service/medialive/testdata/Multiplex/tagsComputed2/main_gen.tf
@@ -4,7 +4,7 @@
 provider "null" {}
 
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/medialive/testdata/Multiplex/tags_defaults/main_gen.tf
+++ b/internal/service/medialive/testdata/Multiplex/tags_defaults/main_gen.tf
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/medialive/testdata/Multiplex/tags_ignore/main_gen.tf
+++ b/internal/service/medialive/testdata/Multiplex/tags_ignore/main_gen.tf
@@ -11,7 +11,7 @@ provider "aws" {
 }
 
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/medialive/testdata/tmpl/multiplex_tags.gtpl
+++ b/internal/service/medialive/testdata/tmpl/multiplex_tags.gtpl
@@ -1,5 +1,5 @@
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/pinpoint/app_test.go
+++ b/internal/service/pinpoint/app_test.go
@@ -529,7 +529,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "lambdapinpoint.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
   publish       = true
 }
 

--- a/internal/service/pipes/pipe_test.go
+++ b/internal/service/pipes/pipe_test.go
@@ -3066,7 +3066,7 @@ resource "aws_lambda_function" "target" {
   function_name = "%[1]s-target"
   role          = aws_iam_role.target.arn
   handler       = "index.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_pipes_pipe" "test" {

--- a/internal/service/rds/testdata/DBInstance/data.tags/main_gen.tf
+++ b/internal/service/rds/testdata/DBInstance/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_db_instance" "test" {
   db_instance_identifier = aws_db_instance.test.identifier
 }

--- a/internal/service/rekognition/stream_processor_test.go
+++ b/internal/service/rekognition/stream_processor_test.go
@@ -452,14 +452,14 @@ resource "aws_iam_role" "test" {
             "kinesis:DescribeStreamSummary"
           ]
           Effect   = "Allow"
-          Resource = ["${aws_kinesis_video_stream.test.arn}"]
+          Resource = [aws_kinesis_video_stream.test.arn]
         },
         {
           Action = [
             "kinesis:PutRecord"
           ]
           Effect   = "Allow"
-          Resource = ["${aws_kinesis_stream.test_output.arn}"]
+          Resource = [aws_kinesis_stream.test_output.arn]
         },
       ]
     })

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -2474,8 +2474,8 @@ resource "aws_route53_record" "test" {
 
   alias {
     evaluate_target_health = false
-    name                   = lookup(aws_vpc_endpoint.test.dns_entry[0], "hosted_zone_id")
-    zone_id                = lookup(aws_vpc_endpoint.test.dns_entry[0], "dns_name")
+    name                   = lookup(aws_vpc_endpoint.test.dns_entry[0], "hosted_zone_id", "")
+    zone_id                = lookup(aws_vpc_endpoint.test.dns_entry[0], "dns_name", "")
   }
 }
 `)
@@ -2490,8 +2490,8 @@ resource "aws_route53_record" "test" {
 
   alias {
     evaluate_target_health = false
-    name                   = lookup(aws_vpc_endpoint.test.dns_entry[0], "dns_name")
-    zone_id                = lookup(aws_vpc_endpoint.test.dns_entry[0], "hosted_zone_id")
+    name                   = lookup(aws_vpc_endpoint.test.dns_entry[0], "dns_name", "")
+    zone_id                = lookup(aws_vpc_endpoint.test.dns_entry[0], "hosted_zone_id", "")
   }
 }
 `)

--- a/internal/service/s3/bucket_notification_test.go
+++ b/internal/service/s3/bucket_notification_test.go
@@ -560,7 +560,7 @@ resource "aws_lambda_permission" "test" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.test.arn
-  principal     = "${data.aws_service_principal.current.name}"
+  principal     = data.aws_service_principal.current.name
   source_arn    = aws_s3_bucket.test.arn
 }
 
@@ -667,7 +667,7 @@ resource "aws_lambda_alias" "test" {
 resource "aws_lambda_permission" "test" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.test.arn
-  principal     = "${data.aws_service_principal.current.name}"
+  principal     = data.aws_service_principal.current.name
   qualifier     = aws_lambda_alias.test.name
   source_arn    = aws_s3_bucket.test.arn
   statement_id  = "AllowExecutionFromS3Bucket"

--- a/internal/service/s3/bucket_notification_test.go
+++ b/internal/service/s3/bucket_notification_test.go
@@ -569,7 +569,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_s3_bucket" "test" {
@@ -655,7 +655,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   handler       = "exports.example"
   role          = aws_iam_role.test.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_lambda_alias" "test" {

--- a/internal/service/s3/bucket_policy_data_source_test.go
+++ b/internal/service/s3/bucket_policy_data_source_test.go
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "test" {
 
     principals {
       type        = "Service"
-      identifiers = ["${data.aws_service_principal.current.name}"]
+      identifiers = [data.aws_service_principal.current.name]
     }
   }
 }

--- a/internal/service/s3/bucket_policy_test.go
+++ b/internal/service/s3/bucket_policy_test.go
@@ -603,7 +603,7 @@ resource "aws_iam_role" "test1" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-        Service = "${data.aws_service_principal.current.name}"
+        Service = data.aws_service_principal.current.name
       }
     }]
     Version = "2012-10-17"
@@ -618,7 +618,7 @@ resource "aws_iam_role" "test2" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-        Service = "${data.aws_service_principal.current.name}"
+        Service = data.aws_service_principal.current.name
       }
     }]
     Version = "2012-10-17"
@@ -633,7 +633,7 @@ resource "aws_iam_role" "test3" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-        Service = "${data.aws_service_principal.current.name}"
+        Service = data.aws_service_principal.current.name
       }
     }]
     Version = "2012-10-17"
@@ -648,7 +648,7 @@ resource "aws_iam_role" "test4" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-        Service = "${data.aws_service_principal.current.name}"
+        Service = data.aws_service_principal.current.name
       }
     }]
     Version = "2012-10-17"
@@ -663,7 +663,7 @@ resource "aws_iam_role" "test5" {
       Action = "sts:AssumeRole"
       Effect = "Allow"
       Principal = {
-        Service = "${data.aws_service_principal.current.name}"
+        Service = data.aws_service_principal.current.name
       }
     }]
     Version = "2012-10-17"

--- a/internal/service/s3/testdata/BucketObject/data.tags/main_gen.tf
+++ b/internal/service/s3/testdata/BucketObject/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_s3_bucket_object" "test" {
   bucket = aws_s3_bucket_object.test.bucket
   key    = aws_s3_bucket_object.test.key

--- a/internal/service/s3/testdata/Object/data.tags/main_gen.tf
+++ b/internal/service/s3/testdata/Object/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_s3_object" "test" {
   bucket = aws_s3_bucket.test.bucket
   key    = aws_s3_object.test.key

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -1470,7 +1470,7 @@ data "aws_iam_policy_document" "managed_instance_scaling_test_policy" {
     ]
 
     resources = [
-      "${aws_s3_bucket.managed_instance_scaling_test.arn}",
+      aws_s3_bucket.managed_instance_scaling_test.arn,
       "${aws_s3_bucket.managed_instance_scaling_test.arn}/*",
     ]
   }

--- a/internal/service/sagemaker/model_test.go
+++ b/internal/service/sagemaker/model_test.go
@@ -942,7 +942,7 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "${aws_s3_bucket.test.arn}",
+      aws_s3_bucket.test.arn,
       "${aws_s3_bucket.test.arn}/*",
     ]
   }

--- a/internal/service/secretsmanager/secret_rotation_data_source_test.go
+++ b/internal/service/secretsmanager/secret_rotation_data_source_test.go
@@ -55,7 +55,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s-1"
   handler       = "exports.example"
   role          = aws_iam_role.iam_for_lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/secretsmanager/secret_rotation_test.go
+++ b/internal/service/secretsmanager/secret_rotation_test.go
@@ -471,7 +471,7 @@ resource "aws_lambda_function" "test" {
   function_name = "%[1]s-1"
   handler       = "exports.example"
   role          = aws_iam_role.iam_for_lambda.arn
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/secretsmanager/testdata/Secret/data.tags/main_gen.tf
+++ b/internal/service/secretsmanager/testdata/Secret/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_secretsmanager_secret" "test" {
   arn = aws_secretsmanager_secret.test.arn
 }

--- a/internal/service/servicecatalog/testdata/Portfolio/data.tags/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Portfolio/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_servicecatalog_portfolio" "test" {
   id = aws_servicecatalog_portfolio.test.id
 }

--- a/internal/service/servicecatalog/testdata/Product/data.tags/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_servicecatalog_product" "test" {
   id = aws_servicecatalog_product.test.id
 }

--- a/internal/service/servicecatalog/testdata/Product/data.tags/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/data.tags/main_gen.tf
@@ -56,8 +56,6 @@ resource "aws_s3_object" "test" {
   })
 }
 
-data "aws_partition" "current" {}
-
 variable "rName" {
   description = "Name for resource"
   type        = string

--- a/internal/service/servicecatalog/testdata/Product/tags/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tags/main_gen.tf
@@ -51,8 +51,6 @@ resource "aws_s3_object" "test" {
   })
 }
 
-data "aws_partition" "current" {}
-
 variable "rName" {
   description = "Name for resource"
   type        = string

--- a/internal/service/servicecatalog/testdata/Product/tagsComputed1/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tagsComputed1/main_gen.tf
@@ -55,8 +55,6 @@ resource "aws_s3_object" "test" {
   })
 }
 
-data "aws_partition" "current" {}
-
 resource "null_resource" "test" {}
 
 variable "rName" {

--- a/internal/service/servicecatalog/testdata/Product/tagsComputed2/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tagsComputed2/main_gen.tf
@@ -56,8 +56,6 @@ resource "aws_s3_object" "test" {
   })
 }
 
-data "aws_partition" "current" {}
-
 resource "null_resource" "test" {}
 
 variable "rName" {

--- a/internal/service/servicecatalog/testdata/Product/tags_defaults/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tags_defaults/main_gen.tf
@@ -57,8 +57,6 @@ resource "aws_s3_object" "test" {
   })
 }
 
-data "aws_partition" "current" {}
-
 variable "rName" {
   description = "Name for resource"
   type        = string

--- a/internal/service/servicecatalog/testdata/Product/tags_ignore/main_gen.tf
+++ b/internal/service/servicecatalog/testdata/Product/tags_ignore/main_gen.tf
@@ -60,8 +60,6 @@ resource "aws_s3_object" "test" {
   })
 }
 
-data "aws_partition" "current" {}
-
 variable "rName" {
   description = "Name for resource"
   type        = string

--- a/internal/service/servicecatalog/testdata/tmpl/product_tags.gtpl
+++ b/internal/service/servicecatalog/testdata/tmpl/product_tags.gtpl
@@ -46,5 +46,3 @@ resource "aws_s3_object" "test" {
     }
   })
 }
-
-data "aws_partition" "current" {}

--- a/internal/service/ses/receipt_rule_test.go
+++ b/internal/service/ses/receipt_rule_test.go
@@ -601,7 +601,7 @@ resource "aws_lambda_function" "test" {
   function_name    = %[1]q
   role             = aws_iam_role.test.arn
   handler          = "exports.example"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 }
 
 resource "aws_lambda_permission" "test" {

--- a/internal/service/sfn/alias_test.go
+++ b/internal/service/sfn/alias_test.go
@@ -192,7 +192,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 data "aws_region" "current" {}

--- a/internal/service/sfn/state_machine_test.go
+++ b/internal/service/sfn/state_machine_test.go
@@ -702,7 +702,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 data "aws_region" "current" {}

--- a/internal/service/sns/testdata/Topic/data.tags/main_gen.tf
+++ b/internal/service/sns/testdata/Topic/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_sns_topic" "test" {
   name = aws_sns_topic.test.name
 }

--- a/internal/service/sns/testdata/tmpl/topic_data_source.gtpl
+++ b/internal/service/sns/testdata/tmpl/topic_data_source.gtpl
@@ -1,0 +1,3 @@
+data "aws_sns_topic" "test" {
+  name = aws_sns_topic.test.name
+}

--- a/internal/service/sns/topic_data_source.go
+++ b/internal/service/sns/topic_data_source.go
@@ -21,6 +21,7 @@ import (
 )
 
 // @SDKDataSource("aws_sns_topic")
+// @Testing(tagsTest=true)
 func dataSourceTopic() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceTopicRead,

--- a/internal/service/sns/topic_data_source_tags_gen_test.go
+++ b/internal/service/sns/topic_data_source_tags_gen_test.go
@@ -42,3 +42,51 @@ func TestAccSNSTopicDataSource_tags(t *testing.T) {
 		},
 	})
 }
+
+func TestAccSNSTopicDataSource_tags_NullMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_sns_topic.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Topic/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: nil,
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSNSTopicDataSource_tags_EmptyMap(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_sns_topic.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: config.StaticDirectory("testdata/Topic/data.tags/"),
+				ConfigVariables: config.Variables{
+					acctest.CtRName:        config.StringVariable(rName),
+					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
+			},
+		},
+	})
+}

--- a/internal/service/sns/topic_subscription_test.go
+++ b/internal/service/sns/topic_subscription_test.go
@@ -1254,7 +1254,7 @@ resource "aws_lambda_function" "authorizer" {
   function_name    = "%[1]s-2"
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = "main.authenticate"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
 
   environment {
     variables = {

--- a/internal/service/sqs/testdata/Queue/data.tags/main_gen.tf
+++ b/internal/service/sqs/testdata/Queue/data.tags/main_gen.tf
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# tflint-ignore: terraform_unused_declarations
 data "aws_sqs_queue" "test" {
   name = aws_sqs_queue.test.name
 }

--- a/internal/service/ssm/maintenance_window_task_test.go
+++ b/internal/service/ssm/maintenance_window_task_test.go
@@ -1116,7 +1116,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 `, funcName))
 }

--- a/internal/service/timestreaminfluxdb/db_instance_test.go
+++ b/internal/service/timestreaminfluxdb/db_instance_test.go
@@ -310,7 +310,7 @@ resource "aws_timestreaminfluxdb_db_instance" "test" {
   allocated_storage      = 20
   username               = "admin"
   password               = "testpassword"
-  vpc_subnet_ids         = aws_subnet.test.*.id
+  vpc_subnet_ids         = aws_subnet.test[*].id
   vpc_security_group_ids = [aws_security_group.test.id]
   db_instance_type       = "db.influx.medium"
   bucket                 = "initial"
@@ -350,7 +350,7 @@ resource "aws_timestreaminfluxdb_db_instance" "test" {
   allocated_storage      = 20
   username               = "admin"
   password               = "testpassword"
-  vpc_subnet_ids         = aws_subnet.test.*.id
+  vpc_subnet_ids         = aws_subnet.test[*].id
   vpc_security_group_ids = [aws_security_group.test.id]
   db_instance_type       = "db.influx.medium"
   publicly_accessible    = false
@@ -396,7 +396,7 @@ resource "aws_timestreaminfluxdb_db_instance" "test" {
   username               = "admin"
   password               = "testpassword"
   db_storage_type        = "InfluxIOIncludedT1"
-  vpc_subnet_ids         = aws_subnet.test.*.id
+  vpc_subnet_ids         = aws_subnet.test[*].id
   vpc_security_group_ids = [aws_security_group.test.id]
   db_instance_type       = "db.influx.medium"
   bucket                 = "initial"
@@ -415,7 +415,7 @@ resource "aws_timestreaminfluxdb_db_instance" "test" {
   username               = "admin"
   password               = "testpassword"
   db_storage_type        = "InfluxIOIncludedT1"
-  vpc_subnet_ids         = aws_subnet.test.*.id
+  vpc_subnet_ids         = aws_subnet.test[*].id
   vpc_security_group_ids = [aws_security_group.test.id]
   db_instance_type       = "db.influx.medium"
   bucket                 = "initial"

--- a/internal/service/timestreaminfluxdb/testdata/DBInstance/tags/main_gen.tf
+++ b/internal/service/timestreaminfluxdb/testdata/DBInstance/tags/main_gen.tf
@@ -32,7 +32,7 @@ resource "aws_timestreaminfluxdb_db_instance" "test" {
   allocated_storage      = 20
   username               = "admin"
   password               = "testpassword"
-  vpc_subnet_ids         = aws_subnet.test.*.id
+  vpc_subnet_ids         = aws_subnet.test[*].id
   vpc_security_group_ids = [aws_security_group.test.id]
   db_instance_type       = "db.influx.medium"
   bucket                 = "initial"

--- a/internal/service/timestreaminfluxdb/testdata/DBInstance/tagsComputed1/main_gen.tf
+++ b/internal/service/timestreaminfluxdb/testdata/DBInstance/tagsComputed1/main_gen.tf
@@ -34,7 +34,7 @@ resource "aws_timestreaminfluxdb_db_instance" "test" {
   allocated_storage      = 20
   username               = "admin"
   password               = "testpassword"
-  vpc_subnet_ids         = aws_subnet.test.*.id
+  vpc_subnet_ids         = aws_subnet.test[*].id
   vpc_security_group_ids = [aws_security_group.test.id]
   db_instance_type       = "db.influx.medium"
   bucket                 = "initial"

--- a/internal/service/timestreaminfluxdb/testdata/DBInstance/tagsComputed2/main_gen.tf
+++ b/internal/service/timestreaminfluxdb/testdata/DBInstance/tagsComputed2/main_gen.tf
@@ -34,7 +34,7 @@ resource "aws_timestreaminfluxdb_db_instance" "test" {
   allocated_storage      = 20
   username               = "admin"
   password               = "testpassword"
-  vpc_subnet_ids         = aws_subnet.test.*.id
+  vpc_subnet_ids         = aws_subnet.test[*].id
   vpc_security_group_ids = [aws_security_group.test.id]
   db_instance_type       = "db.influx.medium"
   bucket                 = "initial"

--- a/internal/service/timestreaminfluxdb/testdata/DBInstance/tags_defaults/main_gen.tf
+++ b/internal/service/timestreaminfluxdb/testdata/DBInstance/tags_defaults/main_gen.tf
@@ -38,7 +38,7 @@ resource "aws_timestreaminfluxdb_db_instance" "test" {
   allocated_storage      = 20
   username               = "admin"
   password               = "testpassword"
-  vpc_subnet_ids         = aws_subnet.test.*.id
+  vpc_subnet_ids         = aws_subnet.test[*].id
   vpc_security_group_ids = [aws_security_group.test.id]
   db_instance_type       = "db.influx.medium"
   bucket                 = "initial"

--- a/internal/service/timestreaminfluxdb/testdata/DBInstance/tags_ignore/main_gen.tf
+++ b/internal/service/timestreaminfluxdb/testdata/DBInstance/tags_ignore/main_gen.tf
@@ -41,7 +41,7 @@ resource "aws_timestreaminfluxdb_db_instance" "test" {
   allocated_storage      = 20
   username               = "admin"
   password               = "testpassword"
-  vpc_subnet_ids         = aws_subnet.test.*.id
+  vpc_subnet_ids         = aws_subnet.test[*].id
   vpc_security_group_ids = [aws_security_group.test.id]
   db_instance_type       = "db.influx.medium"
   bucket                 = "initial"

--- a/internal/service/timestreaminfluxdb/testdata/tmpl/db_instance_tags.gtpl
+++ b/internal/service/timestreaminfluxdb/testdata/tmpl/db_instance_tags.gtpl
@@ -29,7 +29,7 @@ resource "aws_timestreaminfluxdb_db_instance" "test" {
   allocated_storage      = 20
   username               = "admin"
   password               = "testpassword"
-  vpc_subnet_ids         = aws_subnet.test.*.id
+  vpc_subnet_ids         = aws_subnet.test[*].id
   vpc_security_group_ids = [aws_security_group.test.id]
   db_instance_type       = "db.influx.medium"
   bucket                 = "initial"

--- a/internal/service/vpclattice/target_group_attachment_test.go
+++ b/internal/service/vpclattice/target_group_attachment_test.go
@@ -236,7 +236,7 @@ resource "aws_lambda_function" "test" {
   function_name = %[1]q
   role          = aws_iam_role.test.arn
   handler       = "test.handler"
-  runtime       = "python3.7"
+  runtime       = "python3.12"
 }
 
 resource "aws_iam_role" "test" {

--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -106,7 +106,7 @@ resource "aws_lambda_function" "lambda" {
   function_name = "mylambda"
   role          = aws_iam_role.role.arn
   handler       = "lambda.lambda_handler"
-  runtime       = "python3.7"
+  runtime       = "python3.12"
 
   source_code_hash = filebase64sha256("lambda.zip")
 }

--- a/website/docs/r/apigatewayv2_integration.html.markdown
+++ b/website/docs/r/apigatewayv2_integration.html.markdown
@@ -30,7 +30,7 @@ resource "aws_lambda_function" "example" {
   function_name = "Example"
   role          = aws_iam_role.example.arn
   handler       = "index.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_apigatewayv2_integration" "example" {

--- a/website/docs/r/appflow_connector_profile.html.markdown
+++ b/website/docs/r/appflow_connector_profile.html.markdown
@@ -42,7 +42,7 @@ resource "aws_iam_role" "example" {
 }
 
 resource "aws_s3_bucket" "example" {
-  bucket = "example_bucket"
+  bucket = "example-bucket"
 }
 
 resource "aws_redshift_cluster" "example" {

--- a/website/docs/r/cloudwatch_log_account_policy.html.markdown
+++ b/website/docs/r/cloudwatch_log_account_policy.html.markdown
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_log_account_policy" "subscription_filter" {
   policy_type = "SUBSCRIPTION_FILTER_POLICY"
   policy_document = jsonencode(
     {
-      DestinationArn = "${aws_lambda_function.test.arn}"
+      DestinationArn = aws_lambda_function.test.arn
       FilterPattern  = "test"
     }
   )

--- a/website/docs/r/datazone_form_type.html.markdown
+++ b/website/docs/r/datazone_form_type.html.markdown
@@ -16,7 +16,7 @@ Terraform resource for managing an AWS DataZone Form Type.
 
 ```terraform
 resource "aws_iam_role" "domain_execution_role" {
-  name = "example name"
+  name = "example-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -38,7 +38,7 @@ resource "aws_iam_role" "domain_execution_role" {
   })
 
   inline_policy {
-    name = "example name"
+    name = "example-policy"
     policy = jsonencode({
       Version = "2012-10-17"
       Statement = [
@@ -58,12 +58,12 @@ resource "aws_iam_role" "domain_execution_role" {
 }
 
 resource "aws_datazone_domain" "test" {
-  name                  = "example name"
+  name                  = "example"
   domain_execution_role = aws_iam_role.domain_execution_role.arn
 }
 
 resource "aws_security_group" "test" {
-  name = "example name"
+  name = "example"
 }
 
 resource "aws_datazone_project" "test" {

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -90,7 +90,7 @@ resource "aws_lambda_function" "lambda_processor" {
   function_name = "firehose_lambda_processor"
   role          = aws_iam_role.lambda_iam.arn
   handler       = "exports.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 ```
 

--- a/website/docs/r/lambda_layer_version.html.markdown
+++ b/website/docs/r/lambda_layer_version.html.markdown
@@ -21,7 +21,7 @@ resource "aws_lambda_layer_version" "lambda_layer" {
   filename   = "lambda_layer_payload.zip"
   layer_name = "lambda_layer_name"
 
-  compatible_runtimes = ["nodejs16.x"]
+  compatible_runtimes = ["nodejs20.x"]
 }
 ```
 

--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "test_lambda" {
   function_name = "lambda_function_name"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.handler"
-  runtime       = "nodejs16.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -86,7 +86,7 @@ resource "aws_lambda_function" "func" {
   function_name = "lambda_called_from_sns"
   role          = aws_iam_role.default.arn
   handler       = "exports.handler"
-  runtime       = "python3.7"
+  runtime       = "python3.12"
 }
 
 resource "aws_iam_role" "default" {
@@ -157,7 +157,7 @@ resource "aws_lambda_function" "logging" {
   function_name = "lambda_called_from_cloudwatch_logs"
   handler       = "exports.handler"
   role          = aws_iam_role.default.arn
-  runtime       = "python3.7"
+  runtime       = "python3.12"
 }
 
 data "aws_iam_policy_document" "assume_role" {

--- a/website/docs/r/rekognition_stream_processor.html.markdown
+++ b/website/docs/r/rekognition_stream_processor.html.markdown
@@ -50,7 +50,7 @@ resource "aws_iam_role" "example" {
         {
           Action   = ["sns:Publish"]
           Effect   = "Allow"
-          Resource = ["${aws_sns_topic.example.arn}"]
+          Resource = [aws_sns_topic.example.arn]
         },
         {
           Action = [
@@ -58,7 +58,7 @@ resource "aws_iam_role" "example" {
             "kinesis:DescribeStreamSummary"
           ]
           Effect   = "Allow"
-          Resource = ["${aws_kinesis_video_stream.example.arn}"]
+          Resource = [aws_kinesis_video_stream.example.arn]
         },
       ]
     })
@@ -139,14 +139,14 @@ resource "aws_iam_role" "example" {
             "kinesis:DescribeStreamSummary"
           ]
           Effect   = "Allow"
-          Resource = ["${aws_kinesis_video_stream.example.arn}"]
+          Resource = [aws_kinesis_video_stream.example.arn]
         },
         {
           Action = [
             "kinesis:PutRecord"
           ]
           Effect   = "Allow"
-          Resource = ["${aws_kinesis_stream.example.arn}"]
+          Resource = [aws_kinesis_stream.example.arn]
         },
       ]
     })

--- a/website/docs/r/s3_bucket_analytics_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_analytics_configuration.html.markdown
@@ -37,7 +37,7 @@ resource "aws_s3_bucket" "example" {
 }
 
 resource "aws_s3_bucket" "analytics" {
-  bucket = "analytics destination"
+  bucket = "analytics-destination"
 }
 ```
 

--- a/website/docs/r/s3_bucket_notification.html.markdown
+++ b/website/docs/r/s3_bucket_notification.html.markdown
@@ -135,7 +135,7 @@ resource "aws_lambda_function" "func" {
   function_name = "example_lambda_name"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "go1.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -190,7 +190,7 @@ resource "aws_lambda_function" "func1" {
   function_name = "example_lambda_name1"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
-  runtime       = "go1.x"
+  runtime       = "nodejs20.x"
 }
 
 resource "aws_lambda_permission" "allow_bucket2" {

--- a/website/docs/r/shield_application_layer_automatic_response.html.markdown
+++ b/website/docs/r/shield_application_layer_automatic_response.html.markdown
@@ -20,7 +20,7 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 variable "distribution_id" {
-  type        = "string"
+  type        = string
   description = "The Cloudfront Distribution on which to enable the Application Layer Automatic Response."
 }
 

--- a/website/docs/r/shield_drt_access_role_arn_association.html.markdown
+++ b/website/docs/r/shield_drt_access_role_arn_association.html.markdown
@@ -16,8 +16,12 @@ For more information see [Configure AWS SRT Support](https://docs.aws.amazon.com
 ### Basic Usage
 
 ```terraform
-resource "aws_iam_role" "test" {
-  name = var.aws_shield_drt_access_role_arn
+resource "aws_shield_drt_access_role_arn_association" "example" {
+  role_arn = aws_iam_role.example.arn
+}
+
+resource "aws_iam_role" "example" {
+  name = "example-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -33,13 +37,9 @@ resource "aws_iam_role" "test" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "test" {
-  role       = aws_iam_role.test.name
+resource "aws_iam_role_policy_attachment" "example" {
+  role       = aws_iam_role.example.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSShieldDRTAccessPolicy"
-}
-
-resource "aws_shield_drt_access_role_arn_association" "test" {
-  role_arn = aws_iam_role.test.arn
 }
 ```
 

--- a/website/docs/r/shield_proactive_engagement.html.markdown
+++ b/website/docs/r/shield_proactive_engagement.html.markdown
@@ -16,8 +16,26 @@ Proactive engagement authorizes the Shield Response Team (SRT) to use email and 
 ### Basic Usage
 
 ```terraform
+resource "aws_shield_proactive_engagement" "example" {
+  enabled = true
+
+  emergency_contact {
+    contact_notes = "Notes"
+    email_address = "contact1@example.com"
+    phone_number  = "+12358132134"
+  }
+
+  emergency_contact {
+    contact_notes = "Notes 2"
+    email_address = "contact2@example.com"
+    phone_number  = "+12358132134"
+  }
+
+  depends_on = [aws_shield_drt_access_role_arn_association.example]
+}
+
 resource "aws_iam_role" "example" {
-  name = var.aws_shield_drt_access_role_arn
+  name = "example-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -42,28 +60,10 @@ resource "aws_shield_drt_access_role_arn_association" "example" {
   role_arn = aws_iam_role.example.arn
 }
 
-resource "aws_shield_protection_group" "test" {
+resource "aws_shield_protection_group" "example" {
   protection_group_id = "example"
   aggregation         = "MAX"
   pattern             = "ALL"
-}
-
-resource "aws_shield_proactive_engagement" "test" {
-  enabled = true
-
-  emergency_contact {
-    contact_notes = "Notes"
-    email_address = "test@company.com"
-    phone_number  = "+12358132134"
-  }
-
-  emergency_contact {
-    contact_notes = "Notes 2"
-    email_address = "test2@company.com"
-    phone_number  = "+12358132134"
-  }
-
-  depends_on = [aws_shield_drt_access_role_arn_association.test]
 }
 ```
 


### PR DESCRIPTION
### Description

Adds Terraform configuration linting with `tflint` and `terraform fmt` for acceptance tests using Terraform directories

Restores linting of Terraform configurations embedded in Go acceptance tests and documentation files.