### PR TITLE
vpc/dhcp_options: Fix panic

### DIFF
--- a/.changelog/39427.txt
+++ b/.changelog/39427.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_vpc_dhcp_options: Fix a bug causing a panic crash when an option is absent
+```

--- a/internal/service/ec2/vpc_dhcp_options.go
+++ b/internal/service/ec2/vpc_dhcp_options.go
@@ -255,27 +255,33 @@ func newDHCPOptionsMap(tfToApi map[string]string) *dhcpOptionsMap {
 
 // dhcpConfigurationsToResourceData sets Terraform ResourceData from a list of AWS API DHCP configurations.
 func (m *dhcpOptionsMap) dhcpConfigurationsToResourceData(dhcpConfigurations []awstypes.DhcpConfiguration, d *schema.ResourceData) error {
-	for v := range m.tfToApi {
-		d.Set(v, nil)
+	// Clear existing values
+	for tfName := range m.tfToApi {
+		d.Set(tfName, nil)
 	}
 
 	for _, dhcpConfiguration := range dhcpConfigurations {
 		apiName := aws.ToString(dhcpConfiguration.Key)
-		if tfName, ok := m.apiToTf[apiName]; ok {
-			switch v := d.Get(tfName).(type) {
-			case string:
-				d.Set(tfName, dhcpConfiguration.Values[0].Value)
-			case []interface{}:
-				var values []*string
-				for _, v := range dhcpConfiguration.Values {
-					values = append(values, v.Value)
+		tfName, ok := m.apiToTf[apiName]
+		if !ok {
+			return fmt.Errorf("unsupported DHCP option: %s", apiName)
+		}
+
+		currentValue := d.Get(tfName)
+
+		switch currentValue.(type) {
+		case string:
+			d.Set(tfName, dhcpConfiguration.Values[0].Value)
+		case []interface{}:
+			var values []string
+			for _, v := range dhcpConfiguration.Values {
+				if v.Value != nil {
+					values = append(values, aws.ToString(v.Value))
 				}
-				d.Set(tfName, values)
-			default:
-				return fmt.Errorf("Attribute (%s) is of unsupported type: %T", tfName, v)
 			}
-		} else {
-			return fmt.Errorf("Unsupported DHCP option: %s", apiName)
+			d.Set(tfName, values)
+		default:
+			return fmt.Errorf("attribute (%s) is of unsupported type: %T", tfName, currentValue)
 		}
 	}
 
@@ -287,7 +293,8 @@ func (m *dhcpOptionsMap) resourceDataToDHCPConfigurations(d *schema.ResourceData
 	var output []awstypes.NewDhcpConfiguration
 
 	for tfName, apiName := range m.tfToApi {
-		switch v := d.Get(tfName).(type) {
+		value := d.Get(tfName)
+		switch v := value.(type) {
 		case string:
 			if v != "" {
 				output = append(output, awstypes.NewDhcpConfiguration{
@@ -297,10 +304,9 @@ func (m *dhcpOptionsMap) resourceDataToDHCPConfigurations(d *schema.ResourceData
 			}
 		case []interface{}:
 			var values []string
-			for _, v := range v {
-				v := v.(string)
-				if v != "" {
-					values = append(values, v)
+			for _, item := range v {
+				if str, ok := item.(string); ok && str != "" {
+					values = append(values, str)
 				}
 			}
 			if len(values) > 0 {
@@ -310,7 +316,7 @@ func (m *dhcpOptionsMap) resourceDataToDHCPConfigurations(d *schema.ResourceData
 				})
 			}
 		default:
-			return nil, fmt.Errorf("Attribute (%s) is of unsupported type: %T", tfName, v)
+			return nil, fmt.Errorf("attribute (%s) is of unsupported type: %T", tfName, value)
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39343

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccVPCDHCPOptions_ K=vpc P=14
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/ec2/... -v -count 1 -parallel 14 -run='TestAccVPCDHCPOptions_'  -timeout 360m
=== RUN   TestAccVPCDHCPOptions_basic
=== PAUSE TestAccVPCDHCPOptions_basic
=== RUN   TestAccVPCDHCPOptions_full
=== PAUSE TestAccVPCDHCPOptions_full
=== RUN   TestAccVPCDHCPOptions_tags
=== PAUSE TestAccVPCDHCPOptions_tags
=== RUN   TestAccVPCDHCPOptions_disappears
=== PAUSE TestAccVPCDHCPOptions_disappears
=== CONT  TestAccVPCDHCPOptions_basic
=== CONT  TestAccVPCDHCPOptions_tags
=== CONT  TestAccVPCDHCPOptions_disappears
=== CONT  TestAccVPCDHCPOptions_full
--- PASS: TestAccVPCDHCPOptions_disappears (17.05s)
--- PASS: TestAccVPCDHCPOptions_basic (19.54s)
--- PASS: TestAccVPCDHCPOptions_full (19.55s)
--- PASS: TestAccVPCDHCPOptions_tags (40.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	45.780s
```
