### PR TITLE
r/aws_iam_role: retry `ConcurrentModificationException`s

### DIFF
--- a/.changelog/39429.txt
+++ b/.changelog/39429.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_role: Retry `ConcurrentModificationException`s during role creation
+```

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -601,6 +601,9 @@ func retryCreateRole(ctx context.Context, conn *iam.Client, input *iam.CreateRol
 			if errs.IsAErrorMessageContains[*awstypes.MalformedPolicyDocumentException](err, "Invalid principal in policy") {
 				return true, err
 			}
+			if errs.IsA[*awstypes.ConcurrentModificationException](err) {
+				return true, err
+			}
 
 			return false, err
 		},


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This condition is not easily reproducible, but has been the subject of a regression report. This change will retry `ConcurrentModificationException`s during role creation, alongside other retryable conditions resulting from IAM propagation delays.

From the [`CreateRole` API documentation](https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html#API_CreateRole_Errors).

> ConcurrentModification
> The request was rejected because multiple requests to change this object were submitted simultaneously. Wait a few minutes and submit your request again.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39421


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=iam TESTS=TestAccIAMRole_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRole_'  -timeout 360m

--- PASS: TestAccIAMRole_badJSON (10.88s)
=== CONT  TestAccIAMRole_nameGenerated
--- PASS: TestAccIAMRole_InlinePolicy_malformed (21.38s)
=== CONT  TestAccIAMRole_description
--- PASS: TestAccIAMRole_InlinePolicy_empty (28.70s)
=== CONT  TestAccIAMRole_basic
--- PASS: TestAccIAMRole_nameGenerated (35.52s)
=== CONT  TestAccIAMRole_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccIAMRole_tags_EmptyTag_OnUpdate_Replace (52.89s)
=== CONT  TestAccIAMRole_diffs
--- PASS: TestAccIAMRole_disappears (54.05s)
=== CONT  TestAccIAMRole_tags_DefaultTags_overlapping
--- PASS: TestAccIAMRole_tags_DefaultTags_updateToResourceOnly (57.77s)
=== CONT  TestAccIAMRole_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (62.09s)
=== CONT  TestAccIAMRole_InlinePolicy_basic
--- PASS: TestAccIAMRole_namePrefix (71.49s)
=== CONT  TestAccIAMRole_InlinePolicy_ignoreOrder
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (72.09s)
=== CONT  TestAccIAMRole_tags_AddOnUpdate
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (74.20s)
=== CONT  TestAccIAMRole_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccIAMRole_policiesForceDetach (74.46s)
=== CONT  TestAccIAMRole_tags_EmptyTag_OnCreate
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (82.70s)
=== CONT  TestAccIAMRole_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccIAMRole_basic (61.09s)
=== CONT  TestAccIAMRole_tags_ComputedTag_OnCreate
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (96.43s)
=== CONT  TestAccIAMRole_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (106.90s)
=== CONT  TestAccIAMRole_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccIAMRole_ManagedPolicy_basic (106.95s)
=== CONT  TestAccIAMRole_permissionsBoundary
--- PASS: TestAccIAMRole_diffsCondition (114.92s)
=== CONT  TestAccIAMRole_testNameChange
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (122.50s)
=== CONT  TestAccIAMRole_maxSessionDuration
--- PASS: TestAccIAMRole_tags_ComputedTag_OnUpdate_Replace (83.01s)
=== CONT  TestAccIAMRole_tags_DefaultTags_nonOverlapping
--- PASS: TestAccIAMRole_tags_ComputedTag_OnUpdate_Add (135.98s)
=== CONT  TestAccIAMRole_tags_DefaultTags_providerOnly
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (138.94s)
=== CONT  TestAccIAMRole_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccIAMRole_tags_DefaultTags_nullOverlappingResourceTag (56.54s)
=== CONT  TestAccIAMRole_tags_EmptyMap
--- PASS: TestAccIAMRole_description (123.07s)
=== CONT  TestAccIAMRole_tags_null
--- PASS: TestAccIAMRole_tags_DefaultTags_updateToProviderOnly (90.71s)
--- PASS: TestAccIAMRole_tags_ComputedTag_OnCreate (61.96s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nullNonOverlappingResourceTag (64.97s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (94.18s)
--- PASS: TestAccIAMRole_tags_AddOnUpdate (97.70s)
--- PASS: TestAccIAMRole_tags_DefaultTags_emptyProviderOnlyTag (63.14s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (114.38s)
--- PASS: TestAccIAMRole_tags_EmptyTag_OnCreate (104.03s)
--- PASS: TestAccIAMRole_tags (181.54s)
--- PASS: TestAccIAMRole_testNameChange (72.33s)
--- PASS: TestAccIAMRole_tags_DefaultTags_emptyResourceTag (50.75s)
--- PASS: TestAccIAMRole_tags_DefaultTags_overlapping (137.33s)
--- PASS: TestAccIAMRole_tags_EmptyMap (54.34s)
--- PASS: TestAccIAMRole_tags_null (49.84s)
--- PASS: TestAccIAMRole_tags_EmptyTag_OnUpdate_Add (120.75s)
--- PASS: TestAccIAMRole_maxSessionDuration (75.97s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nonOverlapping (85.89s)
--- PASS: TestAccIAMRole_permissionsBoundary (115.88s)
--- PASS: TestAccIAMRole_tags_DefaultTags_providerOnly (94.41s)
--- PASS: TestAccIAMRole_diffs (235.49s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        293.586s
```

