### PR TITLE
r/aws_iam_role: improve `inline_policy` deprecation message 

### DIFF
--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -88,10 +88,14 @@ func resourceRole() *schema.Resource {
 				Default:  false,
 			},
 			"inline_policy": {
-				Type:       schema.TypeSet,
-				Optional:   true,
-				Computed:   true,
-				Deprecated: "Use the aws_iam_role_policy resource instead. If Terraform should exclusively manage all inline policy associations (the current behavior of this argument), use the aws_iam_role_policies_exclusive resource as well.",
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Deprecated: "The inline_policy argument is deprecated. " +
+					"Use the aws_iam_role_policy resource instead. If Terraform should " +
+					"exclusively manage all inline policy associations (the current " +
+					"behavior of this argument), use the aws_iam_role_policies_exclusive " +
+					"resource as well.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrName: {

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -69,6 +69,8 @@ resource "aws_iam_role" "instance" {
 
 ### Example of Exclusive Inline Policies
 
+~> The `inline_policy` argument is deprecated. Use the [`aws_iam_role_policy`](./iam_role_policy.html.markdown) resource instead. If Terraform should exclusively manage all inline policy associations (the current behavior of this argument), use the [`aws_iam_role_policies_exclusive`](./iam_role_policies_exclusive.html.markdown) resource as well.
+
 This example creates an IAM role with two inline IAM policies. If someone adds another inline policy out-of-band, on the next apply, Terraform will remove that policy. If someone deletes these policies out-of-band, Terraform will recreate them.
 
 ```terraform
@@ -106,6 +108,8 @@ data "aws_iam_policy_document" "inline_policy" {
 ```
 
 ### Example of Removing Inline Policies
+
+~> The `inline_policy` argument is deprecated. Use the [`aws_iam_role_policy`](./iam_role_policy.html.markdown) resource instead. If Terraform should exclusively manage all inline policy associations (the current behavior of this argument), use the [`aws_iam_role_policies_exclusive`](./iam_role_policies_exclusive.html.markdown) resource as well.
 
 This example creates an IAM role with what appears to be empty IAM `inline_policy` argument instead of using `inline_policy` as a configuration block. The result is that if someone were to add an inline policy out-of-band, on the next apply, Terraform will remove that policy.
 
@@ -184,7 +188,7 @@ The following arguments are optional:
 
 * `description` - (Optional) Description of the role.
 * `force_detach_policies` - (Optional) Whether to force detaching any policies the role has before destroying it. Defaults to `false`.
-* `inline_policy` - (Optional) Configuration block defining an exclusive set of IAM inline policies associated with the IAM role. See below. If no blocks are configured, Terraform will not manage any inline policies in this resource. Configuring one empty block (i.e., `inline_policy {}`) will cause Terraform to remove _all_ inline policies added out of band on `apply`.
+* `inline_policy` - (Optional, **Deprecated**) Configuration block defining an exclusive set of IAM inline policies associated with the IAM role. See below. If no blocks are configured, Terraform will not manage any inline policies in this resource. Configuring one empty block (i.e., `inline_policy {}`) will cause Terraform to remove _all_ inline policies added out of band on `apply`.
 * `managed_policy_arns` - (Optional) Set of exclusive IAM managed policy ARNs to attach to the IAM role. If this attribute is not configured, Terraform will ignore policy attachments to this resource. When configured, Terraform will align the role's managed policy attachments with this set by attaching or detaching managed policies. Configuring an empty set (i.e., `managed_policy_arns = []`) will cause Terraform to remove _all_ managed policy attachments.
 * `max_session_duration` - (Optional) Maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours.
 * `name` - (Optional, Forces new resource) Friendly name of the role. If omitted, Terraform will assign a random, unique name. See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The updated deprecation message now includes the impacted argument name, providing clarity around what argument should be addressed.

```
│ Warning: Argument is deprecated
│
│   with aws_iam_role.test,
│   on main.tf line 33, in resource "aws_iam_role" "test":
│   33: resource "aws_iam_role" "test" {
│
│ The inline_policy argument is deprecated. Use the aws_iam_role_policy resource instead. If Terraform should exclusively manage all inline policy associations (the current behavior
│ of this argument), use the aws_iam_role_policies_exclusive resource as well.
```

Also updates the registry documentation to include deprecation warnings above the `inline_policy` examples.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


Relates #39203
Relates #22336 


