### PR TITLE
docs: Move primary_ipv6 arg desc from aws_launch_configuration doc to aws_launch_template doc

### DIFF
--- a/website/docs/d/launch_configuration.html.markdown
+++ b/website/docs/d/launch_configuration.html.markdown
@@ -41,7 +41,6 @@ This data source exports the following attributes in addition to the arguments a
     * `http_put_response_hop_limit` - The desired HTTP PUT response hop limit for instance metadata requests.
 * `security_groups` - List of associated Security Group IDS.
 * `associate_public_ip_address` - Whether a Public IP address is associated with the instance.
-* `primary_ipv6` - Whether the first IPv6 GUA will be made the primary IPv6 address.
 * `user_data` - User Data of the instance.
 * `enable_monitoring` - Whether Detailed Monitoring is Enabled.
 * `ebs_optimized` - Whether the launched EC2 instance will be EBS-optimized.

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -455,6 +455,7 @@ Each `network_interfaces` block supports the following:
 * `ipv6_prefixes` - (Optional) One or more IPv6 prefixes to be assigned to the network interface. Conflicts with `ipv6_prefix_count`
 * `network_interface_id` - (Optional) The ID of the network interface to attach.
 * `network_card_index` - (Optional) The index of the network card. Some instance types support multiple network cards. The primary network interface must be assigned to network card index 0. The default is network card index 0.
+* `primary_ipv6` - (Optional) Whether the first IPv6 GUA will be made the primary IPv6 address.
 * `private_ip_address` - (Optional) The primary private IPv4 address.
 * `ipv4_address_count` - (Optional) The number of secondary private IPv4 addresses to assign to a network interface. Conflicts with `ipv4_addresses`
 * `ipv4_addresses` - (Optional) One or more private IPv4 addresses to associate. Conflicts with `ipv4_address_count`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to correctly put the `primary_ipv6` argument description in the `aws_launch_template` resource doc instead of the `aws_launch_configuration` data source doc. The `aws_launch_template` data source doc does not need to be updated because it just has a blanket reference to the resource doc.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39434

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a