### PR TITLE
docs: Added behavior ref to instance_warmup_period arg desc for aws_ecs_capacity_provider

### DIFF
--- a/website/docs/r/ecs_capacity_provider.html.markdown
+++ b/website/docs/r/ecs_capacity_provider.html.markdown
@@ -60,6 +60,8 @@ This resource supports the following arguments:
 ### `managed_scaling`
 
 * `instance_warmup_period` - (Optional) Period of time, in seconds, after a newly launched Amazon EC2 instance can contribute to CloudWatch metrics for Auto Scaling group. If this parameter is omitted, the default value of 300 seconds is used.
+
+  For more information on how the instance warmup period contributes to managed scale-out behavior, see [Control the instances Amazon ECS terminates](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-termination-protection.html) in the _Amazon Elastic Container Service Developer Guide_.
 * `maximum_scaling_step_size` - (Optional) Maximum step adjustment size. A number between 1 and 10,000.
 * `minimum_scaling_step_size` - (Optional) Minimum step adjustment size. A number between 1 and 10,000.
 * `status` - (Optional) Whether auto scaling is managed by ECS. Valid values are `ENABLED` and `DISABLED`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add additional information about managed scale-out behavior for the `instance_warmup_period` argument in the `aws_ecs_capacity_provider` resource doc. Instead of adding excessive details to the documentation, I decided to keep the argument description consistent with the AWS API doc and link to additional information in the ECS Developer Guide.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39420

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referenced [Control the instances Amazon ECS terminates](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/managed-termination-protection.html#managed-scaling-scaleout) for context and [CreateCapacityProvider](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateCapacityProvider.html) for specs.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
n/a