### PR TITLE
docs: Standardize config block descs and refs for aws_elasticache_serverless_cache

### DIFF
--- a/website/docs/r/elasticache_serverless_cache.html.markdown
+++ b/website/docs/r/elasticache_serverless_cache.html.markdown
@@ -69,7 +69,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `cache_usage_limits` - (Optional) Sets the cache usage limits for storage and ElastiCache Processing Units for the cache. See configuration below.
+* `cache_usage_limits` - (Optional) Sets the cache usage limits for storage and ElastiCache Processing Units for the cache. See [`cache_usage_limits` Block](#cache_usage_limits-block) for details.
 * `daily_snapshot_time` - (Optional) The daily time that snapshots will be created from the new serverless cache. Only supported for engine type `"redis"`. Defaults to `0`.
 * `description` - (Optional) User-provided description for the serverless cache. The default is NULL.
 * `kms_key_id` - (Optional) ARN of the customer managed key for encrypting the data at rest. If no KMS key is provided, a default service key is used.
@@ -82,18 +82,24 @@ The following arguments are optional:
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `user_group_id` - (Optional) The identifier of the UserGroup to be associated with the serverless cache. Available for Redis only. Default is NULL.
 
-### CacheUsageLimits Configuration
+### `cache_usage_limits` Block
 
-* `data_storage` - The maximum data storage limit in the cache, expressed in Gigabytes. See Data Storage config for more details.
-* `ecpu_per_second` - The configuration for the number of ElastiCache Processing Units (ECPU) the cache can consume per second.See config block for more details.
+The `cache_usage_limits` configuration block supports the following arguments:
 
-### DataStorage Configuration
+* `data_storage` - The maximum data storage limit in the cache, expressed in Gigabytes. See [`data_storage` Block](#data_storage-block) for details.
+* `ecpu_per_second` - The configuration for the number of ElastiCache Processing Units (ECPU) the cache can consume per second. See [`ecpu_per_second` Block](#ecpu_per_second-block) for details.
+
+### `data_storage` Block
+
+The `data_storage` configuration block supports the following arguments:
 
 * `minimum` - The lower limit for data storage the cache is set to use. Must be between 1 and 5,000.
 * `maximum` - The upper limit for data storage the cache is set to use. Must be between 1 and 5,000.
 * `unit` - The unit that the storage is measured in, in GB.
 
-### ECPUPerSecond Configuration
+### `ecpu_per_second` Block
+
+The `ecpu_per_second` configuration block supports the following arguments:
 
 * `minimum` - The minimum number of ECPUs the cache can consume per second. Must be between 1,000 and 15,000,000.
 * `maximum` - The maximum number of ECPUs the cache can consume per second. Must be between 1,000 and 15,000,000.
@@ -104,13 +110,22 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `arn` - The Amazon Resource Name (ARN) of the serverless cache.
 * `create_time` - Timestamp of when the serverless cache was created.
-* `endpoint` - Represents the information required for client programs to connect to a cache node. See config below for details.
+* `endpoint` - Represents the information required for client programs to connect to a cache node. See [`endpoint` Block](#endpoint-block) for details.
 * `full_engine_version` - The name and version number of the engine the serverless cache is compatible with.
 * `major_engine_version` - The version number of the engine the serverless cache is compatible with.
-* `reader_endpoint` - Represents the information required for client programs to connect to a cache node. See config below for details.
+* `reader_endpoint` - Represents the information required for client programs to connect to a cache node. See [`reader_endpoint` Block](#reader_endpoint-block) for details.
 * `status` - The current status of the serverless cache. The allowed values are CREATING, AVAILABLE, DELETING, CREATE-FAILED and MODIFYING.
 
-### Endpoint Configuration
+### `endpoint` Block
+
+The `endpoint` configuration block exports the following attributes:
+
+* `address` - The DNS hostname of the cache node.
+* `port` - The port number that the cache engine is listening on. Set as integer.
+
+### `reader_endpoint` Block
+
+The `reader_endpoint` configuration block exports the following attributes:
 
 * `address` - The DNS hostname of the cache node.
 * `port` - The port number that the cache engine is listening on. Set as integer.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR standardizes the descriptions for configuration blocks and argument/attribute links to them, so that it is clearer that they are config blocks.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39417

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

n/a