### PR TITLE
r/aws_ db_cluster: add read replica to domain on create

### DIFF
--- a/.changelog/39448.txt
+++ b/.changelog/39448.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_db_instance: Allow replica database to be added to domain on create
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -789,6 +789,30 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.DedicatedLogVolume = aws.Bool(v.(bool))
 		}
 
+		if v, ok := d.GetOk(names.AttrDomain); ok {
+			input.Domain = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("domain_auth_secret_arn"); ok {
+			input.DomainAuthSecretArn = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]interface{})) > 0 {
+			input.DomainDnsIps = flex.ExpandStringValueList(v.([]interface{}))
+		}
+
+		if v, ok := d.GetOk("domain_fqdn"); ok {
+			input.DomainFqdn = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("domain_iam_role_name"); ok {
+			input.DomainIAMRoleName = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("domain_ou"); ok {
+			input.DomainOu = aws.String(v.(string))
+		}
+
 		if v, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && v.(*schema.Set).Len() > 0 {
 			input.EnableCloudwatchLogsExports = flex.ExpandStringValueSet(v.(*schema.Set))
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTS="TestAccRDSInstance_ReplicateSourceDB_mssqlDomain"

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_ReplicateSourceDB_mssqlDomain'  -timeout 360m
=== RUN   TestAccRDSInstance_ReplicateSourceDB_mssqlDomain
=== PAUSE TestAccRDSInstance_ReplicateSourceDB_mssqlDomain
=== CONT  TestAccRDSInstance_ReplicateSourceDB_mssqlDomain
--- PASS: TestAccRDSInstance_ReplicateSourceDB_mssqlDomain (5167.75s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	5174.387s
```
