### PR TITLE
fix: fix typo in mapping for cascading_control_configuration

### DIFF
--- a/.changelog/39453.txt
+++ b/.changelog/39453.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_quicksight_dashboard: Fix mapping issue when using templates with cascading control configurations.
+resource/aws_quicksight_dashboard: Fix mapping of `sheets.filter_controls.list.cascading_control_configuration` and `sheets.parameter_controls.list.cascading_control_configuration` attributes
 ```

--- a/.changelog/39453.txt
+++ b/.changelog/39453.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_dashboard: Fix mapping issue when using templates with cascading control configurations.
+```

--- a/internal/service/quicksight/schema/template_control.go
+++ b/internal/service/quicksight/schema/template_control.go
@@ -1348,7 +1348,7 @@ func flattenFilterListControl(apiObject *awstypes.FilterListControl) []interface
 	}
 
 	if apiObject.CascadingControlConfiguration != nil {
-		tfMap["cacading_control_configuration"] = flattenCascadingControlConfiguration(apiObject.CascadingControlConfiguration)
+		tfMap["cascading_control_configuration"] = flattenCascadingControlConfiguration(apiObject.CascadingControlConfiguration)
 	}
 	if apiObject.DisplayOptions != nil {
 		tfMap["display_options"] = flattenListControlDisplayOptions(apiObject.DisplayOptions)

--- a/internal/service/quicksight/schema/template_parameter.go
+++ b/internal/service/quicksight/schema/template_parameter.go
@@ -1097,7 +1097,7 @@ func flattenParameterListControl(apiObject *awstypes.ParameterListControl) []int
 	}
 
 	if apiObject.CascadingControlConfiguration != nil {
-		tfMap["cacading_control_configuration"] = flattenCascadingControlConfiguration(apiObject.CascadingControlConfiguration)
+		tfMap["cascading_control_configuration"] = flattenCascadingControlConfiguration(apiObject.CascadingControlConfiguration)
 	}
 	if apiObject.DisplayOptions != nil {
 		tfMap["display_options"] = flattenListControlDisplayOptions(apiObject.DisplayOptions)


### PR DESCRIPTION
### Description

The internally used key `cacading_control_configuration` contains a typo, so that the mapping fails.

### Relations

Closes #39139 

### References

- [Cloudformation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-quicksight-template-cascadingcontrolconfiguration.html)

### Output from Acceptance Testing

TDB - I would need to check how to provide a test for the fix.