### PR TITLE
[TechDebt]: Remove use of `errs.Must` within service packages

### DIFF
--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -659,3 +659,14 @@ rules:
             $DIAGS = sdkdiag.AppendErrorf($DIAGS, ...)
           }
     severity: ERROR
+
+  - id: avoid-errs-Must
+    languages: [go]
+    message: Avoid use of `errs.Must()` in service packages, handle errors explicitly instead.
+    paths:
+      include:
+        - internal/service
+    patterns:
+      - pattern-either:
+          - pattern: errs.Must(...)
+    severity: WARNING

--- a/internal/service/account/region.go
+++ b/internal/service/account/region.go
@@ -73,13 +73,14 @@ func resourceRegionUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	conn := meta.(*conns.AWSClient).AccountClient(ctx)
 
 	var id string
+	var err error
 	region := d.Get("region_name").(string)
 	accountID := ""
 	if v, ok := d.GetOk(names.AttrAccountID); ok {
 		accountID = v.(string)
-		id, err := flex.FlattenResourceId([]string{accountID, region}, regionResourceIDPartCount, false)
+		id, err = flex.FlattenResourceId([]string{accountID, region}, regionResourceIDPartCount, false)
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "enabling Account Region (%s): %s", id, err)
+			return sdkdiag.AppendFromErr(diags, err)
 		}
 	} else {
 		id = region

--- a/internal/service/account/region.go
+++ b/internal/service/account/region.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -78,7 +77,10 @@ func resourceRegionUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	accountID := ""
 	if v, ok := d.GetOk(names.AttrAccountID); ok {
 		accountID = v.(string)
-		id = errs.Must(flex.FlattenResourceId([]string{accountID, region}, regionResourceIDPartCount, false))
+		id, err := flex.FlattenResourceId([]string{accountID, region}, regionResourceIDPartCount, false)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "enabling Account Region (%s): %s", id, err)
+		}
 	} else {
 		id = region
 	}

--- a/internal/service/acmpca/permission.go
+++ b/internal/service/acmpca/permission.go
@@ -83,7 +83,7 @@ func resourcePermissionCreate(ctx context.Context, d *schema.ResourceData, meta 
 	sourceAccount := d.Get("source_account").(string)
 	id, err := flex.FlattenResourceId([]string{caARN, principal, sourceAccount}, permissionResourceIDPartCount, true)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating ACM PCA Permission (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &acmpca.CreatePermissionInput{

--- a/internal/service/acmpca/permission.go
+++ b/internal/service/acmpca/permission.go
@@ -81,7 +81,11 @@ func resourcePermissionCreate(ctx context.Context, d *schema.ResourceData, meta 
 	caARN := d.Get("certificate_authority_arn").(string)
 	principal := d.Get(names.AttrPrincipal).(string)
 	sourceAccount := d.Get("source_account").(string)
-	id := errs.Must(flex.FlattenResourceId([]string{caARN, principal, sourceAccount}, permissionResourceIDPartCount, true))
+	id, err := flex.FlattenResourceId([]string{caARN, principal, sourceAccount}, permissionResourceIDPartCount, true)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating ACM PCA Permission (%s): %s", id, err)
+	}
+
 	input := &acmpca.CreatePermissionInput{
 		Actions:                 expandPermissionActions(d.Get(names.AttrActions).(*schema.Set)),
 		CertificateAuthorityArn: aws.String(caARN),
@@ -92,9 +96,7 @@ func resourcePermissionCreate(ctx context.Context, d *schema.ResourceData, meta 
 		input.SourceAccount = aws.String(sourceAccount)
 	}
 
-	_, err := conn.CreatePermission(ctx, input)
-
-	if err != nil {
+	if _, err := conn.CreatePermission(ctx, input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating ACM PCA Permission (%s): %s", id, err)
 	}
 

--- a/internal/service/appfabric/app_authorization_connection.go
+++ b/internal/service/appfabric/app_authorization_connection.go
@@ -135,8 +135,12 @@ func (r *appAuthorizationConnectionResource) Create(ctx context.Context, request
 		return
 	}
 
-	// Set values for unknowns.
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("flattening resource ID AppFabric App Authorization (%s) Connection", data.AppAuthorizationARN.ValueString()), err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	appAuthorization, err := waitConnectAppAuthorizationCreated(ctx, conn, data.AppAuthorizationARN.ValueString(), data.AppBundleARN.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
 
@@ -167,7 +171,7 @@ func (r *appAuthorizationConnectionResource) Read(ctx context.Context, request r
 		return
 	}
 
-	if err := data.InitFromID(); err != nil {
+	if err := data.initFromID(); err != nil {
 		response.Diagnostics.AddError("parsing resource ID", err.Error())
 
 		return
@@ -272,7 +276,7 @@ const (
 	appAuthorizationConnectionResourceIDPartCount = 2
 )
 
-func (m *appAuthorizationConnectionResourceModel) InitFromID() error {
+func (m *appAuthorizationConnectionResourceModel) initFromID() error {
 	parts, err := flex.ExpandResourceId(m.ID.ValueString(), appAuthorizationConnectionResourceIDPartCount, false)
 	if err != nil {
 		return err
@@ -284,8 +288,13 @@ func (m *appAuthorizationConnectionResourceModel) InitFromID() error {
 	return nil
 }
 
-func (m *appAuthorizationConnectionResourceModel) setID() {
-	m.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{m.AppAuthorizationARN.ValueString(), m.AppBundleARN.ValueString()}, appAuthorizationConnectionResourceIDPartCount, false)))
+func (m *appAuthorizationConnectionResourceModel) setID() (string, error) {
+	parts := []string{
+		m.AppAuthorizationARN.ValueString(),
+		m.AppBundleARN.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, appAuthorizationConnectionResourceIDPartCount, false)
 }
 
 type authRequestModel struct {

--- a/internal/service/appfabric/app_bundle.go
+++ b/internal/service/appfabric/app_bundle.go
@@ -75,8 +75,13 @@ func (r *appBundleResource) Create(ctx context.Context, request resource.CreateR
 
 	conn := r.Meta().AppFabricClient(ctx)
 
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		response.Diagnostics.AddError("creating AppFabric App Bundle", err.Error())
+	}
+
 	input := &appfabric.CreateAppBundleInput{
-		ClientToken:                  aws.String(errs.Must(uuid.GenerateUUID())),
+		ClientToken:                  aws.String(uuid),
 		CustomerManagedKeyIdentifier: fwflex.StringFromFramework(ctx, data.CustomerManagedKeyARN),
 		Tags:                         getTagsIn(ctx),
 	}

--- a/internal/service/bedrockagent/agent_action_group.go
+++ b/internal/service/bedrockagent/agent_action_group.go
@@ -252,7 +252,12 @@ func (r *agentActionGroupResource) Create(ctx context.Context, request resource.
 	// Set values for unknowns.
 	data.ActionGroupID = fwflex.StringToFramework(ctx, output.AgentActionGroup.ActionGroupId)
 	data.ActionGroupState = fwtypes.StringEnumValue(output.AgentActionGroup.ActionGroupState)
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError("flattening resource ID Bedrock Agent Action Group", err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -430,8 +435,14 @@ func (m *agentActionGroupResourceModel) InitFromID() error {
 	return nil
 }
 
-func (m *agentActionGroupResourceModel) setID() {
-	m.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{m.ActionGroupID.ValueString(), m.AgentID.ValueString(), m.AgentVersion.ValueString()}, agentActionGroupResourceIDPartCount, false)))
+func (m *agentActionGroupResourceModel) setID() (string, error) {
+	parts := []string{
+		m.ActionGroupID.ValueString(),
+		m.AgentID.ValueString(),
+		m.AgentVersion.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, agentActionGroupResourceIDPartCount, false)
 }
 
 type actionGroupExecutorModel struct {

--- a/internal/service/bedrockagent/agent_alias.go
+++ b/internal/service/bedrockagent/agent_alias.go
@@ -139,7 +139,7 @@ func (r *agentAliasResource) Create(ctx context.Context, request resource.Create
 	data.AgentAliasID = fwflex.StringToFramework(ctx, output.AgentAlias.AgentAliasId)
 	id, err := data.setID()
 	if err != nil {
-		response.Diagnostics.AddError("flattning resource ID Bedrock Agent Alias", err.Error())
+		response.Diagnostics.AddError("creating Bedrock Agent Alias", err.Error())
 		return
 	}
 	data.ID = types.StringValue(id)

--- a/internal/service/bedrockagent/agent_alias.go
+++ b/internal/service/bedrockagent/agent_alias.go
@@ -137,7 +137,12 @@ func (r *agentAliasResource) Create(ctx context.Context, request resource.Create
 
 	// Set values for unknowns.
 	data.AgentAliasID = fwflex.StringToFramework(ctx, output.AgentAlias.AgentAliasId)
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError("flattning resource ID Bedrock Agent Alias", err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	alias, err := waitAgentAliasCreated(ctx, conn, data.AgentAliasID.ValueString(), data.AgentID.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
 
@@ -376,8 +381,13 @@ func (m *agentAliasResourceModel) InitFromID() error {
 	return nil
 }
 
-func (m *agentAliasResourceModel) setID() {
-	m.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{m.AgentAliasID.ValueString(), m.AgentID.ValueString()}, agentAliasResourceIDPartCount, false)))
+func (m *agentAliasResourceModel) setID() (string, error) {
+	parts := []string{
+		m.AgentAliasID.ValueString(),
+		m.AgentID.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, agentAliasResourceIDPartCount, false)
 }
 
 type agentAliasRoutingConfigurationListItemModel struct {

--- a/internal/service/bedrockagent/agent_knowledge_base_association.go
+++ b/internal/service/bedrockagent/agent_knowledge_base_association.go
@@ -121,7 +121,12 @@ func (r *agentKnowledgeBaseAssociationResource) Create(ctx context.Context, requ
 	}
 
 	// Set values for unknowns.
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError("flattening resource ID Bedrock Agent Knowledge Base Association", err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	_, err = prepareAgent(ctx, conn, data.AgentID.ValueString(), r.CreateTimeout(ctx, data.Timeouts))
 	if err != nil {
@@ -288,6 +293,12 @@ func (m *agentKnowledgeBaseAssociationResourceModel) InitFromID() error {
 	return nil
 }
 
-func (m *agentKnowledgeBaseAssociationResourceModel) setID() {
-	m.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{m.AgentID.ValueString(), m.AgentVersion.ValueString(), m.KnowledgeBaseID.ValueString()}, agentKnowledgeBaseAssociationResourceIDPartCount, false)))
+func (m *agentKnowledgeBaseAssociationResourceModel) setID() (string, error) {
+	parts := []string{
+		m.AgentID.ValueString(),
+		m.AgentVersion.ValueString(),
+		m.KnowledgeBaseID.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, agentKnowledgeBaseAssociationResourceIDPartCount, false)
 }

--- a/internal/service/cloudformation/stack_instances_test.go
+++ b/internal/service/cloudformation/stack_instances_test.go
@@ -573,7 +573,7 @@ func testAccCheckStackInstancesExists(ctx context.Context, resourceName string, 
 }
 
 func attributeLength(attribute string) int {
-	return errs.Must(strconv.Atoi(attribute))
+	return errs.Must(strconv.Atoi(attribute)) // nosemgrep: ci.avoid-errs-Must
 }
 
 // testAccCheckStackInstancesForOrganizationalUnitExists is a variant of the

--- a/internal/service/cloudformation/sweep.go
+++ b/internal/service/cloudformation/sweep.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tforganizations "github.com/hashicorp/terraform-provider-aws/internal/service/organizations"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
@@ -107,7 +106,10 @@ func sweepStackSetInstances(region string) error {
 
 					r := resourceStackSetInstance()
 					d := r.Data(nil)
-					id := errs.Must(flex.FlattenResourceId([]string{stackSetID, accountOrOrgID, aws.ToString(v.Region)}, stackSetInstanceResourceIDPartCount, false))
+					id, err := flex.FlattenResourceId([]string{stackSetID, accountOrOrgID, aws.ToString(v.Region)}, stackSetInstanceResourceIDPartCount, false)
+					if err != nil {
+						sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error flattening resource ID CloudFormation StackSet Instances (%s): %w", region, err))
+					}
 					d.SetId(id)
 					d.Set("call_as", awstypes.CallAsSelf)
 					if ouID != "" {

--- a/internal/service/cognitoidp/user_pool_ui_customization.go
+++ b/internal/service/cognitoidp/user_pool_ui_customization.go
@@ -86,7 +86,7 @@ func resourceUserPoolUICustomizationPut(ctx context.Context, d *schema.ResourceD
 	userPoolID, clientID := d.Get(names.AttrUserPoolID).(string), d.Get(names.AttrClientID).(string)
 	id, err := flex.FlattenResourceId([]string{userPoolID, clientID}, userPoolUICustomizationResourceIDPartCount, false)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Cognito User Pool UI Customization (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &cognitoidentityprovider.SetUICustomizationInput{

--- a/internal/service/cognitoidp/user_pool_ui_customization.go
+++ b/internal/service/cognitoidp/user_pool_ui_customization.go
@@ -84,7 +84,11 @@ func resourceUserPoolUICustomizationPut(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
 	userPoolID, clientID := d.Get(names.AttrUserPoolID).(string), d.Get(names.AttrClientID).(string)
-	id := errs.Must(flex.FlattenResourceId([]string{userPoolID, clientID}, userPoolUICustomizationResourceIDPartCount, false))
+	id, err := flex.FlattenResourceId([]string{userPoolID, clientID}, userPoolUICustomizationResourceIDPartCount, false)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Cognito User Pool UI Customization (%s): %s", id, err)
+	}
+
 	input := &cognitoidentityprovider.SetUICustomizationInput{
 		ClientId:   aws.String(clientID),
 		UserPoolId: aws.String(userPoolID),
@@ -102,9 +106,7 @@ func resourceUserPoolUICustomizationPut(ctx context.Context, d *schema.ResourceD
 		input.ImageFile = v
 	}
 
-	_, err := conn.SetUICustomization(ctx, input)
-
-	if err != nil {
+	if _, err := conn.SetUICustomization(ctx, input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting Cognito User Pool UI Customization (%s): %s", id, err)
 	}
 

--- a/internal/service/computeoptimizer/recommendation_preferences.go
+++ b/internal/service/computeoptimizer/recommendation_preferences.go
@@ -220,7 +220,12 @@ func (r *recommendationPreferencesResource) Create(ctx context.Context, request 
 	}
 
 	// Set values for unknowns.
-	data.setID(ctx)
+	id, err := data.setID(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("flattening resource ID Compute Optimizer Recommendation Preferences (%s)", data.ID.ValueString()), err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	// Read the resource to get other Computed attribute values.
 	scope := fwdiag.Must(data.Scope.ToPtr(ctx))
@@ -439,9 +444,15 @@ func (m *recommendationPreferencesResourceModel) InitFromID(ctx context.Context)
 	return nil
 }
 
-func (m *recommendationPreferencesResourceModel) setID(ctx context.Context) {
+func (m *recommendationPreferencesResourceModel) setID(ctx context.Context) (string, error) {
 	scope := fwdiag.Must(m.Scope.ToPtr(ctx))
-	m.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{m.ResourceType.ValueString(), scope.Name.ValueString(), scope.Value.ValueString()}, recommendationPreferencesResourceIDPartCount, false)))
+	parts := []string{
+		m.ResourceType.ValueString(),
+		scope.Name.ValueString(),
+		scope.Value.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, recommendationPreferencesResourceIDPartCount, false)
 }
 
 type externalMetricsPreferenceModel struct {

--- a/internal/service/connect/lambda_function_association.go
+++ b/internal/service/connect/lambda_function_association.go
@@ -60,15 +60,17 @@ func resourceLambdaFunctionAssociationCreate(ctx context.Context, d *schema.Reso
 
 	instanceID := d.Get(names.AttrInstanceID).(string)
 	functionARN := d.Get(names.AttrFunctionARN).(string)
-	id := errs.Must(flex.FlattenResourceId([]string{instanceID, functionARN}, lambdaFunctionAssociationResourceIDPartCount, true))
+	id, err := flex.FlattenResourceId([]string{instanceID, functionARN}, lambdaFunctionAssociationResourceIDPartCount, true)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Connect Lambda Function Association (%s): %s", id, err)
+	}
+
 	input := &connect.AssociateLambdaFunctionInput{
 		FunctionArn: aws.String(functionARN),
 		InstanceId:  aws.String(instanceID),
 	}
 
-	_, err := conn.AssociateLambdaFunction(ctx, input)
-
-	if err != nil {
+	if _, err := conn.AssociateLambdaFunction(ctx, input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Connect Lambda Function Association (%s): %s", id, err)
 	}
 

--- a/internal/service/connect/lambda_function_association.go
+++ b/internal/service/connect/lambda_function_association.go
@@ -62,7 +62,7 @@ func resourceLambdaFunctionAssociationCreate(ctx context.Context, d *schema.Reso
 	functionARN := d.Get(names.AttrFunctionARN).(string)
 	id, err := flex.FlattenResourceId([]string{instanceID, functionARN}, lambdaFunctionAssociationResourceIDPartCount, true)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Connect Lambda Function Association (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &connect.AssociateLambdaFunctionInput{

--- a/internal/service/controltower/control.go
+++ b/internal/service/controltower/control.go
@@ -108,7 +108,11 @@ func resourceControlCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	controlIdentifier := d.Get("control_identifier").(string)
 	targetIdentifier := d.Get("target_identifier").(string)
-	id := errs.Must(flex.FlattenResourceId([]string{targetIdentifier, controlIdentifier}, controlResourceIDPartCount, false))
+	id, err := flex.FlattenResourceId([]string{targetIdentifier, controlIdentifier}, controlResourceIDPartCount, false)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating ControlTower Control (%s): %s", id, err)
+	}
+
 	input := &controltower.EnableControlInput{
 		ControlIdentifier: aws.String(controlIdentifier),
 		TargetIdentifier:  aws.String(targetIdentifier),

--- a/internal/service/controltower/control.go
+++ b/internal/service/controltower/control.go
@@ -110,7 +110,7 @@ func resourceControlCreate(ctx context.Context, d *schema.ResourceData, meta int
 	targetIdentifier := d.Get("target_identifier").(string)
 	id, err := flex.FlattenResourceId([]string{targetIdentifier, controlIdentifier}, controlResourceIDPartCount, false)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating ControlTower Control (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &controltower.EnableControlInput{

--- a/internal/service/dynamodb/kinesis_streaming_destination.go
+++ b/internal/service/dynamodb/kinesis_streaming_destination.go
@@ -65,7 +65,7 @@ func resourceKinesisStreamingDestinationCreate(ctx context.Context, d *schema.Re
 	tableName := d.Get(names.AttrTableName).(string)
 	id, err := flex.FlattenResourceId([]string{tableName, streamARN}, kinesisStreamingDestinationResourceIDPartCount, false)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "enabling DynamoDB Kinesis Streaming Destination (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &dynamodb.EnableKinesisStreamingDestinationInput{

--- a/internal/service/dynamodb/kinesis_streaming_destination.go
+++ b/internal/service/dynamodb/kinesis_streaming_destination.go
@@ -63,15 +63,17 @@ func resourceKinesisStreamingDestinationCreate(ctx context.Context, d *schema.Re
 
 	streamARN := d.Get(names.AttrStreamARN).(string)
 	tableName := d.Get(names.AttrTableName).(string)
-	id := errs.Must(flex.FlattenResourceId([]string{tableName, streamARN}, kinesisStreamingDestinationResourceIDPartCount, false))
+	id, err := flex.FlattenResourceId([]string{tableName, streamARN}, kinesisStreamingDestinationResourceIDPartCount, false)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "enabling DynamoDB Kinesis Streaming Destination (%s): %s", id, err)
+	}
+
 	input := &dynamodb.EnableKinesisStreamingDestinationInput{
 		StreamArn: aws.String(streamARN),
 		TableName: aws.String(tableName),
 	}
 
-	_, err := conn.EnableKinesisStreamingDestination(ctx, input)
-
-	if err != nil {
+	if _, err := conn.EnableKinesisStreamingDestination(ctx, input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "enabling DynamoDB Kinesis Streaming Destination (%s): %s", id, err)
 	}
 

--- a/internal/service/ec2/ebs_fast_snapshot_restore.go
+++ b/internal/service/ec2/ebs_fast_snapshot_restore.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
@@ -103,7 +102,12 @@ func (r *ebsFastSnapshotRestoreResource) Create(ctx context.Context, request res
 	}
 
 	// Set values for unknowns.
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError("creating EC2 EBS Fast Snapshot Restore", err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	v, err := waitFastSnapshotRestoreCreated(ctx, conn, availabilityZone, snapshotID, r.CreateTimeout(ctx, data.Timeouts))
 
@@ -208,6 +212,11 @@ func (data *ebsFastSnapshotRestoreResourceModel) InitFromID() error {
 	return nil
 }
 
-func (data *ebsFastSnapshotRestoreResourceModel) setID() {
-	data.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{data.AvailabilityZone.ValueString(), data.SnapshotID.ValueString()}, ebsFastSnapshotRestoreIDPartCount, false)))
+func (data *ebsFastSnapshotRestoreResourceModel) setID() (string, error) {
+	parts := []string{
+		data.AvailabilityZone.ValueString(),
+		data.SnapshotID.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, ebsFastSnapshotRestoreIDPartCount, false)
 }

--- a/internal/service/elasticache/user_group_association.go
+++ b/internal/service/elasticache/user_group_association.go
@@ -64,7 +64,7 @@ func resourceUserGroupAssociationCreate(ctx context.Context, d *schema.ResourceD
 	userID := d.Get("user_id").(string)
 	id, err := flex.FlattenResourceId([]string{userGroupID, userID}, userGroupAssociationResourceIDPartCount, true)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating ElastiCache User Group Association (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 	input := &elasticache.ModifyUserGroupInput{
 		UserGroupId:  aws.String(userGroupID),

--- a/internal/service/elasticache/user_group_association.go
+++ b/internal/service/elasticache/user_group_association.go
@@ -62,17 +62,18 @@ func resourceUserGroupAssociationCreate(ctx context.Context, d *schema.ResourceD
 
 	userGroupID := d.Get("user_group_id").(string)
 	userID := d.Get("user_id").(string)
-	id := errs.Must(flex.FlattenResourceId([]string{userGroupID, userID}, userGroupAssociationResourceIDPartCount, true))
+	id, err := flex.FlattenResourceId([]string{userGroupID, userID}, userGroupAssociationResourceIDPartCount, true)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating ElastiCache User Group Association (%s): %s", id, err)
+	}
 	input := &elasticache.ModifyUserGroupInput{
 		UserGroupId:  aws.String(userGroupID),
 		UserIdsToAdd: []string{userID},
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidUserGroupStateFault](ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	if _, err := tfresource.RetryWhenIsA[*awstypes.InvalidUserGroupStateFault](ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		return conn.ModifyUserGroup(ctx, input)
-	})
-
-	if err != nil {
+	}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating ElastiCache User Group Association (%s): %s", id, err)
 	}
 

--- a/internal/service/fms/sweep.go
+++ b/internal/service/fms/sweep.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright (c) HashiCorp, Inc.fms/sweep
 // SPDX-License-Identifier: MPL-2.0
 
 package fms
@@ -103,7 +103,7 @@ func (aas adminAccountSweeper) Delete(ctx context.Context, timeout time.Duration
 		})
 		return nil
 	}
-	if err != nil && errs.Must(regexp.MatchString(`InvalidOperationException: This operation is not supported in the '[-a-z0-9]+' region`, err.Error())) {
+	if err != nil && errs.Must(regexp.MatchString(`InvalidOperationException: This operation is not supported in the '[-a-z0-9]+' region`, err.Error())) { // nosemgrep: ci.avoid-errs-Must
 		tflog.Warn(ctx, "Skipping resource", map[string]any{
 			"attr.account_id": aas.d.Get(names.AttrAccountID),
 			"error":           err.Error(),

--- a/internal/service/grafana/workspace_service_account_token.go
+++ b/internal/service/grafana/workspace_service_account_token.go
@@ -133,7 +133,12 @@ func (r *workspaceServiceAccountTokenResource) Create(ctx context.Context, reque
 	// Set values for unknowns.
 	data.Key = fwflex.StringToFramework(ctx, output.ServiceAccountToken.Key)
 	data.TokenID = fwflex.StringToFramework(ctx, output.ServiceAccountToken.Id)
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError("setting resource ID", err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	serviceAccountToken, err := findWorkspaceServiceAccountTokenByThreePartKey(ctx, conn, data.WorkspaceID.ValueString(), data.ServiceAccountID.ValueString(), data.TokenID.ValueString())
 
@@ -187,7 +192,12 @@ func (r *workspaceServiceAccountTokenResource) Read(ctx context.Context, request
 
 	// Restore resource ID.
 	// It has been overwritten by the 'Id' field from the API response.
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError("setting resource ID", err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
@@ -300,6 +310,12 @@ func (data *workspaceServiceAccountTokenResourceModel) InitFromID() error {
 	return nil
 }
 
-func (data *workspaceServiceAccountTokenResourceModel) setID() {
-	data.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{data.WorkspaceID.ValueString(), data.ServiceAccountID.ValueString(), data.TokenID.ValueString()}, workspaceServiceAccountTokenResourceIDPartCount, false)))
+func (data *workspaceServiceAccountTokenResourceModel) setID() (string, error) {
+	parts := []string{
+		data.WorkspaceID.ValueString(),
+		data.ServiceAccountID.ValueString(),
+		data.TokenID.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, workspaceServiceAccountTokenResourceIDPartCount, false)
 }

--- a/internal/service/lambda/layer_version_permission.go
+++ b/internal/service/lambda/layer_version_permission.go
@@ -102,7 +102,10 @@ func resourceLayerVersionPermissionCreate(ctx context.Context, d *schema.Resourc
 
 	layerName := d.Get("layer_name").(string)
 	versionNumber := d.Get("version_number").(int)
-	id := errs.Must(flex.FlattenResourceId([]string{layerName, strconv.FormatInt(int64(versionNumber), 10)}, layerVersionPermissionResourceIDPartCount, true))
+	id, err := flex.FlattenResourceId([]string{layerName, strconv.FormatInt(int64(versionNumber), 10)}, layerVersionPermissionResourceIDPartCount, true)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "adding Lambda Layer Version Permission (%s): %s", id, err)
+	}
 	input := &lambda.AddLayerVersionPermissionInput{
 		Action:        aws.String(d.Get(names.AttrAction).(string)),
 		LayerName:     aws.String(layerName),
@@ -115,9 +118,7 @@ func resourceLayerVersionPermissionCreate(ctx context.Context, d *schema.Resourc
 		input.OrganizationId = aws.String(v.(string))
 	}
 
-	_, err := conn.AddLayerVersionPermission(ctx, input)
-
-	if err != nil {
+	if _, err := conn.AddLayerVersionPermission(ctx, input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "adding Lambda Layer Version Permission (%s): %s", id, err)
 	}
 

--- a/internal/service/lambda/layer_version_permission.go
+++ b/internal/service/lambda/layer_version_permission.go
@@ -104,7 +104,7 @@ func resourceLayerVersionPermissionCreate(ctx context.Context, d *schema.Resourc
 	versionNumber := d.Get("version_number").(int)
 	id, err := flex.FlattenResourceId([]string{layerName, strconv.FormatInt(int64(versionNumber), 10)}, layerVersionPermissionResourceIDPartCount, true)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "adding Lambda Layer Version Permission (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 	input := &lambda.AddLayerVersionPermissionInput{
 		Action:        aws.String(d.Get(names.AttrAction).(string)),

--- a/internal/service/lambda/provisioned_concurrency_config.go
+++ b/internal/service/lambda/provisioned_concurrency_config.go
@@ -88,16 +88,17 @@ func resourceProvisionedConcurrencyConfigCreate(ctx context.Context, d *schema.R
 
 	functionName := d.Get("function_name").(string)
 	qualifier := d.Get("qualifier").(string)
-	id := errs.Must(flex.FlattenResourceId([]string{functionName, qualifier}, provisionedConcurrencyConfigResourceIDPartCount, true))
+	id, err := flex.FlattenResourceId([]string{functionName, qualifier}, provisionedConcurrencyConfigResourceIDPartCount, true)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Lambda Provisioned Concurrency Config (%s): %s", id, err)
+	}
 	input := &lambda.PutProvisionedConcurrencyConfigInput{
 		FunctionName:                    aws.String(functionName),
 		ProvisionedConcurrentExecutions: aws.Int32(int32(d.Get("provisioned_concurrent_executions").(int))),
 		Qualifier:                       aws.String(qualifier),
 	}
 
-	_, err := conn.PutProvisionedConcurrencyConfig(ctx, input)
-
-	if err != nil {
+	if _, err := conn.PutProvisionedConcurrencyConfig(ctx, input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Lambda Provisioned Concurrency Config (%s): %s", id, err)
 	}
 

--- a/internal/service/lambda/provisioned_concurrency_config.go
+++ b/internal/service/lambda/provisioned_concurrency_config.go
@@ -90,7 +90,7 @@ func resourceProvisionedConcurrencyConfigCreate(ctx context.Context, d *schema.R
 	qualifier := d.Get("qualifier").(string)
 	id, err := flex.FlattenResourceId([]string{functionName, qualifier}, provisionedConcurrencyConfigResourceIDPartCount, true)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Lambda Provisioned Concurrency Config (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 	input := &lambda.PutProvisionedConcurrencyConfigInput{
 		FunctionName:                    aws.String(functionName),

--- a/internal/service/lexv2models/intent_test.go
+++ b/internal/service/lexv2models/intent_test.go
@@ -647,7 +647,7 @@ func TestIntentAutoFlex(t *testing.T) {
 	}
 
 	testTimeStr := "2023-12-08T09:34:01Z"
-	testTimeTime := errs.Must(time.Parse(time.RFC3339, testTimeStr))
+	testTimeTime := errs.Must(time.Parse(time.RFC3339, testTimeStr)) // nosemgrep: ci.avoid-errs-Must
 
 	intentDescribeTF := tflexv2models.ResourceIntentData{
 		BotID:                  types.StringValue(testString),

--- a/internal/service/m2/deployment.go
+++ b/internal/service/m2/deployment.go
@@ -118,7 +118,12 @@ func (r *deploymentResource) Create(ctx context.Context, request resource.Create
 
 	// Set values for unknowns.
 	data.DeploymentID = fwflex.StringToFramework(ctx, output.DeploymentId)
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError("creating Mainframe Modernization Deployment", err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	timeout := r.CreateTimeout(ctx, data.Timeouts)
 	if _, err := waitDeploymentCreated(ctx, conn, data.ApplicationID.ValueString(), data.DeploymentID.ValueString(), timeout); err != nil {
@@ -233,7 +238,12 @@ func (r *deploymentResource) Update(ctx context.Context, request resource.Update
 
 		// Set values for unknowns.
 		new.DeploymentID = fwflex.StringToFramework(ctx, output.DeploymentId)
-		new.setID()
+		id, err := new.setID()
+		if err != nil {
+			response.Diagnostics.AddError("creating Mainframe Modernization Deployment", err.Error())
+			return
+		}
+		new.ID = types.StringValue(id)
 
 		if _, err := waitDeploymentUpdated(ctx, conn, new.ApplicationID.ValueString(), new.DeploymentID.ValueString(), timeout); err != nil {
 			response.Diagnostics.AddError(fmt.Sprintf("waiting for Mainframe Modernization Deployment (%s) update", new.ID.ValueString()), err.Error())
@@ -443,6 +453,11 @@ func (data *deploymentResourceModel) InitFromID() error {
 	return nil
 }
 
-func (data *deploymentResourceModel) setID() {
-	data.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{data.ApplicationID.ValueString(), data.DeploymentID.ValueString()}, deploymentResourceIDPartCount, false)))
+func (data *deploymentResourceModel) setID() (string, error) {
+	parts := []string{
+		data.ApplicationID.ValueString(),
+		data.DeploymentID.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, deploymentResourceIDPartCount, false)
 }

--- a/internal/service/networkmonitor/probe.go
+++ b/internal/service/networkmonitor/probe.go
@@ -153,7 +153,12 @@ func (r *probeResource) Create(ctx context.Context, request resource.CreateReque
 	// Set values for unknowns.
 	data.ProbeARN = fwflex.StringToFramework(ctx, outputCP.ProbeArn)
 	data.ProbeID = fwflex.StringToFramework(ctx, outputCP.ProbeId)
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError("creating CloudWatch Network Monitor Probe (%s)", err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	outputGP, err := waitProbeReady(ctx, conn, data.MonitorName.ValueString(), data.ProbeID.ValueString())
 
@@ -427,6 +432,11 @@ func (m *probeResourceModel) InitFromID() error {
 	return nil
 }
 
-func (m *probeResourceModel) setID() {
-	m.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{m.MonitorName.ValueString(), m.ProbeID.ValueString()}, probeResourceIDPartCount, false)))
+func (m *probeResourceModel) setID() (string, error) {
+	parts := []string{
+		m.MonitorName.ValueString(),
+		m.ProbeID.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, probeResourceIDPartCount, false)
 }

--- a/internal/service/ram/principal_association.go
+++ b/internal/service/ram/principal_association.go
@@ -72,8 +72,12 @@ func resourcePrincipalAssociationCreate(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*conns.AWSClient).RAMClient(ctx)
 
 	resourceShareARN, principal := d.Get("resource_share_arn").(string), d.Get(names.AttrPrincipal).(string)
-	id := errs.Must(flex.FlattenResourceId([]string{resourceShareARN, principal}, principalAssociationResourceIDPartCount, false))
-	_, err := findPrincipalAssociationByTwoPartKey(ctx, conn, resourceShareARN, principal)
+	id, err := flex.FlattenResourceId([]string{resourceShareARN, principal}, principalAssociationResourceIDPartCount, false)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating RAM Principal Association (%s): %s", id, err)
+	}
+
+	_, err = findPrincipalAssociationByTwoPartKey(ctx, conn, resourceShareARN, principal)
 
 	switch {
 	case err == nil:

--- a/internal/service/ram/principal_association.go
+++ b/internal/service/ram/principal_association.go
@@ -74,7 +74,7 @@ func resourcePrincipalAssociationCreate(ctx context.Context, d *schema.ResourceD
 	resourceShareARN, principal := d.Get("resource_share_arn").(string), d.Get(names.AttrPrincipal).(string)
 	id, err := flex.FlattenResourceId([]string{resourceShareARN, principal}, principalAssociationResourceIDPartCount, false)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating RAM Principal Association (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	_, err = findPrincipalAssociationByTwoPartKey(ctx, conn, resourceShareARN, principal)

--- a/internal/service/ram/resource_association.go
+++ b/internal/service/ram/resource_association.go
@@ -66,7 +66,7 @@ func resourceResourceAssociationCreate(ctx context.Context, d *schema.ResourceDa
 	resourceShareARN, resourceARN := d.Get("resource_share_arn").(string), d.Get(names.AttrResourceARN).(string)
 	id, err := flex.FlattenResourceId([]string{resourceShareARN, resourceARN}, resourceAssociationResourceIDPartCount, false)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating RAM Resource Association (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	_, err = findResourceAssociationByTwoPartKey(ctx, conn, resourceShareARN, resourceARN)

--- a/internal/service/ram/resource_association.go
+++ b/internal/service/ram/resource_association.go
@@ -64,8 +64,12 @@ func resourceResourceAssociationCreate(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*conns.AWSClient).RAMClient(ctx)
 
 	resourceShareARN, resourceARN := d.Get("resource_share_arn").(string), d.Get(names.AttrResourceARN).(string)
-	id := errs.Must(flex.FlattenResourceId([]string{resourceShareARN, resourceARN}, resourceAssociationResourceIDPartCount, false))
-	_, err := findResourceAssociationByTwoPartKey(ctx, conn, resourceShareARN, resourceARN)
+	id, err := flex.FlattenResourceId([]string{resourceShareARN, resourceARN}, resourceAssociationResourceIDPartCount, false)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating RAM Resource Association (%s): %s", id, err)
+	}
+
+	_, err = findResourceAssociationByTwoPartKey(ctx, conn, resourceShareARN, resourceARN)
 
 	switch {
 	case err == nil:

--- a/internal/service/redshiftserverless/custom_domain_association.go
+++ b/internal/service/redshiftserverless/custom_domain_association.go
@@ -107,7 +107,12 @@ func (r *customDomainAssociationResource) Create(ctx context.Context, request re
 
 	// Set values for unknowns.
 	data.CustomDomainCertificateExpiryTime = timetypes.NewRFC3339TimePointerValue(output.CustomDomainCertificateExpiryTime)
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError("creating Redshift Serverless Custom Domain Association", err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
@@ -260,6 +265,11 @@ func (data *customDomainAssociationResourceModel) InitFromID() error {
 	return nil
 }
 
-func (data *customDomainAssociationResourceModel) setID() {
-	data.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{data.WorkgroupName.ValueString(), data.CustomDomainName.ValueString()}, customDomainAssociationResourceIDPartCount, false)))
+func (data *customDomainAssociationResourceModel) setID() (string, error) {
+	parts := []string{
+		data.WorkgroupName.ValueString(),
+		data.CustomDomainName.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, customDomainAssociationResourceIDPartCount, false)
 }

--- a/internal/service/route53/key_signing_key.go
+++ b/internal/service/route53/key_signing_key.go
@@ -131,7 +131,10 @@ func resourceKeySigningKeyCreate(ctx context.Context, d *schema.ResourceData, me
 	hostedZoneID := d.Get(names.AttrHostedZoneID).(string)
 	name := d.Get(names.AttrName).(string)
 	status := d.Get(names.AttrStatus).(string)
-	id := errs.Must(flex.FlattenResourceId([]string{hostedZoneID, name}, keySigningKeyResourceIDPartCount, false))
+	id, err := flex.FlattenResourceId([]string{hostedZoneID, name}, keySigningKeyResourceIDPartCount, false)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating Route 53 Key Signing Key (%s): %s", id, err)
+	}
 	input := &route53.CreateKeySigningKeyInput{
 		CallerReference: aws.String(sdkid.UniqueId()),
 		HostedZoneId:    aws.String(hostedZoneID),

--- a/internal/service/route53/key_signing_key.go
+++ b/internal/service/route53/key_signing_key.go
@@ -133,7 +133,7 @@ func resourceKeySigningKeyCreate(ctx context.Context, d *schema.ResourceData, me
 	status := d.Get(names.AttrStatus).(string)
 	id, err := flex.FlattenResourceId([]string{hostedZoneID, name}, keySigningKeyResourceIDPartCount, false)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating Route 53 Key Signing Key (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 	input := &route53.CreateKeySigningKeyInput{
 		CallerReference: aws.String(sdkid.UniqueId()),

--- a/internal/service/route53domains/delegation_signer_record.go
+++ b/internal/service/route53domains/delegation_signer_record.go
@@ -149,7 +149,12 @@ func (r *delegationSignerRecordResource) Create(ctx context.Context, request res
 
 	// Set values for unknowns.
 	data.DNSSECKeyID = fwflex.StringToFramework(ctx, dnssecKey.Id)
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("flattening resource ID Route 53 Domains Domain (%s) DNSSEC key", data.DomainName.ValueString()), err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
@@ -257,6 +262,11 @@ func (data *delegationSignerRecordResourceModel) InitFromID() error {
 	return nil
 }
 
-func (data *delegationSignerRecordResourceModel) setID() {
-	data.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{data.DomainName.ValueString(), data.DNSSECKeyID.ValueString()}, delegationSignerRecordResourceIDPartCount, false)))
+func (data *delegationSignerRecordResourceModel) setID() (string, error) {
+	parts := []string{
+		data.DomainName.ValueString(),
+		data.DNSSECKeyID.ValueString(),
+	}
+
+	return flex.FlattenResourceId(parts, delegationSignerRecordResourceIDPartCount, false)
 }

--- a/internal/service/securityhub/product_subscription.go
+++ b/internal/service/securityhub/product_subscription.go
@@ -69,7 +69,7 @@ func resourceProductSubscriptionCreate(ctx context.Context, d *schema.ResourceDa
 
 	id, err := flex.FlattenResourceId([]string{productARN, aws.ToString(output.ProductSubscriptionArn)}, productSubscriptionResourceIDPartCount, false)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "enabling Security Hub Product Subscription (%s): %s", productARN, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 	d.SetId(id)
 

--- a/internal/service/securityhub/product_subscription.go
+++ b/internal/service/securityhub/product_subscription.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
@@ -68,7 +67,11 @@ func resourceProductSubscriptionCreate(ctx context.Context, d *schema.ResourceDa
 		return sdkdiag.AppendErrorf(diags, "enabling Security Hub Product Subscription (%s): %s", productARN, err)
 	}
 
-	d.SetId(errs.Must(flex.FlattenResourceId([]string{productARN, aws.ToString(output.ProductSubscriptionArn)}, productSubscriptionResourceIDPartCount, false)))
+	id, err := flex.FlattenResourceId([]string{productARN, aws.ToString(output.ProductSubscriptionArn)}, productSubscriptionResourceIDPartCount, false)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "enabling Security Hub Product Subscription (%s): %s", productARN, err)
+	}
+	d.SetId(id)
 
 	return append(diags, resourceProductSubscriptionRead(ctx, d, meta)...)
 }

--- a/internal/service/securitylake/subscriber_notification.go
+++ b/internal/service/securitylake/subscriber_notification.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
@@ -152,7 +151,12 @@ func (r *subscriberNotificationResource) Create(ctx context.Context, request res
 	// Set values for unknowns.
 	data.EndpointID = fwflex.StringToFramework(ctx, output.SubscriberEndpoint)
 	data.SubscriberEndpoint = fwflex.StringToFramework(ctx, output.SubscriberEndpoint)
-	data.setID()
+	id, err := data.setID()
+	if err != nil {
+		response.Diagnostics.AddError("creating Security Lake Subscriber Notification", err.Error())
+		return
+	}
+	data.ID = types.StringValue(id)
 
 	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
@@ -241,7 +245,15 @@ func (r *subscriberNotificationResource) Update(ctx context.Context, request res
 
 		new.EndpointID = fwflex.StringToFramework(ctx, output.SubscriberEndpoint)
 		new.SubscriberEndpoint = fwflex.StringToFramework(ctx, output.SubscriberEndpoint)
-		new.setID()
+		id, err := new.setID()
+		if err != nil {
+			response.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.SecurityLake, create.ErrActionUpdating, ResNameSubscriberNotification, new.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		new.ID = types.StringValue(id)
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
@@ -366,8 +378,13 @@ func (data *subscriberNotificationResourceModel) initFromID() error {
 	return nil
 }
 
-func (data *subscriberNotificationResourceModel) setID() {
-	data.ID = types.StringValue(errs.Must(flex.FlattenResourceId([]string{data.SubscriberID.ValueString(), "notification"}, subscriberNotificationIdPartCount, false)))
+func (data *subscriberNotificationResourceModel) setID() (string, error) {
+	parts := []string{
+		data.SubscriberID.ValueString(),
+		"notification",
+	}
+
+	return flex.FlattenResourceId(parts, subscriberNotificationIdPartCount, false)
 }
 
 func refreshConfiguration(ctx context.Context, config fwtypes.ListNestedObjectValueOf[subscriberNotificationResourceConfigurationModel], subscriber *awstypes.SubscriberResource, diags *diag.Diagnostics) fwtypes.ListNestedObjectValueOf[subscriberNotificationResourceConfigurationModel] {

--- a/internal/service/ssm/patch_group.go
+++ b/internal/service/ssm/patch_group.go
@@ -61,15 +61,16 @@ func resourcePatchGroupCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	baselineID := d.Get("baseline_id").(string)
 	patchGroup := d.Get("patch_group").(string)
-	id := errs.Must(flex.FlattenResourceId([]string{patchGroup, baselineID}, patchGroupResourceIDPartCount, false))
+	id, err := flex.FlattenResourceId([]string{patchGroup, baselineID}, patchGroupResourceIDPartCount, false)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating SSM Patch Group (%s): %s", id, err)
+	}
 	input := &ssm.RegisterPatchBaselineForPatchGroupInput{
 		BaselineId: aws.String(baselineID),
 		PatchGroup: aws.String(patchGroup),
 	}
 
-	_, err := conn.RegisterPatchBaselineForPatchGroup(ctx, input)
-
-	if err != nil {
+	if _, err := conn.RegisterPatchBaselineForPatchGroup(ctx, input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating SSM Patch Group (%s): %s", id, err)
 	}
 

--- a/internal/service/ssm/patch_group.go
+++ b/internal/service/ssm/patch_group.go
@@ -63,7 +63,7 @@ func resourcePatchGroupCreate(ctx context.Context, d *schema.ResourceData, meta 
 	patchGroup := d.Get("patch_group").(string)
 	id, err := flex.FlattenResourceId([]string{patchGroup, baselineID}, patchGroupResourceIDPartCount, false)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating SSM Patch Group (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 	input := &ssm.RegisterPatchBaselineForPatchGroupInput{
 		BaselineId: aws.String(baselineID),

--- a/internal/service/wafv2/web_acl_association.go
+++ b/internal/service/wafv2/web_acl_association.go
@@ -67,18 +67,20 @@ func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData
 
 	webACLARN := d.Get("web_acl_arn").(string)
 	resourceARN := d.Get(names.AttrResourceARN).(string)
-	id := errs.Must(flex.FlattenResourceId([]string{webACLARN, resourceARN}, webACLAssociationResourceIDPartCount, true))
+	id, err := flex.FlattenResourceId([]string{webACLARN, resourceARN}, webACLAssociationResourceIDPartCount, true)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating WAFv2 WebACL Association (%s): %s", id, err)
+	}
+
 	input := &wafv2.AssociateWebACLInput{
 		ResourceArn: aws.String(resourceARN),
 		WebACLArn:   aws.String(webACLARN),
 	}
 
 	log.Printf("[INFO] Creating WAFv2 WebACL Association: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	if _, err = tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
 		return conn.AssociateWebACL(ctx, input)
-	})
-
-	if err != nil {
+	}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating WAFv2 WebACL Association (%s): %s", id, err)
 	}
 

--- a/internal/service/wafv2/web_acl_association.go
+++ b/internal/service/wafv2/web_acl_association.go
@@ -69,7 +69,7 @@ func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData
 	resourceARN := d.Get(names.AttrResourceARN).(string)
 	id, err := flex.FlattenResourceId([]string{webACLARN, resourceARN}, webACLAssociationResourceIDPartCount, true)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "creating WAFv2 WebACL Association (%s): %s", id, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
 	input := &wafv2.AssociateWebACLInput{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This check will match on any use of `errs.Must(...)` within `internal/service/**/`. Errors should be handled explicitly in service packages to avoid the possibility of crashing the provider during execution. This function was originally intended for use while initializing service clients during the `ConfigureProvider` operation, where a panic is the appropriate course of action.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39038

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrockagent TESTS="TestAccBedrockAgent_serial/DataSource/basic|TestAccBedrockAgentAgentActionGroup_basic|TestAccBedrockAgentAgentAlias_basic|TestAccBedrockAgentAgentKnowledgeBaseAssociation_basic"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgent_serial/DataSource/basic|TestAccBedrockAgentAgentActionGroup_basic|TestAccBedrockAgentAgentAlias_basic|TestAccBedrockAgentAgentKnowledgeBaseAssociation_basic'  -timeout 360m

--- PASS: TestAccBedrockAgentAgentAlias_basic (33.15s)
--- PASS: TestAccBedrockAgentAgentActionGroup_basic (34.79s)
--- PASS: TestAccBedrockAgentAgentKnowledgeBaseAssociation_basic (1610.63s)
--- PASS: TestAccBedrockAgent_serial (1664.05s)
    --- PASS: TestAccBedrockAgent_serial/DataSource (1664.05s)
        --- PASS: TestAccBedrockAgent_serial/DataSource/basic (1664.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       1669.423s
```

```console
% make testacc PKG=cloudformation TESTS=TestAccCloudFormationStackInstances_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/cloudformation/... -v -count 1 -parallel 20 -run='TestAccCloudFormationStackInstances_basic'  -timeout 360m

--- PASS: TestAccCloudFormationStackInstances_basic (81.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     88.170s
```

```console
% make testacc PKG=cognitoidp TESTS=TestAccCognitoIDPUserPoolUICustomization_Client_image
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPoolUICustomization_Client_image'  -timeout 360m

--- PASS: TestAccCognitoIDPUserPoolUICustomization_Client_image (31.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 37.177s
```

```console
% make testacc PKG=cloudfrontkeyvaluestore TESTS=TestAccCloudFrontKeyValueStoreKey_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/cloudfrontkeyvaluestore/... -v -count 1 -parallel 20 -run='TestAccCloudFrontKeyValueStoreKey_basic'  -timeout 360m

--- PASS: TestAccCloudFrontKeyValueStoreKey_basic (110.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfrontkeyvaluestore    117.716s
```

```console
% make testacc PKG=connect TESTS=TestAccConnect_serial/LambdaFunctionAssociation/basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnect_serial/LambdaFunctionAssociation/basic'  -timeout 360m

--- PASS: TestAccConnect_serial (175.23s)
    --- PASS: TestAccConnect_serial/LambdaFunctionAssociation (175.23s)
        --- PASS: TestAccConnect_serial/LambdaFunctionAssociation/basic (89.25s)
        --- PASS: TestAccConnect_serial/LambdaFunctionAssociation/dataSource_basic (85.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/connect    181.961s
```

```console
% make testacc PKG=ebs TESTS=TestAccEC2EBSFastSnapshotRestore_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2EBSFastSnapshotRestore_basic'  -timeout 360m

--- PASS: TestAccEC2EBSFastSnapshotRestore_basic (168.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        175.209s
```

```console
% make testacc PKG=elbv2 TESTS=TestAccELBV2TrustStoreRevocation_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TrustStoreRevocation_basic'  -timeout 360m

--- PASS: TestAccELBV2TrustStoreRevocation_basic (43.79s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      49.271s
```

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheUserGroupAssociation_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUserGroupAssociation_basic'  -timeout 360m
=== RUN   TestAccElastiCacheUserGroupAssociation_basic
=== PAUSE TestAccElastiCacheUserGroupAssociation_basic
=== CONT  TestAccElastiCacheUserGroupAssociation_basic
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (257.08s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        262.428s
```

```console
% make testacc PKG=lambda TESTS="TestAccLambdaLayerVersionPermission_basic_byARN|TestAccLambdaLayerVersionPermission_basic_byName|TestAccLambdaProvisionedConcurrencyConfig_basic"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaLayerVersionPermission_basic_byARN|TestAccLambdaLayerVersionPermission_basic_byName|TestAccLambdaProvisionedConcurrencyConfig_basic'  -timeout 360m

--- PASS: TestAccLambdaLayerVersionPermission_basic_byName (15.52s)
--- PASS: TestAccLambdaLayerVersionPermission_basic_byARN (19.29s)
--- PASS: TestAccLambdaProvisionedConcurrencyConfig_basic (134.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     139.738s
```

```console
% make testacc PKG=m2 TESTS=TestAccM2Deployment_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/m2/... -v -count 1 -parallel 20 -run='TestAccM2Deployment_basic'  -timeout 360m

--- PASS: TestAccM2Deployment_basic (2507.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/m2 2514.812s
```

```console
% make testacc PKG=networkmonitor TESTS=TestAccNetworkMonitorProbe_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/networkmonitor/... -v -count 1 -parallel 20 -run='TestAccNetworkMonitorProbe_basic'  -timeout 360m
=== RUN   TestAccNetworkMonitorProbe_basic
=== PAUSE TestAccNetworkMonitorProbe_basic
=== CONT  TestAccNetworkMonitorProbe_basic
    probe_test.go:34: Step 3/3 error: Error running apply: exit status 1

        Error: waiting for CloudWatch Network Monitor Probe (tf-acc-test-7273269475067989614,probe-5ujg03zhv8segr8lda074dezf) delete

        timeout while waiting for resource to be gone (last state: 'DELETING',
        timeout: 15m0s)
    panic.go:626: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting CloudWatch Network Monitor Probe (tf-acc-test-7273269475067989614,probe-5ujg03zhv8segr8lda074dezf)

        operation error NetworkMonitor: DeleteProbe, exceeded maximum number of
        attempts, 25, https response error StatusCode: 500, RequestID:
        843deb04-f53d-46e6-b3d1-583dae3cf4c8, InternalServerException: Unexpected
        error occurred.
--- FAIL: TestAccNetworkMonitorProbe_basic (4410.10s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/networkmonitor     4416.932s
```

☝️ Error is pre-existing and occurring in CI.

```console
% make testacc PKG=route53 TESTS="TestAccRoute53CIDRLocation_basic|TestAccRoute53KeySigningKey_basic"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53CIDRLocation_basic|TestAccRoute53KeySigningKey_basic'  -timeout 360m

--- PASS: TestAccRoute53CIDRLocation_basic (11.21s)
--- PASS: TestAccRoute53KeySigningKey_basic (205.49s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    210.870s
```

```console
% make testacc PKG=s3control TESTS="TestAccS3ControlAccessGrants_serial/Location/basic|TestAccS3ControlAccessGrants_serial/Grant/basic"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/s3control/... -v -count 1 -parallel 20 -run='TestAccS3ControlAccessGrants_serial/Location/basic|TestAccS3ControlAccessGrants_serial/Grant/basic'  -timeout 360m

--- PASS: TestAccS3ControlAccessGrants_serial (48.42s)
    --- PASS: TestAccS3ControlAccessGrants_serial/Location (24.39s)
        --- PASS: TestAccS3ControlAccessGrants_serial/Location/basic (24.39s)
    --- PASS: TestAccS3ControlAccessGrants_serial/Grant (24.03s)
        --- PASS: TestAccS3ControlAccessGrants_serial/Grant/basic (24.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3control  55.084s
```

```console
% make testacc PKG=ssm TESTS=TestAccSSMPatchGroup_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMPatchGroup_basic'  -timeout 360m

--- PASS: TestAccSSMPatchGroup_basic (8.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        14.115s
```

```console
% make testacc PKG=wafv2 TESTS=TestAccWAFV2WebACLAssociation_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACLAssociation_basic'  -timeout 360m

--- PASS: TestAccWAFV2WebACLAssociation_basic (46.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      51.404s
```
