### PR TITLE
r/rds_role_association: wait for cluster/instance to be available

### DIFF
--- a/.changelog/39457.txt
+++ b/.changelog/39457.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_rds_cluster_role_association: Fix intermittent failure when cluster is not in an available state
+```
+
+```release-note:bug
+resource/aws_db_instance_role_association: Fix intermittent failure when instance is not in an available state
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1919,7 +1919,7 @@ func statusDBCluster(ctx context.Context, conn *rds.Client, id string, waitNoPen
 	}
 }
 
-func waitDBClusterAvailable(ctx context.Context, conn *rds.Client, id string, waitNoPendingModifiedValues bool, timeout time.Duration) (*types.DBCluster, error) { //nolint:unparam
+func waitDBClusterAvailable(ctx context.Context, conn *rds.Client, id string, waitNoPendingModifiedValues bool, timeout time.Duration) (*types.DBCluster, error) {
 	pendingStatuses := []string{
 		clusterStatusCreating,
 		clusterStatusMigrating,

--- a/internal/service/rds/cluster_role_association.go
+++ b/internal/service/rds/cluster_role_association.go
@@ -87,10 +87,10 @@ func resourceClusterRoleAssociationCreate(ctx context.Context, d *schema.Resourc
 		_, err = conn.AddRoleToDBCluster(ctx, input)
 	}
 
-	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, errIamRolePropagationMessage) {
+	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, errIAMRolePropagationMessage) {
 		_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
 			return conn.AddRoleToDBCluster(ctx, input)
-		}, errCodeInvalidParameterValue, errIamRolePropagationMessage)
+		}, errCodeInvalidParameterValue, errIAMRolePropagationMessage)
 	}
 
 	if err != nil {

--- a/internal/service/rds/cluster_role_association.go
+++ b/internal/service/rds/cluster_role_association.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -75,9 +76,22 @@ func resourceClusterRoleAssociationCreate(ctx context.Context, d *schema.Resourc
 		RoleArn:             aws.String(roleARN),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
-		return conn.AddRoleToDBCluster(ctx, input)
-	}, errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
+	_, err := conn.AddRoleToDBCluster(ctx, input)
+
+	// check if the cluster is in a valid state to add the role association
+	if errs.IsA[*types.InvalidDBClusterStateFault](err) {
+		if _, err := waitDBClusterAvailable(ctx, conn, dbClusterID, true, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for RDS Cluster (%s) available: %s", dbClusterID, err)
+		}
+
+		_, err = conn.AddRoleToDBCluster(ctx, input)
+	}
+
+	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, errIamRolePropagationMessage) {
+		_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
+			return conn.AddRoleToDBCluster(ctx, input)
+		}, errCodeInvalidParameterValue, errIamRolePropagationMessage)
+	}
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating RDS Cluster IAM Role Association (%s): %s", id, err)

--- a/internal/service/rds/errors.go
+++ b/internal/service/rds/errors.go
@@ -11,5 +11,5 @@ const (
 )
 
 const (
-	errIamRolePropagationMessage = "IAM role ARN value is invalid or does not include the required permissions"
+	errIAMRolePropagationMessage = "IAM role ARN value is invalid or does not include the required permissions"
 )

--- a/internal/service/rds/errors.go
+++ b/internal/service/rds/errors.go
@@ -9,3 +9,7 @@ const (
 	errCodeInvalidParameterValue       = "InvalidParameterValue"
 	errCodeValidationError             = "ValidationError"
 )
+
+const (
+	errIamRolePropagationMessage = "IAM role ARN value is invalid or does not include the required permissions"
+)

--- a/internal/service/rds/instance_role_association.go
+++ b/internal/service/rds/instance_role_association.go
@@ -93,10 +93,10 @@ func resourceInstanceRoleAssociationCreate(ctx context.Context, d *schema.Resour
 		_, err = conn.AddRoleToDBInstance(ctx, input)
 	}
 
-	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, errIamRolePropagationMessage) {
+	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, errIAMRolePropagationMessage) {
 		_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
 			return conn.AddRoleToDBInstance(ctx, input)
-		}, errCodeInvalidParameterValue, errIamRolePropagationMessage)
+		}, errCodeInvalidParameterValue, errIAMRolePropagationMessage)
 	}
 
 	if err != nil {

--- a/internal/service/rds/instance_role_association.go
+++ b/internal/service/rds/instance_role_association.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -40,6 +41,11 @@ func resourceInstanceRoleAssociation() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -76,9 +82,22 @@ func resourceInstanceRoleAssociationCreate(ctx context.Context, d *schema.Resour
 		RoleArn:              aws.String(roleARN),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
-		return conn.AddRoleToDBInstance(ctx, input)
-	}, errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
+	_, err := conn.AddRoleToDBInstance(ctx, input)
+
+	// check if the instance is in a valid state to add the role association
+	if errs.IsA[*types.InvalidDBInstanceStateFault](err) {
+		if _, err := waitDBInstanceAvailable(ctx, conn, dbInstanceIdentifier, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance (%s) available: %s", dbInstanceIdentifier, err)
+		}
+
+		_, err = conn.AddRoleToDBInstance(ctx, input)
+	}
+
+	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, errIamRolePropagationMessage) {
+		_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
+			return conn.AddRoleToDBInstance(ctx, input)
+		}, errCodeInvalidParameterValue, errIamRolePropagationMessage)
+	}
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating RDS DB Instance IAM Role Association (%s): %s", id, err)
@@ -86,10 +105,7 @@ func resourceInstanceRoleAssociationCreate(ctx context.Context, d *schema.Resour
 
 	d.SetId(id)
 
-	const (
-		timeout = 10 * time.Minute
-	)
-	if _, err := waitDBInstanceRoleAssociationCreated(ctx, conn, dbInstanceIdentifier, roleARN, timeout); err != nil {
+	if _, err := waitDBInstanceRoleAssociationCreated(ctx, conn, dbInstanceIdentifier, roleARN, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance IAM Role Association (%s) create: %s", d.Id(), err)
 	}
 
@@ -148,10 +164,7 @@ func resourceInstanceRoleAssociationDelete(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "deleting RDS DB Instance IAM Role Association (%s): %s", d.Id(), err)
 	}
 
-	const (
-		timeout = 10 * time.Minute
-	)
-	if _, err := waitDBInstanceRoleAssociationDeleted(ctx, conn, dbInstanceIdentifier, roleARN, timeout); err != nil {
+	if _, err := waitDBInstanceRoleAssociationDeleted(ctx, conn, dbInstanceIdentifier, roleARN, d.Timeout(schema.TimeoutDelete)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for RDS DB Instance IAM Role Association (%s) delete: %s", d.Id(), err)
 	}
 

--- a/website/docs/r/db_instance_role_association.html.markdown
+++ b/website/docs/r/db_instance_role_association.html.markdown
@@ -46,6 +46,13 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `id` - DB Instance Identifier and IAM Role ARN separated by a comma (`,`)
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `10m`)
+- `delete` - (Default `10m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import `aws_db_instance_role_association` using the DB Instance Identifier and IAM Role ARN separated by a comma (`,`). For example:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Role association will intermittently fail to apply if the cluster/instance is not in an available state.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccRDSInstanceRoleAssociation_\|TestAccRDSClusterRoleAssociation_" PKG=rds

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSInstanceRoleAssociation_\|TestAccRDSClusterRoleAssociation_ -timeout 360m
--- PASS: TestAccRDSClusterRoleAssociation_Disappears_cluster (176.35s)
--- PASS: TestAccRDSClusterRoleAssociation_disappears (197.03s)
--- PASS: TestAccRDSClusterRoleAssociation_basic (199.32s)
--- PASS: TestAccRDSClusterRoleAssociation_Disappears_role (207.08s)
--- PASS: TestAccRDSInstanceRoleAssociation_basic (1007.08s)
--- PASS: TestAccRDSInstanceRoleAssociation_disappears (1013.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1019.897s
```
