### PR TITLE
Update sagemaker_workteam.html.markdown

### DIFF
--- a/website/docs/r/sagemaker_workteam.html.markdown
+++ b/website/docs/r/sagemaker_workteam.html.markdown
@@ -24,7 +24,7 @@ resource "aws_sagemaker_workteam" "example" {
     cognito_member_definition {
       client_id  = aws_cognito_user_pool_client.example.id
       user_pool  = aws_cognito_user_pool_domain.example.user_pool_id
-      user_group = aws_cognito_user_group.example.id
+      user_group = aws_cognito_user_group.example.name
     }
   }
 }
@@ -51,8 +51,8 @@ resource "aws_sagemaker_workteam" "example" {
 This resource supports the following arguments:
 
 * `description` - (Required) A description of the work team.
-* `workforce_name` - (Required) The name of the Workteam (must be unique).
-* `workteam_name` - (Required) The name of the workforce.
+* `workforce_name` - (Required) The name of the workforce.
+* `workteam_name` - (Required) The name of the Workteam (must be unique).
 * `member_definition` - (Required) A list of Member Definitions that contains objects that identify the workers that make up the work team. Workforces can be created using Amazon Cognito or your own OIDC Identity Provider (IdP). For private workforces created using Amazon Cognito use `cognito_member_definition`. For workforces created using your own OIDC identity provider (IdP) use `oidc_member_definition`. Do not provide input for both of these parameters in a single request. see [Member Definition](#member-definition) details below.
 * `notification_configuration` - (Optional) Configures notification of workers regarding available or expiring work items. see [Notification Configuration](#notification-configuration) details below.
 * `worker_access_configuration` - (Optional) Use this optional parameter to constrain access to an Amazon S3 resource based on the IP address using supported IAM global condition keys. The Amazon S3 resource is accessed in the worker portal using a Amazon S3 presigned URL. see [Worker Access Configuration](#worker-access-configuration) details below.


### PR DESCRIPTION
Definition for workforce_name and workteam_name were interchanged .

UPdated the example for resource "aws_sagemaker_workteam" with user_group=aws_cognito_user_group.example.name.

issue fixed : https://github.com/hashicorp/terraform-provider-aws/issues/38123

Documentation Referred : https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_workteam

Updated the example after testing.