### PR TITLE
Add failure reason and failure code for collection failures

### DIFF
--- a/internal/service/opensearchserverless/collection.go
+++ b/internal/service/opensearchserverless/collection.go
@@ -5,6 +5,7 @@ package opensearchserverless
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -330,6 +331,9 @@ func waitCollectionCreated(ctx context.Context, conn *opensearchserverless.Clien
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*awstypes.CollectionDetail); ok {
+		if output.Status == awstypes.CollectionStatusFailed {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.ToString(output.FailureCode), aws.ToString(output.FailureMessage)))
+		}
 		return output, err
 	}
 
@@ -349,6 +353,10 @@ func waitCollectionDeleted(ctx context.Context, conn *opensearchserverless.Clien
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*awstypes.CollectionDetail); ok {
+		if output.Status == awstypes.CollectionStatusFailed {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.ToString(output.FailureCode), aws.ToString(output.FailureMessage)))
+		}
+
 		return output, err
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---

--->

Added FailureMessage and FailureCode to the output if Collection Creation or Deletion fails.
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```make testacc TESTS=TestAccOpenSearchServerlessCollection PKG=opensearchserverless
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20 -run='TestAccOpenSearchServerlessCollection'  -timeout 360m
=== RUN   TestAccOpenSearchServerlessCollectionDataSource_basic
=== PAUSE TestAccOpenSearchServerlessCollectionDataSource_basic
=== RUN   TestAccOpenSearchServerlessCollectionDataSource_name
=== PAUSE TestAccOpenSearchServerlessCollectionDataSource_name
=== RUN   TestAccOpenSearchServerlessCollection_basic
=== PAUSE TestAccOpenSearchServerlessCollection_basic
=== RUN   TestAccOpenSearchServerlessCollection_standbyReplicas
=== PAUSE TestAccOpenSearchServerlessCollection_standbyReplicas
=== RUN   TestAccOpenSearchServerlessCollection_tags
=== PAUSE TestAccOpenSearchServerlessCollection_tags
=== RUN   TestAccOpenSearchServerlessCollection_update
=== PAUSE TestAccOpenSearchServerlessCollection_update
=== RUN   TestAccOpenSearchServerlessCollection_disappears
=== PAUSE TestAccOpenSearchServerlessCollection_disappears
=== CONT  TestAccOpenSearchServerlessCollectionDataSource_basic
=== CONT  TestAccOpenSearchServerlessCollection_tags
=== CONT  TestAccOpenSearchServerlessCollection_standbyReplicas
=== CONT  TestAccOpenSearchServerlessCollectionDataSource_name
=== CONT  TestAccOpenSearchServerlessCollection_basic
=== CONT  TestAccOpenSearchServerlessCollection_disappears
=== CONT  TestAccOpenSearchServerlessCollection_update
--- PASS: TestAccOpenSearchServerlessCollection_disappears (75.92s)
--- PASS: TestAccOpenSearchServerlessCollectionDataSource_basic (78.17s)
--- PASS: TestAccOpenSearchServerlessCollectionDataSource_name (78.30s)
--- PASS: TestAccOpenSearchServerlessCollection_basic (90.04s)
--- PASS: TestAccOpenSearchServerlessCollection_standbyReplicas (90.11s)
--- PASS: TestAccOpenSearchServerlessCollection_update (96.83s)
--- PASS: TestAccOpenSearchServerlessCollection_tags (99.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless      99.257s
```
