### PR TITLE
Restrict backup example policy

### DIFF
--- a/website/docs/r/backup_vault_policy.html.markdown
+++ b/website/docs/r/backup_vault_policy.html.markdown
@@ -13,6 +13,8 @@ Provides an AWS Backup vault policy resource.
 ## Example Usage
 
 ```terraform
+data "aws_caller_identity" "current" {}
+
 resource "aws_backup_vault" "example" {
   name = "example"
 }
@@ -23,7 +25,7 @@ data "aws_iam_policy_document" "example" {
 
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = [data.aws_caller_identity.current.account_id]
     }
 
     actions = [


### PR DESCRIPTION
### Description

The current example of an AWS Backup vault policy allows any user to put a new policy (since it uses Principal "*"). Therefore deploying the provided example would allow anyone to replace this policy with one in which they had full control over the backup vault. This would include taking copies of the data in there or deleting snapshots.

AWS "[strongly recommend that you do not use a wildcard (*) in the Principal element of a resource-based policy with an Allow effect](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-anonymous)". Following this, this PR replaces the Principal with the account id, therefore giving this power only to roles already within this account,  which is much less dangerous.

### Relations
None

### References
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-anonymous
