### PR TITLE
doc: Update object_size_greater_than of s3 lifecycle defaults to 128000

### DIFF
--- a/website/docs/cdktf/python/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/cdktf/python/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -460,7 +460,7 @@ The `expiration` configuration block supports the following arguments:
 The `filter` configuration block supports the following arguments:
 
 * `and`- (Optional) Configuration block used to apply a logical `AND` to two or more predicates. [See below](#and). The Lifecycle Rule will apply to any object matching all the predicates configured inside the `and` block.
-* `object_size_greater_than` - (Optional) Minimum object size (in bytes) to which the rule applies.
+* `object_size_greater_than` - (Optional) Minimum object size (in bytes) to which the rule applies. Defaults to 128000.
 * `object_size_less_than` - (Optional) Maximum object size (in bytes) to which the rule applies.
 * `prefix` - (Optional) Prefix identifying one or more objects to which the rule applies. Defaults to an empty string (`""`) if not specified.
 * `tag` - (Optional) Configuration block for specifying a tag key and value. [See below](#tag).

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -444,7 +444,7 @@ The `transition` configuration block supports the following arguments:
 
 The `and` configuration block supports the following arguments:
 
-* `object_size_greater_than` - (Optional) Minimum object size to which the rule applies. Value must be at least `0` if specified.
+* `object_size_greater_than` - (Optional) Minimum object size to which the rule applies. Value must be at least `0` if specified. Defaults to 128000.
 * `object_size_less_than` - (Optional) Maximum object size to which the rule applies. Value must be at least `1` if specified.
 * `prefix` - (Optional) Prefix identifying one or more objects to which the rule applies.
 * `tags` - (Optional) Key-value map of resource tags. All of these tags must exist in the object's tag set in order for the rule to apply.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
As announcement from AWS https://aws.amazon.com/about-aws/whats-new/2024/09/amazon-s3-default-minimum-object-size-lifecycle-transition-rules/. I think it's better to note for user to notice about the default value changed to 128KB.