### PR TITLE
New Resource: aws_ec2_transit_gateway_default_route_table_association

### DIFF
--- a/.changelog/39496.txt
+++ b/.changelog/39496.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_ec2_transit_gateway_default_route_table_association
+```

--- a/internal/service/ec2/exports_test.go
+++ b/internal/service/ec2/exports_test.go
@@ -81,7 +81,7 @@ var (
 	ResourceTrafficMirrorSession                          = resourceTrafficMirrorSession
 	ResourceTrafficMirrorTarget                           = resourceTrafficMirrorTarget
 	ResourceTransitGatewayConnect                         = resourceTransitGatewayConnect
-	ResourceTransitgatewayDefaultRouteTableAssociation    = newResourceTransitGatewayDefaultRouteTableAssociation
+	ResourceTransitGatewayDefaultRouteTableAssociation    = newTransitGatewayDefaultRouteTableAssociationResource
 	ResourceTransitGatewayMulticastDomain                 = resourceTransitGatewayMulticastDomain
 	ResourceTransitGatewayMulticastDomainAssociation      = resourceTransitGatewayMulticastDomainAssociation
 	ResourceTransitGatewayMulticastGroupMember            = resourceTransitGatewayMulticastGroupMember

--- a/internal/service/ec2/exports_test.go
+++ b/internal/service/ec2/exports_test.go
@@ -81,6 +81,7 @@ var (
 	ResourceTrafficMirrorSession                          = resourceTrafficMirrorSession
 	ResourceTrafficMirrorTarget                           = resourceTrafficMirrorTarget
 	ResourceTransitGatewayConnect                         = resourceTransitGatewayConnect
+	ResourceTransitgatewayDefaultRouteTableAssociation    = newResourceTransitGatewayDefaultRouteTableAssociation
 	ResourceTransitGatewayMulticastDomain                 = resourceTransitGatewayMulticastDomain
 	ResourceTransitGatewayMulticastDomainAssociation      = resourceTransitGatewayMulticastDomainAssociation
 	ResourceTransitGatewayMulticastGroupMember            = resourceTransitGatewayMulticastGroupMember

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -58,10 +58,6 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Name:    "Instance Metadata Defaults",
 		},
 		{
-			Factory: newResourceTransitGatewayDefaultRouteTableAssociation,
-			Name:    "Transit Gateway Default Route Table Association",
-		},
-		{
 			Factory: newSecurityGroupEgressRuleResource,
 			Name:    "Security Group Egress Rule",
 			Tags: &types.ServicePackageResourceTags{
@@ -74,6 +70,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrID,
 			},
+		},
+		{
+			Factory: newTransitGatewayDefaultRouteTableAssociationResource,
+			Name:    "Transit Gateway Default Route Table Association",
 		},
 		{
 			Factory: newVPCEndpointPrivateDNSResource,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -58,6 +58,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Name:    "Instance Metadata Defaults",
 		},
 		{
+			Factory: newResourceTransitGatewayDefaultRouteTableAssociation,
+			Name:    "Transit Gateway Default Route Table Association",
+		},
+		{
 			Factory: newSecurityGroupEgressRuleResource,
 			Name:    "Security Group Egress Rule",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/ec2/transitgateway_default_route_table_association.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -52,7 +51,7 @@ func (r *resourceTransitgatewayDefaultRouteTableAssociation) Metadata(_ context.
 func (r *resourceTransitgatewayDefaultRouteTableAssociation) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id": framework.IDAttribute(),
+			names.AttrID: framework.IDAttribute(),
 			"original_route_table_id": schema.StringAttribute{
 				Computed: true,
 			},
@@ -67,7 +66,7 @@ func (r *resourceTransitgatewayDefaultRouteTableAssociation) Schema(ctx context.
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				Update: true,
 				Delete: true,
@@ -174,9 +173,9 @@ func (r *resourceTransitgatewayDefaultRouteTableAssociation) Update(ctx context.
 
 	if !plan.RouteTableId.Equal(state.RouteTableId) {
 		in := &ec2.ModifyTransitGatewayInput{
-			TransitGatewayId: aws.String(state.ID.ValueString()),
+			TransitGatewayId: state.ID.ValueStringPointer(),
 			Options: &awstypes.ModifyTransitGatewayOptions{
-				AssociationDefaultRouteTableId: flex.StringFromFramework(ctx, plan.RouteTableId),
+				AssociationDefaultRouteTableId: plan.RouteTableId.ValueStringPointer(),
 			},
 		}
 

--- a/internal/service/ec2/transitgateway_default_route_table_association.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association.go
@@ -5,28 +5,29 @@ package ec2
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @FrameworkResource("aws_ec2_transit_gateway_default_route_table_association", name="Transit Gateway Default Route Table Association")
-func newResourceTransitGatewayDefaultRouteTableAssociation(_ context.Context) (resource.ResourceWithConfigure, error) {
-	r := &resourceTransitgatewayDefaultRouteTableAssociation{}
+func newTransitGatewayDefaultRouteTableAssociationResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &transitGatewayDefaultRouteTableAssociationResource{}
 
 	r.SetDefaultCreateTimeout(5 * time.Minute)
 	r.SetDefaultUpdateTimeout(5 * time.Minute)
@@ -35,25 +36,24 @@ func newResourceTransitGatewayDefaultRouteTableAssociation(_ context.Context) (r
 	return r, nil
 }
 
-const (
-	ResNameTransitGatewayDefaultRouteTableAssociation = "Transit Gateway Default Route Table Association"
-)
-
-type resourceTransitgatewayDefaultRouteTableAssociation struct {
+type transitGatewayDefaultRouteTableAssociationResource struct {
 	framework.ResourceWithConfigure
 	framework.WithTimeouts
 }
 
-func (r *resourceTransitgatewayDefaultRouteTableAssociation) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = "aws_ec2_transit_gateway_default_route_table_association"
+func (*transitGatewayDefaultRouteTableAssociationResource) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "aws_ec2_transit_gateway_default_route_table_association"
 }
 
-func (r *resourceTransitgatewayDefaultRouteTableAssociation) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = schema.Schema{
+func (r *transitGatewayDefaultRouteTableAssociationResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrID: framework.IDAttribute(),
-			"original_route_table_id": schema.StringAttribute{
+			"original_default_route_table_id": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"transit_gateway_route_table_id": schema.StringAttribute{
 				Required: true,
@@ -75,180 +75,157 @@ func (r *resourceTransitgatewayDefaultRouteTableAssociation) Schema(ctx context.
 	}
 }
 
-func (r *resourceTransitgatewayDefaultRouteTableAssociation) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *transitGatewayDefaultRouteTableAssociationResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data transitGatewayDefaultRouteTableAssociationResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	conn := r.Meta().EC2Client(ctx)
 
-	var plan transitgatewayDefaultRouteTableAssociationResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	tgwID := data.TransitGatewayID.ValueString()
+	tgw, err := findTransitGatewayByID(ctx, conn, tgwID)
 
-	tgw, err := findTransitGatewayByID(ctx, conn, plan.TransitGatewayId.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("reading EC2 Transit Gateway (%s)", tgwID), err.Error())
+
 		return
 	}
 
-	in := &ec2.ModifyTransitGatewayInput{
-		TransitGatewayId: flex.StringFromFramework(ctx, plan.TransitGatewayId),
+	input := &ec2.ModifyTransitGatewayInput{
 		Options: &awstypes.ModifyTransitGatewayOptions{
-			AssociationDefaultRouteTableId: flex.StringFromFramework(ctx, plan.RouteTableId),
+			AssociationDefaultRouteTableId: flex.StringFromFramework(ctx, data.RouteTableID),
 		},
+		TransitGatewayId: aws.String(tgwID),
 	}
 
-	out, err := conn.ModifyTransitGateway(ctx, in)
+	_, err = conn.ModifyTransitGateway(ctx, input)
+
 	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), err),
-			err.Error(),
-		)
-		return
-	}
-	if out == nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), nil),
-			errors.New("empty output").Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("creating EC2 Transit Gateway Default Route Table Association (%s)", tgwID), err.Error())
+
 		return
 	}
 
-	plan.ID = flex.StringToFramework(ctx, out.TransitGateway.TransitGatewayId)
-	plan.OriginalRouteTableId = flex.StringToFramework(ctx, tgw.Options.AssociationDefaultRouteTableId)
+	// Set unknowns.
+	data.ID = flex.StringValueToFramework(ctx, tgwID)
+	data.OriginalDefaultRouteTableID = flex.StringToFramework(ctx, tgw.Options.AssociationDefaultRouteTableId)
 
-	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-	_, err = waitTransitGatewayUpdated(ctx, conn, plan.ID.ValueString(), createTimeout)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionWaitingForCreation, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), err),
-			err.Error(),
-		)
+	if _, err := waitTransitGatewayUpdated(ctx, conn, tgwID, r.CreateTimeout(ctx, data.Timeouts)); err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for EC2 Transit Gateway Default Route Table Association (%s) create", tgwID), err.Error())
+
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
 
-func (r *resourceTransitgatewayDefaultRouteTableAssociation) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	conn := r.Meta().EC2Client(ctx)
-
-	var state transitgatewayDefaultRouteTableAssociationResourceModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+func (r *transitGatewayDefaultRouteTableAssociationResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data transitGatewayDefaultRouteTableAssociationResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
-	out, err := findTransitGatewayByID(ctx, conn, state.ID.ValueString())
+	conn := r.Meta().EC2Client(ctx)
+
+	tgw, err := findTransitGatewayByID(ctx, conn, data.ID.ValueString())
+
 	if tfresource.NotFound(err) {
-		resp.State.RemoveResource(ctx)
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
 		return
 	}
+
 	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionSetting, ResNameTransitGatewayDefaultRouteTableAssociation, state.ID.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("reading EC2 Transit Gateway Default Route Table Association (%s)", data.ID.ValueString()), err.Error())
+
 		return
 	}
 
-	state.ID = flex.StringToFramework(ctx, out.TransitGatewayId)
-	state.TransitGatewayId = flex.StringToFramework(ctx, out.TransitGatewayId)
-	state.RouteTableId = flex.StringToFramework(ctx, out.Options.AssociationDefaultRouteTableId)
+	data.RouteTableID = flex.StringToFramework(ctx, tgw.Options.AssociationDefaultRouteTableId)
+	data.TransitGatewayID = flex.StringToFramework(ctx, tgw.TransitGatewayId)
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
-func (r *resourceTransitgatewayDefaultRouteTableAssociation) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *transitGatewayDefaultRouteTableAssociationResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var new, old transitGatewayDefaultRouteTableAssociationResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	response.Diagnostics.Append(request.State.Get(ctx, &old)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	conn := r.Meta().EC2Client(ctx)
 
-	var plan, state transitgatewayDefaultRouteTableAssociationResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if !plan.RouteTableId.Equal(state.RouteTableId) {
-		in := &ec2.ModifyTransitGatewayInput{
-			TransitGatewayId: state.ID.ValueStringPointer(),
-			Options: &awstypes.ModifyTransitGatewayOptions{
-				AssociationDefaultRouteTableId: plan.RouteTableId.ValueStringPointer(),
-			},
-		}
-
-		out, err := conn.ModifyTransitGateway(ctx, in)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.EC2, create.ErrActionUpdating, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), err),
-				err.Error(),
-			)
-			return
-		}
-		if out == nil {
-			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.EC2, create.ErrActionUpdating, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), nil),
-				errors.New("empty output").Error(),
-			)
-			return
-		}
-	}
-
-	updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
-	_, err := waitTransitGatewayUpdated(ctx, conn, plan.ID.ValueString(), updateTimeout)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionWaitingForUpdate, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), err),
-			err.Error(),
-		)
-		return
-	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-}
-
-func (r *resourceTransitgatewayDefaultRouteTableAssociation) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	conn := r.Meta().EC2Client(ctx)
-
-	var state transitgatewayDefaultRouteTableAssociationResourceModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	in := &ec2.ModifyTransitGatewayInput{
-		TransitGatewayId: flex.StringFromFramework(ctx, state.TransitGatewayId),
+	input := &ec2.ModifyTransitGatewayInput{
 		Options: &awstypes.ModifyTransitGatewayOptions{
-			AssociationDefaultRouteTableId: flex.StringFromFramework(ctx, state.OriginalRouteTableId),
+			AssociationDefaultRouteTableId: flex.StringFromFramework(ctx, new.RouteTableID),
 		},
+		TransitGatewayId: flex.StringFromFramework(ctx, new.TransitGatewayID),
 	}
 
-	_, err := conn.ModifyTransitGateway(ctx, in)
+	_, err := conn.ModifyTransitGateway(ctx, input)
+
 	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionDeleting, ResNameTransitGatewayDefaultRouteTableAssociation, state.ID.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("updating EC2 Transit Gateway Default Route Table Association (%s)", new.ID.ValueString()), err.Error())
+
 		return
 	}
 
-	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
-	_, err = waitTransitGatewayUpdated(ctx, conn, state.ID.ValueString(), deleteTimeout)
+	if _, err := waitTransitGatewayUpdated(ctx, conn, new.ID.ValueString(), r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for EC2 Transit Gateway Default Route Table Association (%s) update", new.ID.ValueString()), err.Error())
+
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
+}
+
+func (r *transitGatewayDefaultRouteTableAssociationResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data transitGatewayDefaultRouteTableAssociationResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().EC2Client(ctx)
+
+	input := &ec2.ModifyTransitGatewayInput{
+		Options: &awstypes.ModifyTransitGatewayOptions{
+			AssociationDefaultRouteTableId: flex.StringFromFramework(ctx, data.OriginalDefaultRouteTableID),
+		},
+		TransitGatewayId: flex.StringFromFramework(ctx, data.TransitGatewayID),
+	}
+
+	_, err := conn.ModifyTransitGateway(ctx, input)
+
+	if tfawserr.ErrCodeEquals(err, errCodeIncorrectState) {
+		return
+	}
+
 	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.EC2, create.ErrActionWaitingForDeletion, ResNameTransitGatewayDefaultRouteTableAssociation, state.ID.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("deleting EC2 Transit Gateway Default Route Table Association (%s)", data.ID.ValueString()), err.Error())
+
+		return
+	}
+
+	if _, err := waitTransitGatewayUpdated(ctx, conn, data.ID.ValueString(), r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for EC2 Transit Gateway Default Route Table Association (%s) delete", data.ID.ValueString()), err.Error())
+
 		return
 	}
 }
 
-type transitgatewayDefaultRouteTableAssociationResourceModel struct {
-	ID                   types.String   `tfsdk:"id"`
-	OriginalRouteTableId types.String   `tfsdk:"original_route_table_id"`
-	RouteTableId         types.String   `tfsdk:"transit_gateway_route_table_id"`
-	TransitGatewayId     types.String   `tfsdk:"transit_gateway_id"`
-	Timeouts             timeouts.Value `tfsdk:"timeouts"`
+type transitGatewayDefaultRouteTableAssociationResourceModel struct {
+	ID                          types.String   `tfsdk:"id"`
+	OriginalDefaultRouteTableID types.String   `tfsdk:"original_default_route_table_id"`
+	RouteTableID                types.String   `tfsdk:"transit_gateway_route_table_id"`
+	TransitGatewayID            types.String   `tfsdk:"transit_gateway_id"`
+	Timeouts                    timeouts.Value `tfsdk:"timeouts"`
 }

--- a/internal/service/ec2/transitgateway_default_route_table_association.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association.go
@@ -29,9 +29,9 @@ import (
 func newResourceTransitGatewayDefaultRouteTableAssociation(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceTransitgatewayDefaultRouteTableAssociation{}
 
-	r.SetDefaultCreateTimeout(30 * time.Minute)
-	r.SetDefaultUpdateTimeout(30 * time.Minute)
-	r.SetDefaultDeleteTimeout(30 * time.Minute)
+	r.SetDefaultCreateTimeout(5 * time.Minute)
+	r.SetDefaultUpdateTimeout(5 * time.Minute)
+	r.SetDefaultDeleteTimeout(5 * time.Minute)
 
 	return r, nil
 }
@@ -56,7 +56,7 @@ func (r *resourceTransitgatewayDefaultRouteTableAssociation) Schema(ctx context.
 			"original_route_table_id": schema.StringAttribute{
 				Computed: true,
 			},
-			"route_table_id": schema.StringAttribute{
+			"transit_gateway_route_table_id": schema.StringAttribute{
 				Required: true,
 			},
 			names.AttrTransitGatewayID: schema.StringAttribute{
@@ -250,7 +250,7 @@ func (r *resourceTransitgatewayDefaultRouteTableAssociation) Delete(ctx context.
 type transitgatewayDefaultRouteTableAssociationResourceModel struct {
 	ID                   types.String   `tfsdk:"id"`
 	OriginalRouteTableId types.String   `tfsdk:"original_route_table_id"`
-	RouteTableId         types.String   `tfsdk:"route_table_id"`
+	RouteTableId         types.String   `tfsdk:"transit_gateway_route_table_id"`
 	TransitGatewayId     types.String   `tfsdk:"transit_gateway_id"`
 	Timeouts             timeouts.Value `tfsdk:"timeouts"`
 }

--- a/internal/service/ec2/transitgateway_default_route_table_association.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association.go
@@ -173,7 +173,6 @@ func (r *resourceTransitgatewayDefaultRouteTableAssociation) Update(ctx context.
 	}
 
 	if !plan.RouteTableId.Equal(state.RouteTableId) {
-
 		in := &ec2.ModifyTransitGatewayInput{
 			TransitGatewayId: aws.String(state.ID.ValueString()),
 			Options: &awstypes.ModifyTransitGatewayOptions{

--- a/internal/service/ec2/transitgateway_default_route_table_association.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association.go
@@ -1,0 +1,256 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource("aws_ec2_transit_gateway_default_route_table_association", name="Transit Gateway Default Route Table Association")
+func newResourceTransitGatewayDefaultRouteTableAssociation(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceTransitgatewayDefaultRouteTableAssociation{}
+
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameTransitGatewayDefaultRouteTableAssociation = "Transit Gateway Default Route Table Association"
+)
+
+type resourceTransitgatewayDefaultRouteTableAssociation struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *resourceTransitgatewayDefaultRouteTableAssociation) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_ec2_transit_gateway_default_route_table_association"
+}
+
+func (r *resourceTransitgatewayDefaultRouteTableAssociation) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttribute(),
+			"original_route_table_id": schema.StringAttribute{
+				Computed: true,
+			},
+			"route_table_id": schema.StringAttribute{
+				Required: true,
+			},
+			names.AttrTransitGatewayID: schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *resourceTransitgatewayDefaultRouteTableAssociation) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().EC2Client(ctx)
+
+	var plan transitgatewayDefaultRouteTableAssociationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tgw, err := findTransitGatewayByID(ctx, conn, plan.TransitGatewayId.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	in := &ec2.ModifyTransitGatewayInput{
+		TransitGatewayId: flex.StringFromFramework(ctx, plan.TransitGatewayId),
+		Options: &awstypes.ModifyTransitGatewayOptions{
+			AssociationDefaultRouteTableId: flex.StringFromFramework(ctx, plan.RouteTableId),
+		},
+	}
+
+	out, err := conn.ModifyTransitGateway(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	if out == nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionCreating, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), nil),
+			errors.New("empty output").Error(),
+		)
+		return
+	}
+
+	plan.ID = flex.StringToFramework(ctx, out.TransitGateway.TransitGatewayId)
+	plan.OriginalRouteTableId = flex.StringToFramework(ctx, tgw.Options.AssociationDefaultRouteTableId)
+
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	_, err = waitTransitGatewayUpdated(ctx, conn, plan.ID.ValueString(), createTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionWaitingForCreation, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceTransitgatewayDefaultRouteTableAssociation) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().EC2Client(ctx)
+
+	var state transitgatewayDefaultRouteTableAssociationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findTransitGatewayByID(ctx, conn, state.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionSetting, ResNameTransitGatewayDefaultRouteTableAssociation, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.ID = flex.StringToFramework(ctx, out.TransitGatewayId)
+	state.TransitGatewayId = flex.StringToFramework(ctx, out.TransitGatewayId)
+	state.RouteTableId = flex.StringToFramework(ctx, out.Options.AssociationDefaultRouteTableId)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceTransitgatewayDefaultRouteTableAssociation) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().EC2Client(ctx)
+
+	var plan, state transitgatewayDefaultRouteTableAssociationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.RouteTableId.Equal(state.RouteTableId) {
+
+		in := &ec2.ModifyTransitGatewayInput{
+			TransitGatewayId: aws.String(state.ID.ValueString()),
+			Options: &awstypes.ModifyTransitGatewayOptions{
+				AssociationDefaultRouteTableId: flex.StringFromFramework(ctx, plan.RouteTableId),
+			},
+		}
+
+		out, err := conn.ModifyTransitGateway(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.EC2, create.ErrActionUpdating, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.EC2, create.ErrActionUpdating, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+	}
+
+	updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
+	_, err := waitTransitGatewayUpdated(ctx, conn, plan.ID.ValueString(), updateTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionWaitingForUpdate, ResNameTransitGatewayDefaultRouteTableAssociation, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceTransitgatewayDefaultRouteTableAssociation) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().EC2Client(ctx)
+
+	var state transitgatewayDefaultRouteTableAssociationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &ec2.ModifyTransitGatewayInput{
+		TransitGatewayId: flex.StringFromFramework(ctx, state.TransitGatewayId),
+		Options: &awstypes.ModifyTransitGatewayOptions{
+			AssociationDefaultRouteTableId: flex.StringFromFramework(ctx, state.OriginalRouteTableId),
+		},
+	}
+
+	_, err := conn.ModifyTransitGateway(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionDeleting, ResNameTransitGatewayDefaultRouteTableAssociation, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	deleteTimeout := r.DeleteTimeout(ctx, state.Timeouts)
+	_, err = waitTransitGatewayUpdated(ctx, conn, state.ID.ValueString(), deleteTimeout)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.EC2, create.ErrActionWaitingForDeletion, ResNameTransitGatewayDefaultRouteTableAssociation, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+type transitgatewayDefaultRouteTableAssociationResourceModel struct {
+	ID                   types.String   `tfsdk:"id"`
+	OriginalRouteTableId types.String   `tfsdk:"original_route_table_id"`
+	RouteTableId         types.String   `tfsdk:"route_table_id"`
+	TransitGatewayId     types.String   `tfsdk:"transit_gateway_id"`
+	Timeouts             timeouts.Value `tfsdk:"timeouts"`
+}

--- a/internal/service/ec2/transitgateway_default_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccEC2TransitGatewayDefaultRouteTableAssociation_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var transitgateway types.TransitGateway
+	resourceName := "aws_ec2_transit_gateway_default_route_table_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTransitGatewayDefaultRouteTableAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitgatewayDefaultRouteTableAssociationConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayDefaultRouteTableAssociationExists(ctx, resourceName, &transitgateway),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEC2TransitGatewayDefaultRouteTableAssociation_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var transitgateway types.TransitGateway
+	resourceName := "aws_ec2_transit_gateway_default_route_table_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTransitGatewayDefaultRouteTableAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitgatewayDefaultRouteTableAssociationConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayDefaultRouteTableAssociationExists(ctx, resourceName, &transitgateway),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfec2.ResourceTransitgatewayDefaultRouteTableAssociation, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTransitGatewayDefaultRouteTableAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_ec2_transit_gateway_default_route_table_association" {
+				continue
+			}
+
+			resp, err := tfec2.FindTransitGatewayByID(ctx, conn, rs.Primary.ID)
+
+			if err != nil {
+				if errs.IsA[*retry.NotFoundError](err) {
+					return nil
+				}
+				return create.Error(names.EC2, create.ErrActionCheckingDestroyed, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, rs.Primary.ID, err)
+			}
+
+			if *resp.Options.PropagationDefaultRouteTableId != *resp.Options.AssociationDefaultRouteTableId {
+
+				return create.Error(names.EC2, create.ErrActionCheckingDestroyed, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, rs.Primary.ID, errors.New("not destroyed"))
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTransitGatewayDefaultRouteTableAssociationExists(ctx context.Context, name string, transitgatewaydefaultroutetableassociation *types.TransitGateway) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+		resp, err := tfec2.FindTransitGatewayByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, rs.Primary.ID, err)
+		}
+
+		if *resp.Options.PropagationDefaultRouteTableId == *resp.Options.AssociationDefaultRouteTableId {
+			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, name, errors.New("not changed"))
+		}
+
+		*transitgatewaydefaultroutetableassociation = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+	input := &ec2.DescribeTransitGatewaysInput{}
+	_, err := conn.DescribeTransitGateways(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccTransitgatewayDefaultRouteTableAssociationConfig_basic() string {
+	return `
+resource "aws_ec2_transit_gateway" "test" {}
+
+resource "aws_ec2_transit_gateway_route_table" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+}
+
+resource "aws_ec2_transit_gateway_default_route_table_association" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+  route_table_id     = aws_ec2_transit_gateway_route_table.test.id
+}
+`
+}

--- a/internal/service/ec2/transitgateway_default_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association_test.go
@@ -163,8 +163,8 @@ resource "aws_ec2_transit_gateway_route_table" "test" {
 }
 
 resource "aws_ec2_transit_gateway_default_route_table_association" "test" {
-  transit_gateway_id                 = aws_ec2_transit_gateway.test.id
-  transit_gateway_route_table_id     = aws_ec2_transit_gateway_route_table.test.id
+  transit_gateway_id             = aws_ec2_transit_gateway.test.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.test.id
 }
 `
 }

--- a/internal/service/ec2/transitgateway_default_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association_test.go
@@ -6,19 +6,19 @@ package ec2_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -28,7 +28,7 @@ func testAccTransitGatewayDefaultRouteTableAssociation_basic(t *testing.T, semap
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var transitgateway types.TransitGateway
+	var transitgateway awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway_default_route_table_association.test"
 	resourceRouteTableName := "aws_ec2_transit_gateway_route_table.test"
 
@@ -59,7 +59,7 @@ func testAccTransitGatewayDefaultRouteTableAssociation_disappears(t *testing.T, 
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	var transitgateway types.TransitGateway
+	var transitgateway awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway_default_route_table_association.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -76,7 +76,38 @@ func testAccTransitGatewayDefaultRouteTableAssociation_disappears(t *testing.T, 
 				Config: testAccTransitgatewayDefaultRouteTableAssociationConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayDefaultRouteTableAssociationExists(ctx, resourceName, &transitgateway),
-					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfec2.ResourceTransitgatewayDefaultRouteTableAssociation, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfec2.ResourceTransitGatewayDefaultRouteTableAssociation, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccTransitGatewayDefaultRouteTableAssociation_Disappears_transitGateway(t *testing.T, semaphore tfsync.Semaphore) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var transitgateway awstypes.TransitGateway
+	resourceName := "aws_ec2_transit_gateway_default_route_table_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckTransitGatewaySynchronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTransitGatewayDefaultRouteTableAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitgatewayDefaultRouteTableAssociationConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayDefaultRouteTableAssociationExists(ctx, resourceName, &transitgateway),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfec2.ResourceTransitGateway(), "aws_ec2_transit_gateway.test"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -93,47 +124,49 @@ func testAccCheckTransitGatewayDefaultRouteTableAssociationDestroy(ctx context.C
 				continue
 			}
 
-			resp, err := tfec2.FindTransitGatewayByID(ctx, conn, rs.Primary.ID)
+			output, err := tfec2.FindTransitGatewayByID(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
 
 			if err != nil {
-				if errs.IsA[*retry.NotFoundError](err) {
-					return nil
-				}
-				return create.Error(names.EC2, create.ErrActionCheckingDestroyed, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, rs.Primary.ID, err)
+				return err
 			}
 
-			if *resp.Options.PropagationDefaultRouteTableId != *resp.Options.AssociationDefaultRouteTableId {
-				return create.Error(names.EC2, create.ErrActionCheckingDestroyed, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, rs.Primary.ID, errors.New("not destroyed"))
+			if aws.ToString(output.Options.PropagationDefaultRouteTableId) == aws.ToString(output.Options.AssociationDefaultRouteTableId) {
+				continue
 			}
+
+			return fmt.Errorf("EC2 Transit Gateway Default Route Table Association %s still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckTransitGatewayDefaultRouteTableAssociationExists(ctx context.Context, name string, transitgatewaydefaultroutetableassociation *types.TransitGateway) resource.TestCheckFunc {
+func testAccCheckTransitGatewayDefaultRouteTableAssociationExists(ctx context.Context, n string, v *awstypes.TransitGateway) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, name, errors.New("not set"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
-		resp, err := tfec2.FindTransitGatewayByID(ctx, conn, rs.Primary.ID)
+
+		output, err := tfec2.FindTransitGatewayByID(ctx, conn, rs.Primary.ID)
+
+		if err == nil {
+			if aws.ToString(output.Options.PropagationDefaultRouteTableId) == aws.ToString(output.Options.AssociationDefaultRouteTableId) {
+				err = errors.New("EC2 Transit Gateway Default Route Table Association not found")
+			}
+		}
 
 		if err != nil {
-			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, rs.Primary.ID, err)
+			return err
 		}
 
-		if *resp.Options.PropagationDefaultRouteTableId == *resp.Options.AssociationDefaultRouteTableId {
-			return create.Error(names.EC2, create.ErrActionCheckingExistence, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, name, errors.New("not changed"))
-		}
-
-		*transitgatewaydefaultroutetableassociation = *resp
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/ec2/transitgateway_default_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association_test.go
@@ -103,7 +103,6 @@ func testAccCheckTransitGatewayDefaultRouteTableAssociationDestroy(ctx context.C
 			}
 
 			if *resp.Options.PropagationDefaultRouteTableId != *resp.Options.AssociationDefaultRouteTableId {
-
 				return create.Error(names.EC2, create.ErrActionCheckingDestroyed, tfec2.ResNameTransitGatewayDefaultRouteTableAssociation, rs.Primary.ID, errors.New("not destroyed"))
 			}
 		}

--- a/internal/service/ec2/transitgateway_default_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association_test.go
@@ -158,8 +158,8 @@ resource "aws_ec2_transit_gateway_route_table" "test" {
 }
 
 resource "aws_ec2_transit_gateway_default_route_table_association" "test" {
-  transit_gateway_id = aws_ec2_transit_gateway.test.id
-  route_table_id     = aws_ec2_transit_gateway_route_table.test.id
+  transit_gateway_id                 = aws_ec2_transit_gateway.test.id
+  transit_gateway_route_table_id     = aws_ec2_transit_gateway_route_table.test.id
 }
 `
 }

--- a/internal/service/ec2/transitgateway_default_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association_test.go
@@ -6,7 +6,6 @@ package ec2_test
 import (
 	"context"
 	"errors"
-	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -18,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )

--- a/internal/service/ec2/transitgateway_default_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func testAccEC2TransitGatewayDefaultRouteTableAssociation_basic(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayDefaultRouteTableAssociation_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -53,7 +53,7 @@ func testAccEC2TransitGatewayDefaultRouteTableAssociation_basic(t *testing.T, se
 	})
 }
 
-func testAccEC2TransitGatewayDefaultRouteTableAssociation_disappears(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayDefaultRouteTableAssociation_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/ec2/transitgateway_default_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_default_route_table_association_test.go
@@ -6,6 +6,7 @@ package ec2_test
 import (
 	"context"
 	"errors"
+	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -21,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccEC2TransitGatewayDefaultRouteTableAssociation_basic(t *testing.T) {
+func testAccEC2TransitGatewayDefaultRouteTableAssociation_basic(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -29,9 +30,11 @@ func TestAccEC2TransitGatewayDefaultRouteTableAssociation_basic(t *testing.T) {
 
 	var transitgateway types.TransitGateway
 	resourceName := "aws_ec2_transit_gateway_default_route_table_association.test"
+	resourceRouteTableName := "aws_ec2_transit_gateway_route_table.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckTransitGatewaySynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},
@@ -43,13 +46,14 @@ func TestAccEC2TransitGatewayDefaultRouteTableAssociation_basic(t *testing.T) {
 				Config: testAccTransitgatewayDefaultRouteTableAssociationConfig_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayDefaultRouteTableAssociationExists(ctx, resourceName, &transitgateway),
+					resource.TestCheckResourceAttrPair(resourceName, "transit_gateway_route_table_id", resourceRouteTableName, names.AttrID),
 				),
 			},
 		},
 	})
 }
 
-func TestAccEC2TransitGatewayDefaultRouteTableAssociation_disappears(t *testing.T) {
+func testAccEC2TransitGatewayDefaultRouteTableAssociation_disappears(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -60,6 +64,7 @@ func TestAccEC2TransitGatewayDefaultRouteTableAssociation_disappears(t *testing.
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckTransitGatewaySynchronize(t, semaphore)
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
 		},

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -46,6 +46,10 @@ func TestAccTransitGateway_serial(t *testing.T) {
 			"InsideCidrBlocks":      testAccTransitGatewayConnectPeer_insideCIDRBlocks,
 			"TransitGatewayAddress": testAccTransitGatewayConnectPeer_TransitGatewayAddress,
 		},
+		"DefaultRouteTableAssociation": {
+			acctest.CtBasic:      testAccEC2TransitGatewayDefaultRouteTableAssociation_basic,
+			acctest.CtDisappears: testAccEC2TransitGatewayDefaultRouteTableAssociation_disappears,
+		},
 		"Gateway": {
 			acctest.CtBasic:               testAccTransitGateway_basic,
 			acctest.CtDisappears:          testAccTransitGateway_disappears,

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -47,8 +47,9 @@ func TestAccTransitGateway_serial(t *testing.T) {
 			"TransitGatewayAddress": testAccTransitGatewayConnectPeer_TransitGatewayAddress,
 		},
 		"DefaultRouteTableAssociation": {
-			acctest.CtBasic:      testAccTransitGatewayDefaultRouteTableAssociation_basic,
-			acctest.CtDisappears: testAccTransitGatewayDefaultRouteTableAssociation_disappears,
+			acctest.CtBasic:            testAccTransitGatewayDefaultRouteTableAssociation_basic,
+			acctest.CtDisappears:       testAccTransitGatewayDefaultRouteTableAssociation_disappears,
+			"disappearsTransitGateway": testAccTransitGatewayDefaultRouteTableAssociation_Disappears_transitGateway,
 		},
 		"Gateway": {
 			acctest.CtBasic:               testAccTransitGateway_basic,

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -47,8 +47,8 @@ func TestAccTransitGateway_serial(t *testing.T) {
 			"TransitGatewayAddress": testAccTransitGatewayConnectPeer_TransitGatewayAddress,
 		},
 		"DefaultRouteTableAssociation": {
-			acctest.CtBasic:      testAccEC2TransitGatewayDefaultRouteTableAssociation_basic,
-			acctest.CtDisappears: testAccEC2TransitGatewayDefaultRouteTableAssociation_disappears,
+			acctest.CtBasic:      testAccTransitGatewayDefaultRouteTableAssociation_basic,
+			acctest.CtDisappears: testAccTransitGatewayDefaultRouteTableAssociation_disappears,
 		},
 		"Gateway": {
 			acctest.CtBasic:               testAccTransitGateway_basic,

--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -2430,7 +2430,7 @@ func waitTransitGatewayRouteTablePropagationDeleted(ctx context.Context, conn *e
 	return err
 }
 
-func waitTransitGatewayUpdated(ctx context.Context, conn *ec2.Client, id string, timeout time.Duration) (*awstypes.TransitGateway, error) {
+func waitTransitGatewayUpdated(ctx context.Context, conn *ec2.Client, id string, timeout time.Duration) (*awstypes.TransitGateway, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.TransitGatewayStateModifying),
 		Target:  enum.Slice(awstypes.TransitGatewayStateAvailable),

--- a/website/docs/r/ec2_transit_gateway_default_route_table_association.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_default_route_table_association.html.markdown
@@ -15,7 +15,7 @@ Terraform resource for managing an AWS EC2 (Elastic Compute Cloud) Transit Gatew
 
 ```terraform
 resource "aws_ec2_transit_gateway_default_route_table_association" "example" {
-  transit_gateway_id = aws_ec2_transit_gateway.example.id
+  transit_gateway_id             = aws_ec2_transit_gateway.example.id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.example.id
 }
 ```

--- a/website/docs/r/ec2_transit_gateway_default_route_table_association.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_default_route_table_association.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "Transit Gateway"
+layout: "aws"
+page_title: "AWS: aws_ec2_transit_gateway_default_route_table_association"
+description: |-
+  Terraform resource for managing an AWS EC2 (Elastic Compute Cloud) Transit Gateway Default Route Table Association.
+---
+# Resource: aws_ec2_transit_gateway_default_route_table_association
+
+Terraform resource for managing an AWS EC2 (Elastic Compute Cloud) Transit Gateway Default Route Table Association.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_ec2_transit_gateway_default_route_table_association" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Transit Gateway Default Route Table Association. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import EC2 (Elastic Compute Cloud) Transit Gateway Default Route Table Association using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_ec2_transitgateway_default_route_table_association.example
+  id = "transitgateway_default_route_table_association-id-12345678"
+}
+```
+
+Using `terraform import`, import EC2 (Elastic Compute Cloud) Transit Gateway Default Route Table Association using the `example_id_arg`. For example:
+
+```console
+% terraform import aws_ec2_transitgateway_default_route_table_association.example transitgateway_default_route_table_association-id-12345678
+```

--- a/website/docs/r/ec2_transit_gateway_default_route_table_association.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_default_route_table_association.html.markdown
@@ -27,6 +27,10 @@ The following arguments are required:
 * `transit_gateway_id` - (Required) ID of the Transit Gateway to change the default association route table on.
 * `transit_gateway_route_table_id` - (Required) ID of the Transit Gateway Route Table to be made the default association route table.
 
+## Attribute Reference
+
+This resource exports no additional attributes.
+
 ## Timeouts
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):

--- a/website/docs/r/ec2_transit_gateway_default_route_table_association.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_default_route_table_association.html.markdown
@@ -15,6 +15,8 @@ Terraform resource for managing an AWS EC2 (Elastic Compute Cloud) Transit Gatew
 
 ```terraform
 resource "aws_ec2_transit_gateway_default_route_table_association" "example" {
+  transit_gateway_id = aws_ec2_transit_gateway.example.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.example.id
 }
 ```
 
@@ -22,40 +24,13 @@ resource "aws_ec2_transit_gateway_default_route_table_association" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-
-The following arguments are optional:
-
-* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-
-## Attribute Reference
-
-This resource exports the following attributes in addition to the arguments above:
-
-* `arn` - ARN of the Transit Gateway Default Route Table Association. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `transit_gateway_id` - (Required) ID of the Transit Gateway to change the default association route table on.
+* `transit_gateway_route_table_id` - (Required) ID of the Transit Gateway Route Table to be made the default association route table.
 
 ## Timeouts
 
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
-
-## Import
-
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import EC2 (Elastic Compute Cloud) Transit Gateway Default Route Table Association using the `example_id_arg`. For example:
-
-```terraform
-import {
-  to = aws_ec2_transitgateway_default_route_table_association.example
-  id = "transitgateway_default_route_table_association-id-12345678"
-}
-```
-
-Using `terraform import`, import EC2 (Elastic Compute Cloud) Transit Gateway Default Route Table Association using the `example_id_arg`. For example:
-
-```console
-% terraform import aws_ec2_transitgateway_default_route_table_association.example transitgateway_default_route_table_association-id-12345678
-```
+* `create` - (Default `5m`)
+* `update` - (Default `5m`)
+* `delete` - (Default `5m`)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

New resource `aws_ec2_transit_gateway_default_route_table_association` that allows you to manage setting the default route table for associations on a transit gateway.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #35085 creates one of the two resources required to fix this.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS='TestAccTransitGateway_serial/DefaultRouteTableAssociation_' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccTransitGateway_serial/DefaultRouteTableAssociation_'  -timeout 360m
=== RUN   TestAccTransitGateway_serial
=== PAUSE TestAccTransitGateway_serial
=== CONT  TestAccTransitGateway_serial
=== RUN   TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappears
=== PAUSE TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappears
=== RUN   TestAccTransitGateway_serial/DefaultRouteTableAssociation_basic
=== PAUSE TestAccTransitGateway_serial/DefaultRouteTableAssociation_basic
=== CONT  TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappears
=== CONT  TestAccTransitGateway_serial/DefaultRouteTableAssociation_basic
--- PASS: TestAccTransitGateway_serial (0.00s)
    --- PASS: TestAccTransitGateway_serial/DefaultRouteTableAssociation_basic (210.17s)
    --- PASS: TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappears (210.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        215.675s
```
