### PR TITLE
r/aws_medialive_multiplex: handle read failure during delete

### DIFF
--- a/.changelog/39498.txt
+++ b/.changelog/39498.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_medialive_multiplex: Fix to properly handle read failures during delete operations which were previously ignored
+```

--- a/internal/create/errors.go
+++ b/internal/create/errors.go
@@ -73,14 +73,6 @@ func AppendDiagError(diags diag.Diagnostics, service, action, resource, id strin
 	)
 }
 
-// DiagError returns a 1-length diag.Diagnostics with a diag.Error-level diag.Diagnostic
-// with a standardized error message
-func DiagError(service, action, resource, id string, gotError error) diag.Diagnostics {
-	return diag.Diagnostics{
-		diagError(service, action, resource, id, gotError),
-	}
-}
-
 func diagError(service, action, resource, id string, gotError error) diag.Diagnostic {
 	return diag.Diagnostic{
 		Severity: diag.Error,

--- a/internal/create/errors.go
+++ b/internal/create/errors.go
@@ -103,10 +103,3 @@ func WarnLog(service, action, resource, id string, gotError error) {
 func LogNotFoundRemoveState(service, action, resource, id string) {
 	WarnLog(service, action, resource, id, errors.New("not found, removing from state"))
 }
-
-func DiagErrorFramework(service, action, resource, id string, gotError error) fwdiag.Diagnostic {
-	return fwdiag.NewErrorDiagnostic(
-		ProblemStandardMessage(service, action, resource, id, nil),
-		gotError.Error(),
-	)
-}

--- a/internal/create/errors.go
+++ b/internal/create/errors.go
@@ -80,12 +80,6 @@ func diagError(service, action, resource, id string, gotError error) diag.Diagno
 	}
 }
 
-func AppendDiagErrorMessage(diags diag.Diagnostics, service, action, resource, id, message string) diag.Diagnostics {
-	return append(diags,
-		diagError(service, action, resource, id, errors.New(message)),
-	)
-}
-
 func AppendDiagSettingError(diags diag.Diagnostics, service, resource, id, argument string, gotError error) diag.Diagnostics {
 	return append(diags,
 		diagError(service, fmt.Sprintf("%s %s", ErrActionSetting, argument), resource, id, gotError),

--- a/internal/service/medialive/multiplex.go
+++ b/internal/service/medialive/multiplex.go
@@ -244,7 +244,7 @@ func resourceMultiplexDelete(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if err != nil {
-		create.DiagError(names.MediaLive, create.ErrActionDeleting, ResNameMultiplex, d.Id(), err)
+		return create.AppendDiagError(diags, names.MediaLive, create.ErrActionDeleting, ResNameMultiplex, d.Id(), err)
 	}
 
 	if out.State == types.MultiplexStateRunning {

--- a/internal/service/medialive/multiplex.go
+++ b/internal/service/medialive/multiplex.go
@@ -29,7 +29,7 @@ import (
 
 // @SDKResource("aws_medialive_multiplex", name="Multiplex")
 // @Tags(identifierAttribute="arn")
-// @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/medialive;medialive.DescribeMultiplexOutput")
+// @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/medialive;medialive.DescribeMultiplexOutput", importIgnore="start_multiplex")
 // @Testing(serialize=true)
 func ResourceMultiplex() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/medialive/multiplex_tags_gen_test.go
+++ b/internal/service/medialive/multiplex_tags_gen_test.go
@@ -98,6 +98,9 @@ func testAccMediaLiveMultiplex_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Multiplex/tags/"),
@@ -147,6 +150,9 @@ func testAccMediaLiveMultiplex_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Multiplex/tags/"),
@@ -190,6 +196,9 @@ func testAccMediaLiveMultiplex_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Multiplex/tags/"),
@@ -221,6 +230,9 @@ func testAccMediaLiveMultiplex_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -273,6 +285,9 @@ func testAccMediaLiveMultiplex_tags_null(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Multiplex/tags/"),
@@ -330,6 +345,9 @@ func testAccMediaLiveMultiplex_tags_EmptyMap(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Multiplex/tags/"),
@@ -420,6 +438,9 @@ func testAccMediaLiveMultiplex_tags_AddOnUpdate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -478,6 +499,9 @@ func testAccMediaLiveMultiplex_tags_EmptyTag_OnCreate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Multiplex/tags/"),
@@ -509,6 +533,9 @@ func testAccMediaLiveMultiplex_tags_EmptyTag_OnCreate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -603,6 +630,9 @@ func testAccMediaLiveMultiplex_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Multiplex/tags/"),
@@ -646,6 +676,9 @@ func testAccMediaLiveMultiplex_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -735,6 +768,9 @@ func testAccMediaLiveMultiplex_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -793,6 +829,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_providerOnly(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -840,6 +879,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_providerOnly(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -883,6 +925,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_providerOnly(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -916,6 +961,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_providerOnly(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -984,6 +1032,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1043,6 +1094,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1076,6 +1130,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -1142,6 +1199,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_overlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1201,6 +1261,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_overlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1252,6 +1315,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_overlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -1342,6 +1408,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_updateToProviderOnly(t *testing.
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -1431,6 +1500,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_updateToResourceOnly(t *testing.
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -1496,6 +1568,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -1553,6 +1628,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -1615,6 +1693,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_nullOverlappingResourceTag(t *te
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -1677,6 +1758,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -1732,6 +1816,9 @@ func testAccMediaLiveMultiplex_tags_ComputedTag_OnCreate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -1829,6 +1916,9 @@ func testAccMediaLiveMultiplex_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})
@@ -1916,6 +2006,9 @@ func testAccMediaLiveMultiplex_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"start_multiplex",
+				},
 			},
 		},
 	})

--- a/internal/service/medialive/testdata/Multiplex/tags/main_gen.tf
+++ b/internal/service/medialive/testdata/Multiplex/tags/main_gen.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/medialive/testdata/Multiplex/tagsComputed1/main_gen.tf
+++ b/internal/service/medialive/testdata/Multiplex/tagsComputed1/main_gen.tf
@@ -4,7 +4,7 @@
 provider "null" {}
 
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/medialive/testdata/Multiplex/tagsComputed2/main_gen.tf
+++ b/internal/service/medialive/testdata/Multiplex/tagsComputed2/main_gen.tf
@@ -4,7 +4,7 @@
 provider "null" {}
 
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/medialive/testdata/Multiplex/tags_defaults/main_gen.tf
+++ b/internal/service/medialive/testdata/Multiplex/tags_defaults/main_gen.tf
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/medialive/testdata/Multiplex/tags_ignore/main_gen.tf
+++ b/internal/service/medialive/testdata/Multiplex/tags_ignore/main_gen.tf
@@ -11,7 +11,7 @@ provider "aws" {
 }
 
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {

--- a/internal/service/medialive/testdata/tmpl/multiplex_tags.gtpl
+++ b/internal/service/medialive/testdata/tmpl/multiplex_tags.gtpl
@@ -1,5 +1,5 @@
 resource "aws_medialive_multiplex" "test" {
-  name               = %[1]q
+  name               = var.rName
   availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 
   multiplex_settings {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- Fixes an error which was silently swallowed by a diagnostic helper that did not append to the response `Diagnostics` field.
- Fixes generated tagging tests for the `aws_medialive_multiplex` resource.
- Removes unused helpers from the `create` package.




### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=medialive TESTS=TestAccMediaLive_serial/Multiplex/basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLive_serial/Multiplex/basic'  -timeout 360m

--- PASS: TestAccMediaLive_serial (129.39s)
    --- PASS: TestAccMediaLive_serial/MultiplexProgram (74.15s)
        --- PASS: TestAccMediaLive_serial/MultiplexProgram/basic (74.15s)
    --- PASS: TestAccMediaLive_serial/Multiplex (55.23s)
        --- PASS: TestAccMediaLive_serial/Multiplex/basic (55.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/medialive  134.612s
```
```console
% make testacc PKG=medialive TESTS=TestAccMediaLive_serial/Multiplex/updateTags
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.1 test ./internal/service/medialive/... -v -count 1 -parallel 20 -run='TestAccMediaLive_serial/Multiplex/updateTags'  -timeout 360m

--- PASS: TestAccMediaLive_serial (1366.68s)
    --- PASS: TestAccMediaLive_serial/Multiplex (1366.68s)
        --- PASS: TestAccMediaLive_serial/Multiplex/updateTags (1366.68s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/ComputedTag_OnUpdate_Replace (89.24s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/EmptyTag_OnUpdate_Replace (69.56s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/ComputedTag_OnCreate (60.76s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/DefaultTags_updateToProviderOnly (70.58s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/DefaultTags_updateToResourceOnly (66.00s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/DefaultTags_nullOverlappingResourceTag (56.95s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/basic (101.66s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/EmptyTag_OnUpdate_Add (107.59s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/DefaultTags_nonOverlapping (92.64s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/DefaultTags_overlapping (93.36s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/DefaultTags_emptyResourceTag (57.71s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/ComputedTag_OnUpdate_Add (71.31s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/null (61.18s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/AddOnUpdate (70.43s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/DefaultTags_providerOnly (105.57s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/DefaultTags_nullNonOverlappingResourceTag (57.85s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/EmptyMap (62.57s)
            --- PASS: TestAccMediaLive_serial/Multiplex/updateTags/EmptyTag_OnCreate (71.73s)
    --- PASS: TestAccMediaLive_serial/MultiplexProgram (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/medialive  1371.937s
```