### PR TITLE
[chore] Update .goreleaser.yml to correct use of deprecated snapshot attribute

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,14 +5,13 @@ archives:
       - src: LICENSE
         dst: LICENSE.txt
     format: zip
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 before:
   hooks:
-    - 'go mod download'
+    - "go mod download"
 builds:
-  -
-    # Binary naming only required for Terraform CLI 0.12
-    binary: '{{ .ProjectName }}_v{{ .Version }}_x5'
+  - # Binary naming only required for Terraform CLI 0.12
+    binary: "{{ .ProjectName }}_v{{ .Version }}_x5"
     env:
       - CGO_ENABLED=0
     flags:
@@ -24,7 +23,7 @@ builds:
       - openbsd
       - windows
     goarch:
-      - '386'
+      - "386"
       - amd64
       - arm
       - arm64
@@ -39,13 +38,13 @@ builds:
         goos: openbsd
     ldflags:
       - -s -w -X 'github.com/hashicorp/terraform-provider-aws/version.ProviderVersion={{ .Version }}'
-    mod_timestamp: '{{ .CommitTimestamp }}'
+    mod_timestamp: "{{ .CommitTimestamp }}"
 checksum:
   algorithm: sha256
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
-      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
 publishers:
   - checksum: true
     # Terraform CLI 0.10 - 0.11 perform discovery via HTTP headers on releases.hashicorp.com
@@ -57,25 +56,27 @@ publishers:
     cmd: |
       hc-releases upload -product {{ .ProjectName }} -version {{ .Version }} -file={{ .ArtifactPath }}={{ .ArtifactName }} -header=x-terraform-protocol-version=5 -header=x-terraform-protocol-versions=5.0
     extra_files:
-      - glob: 'terraform-registry-manifest.json'
-        name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+      - glob: "terraform-registry-manifest.json"
+        name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
     name: upload
     signature: true
 release:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
-      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+    - glob: "terraform-registry-manifest.json"
+      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
   ids:
     - none
 signs:
-  - args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
+  - args:
+      ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
     artifacts: checksum
     cmd: signore
     signature: ${artifact}.sig
-  - args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
+  - args:
+      ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
     artifacts: checksum
     cmd: signore
     id: key-id
     signature: ${artifact}.72D7468F.sig
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,13 +5,14 @@ archives:
       - src: LICENSE
         dst: LICENSE.txt
     format: zip
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 before:
   hooks:
-    - "go mod download"
+    - 'go mod download'
 builds:
-  - # Binary naming only required for Terraform CLI 0.12
-    binary: "{{ .ProjectName }}_v{{ .Version }}_x5"
+  -
+    # Binary naming only required for Terraform CLI 0.12
+    binary: '{{ .ProjectName }}_v{{ .Version }}_x5'
     env:
       - CGO_ENABLED=0
     flags:
@@ -23,7 +24,7 @@ builds:
       - openbsd
       - windows
     goarch:
-      - "386"
+      - '386'
       - amd64
       - arm
       - arm64
@@ -38,13 +39,13 @@ builds:
         goos: openbsd
     ldflags:
       - -s -w -X 'github.com/hashicorp/terraform-provider-aws/version.ProviderVersion={{ .Version }}'
-    mod_timestamp: "{{ .CommitTimestamp }}"
+    mod_timestamp: '{{ .CommitTimestamp }}'
 checksum:
   algorithm: sha256
   extra_files:
-    - glob: "terraform-registry-manifest.json"
-      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
 publishers:
   - checksum: true
     # Terraform CLI 0.10 - 0.11 perform discovery via HTTP headers on releases.hashicorp.com
@@ -56,24 +57,22 @@ publishers:
     cmd: |
       hc-releases upload -product {{ .ProjectName }} -version {{ .Version }} -file={{ .ArtifactPath }}={{ .ArtifactName }} -header=x-terraform-protocol-version=5 -header=x-terraform-protocol-versions=5.0
     extra_files:
-      - glob: "terraform-registry-manifest.json"
-        name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+      - glob: 'terraform-registry-manifest.json'
+        name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
     name: upload
     signature: true
 release:
   extra_files:
-    - glob: "terraform-registry-manifest.json"
-      name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   ids:
     - none
 signs:
-  - args:
-      ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
+  - args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
     artifacts: checksum
     cmd: signore
     signature: ${artifact}.sig
-  - args:
-      ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
+  - args: ["sign", "--dearmor", "--file", "${artifact}", "--out", "${signature}"]
     artifacts: checksum
     cmd: signore
     id: key-id


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Resolves current ci [failure](https://github.com/hashicorp/terraform-provider-aws/actions/runs/11046711477/job/30706399075?pr=39493) here:

```console
/opt/hostedtoolcache/goreleaser-action/2.3.2/x64/goreleaser check
  • checking                                 path=.goreleaser.yml
  • DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotnametemplate for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.3.2/x64/goreleaser' failed with exit code 2
```

https://goreleaser.com/deprecations/#snapshotname_template


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://goreleaser.com/deprecations/#snapshotname_template