### PR TITLE
docs: replace invalid argument for aws_elasticache_reserved_cache_node

### DIFF
--- a/website/docs/r/elasticache_reserved_cache_node.html.markdown
+++ b/website/docs/r/elasticache_reserved_cache_node.html.markdown
@@ -40,7 +40,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `instance_count` - (Optional) Number of cache node instances to reserve.
+* `cache_node_count` - (Optional) Number of cache node instances to reserve.
   Default value is `1`.
 * `id` - (Optional) Customer-specified identifier to track this reservation.
   If not specified, AWS will assign a random ID.


### PR DESCRIPTION
### Description

Replace 'instance_count' with 'cache_node_count'  to match with the internal implementation.

### Relations

Closes #39452 

### References

- The `instance_count`  slipped in is as part of the initial [pull request](https://github.com/hashicorp/terraform-provider-aws/pull/29832/files#diff-bc5d1fb3c6f5b1447badc1c7d3afa2f7777af01fc6ab5b084af4b4fe365c6d92) that added support for the resource `aws_elasticache_reserved_cache_node`.
- [Link](https://github.com/hashicorp/terraform-provider-aws/blob/465d0690625e474010378042164d42595e617d1a/internal/service/elasticache/reserved_cache_node.go#L62) to internal schema.

### Output from Acceptance Testing

Not applicable. Only documentation is updated.