### PR TITLE
Update Go devcontainer image to version 1.23

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,5 @@
 {
 	"name": "Go",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1.22"
+	"image": "mcr.microsoft.com/devcontainers/go:1.23"
 }


### PR DESCRIPTION
### Description
I would like to request an upgrade of the Go version used in the VSCode devcontainer.

Current Go Version: 1.22
Proposed Go Version: 1.23

### Relations
Closes #39525