### PR TITLE
fix: Fix policy_version inconsistent result after apply error for aws_opensearchserverless_lifecycle_policy and aws_opensearchserverless_security_policy

### DIFF
--- a/.changelog/39528.txt
+++ b/.changelog/39528.txt
@@ -1,3 +1,6 @@
 ```release-note:bug
+resource/aws_opensearchserverless_lifecycle_policy: Fix "Provider produced inconsistent result after apply" error on update due to `policy_version` computed attribute changing
+```
+```release-note:bug
 resource/aws_opensearchserverless_security_policy: Fix "Provider produced inconsistent result after apply" error on update due to `policy_version` computed attribute changing
 ```

--- a/.changelog/39528.txt
+++ b/.changelog/39528.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_opensearchserverless_security_policy: Fix "Provider produced inconsistent result after apply" error on update due to `policy_version` computed attribute changing
+```

--- a/internal/service/opensearchserverless/lifecycle_policy.go
+++ b/internal/service/opensearchserverless/lifecycle_policy.go
@@ -76,9 +76,6 @@ func (r *resourceLifecyclePolicy) Schema(ctx context.Context, _ resource.SchemaR
 			},
 			"policy_version": schema.StringAttribute{
 				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			names.AttrType: schema.StringAttribute{
 				CustomType: fwtypes.StringEnumType[awstypes.LifecyclePolicyType](),
@@ -187,6 +184,7 @@ func (r *resourceLifecyclePolicy) Update(ctx context.Context, req resource.Updat
 		}
 
 		in.ClientToken = aws.String(id.UniqueId())
+		in.PolicyVersion = state.PolicyVersion.ValueStringPointer() // use policy version from state since it can be recalculated on update
 
 		out, err := conn.UpdateLifecyclePolicy(ctx, in)
 		if err != nil {

--- a/internal/service/opensearchserverless/security_policy.go
+++ b/internal/service/opensearchserverless/security_policy.go
@@ -84,9 +84,6 @@ func (r *resourceSecurityPolicy) Schema(ctx context.Context, req resource.Schema
 			},
 			"policy_version": schema.StringAttribute{
 				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			names.AttrType: schema.StringAttribute{
 				CustomType: fwtypes.StringEnumType[awstypes.SecurityPolicyType](),
@@ -195,6 +192,7 @@ func (r *resourceSecurityPolicy) Update(ctx context.Context, req resource.Update
 		}
 
 		input.ClientToken = aws.String(id.UniqueId())
+		input.PolicyVersion = state.PolicyVersion.ValueStringPointer() // use policy version from state since it can be recalculated on update
 
 		out, err := conn.UpdateSecurityPolicy(ctx, input)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes an issue where the `policy_version` for the `aws_opensearchserverless_lifecycle_policy` resource and the `aws_opensearchserverless_security_policy` resource produces an inconsistent value after apply on update. It seems that the `UseStateForUnknown` modifier requires that the value be the same before and after apply. Instead of using this, manually setting the API input value using the state value seems to resolve the issue.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39527

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccOpenSearchServerlessLifecyclePolicy_|TestAccOpenSearchServerlessSecurityPolicy_" PKG=opensearchserverless      
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.1 test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20 -run='TestAccOpenSearchServerlessLifecyclePolicy_|TestAccOpenSearchServerlessSecurityPolicy_'  -timeout 360m
=== RUN   TestAccOpenSearchServerlessLifecyclePolicy_basic
=== PAUSE TestAccOpenSearchServerlessLifecyclePolicy_basic
=== RUN   TestAccOpenSearchServerlessLifecyclePolicy_disappears
=== PAUSE TestAccOpenSearchServerlessLifecyclePolicy_disappears
=== RUN   TestAccOpenSearchServerlessLifecyclePolicy_update
=== PAUSE TestAccOpenSearchServerlessLifecyclePolicy_update
=== RUN   TestAccOpenSearchServerlessSecurityPolicy_basic
=== PAUSE TestAccOpenSearchServerlessSecurityPolicy_basic
=== RUN   TestAccOpenSearchServerlessSecurityPolicy_update
=== PAUSE TestAccOpenSearchServerlessSecurityPolicy_update
=== RUN   TestAccOpenSearchServerlessSecurityPolicy_disappears
=== PAUSE TestAccOpenSearchServerlessSecurityPolicy_disappears
=== RUN   TestAccOpenSearchServerlessSecurityPolicy_string
=== PAUSE TestAccOpenSearchServerlessSecurityPolicy_string
=== RUN   TestAccOpenSearchServerlessSecurityPolicy_stringUpdate
=== PAUSE TestAccOpenSearchServerlessSecurityPolicy_stringUpdate
=== CONT  TestAccOpenSearchServerlessLifecyclePolicy_basic
=== CONT  TestAccOpenSearchServerlessSecurityPolicy_update
=== CONT  TestAccOpenSearchServerlessSecurityPolicy_basic
=== CONT  TestAccOpenSearchServerlessSecurityPolicy_string
=== CONT  TestAccOpenSearchServerlessSecurityPolicy_stringUpdate
=== CONT  TestAccOpenSearchServerlessLifecyclePolicy_update
=== CONT  TestAccOpenSearchServerlessSecurityPolicy_disappears
=== CONT  TestAccOpenSearchServerlessLifecyclePolicy_disappears
--- PASS: TestAccOpenSearchServerlessSecurityPolicy_disappears (24.16s)
--- PASS: TestAccOpenSearchServerlessLifecyclePolicy_disappears (24.30s)
--- PASS: TestAccOpenSearchServerlessSecurityPolicy_basic (26.47s)
--- PASS: TestAccOpenSearchServerlessLifecyclePolicy_basic (27.27s)
--- PASS: TestAccOpenSearchServerlessSecurityPolicy_string (33.26s)
--- PASS: TestAccOpenSearchServerlessSecurityPolicy_stringUpdate (36.10s)
--- PASS: TestAccOpenSearchServerlessSecurityPolicy_update (36.18s)
--- PASS: TestAccOpenSearchServerlessLifecyclePolicy_update (36.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless       36.543s

$
```
