### PR TITLE
appfabric: Add sweepers

### DIFF
--- a/internal/service/appfabric/sweep.go
+++ b/internal/service/appfabric/sweep.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package appfabric
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/appfabric"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func RegisterSweepers() {
+	awsv2.Register("aws_appfabric_app_bundle", sweepAppBundles)
+}
+
+func sweepAppBundles(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	conn := client.AppFabricClient(ctx)
+	input := &appfabric.ListAppBundlesInput{}
+	var sweepResources []sweep.Sweepable
+
+	pages := appfabric.NewListAppBundlesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.AppBundleSummaryList {
+			sweepResources = append(sweepResources, framework.NewSweepResource(newAppBundleResource, client,
+				framework.NewAttribute(names.AttrID, aws.ToString(v.Arn))))
+		}
+	}
+
+	return sweepResources, nil
+}

--- a/internal/service/appfabric/sweep.go
+++ b/internal/service/appfabric/sweep.go
@@ -16,7 +16,8 @@ import (
 )
 
 func RegisterSweepers() {
-	awsv2.Register("aws_appfabric_app_bundle", sweepAppBundles)
+	awsv2.Register("aws_appfabric_app_bundle", sweepAppBundles, "aws_appfabric_app_authorization")
+	awsv2.Register("aws_appfabric_app_authorization", sweepAppAuthorizations)
 }
 
 func sweepAppBundles(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
@@ -35,6 +36,45 @@ func sweepAppBundles(ctx context.Context, client *conns.AWSClient) ([]sweep.Swee
 		for _, v := range page.AppBundleSummaryList {
 			sweepResources = append(sweepResources, framework.NewSweepResource(newAppBundleResource, client,
 				framework.NewAttribute(names.AttrID, aws.ToString(v.Arn))))
+		}
+	}
+
+	return sweepResources, nil
+}
+
+func sweepAppAuthorizations(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	conn := client.AppFabricClient(ctx)
+	input := &appfabric.ListAppBundlesInput{}
+	var sweepResources []sweep.Sweepable
+
+	pages := appfabric.NewListAppBundlesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.AppBundleSummaryList {
+			appBundleARN := aws.ToString(v.Arn)
+			input := &appfabric.ListAppAuthorizationsInput{
+				AppBundleIdentifier: aws.String(appBundleARN),
+			}
+
+			pages := appfabric.NewListAppAuthorizationsPaginator(conn, input)
+			for pages.HasMorePages() {
+				page, err := pages.NextPage(ctx)
+
+				if err != nil {
+					return nil, err
+				}
+
+				for _, v := range page.AppAuthorizationSummaryList {
+					sweepResources = append(sweepResources, framework.NewSweepResource(newAppAuthorizationResource, client,
+						framework.NewAttribute("app_bundle_arn", appBundleARN),
+						framework.NewAttribute(names.AttrARN, aws.ToString(v.AppAuthorizationArn))))
+				}
+			}
 		}
 	}
 

--- a/internal/sweep/awsv2/register.go
+++ b/internal/sweep/awsv2/register.go
@@ -43,5 +43,6 @@ func Register(name string, f sweep.SweeperFn, dependencies ...string) {
 
 			return nil
 		},
+		Dependencies: dependencies,
 	})
 }

--- a/internal/sweep/register_gen_test.go
+++ b/internal/sweep/register_gen_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/appautoscaling"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/appconfig"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/appfabric"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/appflow"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/applicationinsights"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/appmesh"
@@ -175,6 +176,7 @@ func registerSweepers() {
 	apigatewayv2.RegisterSweepers()
 	appautoscaling.RegisterSweepers()
 	appconfig.RegisterSweepers()
+	appfabric.RegisterSweepers()
 	appflow.RegisterSweepers()
 	applicationinsights.RegisterSweepers()
 	appmesh.RegisterSweepers()


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds sweepers for `aws_appfabric_app_authorization` and `aws_appfabric_app_bundle`.
Fixes a bug in `awsv2.Register` where `dependencies` weren't being set.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/39542.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SWEEPERS=aws_appfabric_app_bundle make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.23.1 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run='aws_appfabric_app_bundle' -timeout 360m
2024/09/30 15:12:55 [DEBUG] Running Sweepers for region (us-west-2):
2024/09/30 15:12:55 [DEBUG] Sweeper (aws_appfabric_app_bundle) has dependency (aws_appfabric_app_authorization), running..
2024/09/30 15:12:55 [DEBUG] Running Sweeper (aws_appfabric_app_authorization) in region (us-west-2)
2024/09/30 15:12:55 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:55.551-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-west-2
2024-09-30T15:12:55.551-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-west-2
2024-09-30T15:12:55.551-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-2 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:55.552-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-2 tf_resource_type=aws_appfabric_app_authorization tf_aws.credentials_source=EnvConfigCredentials
2024-09-30T15:12:55.552-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:55 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-west-2 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:55 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-2 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:55.552-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:55.947-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-west-2
2024/09/30 15:12:55 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:55 [WARN]  sweeper: Skipping sweeper: sweeper_region=us-west-2 tf_resource_type=aws_appfabric_app_authorization error="operation error AppFabric: ListAppBundles, https response error StatusCode: 0, RequestID: , request send failed, Get \"https://appfabric.us-west-2.amazonaws.com/appbundles\": dial tcp: lookup appfabric.us-west-2.amazonaws.com: no such host"
2024/09/30 15:12:55 [DEBUG] Completed Sweeper (aws_appfabric_app_authorization) in region (us-west-2) in 425.66675ms
2024/09/30 15:12:55 [DEBUG] Running Sweeper (aws_appfabric_app_bundle) in region (us-west-2)
2024/09/30 15:12:55 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_appfabric_app_bundle
2024/09/30 15:12:55 [WARN]  sweeper: Skipping sweeper: tf_resource_type=aws_appfabric_app_bundle error="operation error AppFabric: ListAppBundles, https response error StatusCode: 0, RequestID: , request send failed, Get \"https://appfabric.us-west-2.amazonaws.com/appbundles\": dial tcp: lookup appfabric.us-west-2.amazonaws.com: no such host" sweeper_region=us-west-2
2024/09/30 15:12:55 [DEBUG] Completed Sweeper (aws_appfabric_app_bundle) in region (us-west-2) in 2.281459ms
2024/09/30 15:12:55 [DEBUG] Sweeper (aws_appfabric_app_authorization) already ran in region (us-west-2)
2024/09/30 15:12:55 Completed Sweepers for region (us-west-2) in 428.172958ms
2024/09/30 15:12:55 Sweeper Tests for region (us-west-2) ran successfully:
2024/09/30 15:12:55 	- aws_appfabric_app_authorization
2024/09/30 15:12:55 	- aws_appfabric_app_bundle
2024/09/30 15:12:55 [DEBUG] Running Sweepers for region (us-east-1):
2024/09/30 15:12:55 [DEBUG] Sweeper (aws_appfabric_app_bundle) has dependency (aws_appfabric_app_authorization), running..
2024/09/30 15:12:55 [DEBUG] Running Sweeper (aws_appfabric_app_authorization) in region (us-east-1)
2024/09/30 15:12:55 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:55.979-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:55.979-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:55.979-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-east-1
2024-09-30T15:12:55.979-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_authorization tf_aws.credentials_source=EnvConfigCredentials
2024-09-30T15:12:55.979-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:55 [DEBUG] sweeper: Creating AWS SDK v1 session: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-east-1
2024/09/30 15:12:55 [DEBUG] sweeper: Retrieving AWS account details: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-east-1
2024-09-30T15:12:55.980-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-east-1
2024-09-30T15:12:56.093-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:56 [INFO]  sweeper: listing resources: sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:56 [INFO]  sweeper: Sweeping resource: arn=arn:aws:appfabric:us-east-1:123456789012:appbundle/a536c9aa-11b0-4b76-9db3-daa794800069/appauthorization/b4d3e45b-5f0f-4b75-82dc-40a4105e5d1e sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_authorization resource_type=aws_appfabric_app_authorization app_bundle_arn=arn:aws:appfabric:us-east-1:123456789012:appbundle/a536c9aa-11b0-4b76-9db3-daa794800069
2024/09/30 15:12:56 [DEBUG] Waiting for state to become: [success]
2024-09-30T15:12:56.244-0400 [INFO]  sweeper.autoflex: Expanding: new_logger_warning="This log was generated by a subsystem logger that wasn't created before being used. Use tflog.NewSubsystem to create this logger before it is used." autoflex.target.type="**string" autoflex.source.type=github.com/hashicorp/terraform-plugin-framework/types/basetypes.StringValue
2024-09-30T15:12:56.244-0400 [INFO]  sweeper.autoflex: Converting: new_logger_warning="This log was generated by a subsystem logger that wasn't created before being used. Use tflog.NewSubsystem to create this logger before it is used." autoflex.target.type="*string" autoflex.target.path="" autoflex.source.type=github.com/hashicorp/terraform-plugin-framework/types/basetypes.StringValue autoflex.source.path=""
2024-09-30T15:12:56.244-0400 [INFO]  sweeper.autoflex: Expanding: new_logger_warning="This log was generated by a subsystem logger that wasn't created before being used. Use tflog.NewSubsystem to create this logger before it is used." autoflex.source.type=github.com/hashicorp/terraform-provider-aws/internal/framework/types.ARN autoflex.target.type="**string"
2024-09-30T15:12:56.244-0400 [INFO]  sweeper.autoflex: Converting: new_logger_warning="This log was generated by a subsystem logger that wasn't created before being used. Use tflog.NewSubsystem to create this logger before it is used." autoflex.source.type=github.com/hashicorp/terraform-provider-aws/internal/framework/types.ARN autoflex.target.type="*string" autoflex.source.path="" autoflex.target.path=""
2024/09/30 15:12:56 [INFO]  sweeper: delete timeout configuration not found, using provided default: app_bundle_arn=arn:aws:appfabric:us-east-1:123456789012:appbundle/a536c9aa-11b0-4b76-9db3-daa794800069 arn=arn:aws:appfabric:us-east-1:123456789012:appbundle/a536c9aa-11b0-4b76-9db3-daa794800069/appauthorization/b4d3e45b-5f0f-4b75-82dc-40a4105e5d1e sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_authorization resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:56 [DEBUG] Waiting for state to become: []
2024/09/30 15:12:56 [DEBUG] Completed Sweeper (aws_appfabric_app_authorization) in region (us-east-1) in 441.628167ms
2024/09/30 15:12:56 [DEBUG] Running Sweeper (aws_appfabric_app_bundle) in region (us-east-1)
2024/09/30 15:12:56 [INFO]  sweeper: listing resources: sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_bundle
2024/09/30 15:12:56 [INFO]  sweeper: Sweeping resource: id=arn:aws:appfabric:us-east-1:123456789012:appbundle/a536c9aa-11b0-4b76-9db3-daa794800069 sweeper_region=us-east-1 tf_resource_type=aws_appfabric_app_bundle resource_type=aws_appfabric_app_bundle
2024/09/30 15:12:56 [DEBUG] Waiting for state to become: [success]
2024/09/30 15:12:56 [DEBUG] Completed Sweeper (aws_appfabric_app_bundle) in region (us-east-1) in 119.073625ms
2024/09/30 15:12:56 [DEBUG] Sweeper (aws_appfabric_app_authorization) already ran in region (us-east-1)
2024/09/30 15:12:56 Completed Sweepers for region (us-east-1) in 560.807ms
2024/09/30 15:12:56 Sweeper Tests for region (us-east-1) ran successfully:
2024/09/30 15:12:56 	- aws_appfabric_app_authorization
2024/09/30 15:12:56 	- aws_appfabric_app_bundle
2024/09/30 15:12:56 [DEBUG] Running Sweepers for region (us-east-2):
2024/09/30 15:12:56 [DEBUG] Sweeper (aws_appfabric_app_bundle) has dependency (aws_appfabric_app_authorization), running..
2024/09/30 15:12:56 [DEBUG] Running Sweeper (aws_appfabric_app_authorization) in region (us-east-2)
2024/09/30 15:12:56 [DEBUG] sweeper: Configuring Terraform AWS Provider: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-east-2
2024-09-30T15:12:56.539-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-2 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:56.540-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:56.540-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-2 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:56.540-0400 [INFO]  sweeper.aws-base: Retrieved credentials: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-east-2 tf_aws.credentials_source=EnvConfigCredentials
2024-09-30T15:12:56.540-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:56 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-east-2 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:56 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-2 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:56.540-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-east-2
2024-09-30T15:12:56.717-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-east-2
2024/09/30 15:12:56 [INFO]  sweeper: listing resources: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-east-2
2024/09/30 15:12:56 [WARN]  sweeper: Skipping sweeper: error="operation error AppFabric: ListAppBundles, https response error StatusCode: 0, RequestID: , request send failed, Get \"https://appfabric.us-east-2.amazonaws.com/appbundles\": dial tcp: lookup appfabric.us-east-2.amazonaws.com: no such host" sweeper_region=us-east-2 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:56 [DEBUG] Completed Sweeper (aws_appfabric_app_authorization) in region (us-east-2) in 204.948167ms
2024/09/30 15:12:56 [DEBUG] Running Sweeper (aws_appfabric_app_bundle) in region (us-east-2)
2024/09/30 15:12:56 [INFO]  sweeper: listing resources: sweeper_region=us-east-2 tf_resource_type=aws_appfabric_app_bundle
2024/09/30 15:12:56 [WARN]  sweeper: Skipping sweeper: sweeper_region=us-east-2 tf_resource_type=aws_appfabric_app_bundle error="operation error AppFabric: ListAppBundles, https response error StatusCode: 0, RequestID: , request send failed, Get \"https://appfabric.us-east-2.amazonaws.com/appbundles\": dial tcp: lookup appfabric.us-east-2.amazonaws.com: no such host"
2024/09/30 15:12:56 [DEBUG] Completed Sweeper (aws_appfabric_app_bundle) in region (us-east-2) in 2.265583ms
2024/09/30 15:12:56 [DEBUG] Sweeper (aws_appfabric_app_authorization) already ran in region (us-east-2)
2024/09/30 15:12:56 Completed Sweepers for region (us-east-2) in 207.259208ms
2024/09/30 15:12:56 Sweeper Tests for region (us-east-2) ran successfully:
2024/09/30 15:12:56 	- aws_appfabric_app_authorization
2024/09/30 15:12:56 	- aws_appfabric_app_bundle
2024/09/30 15:12:56 [DEBUG] Running Sweepers for region (us-west-1):
2024/09/30 15:12:56 [DEBUG] Sweeper (aws_appfabric_app_bundle) has dependency (aws_appfabric_app_authorization), running..
2024/09/30 15:12:56 [DEBUG] Running Sweeper (aws_appfabric_app_authorization) in region (us-west-1)
2024/09/30 15:12:56 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:56.747-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-west-1
2024-09-30T15:12:56.747-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:56.747-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:56.747-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_authorization tf_aws.credentials_source=EnvConfigCredentials
2024-09-30T15:12:56.747-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:56 [DEBUG] sweeper: Creating AWS SDK v1 session: tf_resource_type=aws_appfabric_app_authorization sweeper_region=us-west-1
2024/09/30 15:12:56 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:56.747-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_authorization
2024-09-30T15:12:57.132-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:57 [INFO]  sweeper: listing resources: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_authorization
2024/09/30 15:12:57 [WARN]  sweeper: Skipping sweeper: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_authorization error="operation error AppFabric: ListAppBundles, https response error StatusCode: 0, RequestID: , request send failed, Get \"https://appfabric.us-west-1.amazonaws.com/appbundles\": dial tcp: lookup appfabric.us-west-1.amazonaws.com: no such host"
2024/09/30 15:12:57 [DEBUG] Completed Sweeper (aws_appfabric_app_authorization) in region (us-west-1) in 418.648584ms
2024/09/30 15:12:57 [DEBUG] Running Sweeper (aws_appfabric_app_bundle) in region (us-west-1)
2024/09/30 15:12:57 [INFO]  sweeper: listing resources: sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_bundle
2024/09/30 15:12:57 [WARN]  sweeper: Skipping sweeper: error="operation error AppFabric: ListAppBundles, https response error StatusCode: 0, RequestID: , request send failed, Get \"https://appfabric.us-west-1.amazonaws.com/appbundles\": dial tcp: lookup appfabric.us-west-1.amazonaws.com: no such host" sweeper_region=us-west-1 tf_resource_type=aws_appfabric_app_bundle
2024/09/30 15:12:57 [DEBUG] Completed Sweeper (aws_appfabric_app_bundle) in region (us-west-1) in 2.543959ms
2024/09/30 15:12:57 [DEBUG] Sweeper (aws_appfabric_app_authorization) already ran in region (us-west-1)
2024/09/30 15:12:57 Completed Sweepers for region (us-west-1) in 421.238292ms
2024/09/30 15:12:57 Sweeper Tests for region (us-west-1) ran successfully:
2024/09/30 15:12:57 	- aws_appfabric_app_bundle
2024/09/30 15:12:57 	- aws_appfabric_app_authorization
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	7.084s
```
