### PR TITLE
r/aws_iam_user_policies_exclusive: new resource

### DIFF
--- a/.changelog/39544.txt
+++ b/.changelog/39544.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_iam_user_policies_exclusive
+```

--- a/internal/service/iam/exports_test.go
+++ b/internal/service/iam/exports_test.go
@@ -49,6 +49,7 @@ var (
 	FindServerCertificateByName         = findServerCertificateByName
 	FindSSHPublicKeyByThreePartKey      = findSSHPublicKeyByThreePartKey
 	FindUserByName                      = findUserByName
+	FindUserPoliciesByName              = findUserPoliciesByName
 	FindVirtualMFADeviceBySerialNumber  = findVirtualMFADeviceBySerialNumber
 	SESSMTPPasswordFromSecretKeySigV4   = sesSMTPPasswordFromSecretKeySigV4
 )

--- a/internal/service/iam/service_package_gen.go
+++ b/internal/service/iam/service_package_gen.go
@@ -24,6 +24,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Factory: newResourceRolePoliciesExclusive,
 			Name:    "Role Policies Exclusive",
 		},
+		{
+			Factory: newResourceUserPoliciesExclusive,
+			Name:    "User Policies Exclusive",
+		},
 	}
 }
 

--- a/internal/service/iam/user_policies_exclusive.go
+++ b/internal/service/iam/user_policies_exclusive.go
@@ -1,0 +1,217 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	intflex "github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_iam_user_policies_exclusive", name="User Policies Exclusive")
+func newResourceUserPoliciesExclusive(_ context.Context) (resource.ResourceWithConfigure, error) {
+	return &resourceUserPoliciesExclusive{}, nil
+}
+
+const (
+	ResNameUserPoliciesExclusive = "User Policies Exclusive"
+)
+
+type resourceUserPoliciesExclusive struct {
+	framework.ResourceWithConfigure
+	framework.WithNoOpDelete
+}
+
+func (r *resourceUserPoliciesExclusive) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_iam_user_policies_exclusive"
+}
+
+func (r *resourceUserPoliciesExclusive) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrUserName: schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"policy_names": schema.SetAttribute{
+				ElementType: types.StringType,
+				Required:    true,
+			},
+		},
+	}
+}
+
+func (r *resourceUserPoliciesExclusive) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan resourceUserPoliciesExclusiveData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var policyNames []string
+	resp.Diagnostics.Append(plan.PolicyNames.ElementsAs(ctx, &policyNames, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.syncAttachments(ctx, plan.UserName.ValueString(), policyNames)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.IAM, create.ErrActionCreating, ResNameUserPoliciesExclusive, plan.UserName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceUserPoliciesExclusive) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().IAMClient(ctx)
+
+	var state resourceUserPoliciesExclusiveData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findUserPoliciesByName(ctx, conn, state.UserName.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.IAM, create.ErrActionReading, ResNameUserPoliciesExclusive, state.UserName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	state.PolicyNames = flex.FlattenFrameworkStringValueSetLegacy(ctx, out)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceUserPoliciesExclusive) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state resourceUserPoliciesExclusiveData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !plan.PolicyNames.Equal(state.PolicyNames) {
+		var policyNames []string
+		resp.Diagnostics.Append(plan.PolicyNames.ElementsAs(ctx, &policyNames, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		err := r.syncAttachments(ctx, plan.UserName.ValueString(), policyNames)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.IAM, create.ErrActionUpdating, ResNameUserPoliciesExclusive, plan.UserName.String(), err),
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// syncAttachments handles keeping the configured inline policy attachments
+// in sync with the remote resource.
+//
+// Inline policies defined on this resource but not attached to the user will
+// be added. Policies attached to the user but not configured on this resource
+// will be removed.
+func (r *resourceUserPoliciesExclusive) syncAttachments(ctx context.Context, userName string, want []string) error {
+	conn := r.Meta().IAMClient(ctx)
+
+	have, err := findUserPoliciesByName(ctx, conn, userName)
+	if err != nil {
+		return err
+	}
+
+	create, remove, _ := intflex.DiffSlices(have, want, func(s1, s2 string) bool { return s1 == s2 })
+
+	for _, name := range create {
+		in := &iam.PutUserPolicyInput{
+			UserName:   aws.String(userName),
+			PolicyName: aws.String(name),
+		}
+
+		_, err := conn.PutUserPolicy(ctx, in)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, name := range remove {
+		in := &iam.DeleteUserPolicyInput{
+			UserName:   aws.String(userName),
+			PolicyName: aws.String(name),
+		}
+
+		_, err := conn.DeleteUserPolicy(ctx, in)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *resourceUserPoliciesExclusive) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrUserName), req, resp)
+}
+
+func findUserPoliciesByName(ctx context.Context, conn *iam.Client, userName string) ([]string, error) {
+	in := &iam.ListUserPoliciesInput{
+		UserName: aws.String(userName),
+	}
+
+	var policyNames []string
+	paginator := iam.NewListUserPoliciesPaginator(conn, in)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			if errs.IsA[*awstypes.NoSuchEntityException](err) {
+				return nil, &retry.NotFoundError{
+					LastError:   err,
+					LastRequest: in,
+				}
+			}
+			return policyNames, err
+		}
+
+		policyNames = append(policyNames, page.PolicyNames...)
+	}
+
+	return policyNames, nil
+}
+
+type resourceUserPoliciesExclusiveData struct {
+	UserName    types.String `tfsdk:"user_name"`
+	PolicyNames types.Set    `tfsdk:"policy_names"`
+}

--- a/internal/service/iam/user_policies_exclusive_test.go
+++ b/internal/service/iam/user_policies_exclusive_test.go
@@ -1,0 +1,438 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	tfiam "github.com/hashicorp/terraform-provider-aws/internal/service/iam"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccIAMUserPoliciesExclusive_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var user types.User
+	var userPolicy string
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_user_policies_exclusive.test"
+	userResourceName := "aws_iam_user.test"
+	userPolicyResourceName := "aws_iam_user_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, userResourceName, &user),
+					testAccCheckUserPolicyExists(ctx, userPolicyResourceName, &userPolicy),
+					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", userPolicyResourceName, names.AttrName),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccUserPoliciesExclusiveImportStateIdFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrUserName,
+			},
+		},
+	})
+}
+
+func TestAccIAMUserPoliciesExclusive_disappears_User(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var user types.User
+	var userPolicy string
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_user_policies_exclusive.test"
+	userResourceName := "aws_iam_user.test"
+	userPolicyResourceName := "aws_iam_user_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, userResourceName, &user),
+					testAccCheckUserPolicyExists(ctx, userPolicyResourceName, &userPolicy),
+					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					// Inline policy must be deleted before the user can be
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiam.ResourceUserPolicy(), userPolicyResourceName),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfiam.ResourceUser(), userResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccIAMUserPoliciesExclusive_multiple(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var user types.User
+	var userPolicy string
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_user_policies_exclusive.test"
+	userResourceName := "aws_iam_user.test"
+	userPolicyResourceName := "aws_iam_user_policy.test"
+	userPolicyResourceName2 := "aws_iam_user_policy.test2"
+	userPolicyResourceName3 := "aws_iam_user_policy.test3"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoliciesExclusiveConfig_multiple(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, userResourceName, &user),
+					testAccCheckUserPolicyExists(ctx, userPolicyResourceName, &userPolicy),
+					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", userPolicyResourceName, names.AttrName),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", userPolicyResourceName2, names.AttrName),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", userPolicyResourceName3, names.AttrName),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccUserPoliciesExclusiveImportStateIdFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: names.AttrUserName,
+			},
+			{
+				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, userResourceName, &user),
+					testAccCheckUserPolicyExists(ctx, userPolicyResourceName, &userPolicy),
+					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "policy_names.*", userPolicyResourceName, names.AttrName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMUserPoliciesExclusive_empty(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var user types.User
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_user_policies_exclusive.test"
+	userResourceName := "aws_iam_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoliciesExclusiveDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoliciesExclusiveConfig_empty(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, userResourceName, &user),
+					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "policy_names.#", acctest.Ct0),
+				),
+				// The empty `policy_names` argument in the exclusive lock will remove the
+				// inline policy defined in this configuration, so a diff is expected
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// An inline policy removed out of band should be recreated
+func TestAccIAMUserPoliciesExclusive_outOfBandRemoval(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var user types.User
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_user_policies_exclusive.test"
+	userResourceName := "aws_iam_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, userResourceName, &user),
+					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckUserPolicyRemoveInlinePolicy(ctx, &user, rName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, userResourceName, &user),
+					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "policy_names.#", acctest.Ct1),
+				),
+			},
+		},
+	})
+}
+
+// An inline policy added out of band should be removed
+func TestAccIAMUserPoliciesExclusive_outOfBandAddition(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var user types.User
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	policyName := rName + "-out-of-band"
+	resourceName := "aws_iam_user_policies_exclusive.test"
+	userResourceName := "aws_iam_user.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, userResourceName, &user),
+					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					testAccCheckUserPolicyAddInlinePolicy(ctx, &user, policyName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccUserPoliciesExclusiveConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, userResourceName, &user),
+					testAccCheckUserPoliciesExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrUserName, userResourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "policy_names.#", acctest.Ct1),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckUserPoliciesExclusiveDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_iam_user_policies_exclusive" {
+				continue
+			}
+
+			userName := rs.Primary.Attributes[names.AttrUserName]
+			_, err := tfiam.FindUserPoliciesByName(ctx, conn, userName)
+			if errs.IsA[*types.NoSuchEntityException](err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.IAM, create.ErrActionCheckingDestroyed, tfiam.ResNameUserPoliciesExclusive, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.IAM, create.ErrActionCheckingDestroyed, tfiam.ResNameUserPoliciesExclusive, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckUserPoliciesExclusiveExists(ctx context.Context, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameUserPoliciesExclusive, name, errors.New("not found"))
+		}
+
+		userName := rs.Primary.Attributes[names.AttrUserName]
+		if userName == "" {
+			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameUserPoliciesExclusive, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+		out, err := tfiam.FindUserPoliciesByName(ctx, conn, userName)
+		if err != nil {
+			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameUserPoliciesExclusive, userName, err)
+		}
+
+		policyCount := rs.Primary.Attributes["policy_names.#"]
+		if policyCount != fmt.Sprint(len(out)) {
+			return create.Error(names.IAM, create.ErrActionCheckingExistence, tfiam.ResNameUserPoliciesExclusive, userName, errors.New("unexpected policy_names count"))
+		}
+
+		return nil
+	}
+}
+
+func testAccUserPoliciesExclusiveImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return rs.Primary.Attributes[names.AttrUserName], nil
+	}
+}
+
+func testAccCheckUserPolicyAddInlinePolicy(ctx context.Context, user *types.User, inlinePolicy string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+
+		_, err := conn.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+			PolicyDocument: aws.String(testAccUserPolicyExtraInlineConfig()),
+			PolicyName:     aws.String(inlinePolicy),
+			UserName:       user.UserName,
+		})
+
+		return err
+	}
+}
+
+func testAccCheckUserPolicyRemoveInlinePolicy(ctx context.Context, user *types.User, inlinePolicy string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).IAMClient(ctx)
+
+		_, err := conn.DeleteUserPolicy(ctx, &iam.DeleteUserPolicyInput{
+			PolicyName: aws.String(inlinePolicy),
+			UserName:   user.UserName,
+		})
+
+		return err
+	}
+}
+
+func testAccUserPolicyExtraInlineConfig() string {
+	return `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+		"Action": [
+			"ec2:Describe*"
+		],
+		"Effect": "Allow",
+		"Resource": "*"
+		}
+	]
+}`
+}
+
+func testAccUserPoliciesExclusiveConfigBase(rName string) string {
+	return fmt.Sprintf(`
+data "aws_iam_policy_document" "inline" {
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_user" "test" {
+  name = %[1]q
+}
+
+resource "aws_iam_user_policy" "test" {
+  name   = %[1]q
+  user   = aws_iam_user.test.name
+  policy = data.aws_iam_policy_document.inline.json
+}
+`, rName)
+}
+
+func testAccUserPoliciesExclusiveConfig_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserPoliciesExclusiveConfigBase(rName),
+		`
+resource "aws_iam_user_policies_exclusive" "test" {
+  user_name    = aws_iam_user.test.name
+  policy_names = [aws_iam_user_policy.test.name]
+}
+`)
+}
+
+func testAccUserPoliciesExclusiveConfig_multiple(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserPoliciesExclusiveConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_iam_user_policy" "test2" {
+  name   = "%[1]s-2"
+  user   = aws_iam_user.test.name
+  policy = data.aws_iam_policy_document.inline.json
+}
+
+resource "aws_iam_user_policy" "test3" {
+  name   = "%[1]s-3"
+  user   = aws_iam_user.test.name
+  policy = data.aws_iam_policy_document.inline.json
+}
+
+resource "aws_iam_user_policies_exclusive" "test" {
+  user_name = aws_iam_user.test.name
+  policy_names = [
+    aws_iam_user_policy.test.name,
+    aws_iam_user_policy.test2.name,
+    aws_iam_user_policy.test3.name,
+  ]
+}
+`, rName))
+}
+
+func testAccUserPoliciesExclusiveConfig_empty(rName string) string {
+	return acctest.ConfigCompose(
+		testAccUserPoliciesExclusiveConfigBase(rName),
+		`
+resource "aws_iam_user_policies_exclusive" "test" {
+  # Wait until the inline policy is created, then provision
+  # the exclusive lock which will remove it. This creates a diff on
+  # on the next plan (to re-create aws_iam_user_policy.test)
+  # which the test can check for.
+  depends_on = [aws_iam_user_policy.test]
+
+  user_name    = aws_iam_user.test.name
+  policy_names = []
+}
+`)
+}

--- a/website/docs/r/iam_user_policies_exclusive.html.markdown
+++ b/website/docs/r/iam_user_policies_exclusive.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "IAM (Identity & Access Management)"
+layout: "aws"
+page_title: "AWS: aws_iam_user_policies_exclusive"
+description: |-
+  Terraform resource for maintaining exclusive management of inline policies assigned to an AWS IAM (Identity & Access Management) user.
+---
+# Resource: aws_iam_user_policies_exclusive
+
+Terraform resource for maintaining exclusive management of inline policies assigned to an AWS IAM (Identity & Access Management) user.
+
+!> This resource takes exclusive ownership over inline policies assigned to a user. This includes removal of inline policies which are not explicitly configured. To prevent persistent drift, ensure any `aws_iam_user_policy` resources managed alongside this resource are included in the `policy_names` argument.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_iam_user_policies_exclusive" "example" {
+  user_name    = aws_iam_user.example.name
+  policy_names = [aws_iam_user_policy.example.name]
+}
+```
+
+### Disallow Inline Policies
+
+To automatically remove any configured inline policies, set the `policy_names` argument to an empty list.
+
+~> This will not __prevent__ inline policies from being assigned to a user via Terraform (or any other interface). This resource enables bringing inline policy assignments into a configured state, however, this reconciliation happens only when `apply` is proactively run.
+
+```terraform
+resource "aws_iam_user_policies_exclusive" "example" {
+  user_name    = aws_iam_user.example.name
+  policy_names = []
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `user_name` - (Required) IAM user name.
+* `policy_names` - (Required) A list of inline policy names to be assigned to the user. Policies attached to this user but not configured in this argument will be removed.
+
+## Attribute Reference
+
+This resource exports no additional attributes.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to exclusively manage inline policy assignments using the `user_name`. For example:
+
+```terraform
+import {
+  to = aws_iam_user_policies_exclusive.example
+  id = "MyUser"
+}
+```
+
+Using `terraform import`, import exclusive management of inline policy assignments using the `user_name`. For example:
+
+```console
+% terraform import aws_iam_user_policies_exclusive.example MyUser
+```


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This resource will enable exclusive management of inline policy assignments to an IAM user via Terraform.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #39376
Closes #39377 


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=iam TESTS=TestAccIAMUserPoliciesExclusive_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.1 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMUserPoliciesExclusive_'  -timeout 360m

--- PASS: TestAccIAMUserPoliciesExclusive_empty (14.20s)
--- PASS: TestAccIAMUserPoliciesExclusive_disappears_User (14.87s)
--- PASS: TestAccIAMUserPoliciesExclusive_basic (16.78s)
--- PASS: TestAccIAMUserPoliciesExclusive_outOfBandRemoval (23.39s)
--- PASS: TestAccIAMUserPoliciesExclusive_outOfBandAddition (23.42s)
--- PASS: TestAccIAMUserPoliciesExclusive_multiple (25.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        32.023s
```
