### PR TITLE
feat: add start_time attribute to data source aws_ebs_snapshot

### DIFF
--- a/.changelog/39557.txt
+++ b/.changelog/39557.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-data-source/aws_ebs_snapshot: Add start_time attribute
+data-source/aws_ebs_snapshot: Add `start_time` attribute
 ```

--- a/.changelog/39557.txt
+++ b/.changelog/39557.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ebs_snapshot: Add start_time attribute
+```

--- a/internal/service/ec2/ebs_snapshot_data_source.go
+++ b/internal/service/ec2/ebs_snapshot_data_source.go
@@ -90,6 +90,10 @@ func dataSourceEBSSnapshot() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			names.AttrStartTime: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrState: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -177,6 +181,7 @@ func dataSourceEBSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(names.AttrOwnerID, snapshot.OwnerId)
 	d.Set(names.AttrSnapshotID, snapshot.SnapshotId)
 	d.Set(names.AttrState, snapshot.State)
+	d.Set("start_time", aws.ToTime(snapshot.StartTime).Format(time.RFC3339))
 	d.Set("storage_tier", snapshot.StorageTier)
 	d.Set("volume_id", snapshot.VolumeId)
 	d.Set(names.AttrVolumeSize, snapshot.VolumeSize)

--- a/internal/service/ec2/ebs_snapshot_data_source.go
+++ b/internal/service/ec2/ebs_snapshot_data_source.go
@@ -181,7 +181,7 @@ func dataSourceEBSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(names.AttrOwnerID, snapshot.OwnerId)
 	d.Set(names.AttrSnapshotID, snapshot.SnapshotId)
 	d.Set(names.AttrState, snapshot.State)
-	d.Set("start_time", aws.ToTime(snapshot.StartTime).Format(time.RFC3339))
+	d.Set(names.AttrStartTime, aws.ToTime(snapshot.StartTime).Format(time.RFC3339))
 	d.Set("storage_tier", snapshot.StorageTier)
 	d.Set("volume_id", snapshot.VolumeId)
 	d.Set(names.AttrVolumeSize, snapshot.VolumeSize)

--- a/internal/service/ec2/ebs_snapshot_data_source_test.go
+++ b/internal/service/ec2/ebs_snapshot_data_source_test.go
@@ -38,6 +38,7 @@ func TestAccEC2EBSSnapshotDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
 					resource.TestCheckResourceAttrPair(dataSourceName, "volume_id", resourceName, "volume_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrVolumeSize, resourceName, names.AttrVolumeSize),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrStartTime),
 				),
 			},
 		},

--- a/website/docs/d/ebs_snapshot.html.markdown
+++ b/website/docs/d/ebs_snapshot.html.markdown
@@ -60,6 +60,7 @@ This data source exports the following attributes in addition to the arguments a
 * `volume_size` - Size of the drive in GiBs.
 * `kms_key_id` - ARN for the KMS encryption key.
 * `data_encryption_key_id` - The data encryption key identifier for the snapshot.
+* `start_time` - Time stamp when the snapshot was initiated.
 * `state` - Snapshot state.
 * `storage_tier` - Storage tier in which the snapshot is stored.
 * `outpost_arn` - ARN of the Outpost on which the snapshot is stored.


### PR DESCRIPTION
### Description

Add start time attribute to the data source.

### Relations

Closes #39497 

### References

- [Snapshot Definition in AWS Go SDK v2](https://github.com/aws/aws-sdk-go-v2/blob/service/ec2/v1.179.2/service/ec2/types/types.go#L15556)

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccEC2EBSSnapshotDataSource PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.1 test ./internal/service/ec2/... -v -count 1 -parallel 5 -run='TestAccEC2EBSSnapshotDataSource'  -timeout 360m
=== RUN   TestAccEC2EBSSnapshotDataSource_basic
=== PAUSE TestAccEC2EBSSnapshotDataSource_basic
=== RUN   TestAccEC2EBSSnapshotDataSource_filter
=== PAUSE TestAccEC2EBSSnapshotDataSource_filter
=== RUN   TestAccEC2EBSSnapshotDataSource_mostRecent
=== PAUSE TestAccEC2EBSSnapshotDataSource_mostRecent
=== CONT  TestAccEC2EBSSnapshotDataSource_basic
=== CONT  TestAccEC2EBSSnapshotDataSource_mostRecent
=== CONT  TestAccEC2EBSSnapshotDataSource_filter
--- PASS: TestAccEC2EBSSnapshotDataSource_mostRecent (76.67s)
--- PASS: TestAccEC2EBSSnapshotDataSource_filter (87.43s)
--- PASS: TestAccEC2EBSSnapshotDataSource_basic (87.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        87.929s
```
