### PR TITLE
Bug Fix bug where customer_encryption_key_arn was not passed in on update

### DIFF
--- a/.changelog/39565.txt
+++ b/.changelog/39565.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_bedrockagent_agent: Fix "Provider produced inconsistent result after apply" error on update due to `customer_encryption_key_arn` not being passed during update
+```
+
+```release-note:bug
+resource/aws_bedrockagent_agent: Fix "Provider produced inconsistent result after apply" error on update due to `prompt_override_configuration` not being passed when not modified
+```

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -324,15 +324,13 @@ func (r *agentResource) Update(ctx context.Context, request resource.UpdateReque
 			input.GuardrailConfiguration = guardrailConfiguration
 		}
 
-		if !new.PromptOverrideConfiguration.Equal(old.PromptOverrideConfiguration) {
-			promptOverrideConfiguration := &awstypes.PromptOverrideConfiguration{}
-			response.Diagnostics.Append(fwflex.Expand(ctx, new.PromptOverrideConfiguration, promptOverrideConfiguration)...)
-			if response.Diagnostics.HasError() {
-				return
-			}
-
-			input.PromptOverrideConfiguration = promptOverrideConfiguration
+		promptOverrideConfiguration := &awstypes.PromptOverrideConfiguration{}
+		response.Diagnostics.Append(fwflex.Expand(ctx, new.PromptOverrideConfiguration, promptOverrideConfiguration)...)
+		if response.Diagnostics.HasError() {
+			return
 		}
+
+		input.PromptOverrideConfiguration = promptOverrideConfiguration
 
 		_, err := conn.UpdateAgent(ctx, input)
 

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -331,7 +331,9 @@ func (r *agentResource) Update(ctx context.Context, request resource.UpdateReque
 				return
 			}
 
-			input.PromptOverrideConfiguration = promptOverrideConfiguration
+			if len(promptOverrideConfiguration.PromptConfigurations) > 0 {
+				input.PromptOverrideConfiguration = promptOverrideConfiguration
+			}
 		}
 
 		_, err := conn.UpdateAgent(ctx, input)

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -294,17 +294,19 @@ func (r *agentResource) Update(ctx context.Context, request resource.UpdateReque
 		!new.CustomerEncryptionKeyARN.Equal(old.CustomerEncryptionKeyARN) ||
 		!new.Description.Equal(old.Description) ||
 		!new.Instruction.Equal(old.Instruction) ||
+		!new.IdleSessionTTLInSeconds.Equal(old.IdleSessionTTLInSeconds) ||
 		!new.FoundationModel.Equal(old.FoundationModel) ||
 		!new.GuardrailConfiguration.Equal(old.GuardrailConfiguration) ||
 		!new.PromptOverrideConfiguration.Equal(old.PromptOverrideConfiguration) {
 		input := &bedrockagent.UpdateAgentInput{
-			AgentId:                 fwflex.StringFromFramework(ctx, new.AgentID),
-			AgentName:               fwflex.StringFromFramework(ctx, new.AgentName),
-			AgentResourceRoleArn:    fwflex.StringFromFramework(ctx, new.AgentResourceRoleARN),
-			Description:             fwflex.StringFromFramework(ctx, new.Description),
-			FoundationModel:         fwflex.StringFromFramework(ctx, new.FoundationModel),
-			IdleSessionTTLInSeconds: fwflex.Int32FromFramework(ctx, new.IdleSessionTTLInSeconds),
-			Instruction:             fwflex.StringFromFramework(ctx, new.Instruction),
+			AgentId:                  fwflex.StringFromFramework(ctx, new.AgentID),
+			AgentName:                fwflex.StringFromFramework(ctx, new.AgentName),
+			AgentResourceRoleArn:     fwflex.StringFromFramework(ctx, new.AgentResourceRoleARN),
+			CustomerEncryptionKeyArn: fwflex.StringFromFramework(ctx, new.CustomerEncryptionKeyARN),
+			Description:              fwflex.StringFromFramework(ctx, new.Description),
+			FoundationModel:          fwflex.StringFromFramework(ctx, new.FoundationModel),
+			IdleSessionTTLInSeconds:  fwflex.Int32FromFramework(ctx, new.IdleSessionTTLInSeconds),
+			Instruction:              fwflex.StringFromFramework(ctx, new.Instruction),
 		}
 
 		if !new.CustomerEncryptionKeyARN.Equal(old.CustomerEncryptionKeyARN) {

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -324,13 +324,15 @@ func (r *agentResource) Update(ctx context.Context, request resource.UpdateReque
 			input.GuardrailConfiguration = guardrailConfiguration
 		}
 
-		promptOverrideConfiguration := &awstypes.PromptOverrideConfiguration{}
-		response.Diagnostics.Append(fwflex.Expand(ctx, new.PromptOverrideConfiguration, promptOverrideConfiguration)...)
-		if response.Diagnostics.HasError() {
-			return
-		}
+		if !new.PromptOverrideConfiguration.IsNull() {
+			promptOverrideConfiguration := &awstypes.PromptOverrideConfiguration{}
+			response.Diagnostics.Append(fwflex.Expand(ctx, new.PromptOverrideConfiguration, promptOverrideConfiguration)...)
+			if response.Diagnostics.HasError() {
+				return
+			}
 
-		input.PromptOverrideConfiguration = promptOverrideConfiguration
+			input.PromptOverrideConfiguration = promptOverrideConfiguration
+		}
 
 		_, err := conn.UpdateAgent(ctx, input)
 

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -291,6 +291,7 @@ func (r *agentResource) Update(ctx context.Context, request resource.UpdateReque
 	conn := r.Meta().BedrockAgentClient(ctx)
 
 	if !new.AgentName.Equal(old.AgentName) ||
+		!new.AgentResourceRoleARN.Equal(old.AgentResourceRoleARN) ||
 		!new.CustomerEncryptionKeyARN.Equal(old.CustomerEncryptionKeyARN) ||
 		!new.Description.Equal(old.Description) ||
 		!new.Instruction.Equal(old.Instruction) ||

--- a/internal/service/bedrockagent/agent_test.go
+++ b/internal/service/bedrockagent/agent_test.go
@@ -406,7 +406,7 @@ func TestAccBedrockAgentAgent_kms(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "prompt_override_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "basic claude"),
 					resource.TestCheckResourceAttr(resourceName, "prepare_agent", acctest.CtTrue),
-					resource.TestCheckResourceAttrPair(resourceName, "customer_encryption_key_arn", "aws_kms_key.test_agent", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "customer_encryption_key_arn", "aws_kms_key.test_agent", names.AttrARN),
 				),
 			},
 			{
@@ -424,7 +424,7 @@ func TestAccBedrockAgentAgent_kms(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "prompt_override_configuration.#", acctest.Ct1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "basic claude"),
 					resource.TestCheckResourceAttr(resourceName, "prepare_agent", acctest.CtTrue),
-					resource.TestCheckResourceAttrPair(resourceName, "customer_encryption_key_arn", "aws_kms_key.test_agent", "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "customer_encryption_key_arn", "aws_kms_key.test_agent", names.AttrARN),
 				),
 			},
 		},

--- a/internal/service/bedrockagent/agent_test.go
+++ b/internal/service/bedrockagent/agent_test.go
@@ -343,6 +343,52 @@ func TestAccBedrockAgentAgent_tags(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentAgent_kms(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagent_agent.test"
+	var v awstypes.Agent
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAgentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentConfig_kms(rName, "anthropic.claude-v2", "basic claude", "500"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAgentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "agent_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "guardrail_configuration.#", acctest.Ct0),
+					resource.TestCheckResourceAttr(resourceName, "prompt_override_configuration.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "basic claude"),
+					resource.TestCheckResourceAttr(resourceName, "prepare_agent", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "customer_encryption_key_arn", "aws_kms_key.test_agent", "arn"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_resource_in_use_check"},
+			},
+			{
+				Config: testAccAgentConfig_kms(rName, "anthropic.claude-v2", "basic claude", "501"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAgentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "agent_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "guardrail_configuration.#", acctest.Ct0),
+					resource.TestCheckResourceAttr(resourceName, "prompt_override_configuration.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "basic claude"),
+					resource.TestCheckResourceAttr(resourceName, "prepare_agent", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, "customer_encryption_key_arn", "aws_kms_key.test_agent", "arn"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAgentDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).BedrockAgentClient(ctx)
@@ -677,4 +723,24 @@ resource "aws_bedrockagent_agent" "test" {
   }
 }
 `, rName, model, guardrailVersion))
+}
+
+func testAccAgentConfig_kms(rName, model, description, timeout string) string {
+	return acctest.ConfigCompose(testAccAgent_base(rName, model), fmt.Sprintf(`
+resource "aws_bedrockagent_agent" "test" {
+  agent_name                  = %[1]q
+  agent_resource_role_arn     = aws_iam_role.test_agent.arn
+  customer_encryption_key_arn = aws_kms_key.test_agent.arn
+  description                 = %[3]q
+  idle_session_ttl_in_seconds = %[4]s
+  instruction                 = file("${path.module}/test-fixtures/instruction.txt")
+  foundation_model            = %[2]q
+}
+
+resource "aws_kms_key" "test_agent" {
+  description             = "Agent test key"
+  enable_key_rotation     = true
+  deletion_window_in_days = 7
+}
+`, rName, model, description, timeout))
 }

--- a/internal/service/bedrockagent/agent_test.go
+++ b/internal/service/bedrockagent/agent_test.go
@@ -116,6 +116,48 @@ func TestAccBedrockAgentAgent_singlePrompt(t *testing.T) {
 	})
 }
 
+func TestAccBedrockAgentAgent_singlePromptUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bedrockagent_agent.test"
+	var v awstypes.Agent
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.BedrockEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockAgentServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAgentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentConfig_singlePromptUpdate(rName, "anthropic.claude-v2", "basic claude", "500"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAgentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "agent_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "prompt_override_configuration.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "basic claude"),
+					resource.TestCheckResourceAttr(resourceName, "skip_resource_in_use_check", acctest.CtTrue),
+				),
+			},
+			{
+				Config: testAccAgentConfig_singlePromptUpdate(rName, "anthropic.claude-v2", "basic claude", "501"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAgentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "agent_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "prompt_override_configuration.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "basic claude"),
+					resource.TestCheckResourceAttr(resourceName, "skip_resource_in_use_check", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_resource_in_use_check"},
+			},
+		},
+	})
+}
+
 func TestAccBedrockAgentAgent_addPrompt(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -695,6 +737,43 @@ resource "aws_bedrockagent_agent" "test" {
 
 }
 `, rName, model, desc))
+}
+
+func testAccAgentConfig_singlePromptUpdate(rName, model, desc, timeout string) string {
+	return acctest.ConfigCompose(testAccAgent_base(rName, model), fmt.Sprintf(`
+resource "aws_bedrockagent_agent" "test" {
+  agent_name                  = %[1]q
+  agent_resource_role_arn     = aws_iam_role.test_agent.arn
+  description                 = %[3]q
+  idle_session_ttl_in_seconds = %[4]s
+  instruction                 = file("${path.module}/test-fixtures/instruction.txt")
+  foundation_model            = %[2]q
+  skip_resource_in_use_check  = true
+
+  prompt_override_configuration {
+    override_lambda = null
+    prompt_configurations = [
+      {
+        base_prompt_template = file("${path.module}/test-fixtures/post-processing.txt")
+        inference_configuration = [
+          {
+            max_length     = 2048
+            stop_sequences = ["Human:"]
+            temperature    = 0
+            top_k          = 250
+            top_p          = 1
+          },
+        ]
+        parser_mode          = "DEFAULT"
+        prompt_creation_mode = "OVERRIDDEN"
+        prompt_state         = "DISABLED"
+        prompt_type          = "POST_PROCESSING"
+      },
+    ]
+  }
+
+}
+`, rName, model, desc, timeout))
 }
 
 func testAccAgentConfig_guardrail_noConfig(rName, model string) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fix bug where customer_encryption_key_arn was not passed in on update
Fix bug where prompt configuration is lost if you update a different property.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39548 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc TESTS=TestAccBedrockAgentAgent_ PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.1 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentAgent_'  -timeout 360m
=== RUN   TestAccBedrockAgentAgent_basic
=== PAUSE TestAccBedrockAgentAgent_basic
=== RUN   TestAccBedrockAgentAgent_full
=== PAUSE TestAccBedrockAgentAgent_full
=== RUN   TestAccBedrockAgentAgent_singlePrompt
=== PAUSE TestAccBedrockAgentAgent_singlePrompt
=== RUN   TestAccBedrockAgentAgent_singlePromptUpdate
=== PAUSE TestAccBedrockAgentAgent_singlePromptUpdate
=== RUN   TestAccBedrockAgentAgent_addPrompt
=== PAUSE TestAccBedrockAgentAgent_addPrompt
=== RUN   TestAccBedrockAgentAgent_guardrail
=== PAUSE TestAccBedrockAgentAgent_guardrail
=== RUN   TestAccBedrockAgentAgent_update
=== PAUSE TestAccBedrockAgentAgent_update
=== RUN   TestAccBedrockAgentAgent_tags
=== PAUSE TestAccBedrockAgentAgent_tags
=== RUN   TestAccBedrockAgentAgent_kms
=== PAUSE TestAccBedrockAgentAgent_kms
=== CONT  TestAccBedrockAgentAgent_basic
=== CONT  TestAccBedrockAgentAgent_guardrail
=== CONT  TestAccBedrockAgentAgent_singlePromptUpdate
=== CONT  TestAccBedrockAgentAgent_tags
=== CONT  TestAccBedrockAgentAgent_update
=== CONT  TestAccBedrockAgentAgent_kms
=== CONT  TestAccBedrockAgentAgent_singlePrompt
=== CONT  TestAccBedrockAgentAgent_addPrompt
=== CONT  TestAccBedrockAgentAgent_full
--- PASS: TestAccBedrockAgentAgent_full (37.18s)
--- PASS: TestAccBedrockAgentAgent_basic (38.57s)
--- PASS: TestAccBedrockAgentAgent_singlePrompt (41.58s)
--- PASS: TestAccBedrockAgentAgent_singlePromptUpdate (59.12s)
--- PASS: TestAccBedrockAgentAgent_kms (60.14s)
--- PASS: TestAccBedrockAgentAgent_tags (65.60s)
--- PASS: TestAccBedrockAgentAgent_update (74.89s)
--- PASS: TestAccBedrockAgentAgent_guardrail (84.95s)
--- PASS: TestAccBedrockAgentAgent_addPrompt (94.63s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       99.345s

```
