### PR TITLE
provider: Reduce schema memory usage by 18 MB

### DIFF
--- a/internal/provider/factory_test.go
+++ b/internal/provider/factory_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/provider"
 )
 
-// go test -bench=BenchmarkProtoV5ProviderServerFactory -benchtime 1x -benchmem -run=B -v ./internal/provider
+// go test -bench=BenchmarkProtoV5ProviderServerFactory -benchtime 1x -benchmem -run=Bench -v ./internal/provider
 func BenchmarkProtoV5ProviderServerFactory(b *testing.B) {
 	_, p, err := provider.ProtoV5ProviderServerFactory(context.Background())
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -18,6 +18,16 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+// go test -bench=BenchmarkSDKProviderInitialization -benchmem -run=Bench -v ./internal/provider
+func BenchmarkSDKProviderInitialization(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, err := New(context.Background())
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestProvider(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/ec2/tags.go
+++ b/internal/service/ec2/tags.go
@@ -100,7 +100,7 @@ func tagsFromTagDescriptions(tds []awstypes.TagDescription) []awstypes.Tag {
 }
 
 func tagsSchemaConflictsWith(conflictsWith []string) *schema.Schema {
-	v := *tftags.TagsSchema()
+	v := *tftags.TagsSchema() // nosemgrep:ci.semgrep.aws.prefer-pointer-conversion-assignment
 	v.ConflictsWith = conflictsWith
 
 	return &v

--- a/internal/service/ec2/tags.go
+++ b/internal/service/ec2/tags.go
@@ -100,8 +100,8 @@ func tagsFromTagDescriptions(tds []awstypes.TagDescription) []awstypes.Tag {
 }
 
 func tagsSchemaConflictsWith(conflictsWith []string) *schema.Schema {
-	v := tftags.TagsSchema()
+	v := *tftags.TagsSchema()
 	v.ConflictsWith = conflictsWith
 
-	return v
+	return &v
 }

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -38,7 +38,10 @@ var ruleLabelsSchema = sync.OnceValue(func() *schema.Schema {
 					Required: true,
 					ValidateFunc: validation.All(
 						validation.StringLenBetween(1, 1024),
-						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_\-:]+$`), "must contain only alphanumeric, underscore, hyphen, and colon characters"),
+						validation.StringMatch(
+							regexache.MustCompile(`^[0-9A-Za-z_\-:]+$`),
+							"must contain only alphanumeric, underscore, hyphen, and colon characters",
+						),
 					),
 				},
 			},
@@ -85,65 +88,65 @@ type schemaCache struct {
 
 func (c *schemaCache) get(level int) *schema.Schema {
 	c.once.Do(func() {
-		var previous *schema.Schema
-		for i := range statementSchemaCacheSize {
-			if i == 0 {
-				c.values[0] = schema.Schema{
-					Type:     schema.TypeList,
-					Optional: true,
-					MaxItems: 1,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"statement": {
-								Type:     schema.TypeList,
-								Required: true,
-								Elem: &schema.Resource{
-									Schema: map[string]*schema.Schema{
-										"byte_match_statement":                  byteMatchStatementSchema(),
-										"geo_match_statement":                   geoMatchStatementSchema(),
-										"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
-										"label_match_statement":                 labelMatchStatementSchema(),
-										"regex_match_statement":                 regexMatchStatementSchema(),
-										"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
-										"size_constraint_statement":             sizeConstraintSchema(),
-										"sqli_match_statement":                  sqliMatchStatementSchema(),
-										"xss_match_statement":                   xssMatchStatementSchema(),
-									},
+		// Initialize the first element
+		c.values[0] = schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"statement": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"byte_match_statement":                  byteMatchStatementSchema(),
+								"geo_match_statement":                   geoMatchStatementSchema(),
+								"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
+								"label_match_statement":                 labelMatchStatementSchema(),
+								"regex_match_statement":                 regexMatchStatementSchema(),
+								"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
+								"size_constraint_statement":             sizeConstraintSchema(),
+								"sqli_match_statement":                  sqliMatchStatementSchema(),
+								"xss_match_statement":                   xssMatchStatementSchema(),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Initialize the rest of the elements
+		var previous *schema.Schema = &c.values[0]
+		for i := 1; i < statementSchemaCacheSize; i++ {
+			c.values[i] = schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"statement": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"and_statement":                         previous,
+									"byte_match_statement":                  byteMatchStatementSchema(),
+									"geo_match_statement":                   geoMatchStatementSchema(),
+									"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
+									"label_match_statement":                 labelMatchStatementSchema(),
+									"not_statement":                         previous,
+									"or_statement":                          previous,
+									"regex_match_statement":                 regexMatchStatementSchema(),
+									"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
+									"size_constraint_statement":             sizeConstraintSchema(),
+									"sqli_match_statement":                  sqliMatchStatementSchema(),
+									"xss_match_statement":                   xssMatchStatementSchema(),
 								},
 							},
 						},
 					},
-				}
-			} else {
-				c.values[i] = schema.Schema{
-					Type:     schema.TypeList,
-					Optional: true,
-					MaxItems: 1,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"statement": {
-								Type:     schema.TypeList,
-								Required: true,
-								Elem: &schema.Resource{
-									Schema: map[string]*schema.Schema{
-										"and_statement":                         previous,
-										"byte_match_statement":                  byteMatchStatementSchema(),
-										"geo_match_statement":                   geoMatchStatementSchema(),
-										"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
-										"label_match_statement":                 labelMatchStatementSchema(),
-										"not_statement":                         previous,
-										"or_statement":                          previous,
-										"regex_match_statement":                 regexMatchStatementSchema(),
-										"regex_pattern_set_reference_statement": regexPatternSetReferenceStatementSchema(),
-										"size_constraint_statement":             sizeConstraintSchema(),
-										"sqli_match_statement":                  sqliMatchStatementSchema(),
-										"xss_match_statement":                   xssMatchStatementSchema(),
-									},
-								},
-							},
-						},
-					},
-				}
+				},
 			}
 			previous = &c.values[i]
 		}

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -960,7 +960,7 @@ var headersMatchPatternBaseSchema = sync.OnceValue(func() *schema.Schema {
 			Type: schema.TypeString,
 			ValidateFunc: validation.All(
 				validation.StringLenBetween(1, 64),
-				validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+				validation.StringIsNotWhiteSpace,
 			),
 		},
 	}
@@ -1213,7 +1213,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 256),
-									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+									validation.StringIsNotWhiteSpace,
 								),
 							},
 							"registration_page_path": {
@@ -1221,7 +1221,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 256),
-									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+									validation.StringIsNotWhiteSpace,
 								),
 							},
 							"request_inspection":  managedRuleGroupConfigACFPRequestInspectionSchema(),
@@ -1245,7 +1245,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 256),
-									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+									validation.StringIsNotWhiteSpace,
 								),
 							},
 							"request_inspection":  managedRuleGroupConfigATPRequestInspectionSchema(),
@@ -1277,7 +1277,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 					Optional: true,
 					ValidateFunc: validation.All(
 						validation.StringLenBetween(1, 256),
-						validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+						validation.StringIsNotWhiteSpace,
 					),
 				},
 				"password_field": {
@@ -1291,7 +1291,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+									validation.StringIsNotWhiteSpace,
 								),
 							},
 						},
@@ -1313,7 +1313,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+									validation.StringIsNotWhiteSpace,
 								),
 							},
 						},
@@ -1392,7 +1392,7 @@ func managedRuleGroupConfigACFPRequestInspectionSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+									validation.StringIsNotWhiteSpace,
 								),
 							},
 						},
@@ -1409,7 +1409,7 @@ func managedRuleGroupConfigACFPRequestInspectionSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+									validation.StringIsNotWhiteSpace,
 								),
 							},
 						},
@@ -1446,7 +1446,7 @@ func managedRuleGroupConfigACFPRequestInspectionSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+									validation.StringIsNotWhiteSpace,
 								),
 							},
 						},
@@ -1475,7 +1475,7 @@ func managedRuleGroupConfigATPRequestInspectionSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+									validation.StringIsNotWhiteSpace,
 								),
 							},
 						},
@@ -1497,7 +1497,7 @@ func managedRuleGroupConfigATPRequestInspectionSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
+									validation.StringIsNotWhiteSpace,
 								),
 							},
 						},

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -117,7 +117,7 @@ func (c *schemaCache) get(level int) *schema.Schema {
 		}
 
 		// Initialize the rest of the elements
-		var previous *schema.Schema = &c.values[0]
+		previous := &c.values[0]
 		for i := 1; i < statementSchemaCacheSize; i++ {
 			c.values[i] = schema.Schema{
 				Type:     schema.TypeList,

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -5,6 +5,7 @@ package wafv2
 
 import (
 	"math"
+	"sync"
 
 	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
@@ -15,20 +16,18 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-var listOfEmptyObjectSchema *schema.Schema = &schema.Schema{
-	Type:     schema.TypeList,
-	Optional: true,
-	MaxItems: 1,
-	Elem: &schema.Resource{
-		Schema: map[string]*schema.Schema{},
-	},
-}
+var emptySchema = sync.OnceValue(func() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{},
+		},
+	}
+})
 
-func emptySchema() *schema.Schema {
-	return listOfEmptyObjectSchema
-}
-
-func ruleLabelsSchema() *schema.Schema {
+var ruleLabelsSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeSet,
 		Optional: true,
@@ -45,7 +44,7 @@ func ruleLabelsSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
 func ruleGroupRootStatementSchema(level int) *schema.Schema {
 	return &schema.Schema{
@@ -133,7 +132,7 @@ func statementSchema(level int) *schema.Schema {
 	}
 }
 
-func byteMatchStatementSchema() *schema.Schema {
+var byteMatchStatementSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -155,9 +154,9 @@ func byteMatchStatementSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func geoMatchStatementSchema() *schema.Schema {
+var geoMatchStatementSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -174,9 +173,9 @@ func geoMatchStatementSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func ipSetReferenceStatementSchema() *schema.Schema {
+var ipSetReferenceStatementSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -218,9 +217,9 @@ func ipSetReferenceStatementSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func labelMatchStatementSchema() *schema.Schema {
+var labelMatchStatementSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -243,9 +242,9 @@ func labelMatchStatementSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func regexMatchStatementSchema() *schema.Schema {
+var regexMatchStatementSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -265,9 +264,9 @@ func regexMatchStatementSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func regexPatternSetReferenceStatementSchema() *schema.Schema {
+var regexPatternSetReferenceStatementSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -284,9 +283,9 @@ func regexPatternSetReferenceStatementSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func sizeConstraintSchema() *schema.Schema {
+var sizeConstraintSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -308,9 +307,9 @@ func sizeConstraintSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func sqliMatchStatementSchema() *schema.Schema {
+var sqliMatchStatementSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -327,9 +326,9 @@ func sqliMatchStatementSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func xssMatchStatementSchema() *schema.Schema {
+var xssMatchStatementSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -341,9 +340,9 @@ func xssMatchStatementSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func fieldToMatchBaseSchema() *schema.Resource {
+var fieldToMatchBaseSchema = sync.OnceValue(func() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"all_query_arguments": emptySchema(),
@@ -396,18 +395,18 @@ func fieldToMatchBaseSchema() *schema.Resource {
 			"uri_path": emptySchema(),
 		},
 	}
-}
+})
 
-func fieldToMatchSchema() *schema.Schema {
+var fieldToMatchSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
 		MaxItems: 1,
 		Elem:     fieldToMatchBaseSchema(),
 	}
-}
+})
 
-func jsonBodySchema() *schema.Schema {
+var jsonBodySchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -425,13 +424,13 @@ func jsonBodySchema() *schema.Schema {
 					Required:         true,
 					ValidateDiagFunc: enum.Validate[awstypes.JsonMatchScope](),
 				},
-				"oversize_handling": oversizeHandlingOptionalSchema(string(awstypes.OversizeHandlingContinue)),
+				"oversize_handling": oversizeHandlingOptionalDefaultContinueSchema(),
 			},
 		},
 	}
-}
+})
 
-func jsonBodyMatchPatternSchema() *schema.Schema {
+var jsonBodyMatchPatternSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Required: true,
@@ -453,9 +452,9 @@ func jsonBodyMatchPatternSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func forwardedIPConfigSchema() *schema.Schema {
+var forwardedIPConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -474,9 +473,9 @@ func forwardedIPConfigSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func textTransformationSchema() *schema.Schema {
+var textTransformationSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeSet,
 		Required: true,
@@ -495,9 +494,9 @@ func textTransformationSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func visibilityConfigSchema() *schema.Schema {
+var visibilityConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Required: true,
@@ -523,9 +522,9 @@ func visibilityConfigSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func associationConfigSchema() *schema.Schema {
+var associationConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -536,85 +535,42 @@ func associationConfigSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func requestBodySchema() *schema.Schema {
+var requestBodySchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"api_gateway": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"default_size_inspection_limit": {
-								Type:             schema.TypeString,
-								Required:         true,
-								ValidateDiagFunc: enum.Validate[awstypes.SizeInspectionLimit](),
-							},
-						},
-					},
-				},
-				"app_runner_service": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"default_size_inspection_limit": {
-								Type:             schema.TypeString,
-								Required:         true,
-								ValidateDiagFunc: enum.Validate[awstypes.SizeInspectionLimit](),
-							},
-						},
-					},
-				},
-				"cloudfront": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"default_size_inspection_limit": {
-								Type:             schema.TypeString,
-								Required:         true,
-								ValidateDiagFunc: enum.Validate[awstypes.SizeInspectionLimit](),
-							},
-						},
-					},
-				},
-				"cognito_user_pool": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"default_size_inspection_limit": {
-								Type:             schema.TypeString,
-								Required:         true,
-								ValidateDiagFunc: enum.Validate[awstypes.SizeInspectionLimit](),
-							},
-						},
-					},
-				},
-				"verified_access_instance": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"default_size_inspection_limit": {
-								Type:             schema.TypeString,
-								Required:         true,
-								ValidateDiagFunc: enum.Validate[awstypes.SizeInspectionLimit](),
-							},
-						},
-					},
+				"api_gateway":              requestBodyAssociatedResourceTypeSchema(),
+				"app_runner_service":       requestBodyAssociatedResourceTypeSchema(),
+				"cloudfront":               requestBodyAssociatedResourceTypeSchema(),
+				"cognito_user_pool":        requestBodyAssociatedResourceTypeSchema(),
+				"verified_access_instance": requestBodyAssociatedResourceTypeSchema(),
+			},
+		},
+	}
+})
+
+var requestBodyAssociatedResourceTypeSchema = sync.OnceValue(func() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"default_size_inspection_limit": {
+					Type:             schema.TypeString,
+					Required:         true,
+					ValidateDiagFunc: enum.Validate[awstypes.SizeInspectionLimit](),
 				},
 			},
 		},
 	}
-}
+})
 
-func allowConfigSchema() *schema.Schema {
+var allowConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -625,9 +581,9 @@ func allowConfigSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func captchaConfigSchema() *schema.Schema {
+var captchaConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -638,9 +594,9 @@ func captchaConfigSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func outerCaptchaConfigSchema() *schema.Schema {
+var outerCaptchaConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -663,9 +619,9 @@ func outerCaptchaConfigSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func challengeConfigSchema() *schema.Schema {
+var challengeConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -676,9 +632,9 @@ func challengeConfigSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func outerChallengeConfigSchema() *schema.Schema {
+var outerChallengeConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -701,9 +657,9 @@ func outerChallengeConfigSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func countConfigSchema() *schema.Schema {
+var countConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -714,9 +670,9 @@ func countConfigSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func blockConfigSchema() *schema.Schema {
+var blockConfigSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -727,9 +683,9 @@ func blockConfigSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func customRequestHandlingSchema() *schema.Schema {
+var customRequestHandlingSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -761,9 +717,9 @@ func customRequestHandlingSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func customResponseSchema() *schema.Schema {
+var customResponseSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -807,9 +763,9 @@ func customResponseSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
-func customResponseBodySchema() *schema.Schema {
+var customResponseBodySchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeSet,
 		Optional: true,
@@ -836,7 +792,7 @@ func customResponseBodySchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
 func cookiesSchema() *schema.Schema {
 	return &schema.Schema{
@@ -899,36 +855,36 @@ func bodySchema() *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"oversize_handling": oversizeHandlingOptionalSchema(string(awstypes.OversizeHandlingContinue)),
+				"oversize_handling": oversizeHandlingOptionalDefaultContinueSchema(),
 			},
 		},
 	}
 }
 
-func oversizeHandlingOptionalSchema(defaultValue string) *schema.Schema {
+var oversizeHandlingOptionalDefaultContinueSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:             schema.TypeString,
 		Optional:         true,
-		Default:          defaultValue,
+		Default:          string(awstypes.OversizeHandlingContinue),
 		ValidateDiagFunc: enum.Validate[awstypes.OversizeHandling](),
 	}
-}
+})
 
-func oversizeHandlingRequiredSchema() *schema.Schema {
+var oversizeHandlingRequiredSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:             schema.TypeString,
 		Required:         true,
 		ValidateDiagFunc: enum.Validate[awstypes.OversizeHandling](),
 	}
-}
+})
 
-func matchScopeSchema() *schema.Schema {
+var matchScopeSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:             schema.TypeString,
 		Required:         true,
 		ValidateDiagFunc: enum.Validate[awstypes.MapMatchScope](),
 	}
-}
+})
 
 func headerOrderSchema() *schema.Schema {
 	return &schema.Schema{
@@ -968,7 +924,7 @@ func headersSchema() *schema.Schema {
 	}
 }
 
-func headersMatchPatternBaseSchema() *schema.Schema {
+var headersMatchPatternBaseSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -982,7 +938,7 @@ func headersMatchPatternBaseSchema() *schema.Schema {
 			),
 		},
 	}
-}
+})
 
 func webACLRootStatementSchema(level int) *schema.Schema {
 	return &schema.Schema{
@@ -1191,7 +1147,7 @@ func scopeDownStatementSchema(level int) *schema.Schema {
 	}
 }
 
-func ruleActionOverrideSchema() *schema.Schema {
+var ruleActionOverrideSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -1207,7 +1163,7 @@ func ruleActionOverrideSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})
 
 func managedRuleGroupConfigSchema() *schema.Schema {
 	return &schema.Schema{
@@ -1526,7 +1482,7 @@ func managedRuleGroupConfigATPRequestInspectionSchema() *schema.Schema {
 	}
 }
 
-func managedRuleGroupConfigATPResponseInspectionSchema() *schema.Schema {
+var managedRuleGroupConfigATPResponseInspectionSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
@@ -1628,4 +1584,4 @@ func managedRuleGroupConfigATPResponseInspectionSchema() *schema.Schema {
 			},
 		},
 	}
-}
+})

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -934,7 +934,7 @@ var headersMatchPatternBaseSchema = sync.OnceValue(func() *schema.Schema {
 			Type: schema.TypeString,
 			ValidateFunc: validation.All(
 				validation.StringLenBetween(1, 64),
-				validation.StringMatch(regexache.MustCompile(`.*\S.*`), ""),
+				validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 			),
 		},
 	}
@@ -1187,7 +1187,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 256),
-									validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 								),
 							},
 							"registration_page_path": {
@@ -1195,7 +1195,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 256),
-									validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 								),
 							},
 							"request_inspection":  managedRuleGroupConfigACFPRequestInspectionSchema(),
@@ -1219,7 +1219,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 256),
-									validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 								),
 							},
 							"request_inspection":  managedRuleGroupConfigATPRequestInspectionSchema(),
@@ -1251,7 +1251,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 					Optional: true,
 					ValidateFunc: validation.All(
 						validation.StringLenBetween(1, 256),
-						validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+						validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 					),
 				},
 				"password_field": {
@@ -1265,7 +1265,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 								),
 							},
 						},
@@ -1287,7 +1287,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 								),
 							},
 						},
@@ -1366,7 +1366,7 @@ func managedRuleGroupConfigACFPRequestInspectionSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 								),
 							},
 						},
@@ -1383,7 +1383,7 @@ func managedRuleGroupConfigACFPRequestInspectionSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 								),
 							},
 						},
@@ -1420,7 +1420,7 @@ func managedRuleGroupConfigACFPRequestInspectionSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 								),
 							},
 						},
@@ -1449,7 +1449,7 @@ func managedRuleGroupConfigATPRequestInspectionSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 								),
 							},
 						},
@@ -1471,7 +1471,7 @@ func managedRuleGroupConfigATPRequestInspectionSchema() *schema.Schema {
 								Required: true,
 								ValidateFunc: validation.All(
 									validation.StringLenBetween(1, 512),
-									validation.StringMatch(regexache.MustCompile(`.*\S.*`), `must conform to pattern .*\S.* `),
+									validation.StringMatch(regexache.MustCompile(`^\S+$`), "must not contain any white-space characters"),
 								),
 							},
 						},

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -4,32 +4,36 @@
 package tags
 
 import (
+	"sync"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// TagsSchema returns the schema to use for tags.
-func TagsSchema() *schema.Schema {
+// TagsSchema returns the schema to use for configurable resource tags.
+var TagsSchema = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
-}
+})
 
-func TagsSchemaComputed() *schema.Schema {
+// TagsSchema returns the schema to use for computed tags, either resource `tags_all` or for data sources.
+var TagsSchemaComputed = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		Computed: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
-}
+})
 
-func TagsSchemaForceNew() *schema.Schema {
+// TagsSchema returns the schema to use for configurable resource tags where changes recreate the resource.
+var TagsSchemaForceNew = sync.OnceValue(func() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		ForceNew: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
-}
+})


### PR DESCRIPTION
### Description

Reduces schema memory usage by approximately 18 MB and eliminates approximately 117,600 allocations

1. Shares Plugin SDK tag schemas across resources and data sources. Saves approximately 1 MB and eliminates approximately 3,100 allocations.

Before: BenchmarkSDKProviderInitialization-10 40 29284118 ns/op 70426029 B/op 448276 allocs/op
After: BenchmarkSDKProviderInitialization-10 40 28709038 ns/op 69434669 B/op 445177 allocs/op

2. Shares repeated WAFv2 schemas. Saves approximately 17 MB and eliminates approximately 114,500 allocations.

Before: BenchmarkSDKProviderInitialization-10 40 28709038 ns/op 69434669 B/op 445177 allocs/op
After: BenchmarkSDKProviderInitialization-10 50 22838247 ns/op 52270798 B/op 330692 allocs/op

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #31722
