### PR TITLE
resource/aws_spot_instance_request : Fix issue with overwriting shared schema elements

### DIFF
--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -57,10 +57,13 @@ func resourceSpotInstanceRequest() *schema.Resource {
 					continue
 				}
 				// tags_all is Optional+Computed.
-				if k == names.AttrTags || k == names.AttrTagsAll {
+				if k == names.AttrTags || k == names.AttrTagsAll || k == "volume_tags" {
 					continue
 				}
-				v.ForceNew = true
+				// Copy-on-write
+				x := *v
+				x.ForceNew = true
+				s[k] = &x
 			}
 
 			// Remove attributes added for spot instances.
@@ -129,11 +132,6 @@ func resourceSpotInstanceRequest() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.IsRFC3339Time,
 				Computed:     true,
-			}
-			s["volume_tags"] = &schema.Schema{
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
 			}
 			s["wait_for_fulfillment"] = &schema.Schema{
 				Type:     schema.TypeBool,

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -61,7 +61,7 @@ func resourceSpotInstanceRequest() *schema.Resource {
 					continue
 				}
 				// Copy-on-write
-				x := *v
+				x := *v // nosemgrep:ci.semgrep.aws.prefer-pointer-conversion-assignment
 				x.ForceNew = true
 				s[k] = &x
 			}


### PR DESCRIPTION
### Description

The resource `aws_spot_instance_request` modifies the `aws_instance` schema. When shared schema elements are in use, this caused them to be overwritten. 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=iam TESTS=TestAccIAMPolicy_tags

--- PASS: TestAccIAMPolicy_tags_ComputedTag_OnCreate (71.93s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_emptyResourceTag (75.99s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nullNonOverlappingResourceTag (76.01s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nullOverlappingResourceTag (76.25s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_emptyProviderOnlyTag (76.37s)
--- PASS: TestAccIAMPolicy_tags_EmptyMap (95.83s)
--- PASS: TestAccIAMPolicy_tags_null (96.91s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_updateToResourceOnly (110.99s)
--- PASS: TestAccIAMPolicy_tags_AddOnUpdate (116.22s)
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Replace (116.64s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_updateToProviderOnly (116.83s)
--- PASS: TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Replace (117.23s)
--- PASS: TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Add (117.29s)
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnCreate (121.39s)
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Add (132.94s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nonOverlapping (140.77s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_overlapping (141.07s)
--- PASS: TestAccIAMPolicy_tags (154.42s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_providerOnly (155.99s)
```
