### PR TITLE
r/aws_route53profiles_profile: fix inconsistent result on tags update

### DIFF
--- a/internal/service/route53profiles/profile.go
+++ b/internal/service/route53profiles/profile.go
@@ -69,17 +69,29 @@ func (r *resourceProfile) Schema(ctx context.Context, req resource.SchemaRequest
 			},
 			names.AttrOwnerID: schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"share_status": schema.StringAttribute{
 				CustomType: fwtypes.StringEnumType[awstypes.ShareStatus](),
 				Computed:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			names.AttrStatus: schema.StringAttribute{
 				CustomType: fwtypes.StringEnumType[awstypes.ProfileStatus](),
 				Computed:   true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			names.AttrStatusMessage: schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),

--- a/internal/service/route53profiles/profile_test.go
+++ b/internal/service/route53profiles/profile_test.go
@@ -109,6 +109,23 @@ func TestAccRoute53ProfilesProfile_tags(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccProfileConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProfileExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+			{
+				Config: testAccProfileConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProfileExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
 		},
 	})
 }
@@ -164,7 +181,7 @@ resource "aws_route53profiles_profile" "test" {
 `, rName)
 }
 
-func testAccProfileConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
+func testAccProfileConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_route53profiles_profile" "test" {
   name = %[1]q
@@ -174,4 +191,17 @@ resource "aws_route53profiles_profile" "test" {
   }
 }
 `, rName, tagKey1, tagValue1)
+}
+
+func testAccProfileConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return fmt.Sprintf(`
+resource "aws_route53profiles_profile" "test" {
+  name = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Various computed attributes on the `aws_route53profiles_profile` resource were missing `UseStateForUnknown` plan modifiers, causing tag updates to fail. A changelog entry is not necessary for this fix as this resource has not yet been formally released.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #38172 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->



```console
% make testacc PKG=route53profiles TESTS=TestAccRoute53ProfilesProfile_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/route53profiles/... -v -count 1 -parallel 20 -run='TestAccRoute53ProfilesProfile_'  -timeout 360m

--- PASS: TestAccRoute53ProfilesProfile_disappears (13.83s)
--- PASS: TestAccRoute53ProfilesProfile_basic (16.47s)
--- PASS: TestAccRoute53ProfilesProfile_tags (34.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53profiles    39.581s
```
