### PR TITLE
Update string filters in the criteria block of ``aws_securityhub_automation_rule`` to allow different Max Item sizes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ses v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.33.1
-	github.com/aws/aws-sdk-go-v2/service/shield v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/shield v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/signer v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.36.0

--- a/go.mod
+++ b/go.mod
@@ -243,7 +243,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/swf v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.1
-	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.0
+	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.1
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.52.0

--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.1
-	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.0
+	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.0

--- a/go.mod
+++ b/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.49.1
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.1
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.0
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.0

--- a/go.mod
+++ b/go.mod
@@ -244,7 +244,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/swf v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.1
-	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.52.0
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -245,7 +245,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.1
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.1
-	github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.0
+	github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.52.0
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -228,7 +228,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/ses v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.1
-	github.com/aws/aws-sdk-go-v2/service/sfn v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/sfn v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/shield v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/signer v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -204,7 +204,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.1
-	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.0
+	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -249,7 +249,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.1
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.1
-	github.com/aws/aws-sdk-go-v2/service/waf v1.25.0
+	github.com/aws/aws-sdk-go-v2/service/waf v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.0

--- a/go.mod
+++ b/go.mod
@@ -241,7 +241,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.1
-	github.com/aws/aws-sdk-go-v2/service/swf v1.27.0
+	github.com/aws/aws-sdk-go-v2/service/swf v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -227,7 +227,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/ses v1.28.1
-	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.0
+	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/shield v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/signer v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -252,7 +252,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/waf v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.1
-	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.0
+	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.0
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.0

--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.1
-	github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.0
+	github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.0

--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signer v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/sns v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.36.1
-	github.com/aws/aws-sdk-go-v2/service/ssm v1.55.0
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -194,7 +194,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.1
 	github.com/aws/aws-sdk-go-v2/service/ram v1.29.1
-	github.com/aws/aws-sdk-go-v2/service/rbin v1.20.0
+	github.com/aws/aws-sdk-go-v2/service/rbin v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/rds v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.48.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.0

--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.1
-	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.0
+	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.0

--- a/go.mod
+++ b/go.mod
@@ -208,7 +208,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.1
-	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.0
+	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.0
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/rum v1.21.0

--- a/go.mod
+++ b/go.mod
@@ -221,7 +221,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.1
-	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.0
+	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -219,7 +219,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.1
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.1
-	github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.0
+	github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.0

--- a/go.mod
+++ b/go.mod
@@ -239,7 +239,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.1
-	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.0
+	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/swf v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -196,7 +196,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ram v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/rds v1.87.1
-	github.com/aws/aws-sdk-go-v2/service/redshift v1.48.0
+	github.com/aws/aws-sdk-go-v2/service/redshift v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.0

--- a/go.mod
+++ b/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/rum v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1
-	github.com/aws/aws-sdk-go-v2/service/s3control v1.49.0
+	github.com/aws/aws-sdk-go-v2/service/s3control v1.49.1
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -209,7 +209,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.1
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.1
-	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.0
+	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/rum v1.21.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1

--- a/go.mod
+++ b/go.mod
@@ -242,7 +242,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/swf v1.27.1
-	github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.0

--- a/go.mod
+++ b/go.mod
@@ -232,7 +232,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/shield v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/signer v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/sns v1.33.1
-	github.com/aws/aws-sdk-go-v2/service/sqs v1.36.0
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.0

--- a/go.mod
+++ b/go.mod
@@ -230,7 +230,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/shield v1.29.1
-	github.com/aws/aws-sdk-go-v2/service/signer v1.26.0
+	github.com/aws/aws-sdk-go-v2/service/signer v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/sns v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.55.0

--- a/go.mod
+++ b/go.mod
@@ -203,7 +203,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.1
-	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.0
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.0

--- a/go.mod
+++ b/go.mod
@@ -222,7 +222,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.1
-	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.0
+	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.0

--- a/go.mod
+++ b/go.mod
@@ -195,7 +195,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.1
 	github.com/aws/aws-sdk-go-v2/service/ram v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.20.1
-	github.com/aws/aws-sdk-go-v2/service/rds v1.87.0
+	github.com/aws/aws-sdk-go-v2/service/rds v1.87.1
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.48.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.1
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.28.1
-	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.0
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.0

--- a/go.mod
+++ b/go.mod
@@ -193,7 +193,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.1
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.1
-	github.com/aws/aws-sdk-go-v2/service/ram v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/ram v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.48.0

--- a/go.mod
+++ b/go.mod
@@ -234,7 +234,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.55.1
-	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.0
+	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.1

--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.52.1
-	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.0
+	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.1
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.0
 	github.com/aws/aws-sdk-go-v2/service/waf v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.0

--- a/go.mod
+++ b/go.mod
@@ -231,7 +231,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/shield v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/signer v1.26.1
-	github.com/aws/aws-sdk-go-v2/service/sns v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/sns v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -214,7 +214,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rum v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.49.1
-	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.0
+	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.0
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -217,7 +217,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.1
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.1
-	github.com/aws/aws-sdk-go-v2/service/schemas v1.28.0
+	github.com/aws/aws-sdk-go-v2/service/schemas v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -246,7 +246,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.1
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.1
-	github.com/aws/aws-sdk-go-v2/service/transfer v1.52.0
+	github.com/aws/aws-sdk-go-v2/service/transfer v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.0
 	github.com/aws/aws-sdk-go-v2/service/waf v1.25.0

--- a/go.mod
+++ b/go.mod
@@ -189,7 +189,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.17.1
 	github.com/aws/aws-sdk-go-v2/service/polly v1.45.1
-	github.com/aws/aws-sdk-go-v2/service/pricing v1.32.0
+	github.com/aws/aws-sdk-go-v2/service/pricing v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.0
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.0

--- a/go.mod
+++ b/go.mod
@@ -248,7 +248,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/transfer v1.52.1
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.1
-	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.0
+	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.1
 	github.com/aws/aws-sdk-go-v2/service/waf v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.0

--- a/go.mod
+++ b/go.mod
@@ -210,7 +210,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.1
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.1
-	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.0
+	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/rum v1.21.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.49.0

--- a/go.mod
+++ b/go.mod
@@ -191,7 +191,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/polly v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.1
-	github.com/aws/aws-sdk-go-v2/service/qldb v1.25.0
+	github.com/aws/aws-sdk-go-v2/service/qldb v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.0
 	github.com/aws/aws-sdk-go-v2/service/ram v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.20.0

--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.17.1
 	github.com/aws/aws-sdk-go-v2/service/polly v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.32.1
-	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.0
+	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.1
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.0
 	github.com/aws/aws-sdk-go-v2/service/ram v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -251,7 +251,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.1
 	github.com/aws/aws-sdk-go-v2/service/waf v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.1
-	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.0
+	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.0

--- a/go.mod
+++ b/go.mod
@@ -254,7 +254,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2
-	github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.0
+	github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.1
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/xray v1.29.0
 	github.com/aws/smithy-go v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.1
-	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/swf v1.27.0

--- a/go.mod
+++ b/go.mod
@@ -201,7 +201,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.1
-	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.0
+	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -255,7 +255,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.1
-	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.0
+	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/xray v1.29.0
 	github.com/aws/smithy-go v1.22.0
 	github.com/beevik/etree v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -197,7 +197,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/rds v1.87.1
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.49.0
-	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.0
+	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -192,7 +192,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.1
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.25.1
-	github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.0
+	github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.1
 	github.com/aws/aws-sdk-go-v2/service/ram v1.29.0
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.87.0

--- a/go.mod
+++ b/go.mod
@@ -220,7 +220,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.1
-	github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.0
+	github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.0

--- a/go.mod
+++ b/go.mod
@@ -202,7 +202,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.1
-	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.0
+	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.45.0

--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.45.1
-	github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.0
+	github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.0

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.1
-	github.com/aws/aws-sdk-go-v2/service/ses v1.28.0
+	github.com/aws/aws-sdk-go-v2/service/ses v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/shield v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.87.1
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.1
-	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.0
+	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.0

--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.49.1
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.1
-	github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.0
+	github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.1
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.0

--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.1
-	github.com/aws/aws-sdk-go-v2/service/rum v1.21.0
+	github.com/aws/aws-sdk-go-v2/service/rum v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.49.0
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -207,7 +207,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.1
-	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.0
+	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.1
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.0
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.0

--- a/go.mod
+++ b/go.mod
@@ -223,7 +223,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.1
-	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.0
+	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/ses v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.1
-	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.0
+	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.0

--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.1
-	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.0
+	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/ses v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.0

--- a/go.mod
+++ b/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.1
-	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.0
+	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/ses v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -256,7 +256,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.1
 	github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.1
-	github.com/aws/aws-sdk-go-v2/service/xray v1.29.0
+	github.com/aws/aws-sdk-go-v2/service/xray v1.29.1
 	github.com/aws/smithy-go v1.22.0
 	github.com/beevik/etree v1.4.1
 	github.com/cedar-policy/cedar-go v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -250,7 +250,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.1
 	github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.1
 	github.com/aws/aws-sdk-go-v2/service/waf v1.25.1
-	github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.0
+	github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2

--- a/go.mod
+++ b/go.mod
@@ -205,7 +205,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.1
-	github.com/aws/aws-sdk-go-v2/service/route53 v1.45.0
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.1 h1:LSWNrEnNfO3/WB0nLHTYX0
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.1/go.mod h1:pDCTAL74HuN9jgrRMcbiCUE7+Xd6B108rvQNtn9V57M=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.25.1 h1:5NC/v2lzEL975KGLTCGCK+KQgoOnr+QRCo22WP7nvac=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.25.1/go.mod h1:BgW5p6T2g9GkVBUbxvhvtriEv4vnT/L3YCe3kDBa0j0=
-github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.0 h1:DonpKyb7frAZkVQFN8QoVtWe+k4BK+FcfPOFkbRsurs=
-github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.0/go.mod h1:becAKh34jIXQ0ux2lz93ITt/AQzn+kpl/tuBi2Esxgg=
+github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.1 h1:MmT9KqFTmdbv8l/5cp76/PI+E+AqNLnaAw2RLvhN4vQ=
+github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.1/go.mod h1:r1BKM29D3qtTeefZlyFHlNDab2P1DSmGBmaefmrT9AU=
 github.com/aws/aws-sdk-go-v2/service/ram v1.29.0 h1:g5Nn5xdCNdxk2nU2nIXrpB3MMlqhNlhb4qnhznZxNds=
 github.com/aws/aws-sdk-go-v2/service/ram v1.29.0/go.mod h1:z5ZsiLJsbrEd4tJshS60/2HpshO6LHfeMFu0d8SqMOA=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.20.0 h1:nTxhnIrEDPqX61qQ5HwNGbg4uYrkudfMI/cNowh7xbA=

--- a/go.sum
+++ b/go.sum
@@ -444,8 +444,8 @@ github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.1 h1:ulttJb/
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.1/go.mod h1:5qzPKTeJWm7+jezdxx1wf3ABiQZJr6wc3IhDcPHcjpo=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.1 h1:YZ5lTsgswKaOUpBAGOJ2A5L85GwDcDOF4WG4YZUPFA0=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.1/go.mod h1:c1qyH3e8KWjb+cPlKVTnr/6vjxd1kUFF/5SqCk4WL44=
-github.com/aws/aws-sdk-go-v2/service/rum v1.21.0 h1:froFlZL0sQHnS6E5mN3SuiRAl87v22gyLqMdG+Vb+3Q=
-github.com/aws/aws-sdk-go-v2/service/rum v1.21.0/go.mod h1:UKSUPazZlk9fEvAQTaHqiSYolcMnSjh2mpABvTwPY5o=
+github.com/aws/aws-sdk-go-v2/service/rum v1.21.1 h1:PYVd049rbdX3dOvxwwNKhLvZmqi2eNnP0SOrvmWsdRE=
+github.com/aws/aws-sdk-go-v2/service/rum v1.21.1/go.mod h1:yl512stkHG1UoI63PVORQPg2GbKeorm3F5AwJifUbRA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1 h1:HQR79P0F0C2YQOaS2Z+90YK9DH22z9D6Neplaj0yuy4=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1/go.mod h1:xYVl5BX9Ws7+ZM58b3w0kq36TR1Dgw2OMkjSr6YTWXg=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.49.0 h1:E1xsoEi88tEWhXuDuxFaSQhun1bnVwdsW8YAhy7pdDs=

--- a/go.sum
+++ b/go.sum
@@ -516,8 +516,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.1 h1:NmND1B6iw4JlL+Qt
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.1/go.mod h1:2YEqAmt6JZvJPf/N7AJbXlEZxxE+O491DfLfoqUqh3U=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.1 h1:1M63ept1qtAwVPYcXiqcLJB5H35jQW8YT1rQHmH2o/A=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.1/go.mod h1:c5lxLgVqP5012pCf2yxgFvusNCq5DXqEpd+9BQapzno=
-github.com/aws/aws-sdk-go-v2/service/transfer v1.52.0 h1:aKBQyfTYN9Yk7l9FRHZIdXCDn1EZ6t63/97H5Tl+lsA=
-github.com/aws/aws-sdk-go-v2/service/transfer v1.52.0/go.mod h1:eOX2Aq6Ni4wJNy4OSCM1jBUmhFhI77D73j1aBewlkds=
+github.com/aws/aws-sdk-go-v2/service/transfer v1.52.1 h1:0zt9NzKWlleqdV1Q+oQGY/ZJsayEW0/X5zDUTgwopcY=
+github.com/aws/aws-sdk-go-v2/service/transfer v1.52.1/go.mod h1:yC5F7XiU6FD8T7l3AoQX8j7PYfEu1j7mf05sA/yUA0g=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.0 h1:I/RzlfYmTRHMrN5Lj+vOb+x1x4PDCeiZ2ag8DKt0SQQ=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.0/go.mod h1:RqhUE2Id1Mw7Xp1zsIjtPw+x9D6oXWQ5kpm7kv1FXyI=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.0 h1:uV04W6WHAS/OkwHzirEOwJ6MJ4dZ58vAx7Rxi/voKkY=

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/aws/aws-sdk-go-v2/service/sqs v1.36.1 h1:8VpPO5IYvP7ODERfS59E8R+aZixH
 github.com/aws/aws-sdk-go-v2/service/sqs v1.36.1/go.mod h1:FPCleXfdVS/8g4dT8ZRWGQ8hn9xrqJzqtEw6iS2rWp4=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.55.1 h1:HqpHD/vOlIPvVSp9Gy1dSenPXmpWgvcgWrNoVWW3DCg=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.55.1/go.mod h1:az8SwCal1RPwT2TBBfLXW4iMEgX0Pkdv4qXNRDQwMmA=
-github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.0 h1:2I9B3FdEvPqsu9si4ZN4/iL0GPz22AmdA6EOk9apxrw=
-github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.0/go.mod h1:zcKz8ylqpcPVWWPMN0i0dQ9TYL6ncuql3si6h9IdJaU=
+github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.1 h1:uffgV7K0W1uX7wJ0wQZQiSElKKwX+txKpNAeqBSBaTs=
+github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.1/go.mod h1:Np9vCZ47Hp/GjNvPVy2MLNwc1oFxe86Hso2cMjHH0i0=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.0 h1:0hXgMxu4vAkgPb6HVu+rOH7jQecQdtYA3MK98JOKP58=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.0/go.mod h1:myzq95kUgPEjfIrcKw1Vkim53/HS/TzjZFsXLvZjYao=
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.0 h1:Hakxr1VEEoqdZJrzztF/7B885LTXIAigVjY9+OiW7CA=

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/aws/aws-sdk-go-v2/service/polly v1.45.1 h1:81PITmOBRRG6U2sgH2/Sb2HuKs
 github.com/aws/aws-sdk-go-v2/service/polly v1.45.1/go.mod h1:u5IDmN3PWsvgyTwtbCgU7+GIzSiGR1pg+5w6hB9vYpI=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.32.1 h1:Z9g1Xv92iFWsecXPqZWCghcyBYMSksYL6K+QMz5s6TA=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.32.1/go.mod h1:ZZKslHgGl11WsRaQXXG3b7R/IDAQ7CAjf+4TNRYh6D4=
-github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.0 h1:GmnhZOgQ9XJBWa1Gw5OhtfWZ5rCKvgl0hFONgcQ2qis=
-github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.0/go.mod h1:ziyOGX+zLSG4Xe/HH9RF/qHNZBur/xBLGx+upBT+eFA=
+github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.1 h1:LSWNrEnNfO3/WB0nLHTYX0opxtFQRA7zw3oyZzHPREU=
+github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.1/go.mod h1:pDCTAL74HuN9jgrRMcbiCUE7+Xd6B108rvQNtn9V57M=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.25.0 h1:YHAUmDQQnyrvqrb4r04JaENU/X/p7j6Epm+YaZrXwKI=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.25.0/go.mod h1:R31TC0sdnEyqyd7jf+5PDOLzv5Ld3R3NrBn4tyTXn1Y=
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.0 h1:DonpKyb7frAZkVQFN8QoVtWe+k4BK+FcfPOFkbRsurs=

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,8 @@ github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.1 h1:az/RRfnWVUmHcpc9OLkXIm
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.1/go.mod h1:vUcSJmzbhlc4bYUUexFD6sHqln4rKDvLMvhfvMAeaUY=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.28.1 h1:Q9/y3bAOlDihURNAmSSiMFAkKAX3GfiKkIJxbx8X/9M=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.28.1/go.mod h1:nZ1tceWvNkUA+TZG6HgT+dJQ1wOjk+RnW9lkx4oJAeg=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.0 h1:POvqkPd+H/B6No9py/7c//RRVbSp75wtN8nsd/LGHw0=
-github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.0/go.mod h1:G2a06OQdRNbG8bfvdYSFpA9CBuaTQrmnrIyGuU6OgXU=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.1 h1:NxhxUnLx7Bexlz0tcM9ikkWDcg9nqOti4ppCrBIP2/o=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.1/go.mod h1:ZOm+hOpec53Pm14NWBDqg1oSj+FtxphlNIUrFo+fJec=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.0 h1:2aYy17RgJLQ/7byuUnupyG1zwOa/meg7eTQOP4NWBRM=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.0/go.mod h1:DxwMa8+xM898UzufTrwJ52dfrA0iruEmdX/e12k/sxY=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.0 h1:Pzs5BqZJ/R+Dv/v4HThy8PK9yloqnHyArjyU1h2T/Ys=

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.1 h1:bJxeCId/TqCgo3tS+Az
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.1/go.mod h1:8QJDOFF+OxdZXxaa1dfAEv3tt0E+GxU18lIdLwaBWnw=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.1 h1:nHj7BRE9VP5NBbzC8A6nprGKjVz14CZUf88CINoXLxQ=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.1/go.mod h1:VNC+ru3vCew5IVClkwo7kqrmCH5uROBqbjPNQGZErdQ=
-github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.0 h1:UCYouMWbN0d65zQcumHgPQKVQfDBb65tKjGtN3kfjwk=
-github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.0/go.mod h1:W2J8/gDKBHcv07meaBsdKbKYreEXDNLtDH07zCFuKOE=
+github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.1 h1:a1/NIV+lVPNmfv8V1NaqcMjNwJ/QTqyWcEwRYgOAOEg=
+github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.1/go.mod h1:a6paTJsNFBXDDm8LAGe2RTOkG4x5hrgXU66qHuYFA3g=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.0 h1:gINVcGi9Z6Wlw84Ovi7PVgRQKG7iy+XO6cC4swswZcU=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.0/go.mod h1:omuRZH8owz4Ng2SJd6qZoJJa994Z42aeJjID+PW2TUM=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.0 h1:rW7l5p7yFv16o+Qsh9lbn8irCNxSn+YOwpaiTxirKbs=

--- a/go.sum
+++ b/go.sum
@@ -522,8 +522,8 @@ github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.1 h1:gnqtFuuxQq6t
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.1/go.mod h1:egWn3jckqtKKtcQCdnM10rpejnRjVoONDNO0Fpzl5EU=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.1 h1:VSN3StgMPSYxW8Zx4aWSJ3IaOFWxYbpmXQuHY0vhxzo=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.1/go.mod h1:+YPjSOl7R2QY6n3AVkIbr2h/lfltiB8lLxF8zYNKK3Y=
-github.com/aws/aws-sdk-go-v2/service/waf v1.25.0 h1:pcXyQakScYjzkuRmppyugVxls3l+Ip17/FdOP9RNPSA=
-github.com/aws/aws-sdk-go-v2/service/waf v1.25.0/go.mod h1:r7fguRe/kcVfWLtb/7Q7IE/hOcIvLZuVL72vT7YEyW4=
+github.com/aws/aws-sdk-go-v2/service/waf v1.25.1 h1:ARXTu3Zk2paaSkOIjwP+At5MRsgaYAujIyfAb7TXff8=
+github.com/aws/aws-sdk-go-v2/service/waf v1.25.1/go.mod h1:kfz9Qw0tfmgiviSMRebO8VndS9nWadnMRCfRWLfdfFE=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.0 h1:ffGAT/6KC61oDMmvosbSsJryBbzKkHNUhicSllr4wWA=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.0/go.mod h1:JEJN2orUirH4jR9XEChrsFk1IV1h21Gdj1zUaQ/z11g=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.0 h1:KX07HLsIMbFwG/Z7GEgz7BcRCIih8i9/mrVQ+as3VWU=

--- a/go.sum
+++ b/go.sum
@@ -482,8 +482,8 @@ github.com/aws/aws-sdk-go-v2/service/sfn v1.33.1 h1:39B84msn/lmkK7OgHhvHJfbZZx9P
 github.com/aws/aws-sdk-go-v2/service/sfn v1.33.1/go.mod h1:5EpOKPBSOtPLqbE1rJ+RypmehSHgwpnDyrRzL3gt3yE=
 github.com/aws/aws-sdk-go-v2/service/shield v1.29.1 h1:ycZY4cWJGgQ07knRwETVZZI3XanU26s8LEQNbvY1CYU=
 github.com/aws/aws-sdk-go-v2/service/shield v1.29.1/go.mod h1:9EzkR8jfdQDQaSK4TBit+0fjztMuLUVUBUt0FuJks40=
-github.com/aws/aws-sdk-go-v2/service/signer v1.26.0 h1:e+/9/bl+E9GMzg4o2KuCEz4Alr1YlbCbTMe9CzKl7XI=
-github.com/aws/aws-sdk-go-v2/service/signer v1.26.0/go.mod h1:YZjxkEuuHPXjtibRIeQot92+ku++p9DtwDGi8w20C44=
+github.com/aws/aws-sdk-go-v2/service/signer v1.26.1 h1:hdKdIuAEHsy7zhuqX0xe2JaRYUcARdcd16LsOH9Z5PU=
+github.com/aws/aws-sdk-go-v2/service/signer v1.26.1/go.mod h1:CMDWlKzjksZLIAYXq8lyZsA3B66QeYxH6mY/cbZ37kA=
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.0 h1:QuttYvND/OmttAImqJtsZXYJ6bEoUC2qLi29lhw1lss=
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.0/go.mod h1:bZXJof3RK1G0NKSmE3NQGBFDIpQD/ayLu7ffN1cCW/E=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.36.0 h1:t+b3U3fmUiuXyeBhp9c3BpaEQS7bzp/CoGCuj8DW6r8=

--- a/go.sum
+++ b/go.sum
@@ -524,8 +524,8 @@ github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.1 h1:VSN3StgMPSYxW8Zx4aWSJ
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.1/go.mod h1:+YPjSOl7R2QY6n3AVkIbr2h/lfltiB8lLxF8zYNKK3Y=
 github.com/aws/aws-sdk-go-v2/service/waf v1.25.1 h1:ARXTu3Zk2paaSkOIjwP+At5MRsgaYAujIyfAb7TXff8=
 github.com/aws/aws-sdk-go-v2/service/waf v1.25.1/go.mod h1:kfz9Qw0tfmgiviSMRebO8VndS9nWadnMRCfRWLfdfFE=
-github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.0 h1:ffGAT/6KC61oDMmvosbSsJryBbzKkHNUhicSllr4wWA=
-github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.0/go.mod h1:JEJN2orUirH4jR9XEChrsFk1IV1h21Gdj1zUaQ/z11g=
+github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.1 h1:UpQRGrJiUGg7LTO64ISmAQfUlYbIISKQBMRKWt73az8=
+github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.1/go.mod h1:feJTuhX73shl7IOkO60NPGLD3JqGp8tlPEoJYTQx/to=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.0 h1:KX07HLsIMbFwG/Z7GEgz7BcRCIih8i9/mrVQ+as3VWU=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.0/go.mod h1:HbRx9F7QUM5rREHq6Dk8htxe+8a7QWUhseIBwAtAn9M=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.0 h1:AvCS0hEflN2PYQ7kn9s+0x6wIwLGru/wSXkBBeFRLV8=

--- a/go.sum
+++ b/go.sum
@@ -518,8 +518,8 @@ github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.1 h1:1M63ept1qtAwVPYcXiqcL
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.1/go.mod h1:c5lxLgVqP5012pCf2yxgFvusNCq5DXqEpd+9BQapzno=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.52.1 h1:0zt9NzKWlleqdV1Q+oQGY/ZJsayEW0/X5zDUTgwopcY=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.52.1/go.mod h1:yC5F7XiU6FD8T7l3AoQX8j7PYfEu1j7mf05sA/yUA0g=
-github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.0 h1:I/RzlfYmTRHMrN5Lj+vOb+x1x4PDCeiZ2ag8DKt0SQQ=
-github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.0/go.mod h1:RqhUE2Id1Mw7Xp1zsIjtPw+x9D6oXWQ5kpm7kv1FXyI=
+github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.1 h1:gnqtFuuxQq6tkp92xQQKlWjEnMm3hIGTPoTC9zyok98=
+github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.1/go.mod h1:egWn3jckqtKKtcQCdnM10rpejnRjVoONDNO0Fpzl5EU=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.0 h1:uV04W6WHAS/OkwHzirEOwJ6MJ4dZ58vAx7Rxi/voKkY=
 github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.0/go.mod h1:6tIKuPku+QZQS49ysax0tHHpL3BB7aCO6kYdwdwgQh8=
 github.com/aws/aws-sdk-go-v2/service/waf v1.25.0 h1:pcXyQakScYjzkuRmppyugVxls3l+Ip17/FdOP9RNPSA=

--- a/go.sum
+++ b/go.sum
@@ -412,8 +412,8 @@ github.com/aws/aws-sdk-go-v2/service/ram v1.29.1 h1:cjdxjGObaYoGQ0Zt/whkpudg3NvZ
 github.com/aws/aws-sdk-go-v2/service/ram v1.29.1/go.mod h1:m24XUsed393gJQDEQD2qeQYd1uYPvULjhd058dSnvBk=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.20.1 h1:JUJ0hy5GGOIA1zRvPJZ0ogLstQFWdE0f//nZycMu+Gw=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.20.1/go.mod h1:amSW5uKZDHYqNL68oQTj9l0gTAo/2Dp9scSFyzyGOLw=
-github.com/aws/aws-sdk-go-v2/service/rds v1.87.0 h1:f7u5jzUHaIIn5F121ortA0g2yDDWiPeTw2lWrgk9+ZA=
-github.com/aws/aws-sdk-go-v2/service/rds v1.87.0/go.mod h1:agnQGhYbHXxPM2+zZH4WZIpki6IDU6zFGzfOlnu+1Ow=
+github.com/aws/aws-sdk-go-v2/service/rds v1.87.1 h1:1RJ+1wg1wtVTct1nXWZLKRw2O+CtU78krodpliCsang=
+github.com/aws/aws-sdk-go-v2/service/rds v1.87.1/go.mod h1:h8SZLHsQgmV0ZAFymQYIb5oLQdoslfaiAstH0G0fFto=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.48.0 h1:kUEB7p3N8z/qpREJHtHdBtjCoLljXiuybWBcQgYjfuI=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.48.0/go.mod h1:sI0e0L/VngeJZC6S6EI3Mv9b3jTckba8fTsLagWoRjQ=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.0 h1:mCUQwUL7CPCW6gpMJo1yCIwLvxDVp9zHniooCJ7P1QI=

--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,8 @@ github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.1 h1:cbZsfPVqP0EXJr
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.1/go.mod h1:gbQKi0ClVV8cLYjVHaeuw9mYaQDMNTY/ljWfN1M20Fs=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.1 h1:NmND1B6iw4JlL+QtdjY6wBmcu4dIgU9f2db0OeHclk8=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.1/go.mod h1:2YEqAmt6JZvJPf/N7AJbXlEZxxE+O491DfLfoqUqh3U=
-github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.0 h1:yDMWyH7Y2v4FlWyxVvphHofmDoAqteraYzgsRcIXzbo=
-github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.0/go.mod h1:GmUujOo0WwtRAGmBCpD6sY8VcJg1xKeFEePIqwLjles=
+github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.1 h1:1M63ept1qtAwVPYcXiqcLJB5H35jQW8YT1rQHmH2o/A=
+github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.1/go.mod h1:c5lxLgVqP5012pCf2yxgFvusNCq5DXqEpd+9BQapzno=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.52.0 h1:aKBQyfTYN9Yk7l9FRHZIdXCDn1EZ6t63/97H5Tl+lsA=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.52.0/go.mod h1:eOX2Aq6Ni4wJNy4OSCM1jBUmhFhI77D73j1aBewlkds=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.0 h1:I/RzlfYmTRHMrN5Lj+vOb+x1x4PDCeiZ2ag8DKt0SQQ=

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.49.0 h1:aFXTYh/IIIzR2gjEZScdHrr
 github.com/aws/aws-sdk-go-v2/service/redshift v1.49.0/go.mod h1:VC87c1puEEU3v/Wmrt4K6NPhTH+r91QXzSnEip/Kp6M=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.1 h1:bJxeCId/TqCgo3tS+Az10/T7XRs1355+xMdcdyuoTAY=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.1/go.mod h1:8QJDOFF+OxdZXxaa1dfAEv3tt0E+GxU18lIdLwaBWnw=
-github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.0 h1:DD1xo6SbBDVqFVBfc1yYtk8VwnnRT+oPqsiIL4ez3l0=
-github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.0/go.mod h1:DUODNq07+tdIWFdPGrlvSfzS+BofN9o43W5nyQbrtEA=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.1 h1:nHj7BRE9VP5NBbzC8A6nprGKjVz14CZUf88CINoXLxQ=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.1/go.mod h1:VNC+ru3vCew5IVClkwo7kqrmCH5uROBqbjPNQGZErdQ=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.0 h1:UCYouMWbN0d65zQcumHgPQKVQfDBb65tKjGtN3kfjwk=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.0/go.mod h1:W2J8/gDKBHcv07meaBsdKbKYreEXDNLtDH07zCFuKOE=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.0 h1:gINVcGi9Z6Wlw84Ovi7PVgRQKG7iy+XO6cC4swswZcU=

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ github.com/aws/aws-sdk-go-v2/service/schemas v1.28.1 h1:Q9/y3bAOlDihURNAmSSiMFAk
 github.com/aws/aws-sdk-go-v2/service/schemas v1.28.1/go.mod h1:nZ1tceWvNkUA+TZG6HgT+dJQ1wOjk+RnW9lkx4oJAeg=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.1 h1:NxhxUnLx7Bexlz0tcM9ikkWDcg9nqOti4ppCrBIP2/o=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.1/go.mod h1:ZOm+hOpec53Pm14NWBDqg1oSj+FtxphlNIUrFo+fJec=
-github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.0 h1:2aYy17RgJLQ/7byuUnupyG1zwOa/meg7eTQOP4NWBRM=
-github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.0/go.mod h1:DxwMa8+xM898UzufTrwJ52dfrA0iruEmdX/e12k/sxY=
+github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.1 h1:5Z5aKDslmsUbIyZXJ5V14OpauPFCsIBqndIB2QJHUZQ=
+github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.1/go.mod h1:mmLGDyo4VuWb+IsAabryb/9iaCXjGTHT/j2UM1/wraw=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.0 h1:Pzs5BqZJ/R+Dv/v4HThy8PK9yloqnHyArjyU1h2T/Ys=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.0/go.mod h1:qGYvx8v5BG54w/e9gFsmZX9dvynw/DwWhYq2QJDJs/o=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.0 h1:YJDXIKbdPuDFzwAntG1wiIWy2+2maPmZSK5zLoxnJeg=

--- a/go.sum
+++ b/go.sum
@@ -400,8 +400,8 @@ github.com/aws/aws-sdk-go-v2/service/pipes v1.17.1 h1:Ov3G4LgPOzDRZSs72DbXijPol8
 github.com/aws/aws-sdk-go-v2/service/pipes v1.17.1/go.mod h1:ePmnZz2Pzx5OZCbTBrEgDvgjy5Qne7vBl86RMabcX70=
 github.com/aws/aws-sdk-go-v2/service/polly v1.45.1 h1:81PITmOBRRG6U2sgH2/Sb2HuKssneaFLQcRRpi0FAT4=
 github.com/aws/aws-sdk-go-v2/service/polly v1.45.1/go.mod h1:u5IDmN3PWsvgyTwtbCgU7+GIzSiGR1pg+5w6hB9vYpI=
-github.com/aws/aws-sdk-go-v2/service/pricing v1.32.0 h1:1fcjNuwZtlJz0wuvd3DsOuYHgRnmzgu1YncBXxK6zYQ=
-github.com/aws/aws-sdk-go-v2/service/pricing v1.32.0/go.mod h1:NyGSneLXF2SCIfFeGkoQeievcz9g0tt6za5XMXary1k=
+github.com/aws/aws-sdk-go-v2/service/pricing v1.32.1 h1:Z9g1Xv92iFWsecXPqZWCghcyBYMSksYL6K+QMz5s6TA=
+github.com/aws/aws-sdk-go-v2/service/pricing v1.32.1/go.mod h1:ZZKslHgGl11WsRaQXXG3b7R/IDAQ7CAjf+4TNRYh6D4=
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.0 h1:GmnhZOgQ9XJBWa1Gw5OhtfWZ5rCKvgl0hFONgcQ2qis=
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.0/go.mod h1:ziyOGX+zLSG4Xe/HH9RF/qHNZBur/xBLGx+upBT+eFA=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.25.0 h1:YHAUmDQQnyrvqrb4r04JaENU/X/p7j6Epm+YaZrXwKI=

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,8 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.87.1 h1:1RJ+1wg1wtVTct1nXWZLKRw2O+Ct
 github.com/aws/aws-sdk-go-v2/service/rds v1.87.1/go.mod h1:h8SZLHsQgmV0ZAFymQYIb5oLQdoslfaiAstH0G0fFto=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.49.0 h1:aFXTYh/IIIzR2gjEZScdHrrinndbX+Upg4CBWkm51uE=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.49.0/go.mod h1:VC87c1puEEU3v/Wmrt4K6NPhTH+r91QXzSnEip/Kp6M=
-github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.0 h1:mCUQwUL7CPCW6gpMJo1yCIwLvxDVp9zHniooCJ7P1QI=
-github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.0/go.mod h1:wJ/nCNxsHoL9ccZvR7KmOh8ZfwNaTjve9FzZO7uco2s=
+github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.1 h1:bJxeCId/TqCgo3tS+Az10/T7XRs1355+xMdcdyuoTAY=
+github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.1/go.mod h1:8QJDOFF+OxdZXxaa1dfAEv3tt0E+GxU18lIdLwaBWnw=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.0 h1:DD1xo6SbBDVqFVBfc1yYtk8VwnnRT+oPqsiIL4ez3l0=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.0/go.mod h1:DUODNq07+tdIWFdPGrlvSfzS+BofN9o43W5nyQbrtEA=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.0 h1:UCYouMWbN0d65zQcumHgPQKVQfDBb65tKjGtN3kfjwk=

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,8 @@ github.com/aws/aws-sdk-go-v2/service/rbin v1.20.1 h1:JUJ0hy5GGOIA1zRvPJZ0ogLstQF
 github.com/aws/aws-sdk-go-v2/service/rbin v1.20.1/go.mod h1:amSW5uKZDHYqNL68oQTj9l0gTAo/2Dp9scSFyzyGOLw=
 github.com/aws/aws-sdk-go-v2/service/rds v1.87.1 h1:1RJ+1wg1wtVTct1nXWZLKRw2O+CtU78krodpliCsang=
 github.com/aws/aws-sdk-go-v2/service/rds v1.87.1/go.mod h1:h8SZLHsQgmV0ZAFymQYIb5oLQdoslfaiAstH0G0fFto=
-github.com/aws/aws-sdk-go-v2/service/redshift v1.48.0 h1:kUEB7p3N8z/qpREJHtHdBtjCoLljXiuybWBcQgYjfuI=
-github.com/aws/aws-sdk-go-v2/service/redshift v1.48.0/go.mod h1:sI0e0L/VngeJZC6S6EI3Mv9b3jTckba8fTsLagWoRjQ=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.49.0 h1:aFXTYh/IIIzR2gjEZScdHrrinndbX+Upg4CBWkm51uE=
+github.com/aws/aws-sdk-go-v2/service/redshift v1.49.0/go.mod h1:VC87c1puEEU3v/Wmrt4K6NPhTH+r91QXzSnEip/Kp6M=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.0 h1:mCUQwUL7CPCW6gpMJo1yCIwLvxDVp9zHniooCJ7P1QI=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.30.0/go.mod h1:wJ/nCNxsHoL9ccZvR7KmOh8ZfwNaTjve9FzZO7uco2s=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.0 h1:DD1xo6SbBDVqFVBfc1yYtk8VwnnRT+oPqsiIL4ez3l0=

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,8 @@ github.com/aws/aws-sdk-go-v2/service/rum v1.21.1 h1:PYVd049rbdX3dOvxwwNKhLvZmqi2
 github.com/aws/aws-sdk-go-v2/service/rum v1.21.1/go.mod h1:yl512stkHG1UoI63PVORQPg2GbKeorm3F5AwJifUbRA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1 h1:HQR79P0F0C2YQOaS2Z+90YK9DH22z9D6Neplaj0yuy4=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1/go.mod h1:xYVl5BX9Ws7+ZM58b3w0kq36TR1Dgw2OMkjSr6YTWXg=
-github.com/aws/aws-sdk-go-v2/service/s3control v1.49.0 h1:E1xsoEi88tEWhXuDuxFaSQhun1bnVwdsW8YAhy7pdDs=
-github.com/aws/aws-sdk-go-v2/service/s3control v1.49.0/go.mod h1:Bi7DPuEenOxe/a8lez845UfNX8PJPqMxG6P+DupwF9c=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.49.1 h1:NRFjCDBJHxF2kEYkigqd3Jk1OMzEGPu+h/kY4Sgw+po=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.49.1/go.mod h1:yU5Ku/V5VG64XlcU7Gxj8/v8yqqMNtt7eUFcBN2UxlY=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.0 h1:l4PqQnfxVSI7clQyOFpQeg1QS4dSp6h6an5XHuPFMOQ=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.0/go.mod h1:qxyebNHZ9HJ1f/fhege7rVce3b851u6pazlB8A01sB4=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.0 h1:GV/aVbZd4K4gNVWvGM3/2RJEsIucmmU+AWYTp06L1r0=

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,8 @@ github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.1 h1:0Mi6OpfXLojFhx2sVr2
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.1/go.mod h1:ZqIAvqEz4wsGlqthry91c6G94C3bY9tBr7GyC/G3XBg=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.1 h1:XjrcC7mlT2d6vNt4Z7YVb7vn0c2Xlrgz6K/eDKcwjkk=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.1/go.mod h1:Q6LJqWYkJiGKOI6lYHdg67jWj1fGFU+O0RSV58e0qTM=
-github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.0 h1:EqcxrBxHzdx8B/w0JOTkZEG0/t3aZaAQNqfRkiftbyA=
-github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.0/go.mod h1:dtAAuoYbebaCBhTq2iToNHR+flXZbM+MBky8hpcMLLQ=
+github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.1 h1:VBB3OMmAUHSYrbdYFXrRCZIhBuYmT0Nj+GyTGmwNaAs=
+github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.1/go.mod h1:d240WPXwr71aheedA3e1oNn1TI0YQbST9/oRlt2grko=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.0 h1:u54yrJFR6ZvKpuECnnuRwHidTyGlUHOGNHtpg1Onq7I=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.0/go.mod h1:JG65e6XhAXgat+1AAv+eIfDAj6asV9XNWptNwKfBHqQ=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.0 h1:Fcrhw7pe0vahNqpBoT/crqF92RWcBb/d8umD5Am2SkA=

--- a/go.sum
+++ b/go.sum
@@ -472,8 +472,8 @@ github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.1 h1:Lsznpt
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.1/go.mod h1:Hcw30Kzs1CBHG4wS/C90aVWNQxt48SNFyRpO8p+H394=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.1 h1:QRaE6W0KuU5GUGgklly1YK7Owhw3J7ZpO6wFsXpCMJQ=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.1/go.mod h1:OZmsLDFkBEij+uekZcbHfYUK9ixD2IKem+mqAqoHSXM=
-github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.0 h1:IS+tdlxJ7AhPTVIOJC0FDLOxrEF/Jg40J2Q+tOi3jVw=
-github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.0/go.mod h1:t2S7ymrKjKacXHi/1sV/94oZyhlQJr+4uYwza7TswXw=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.1 h1:LMT5ZSXxB8UlcKNraPsZ0D2LwELnoCUF3pNHRKsvrfE=
+github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.1/go.mod h1:Pef3zWt3qUxpxVnAoaXoiZfiCaJ5jr0ys6cqSJQuEio=
 github.com/aws/aws-sdk-go-v2/service/ses v1.28.0 h1:q+uLTiRFjYikxHyKoWd93PIqUtMauFULviv2TSo9DBQ=
 github.com/aws/aws-sdk-go-v2/service/ses v1.28.0/go.mod h1:hnsZ7hRQ9ia0fw8TkGq+str440nue1tymneiXecfZFI=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.0 h1:XbfGIngoLQHGGQySy9zAD3OXcJn8+rpl9im2pO6BbN4=

--- a/go.sum
+++ b/go.sum
@@ -534,8 +534,8 @@ github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2 h1:VN3Qydtdl3UlJRHVxQxSP1d
 github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2/go.mod h1:Z3RLpIq4q49syd921XdsKeD584kPu89iKTEjluh7908=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.1 h1:mPunwUzwoWt3ReX5j8pjYShsU7HXcFXcQ3/joQGU/t0=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.1/go.mod h1:OJXicfvTfPBmIAup2u5W22/mC3fjX5/PvqIuxG7Jrtg=
-github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.0 h1:5FXWXn9U6xLJoKpauNaRwhGv4mfKxUUaZKl7J8RepLE=
-github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.0/go.mod h1:uXHeCA2U0bpd9L7DZUn56gOjhmzMGZJh1QzNnMjlgdM=
+github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.1 h1:EHWnmvtF7w+hbDBPBzi3yw2sG3DVGPrMSD6WkPiSR3w=
+github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.1/go.mod h1:FUoI2lnkH2GR8EwIeAwLK4uEXxUZJlyz+y63Ryz1LLo=
 github.com/aws/aws-sdk-go-v2/service/xray v1.29.0 h1:iUFQp4OIJVY9cNVUX1NKC/lNIjR5a+53iV23rRRNY8E=
 github.com/aws/aws-sdk-go-v2/service/xray v1.29.0/go.mod h1:8T9qszGsXUVSNGYF2JzG21tRem46uPJBjE66GRDeI0M=
 github.com/aws/smithy-go v1.22.0 h1:uunKnWlcoL3zO7q+gG2Pk53joueEOsnNB28QdMsmiMM=

--- a/go.sum
+++ b/go.sum
@@ -450,8 +450,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1 h1:HQR79P0F0C2YQOaS2Z+90YK9DH22z
 github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1/go.mod h1:xYVl5BX9Ws7+ZM58b3w0kq36TR1Dgw2OMkjSr6YTWXg=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.49.1 h1:NRFjCDBJHxF2kEYkigqd3Jk1OMzEGPu+h/kY4Sgw+po=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.49.1/go.mod h1:yU5Ku/V5VG64XlcU7Gxj8/v8yqqMNtt7eUFcBN2UxlY=
-github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.0 h1:l4PqQnfxVSI7clQyOFpQeg1QS4dSp6h6an5XHuPFMOQ=
-github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.0/go.mod h1:qxyebNHZ9HJ1f/fhege7rVce3b851u6pazlB8A01sB4=
+github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.1 h1:MnaHGq7h+H1Vp4g/dSgCZCdkD/ySE8uwtmq8a2j3QZ8=
+github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.1/go.mod h1:lu9ExP0KNREiicRRO+cAPdFHwWOADcO6rchUX0AKC18=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.0 h1:GV/aVbZd4K4gNVWvGM3/2RJEsIucmmU+AWYTp06L1r0=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.0/go.mod h1:1dE5TAcXOp9Z/4KP/vO9N8S2XHZIiJoO/J+pgFX/8rI=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.0 h1:Ab6KTtzTUlHCXRrFzR3VoBnDZWXJbq74SIPrJ9JPrI0=

--- a/go.sum
+++ b/go.sum
@@ -438,8 +438,8 @@ github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.1 h1:qphFA2tBcmIkbfFv+
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.1/go.mod h1:SMj7WSUGwV7U8QFpZxPI7kD0lRCqB905lUVDt8EtQb8=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.1 h1:jRm3L87f92Z2Arf7fjBxSQkUQIrYcAfoFsv6nCCe8Z0=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.1/go.mod h1:EVI9MMbDdd8XLunof1agY0v0eFvxFMZwgvu/kzO7mL0=
-github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.0 h1:OieU9CF8Mkc/Yjg9tY+oG2y2HFJrynaZEgVl7pAuh8w=
-github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.0/go.mod h1:qh4z11zzitV4EyEpFLTUReJA/ZxfiChkpeP4zyqUN0U=
+github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.1 h1:3X4GcNR+YMYpVMhdWyLkF7T/JVeGNi+VI8+OMe+BEUQ=
+github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.1/go.mod h1:UczKD5EZACP66D69wEHkb5xtyE+Nqg7hrVmIC0Y7i+8=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.0 h1:d92tQ6JVqk64YvZgx/tdaknym1wmAZAuvip7Z3g5qAU=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.0/go.mod h1:qZ5z3iSFXz0tUAuO9AefVpLvaaCyK8bfxCCfGa+B6zk=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.0 h1:5M/EgVtiXZGIgdoAuGc83/VwdgHpTMkRwSgvabrQopw=

--- a/go.sum
+++ b/go.sum
@@ -452,8 +452,8 @@ github.com/aws/aws-sdk-go-v2/service/s3control v1.49.1 h1:NRFjCDBJHxF2kEYkigqd3J
 github.com/aws/aws-sdk-go-v2/service/s3control v1.49.1/go.mod h1:yU5Ku/V5VG64XlcU7Gxj8/v8yqqMNtt7eUFcBN2UxlY=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.1 h1:MnaHGq7h+H1Vp4g/dSgCZCdkD/ySE8uwtmq8a2j3QZ8=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.1/go.mod h1:lu9ExP0KNREiicRRO+cAPdFHwWOADcO6rchUX0AKC18=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.0 h1:GV/aVbZd4K4gNVWvGM3/2RJEsIucmmU+AWYTp06L1r0=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.0/go.mod h1:1dE5TAcXOp9Z/4KP/vO9N8S2XHZIiJoO/J+pgFX/8rI=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.1 h1:WZI/wXuY6zG1JSiOO+mritaa3rlXcnGaXYxT0jXwMHU=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.1/go.mod h1:jE/zSskmE910W52Dz9OU2X4qCV+5QQntuqcEYtZr+sg=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.0 h1:Ab6KTtzTUlHCXRrFzR3VoBnDZWXJbq74SIPrJ9JPrI0=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.0/go.mod h1:72FLP4wQfEC7OGz4Iwa9I4WHZUO/Fho5XvXXeF/A9xY=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.28.0 h1:9YWh3m74QgbQcBfKNt2au59+vy6UYxT/ajiGBonwvUY=

--- a/go.sum
+++ b/go.sum
@@ -536,8 +536,8 @@ github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.1 h1:mPunwUzwoWt3ReX5j8pjY
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.1/go.mod h1:OJXicfvTfPBmIAup2u5W22/mC3fjX5/PvqIuxG7Jrtg=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.1 h1:EHWnmvtF7w+hbDBPBzi3yw2sG3DVGPrMSD6WkPiSR3w=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.1/go.mod h1:FUoI2lnkH2GR8EwIeAwLK4uEXxUZJlyz+y63Ryz1LLo=
-github.com/aws/aws-sdk-go-v2/service/xray v1.29.0 h1:iUFQp4OIJVY9cNVUX1NKC/lNIjR5a+53iV23rRRNY8E=
-github.com/aws/aws-sdk-go-v2/service/xray v1.29.0/go.mod h1:8T9qszGsXUVSNGYF2JzG21tRem46uPJBjE66GRDeI0M=
+github.com/aws/aws-sdk-go-v2/service/xray v1.29.1 h1:ZcqRNo398tT7qozZ/F5php0PQJqul+fcA1I5IzgLMoM=
+github.com/aws/aws-sdk-go-v2/service/xray v1.29.1/go.mod h1:8E7zF0f/4SW6F3asVmSitNj48KVYZPyR0zmi5iROim0=
 github.com/aws/smithy-go v1.22.0 h1:uunKnWlcoL3zO7q+gG2Pk53joueEOsnNB28QdMsmiMM=
 github.com/aws/smithy-go v1.22.0/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/beevik/etree v1.4.1 h1:PmQJDDYahBGNKDcpdX8uPy1xRCwoCGVUiW669MEirVI=

--- a/go.sum
+++ b/go.sum
@@ -470,8 +470,8 @@ github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.1 h1:VBB3OMmAUHSYrbdYF
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.1/go.mod h1:d240WPXwr71aheedA3e1oNn1TI0YQbST9/oRlt2grko=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.1 h1:LsznptbfALbXav1YX8PcxbY0r3XVIJhTrAvArud3Pio=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.1/go.mod h1:Hcw30Kzs1CBHG4wS/C90aVWNQxt48SNFyRpO8p+H394=
-github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.0 h1:Fcrhw7pe0vahNqpBoT/crqF92RWcBb/d8umD5Am2SkA=
-github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.0/go.mod h1:VIPaV4ryt9Sj7Xt5+AFPGzmP9ZxjX/l9zPx0XKgnPLk=
+github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.1 h1:QRaE6W0KuU5GUGgklly1YK7Owhw3J7ZpO6wFsXpCMJQ=
+github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.1/go.mod h1:OZmsLDFkBEij+uekZcbHfYUK9ixD2IKem+mqAqoHSXM=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.0 h1:IS+tdlxJ7AhPTVIOJC0FDLOxrEF/Jg40J2Q+tOi3jVw=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.0/go.mod h1:t2S7ymrKjKacXHi/1sV/94oZyhlQJr+4uYwza7TswXw=
 github.com/aws/aws-sdk-go-v2/service/ses v1.28.0 h1:q+uLTiRFjYikxHyKoWd93PIqUtMauFULviv2TSo9DBQ=

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.1 h1:UpQRGrJiUGg7LTO64ISm
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.1/go.mod h1:feJTuhX73shl7IOkO60NPGLD3JqGp8tlPEoJYTQx/to=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.1 h1:1UQEx2IPoBnVd3Fue55GKwLQV91gWaX8gTeDdJlOD/4=
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.1/go.mod h1:czYEoDBD1goOpyeHLPK6fsqRoZH04T77pxo67YPA0g8=
-github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.0 h1:AvCS0hEflN2PYQ7kn9s+0x6wIwLGru/wSXkBBeFRLV8=
-github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.0/go.mod h1:rzBMeN2c3ZF8BFRCfzJHO7ATmPsqEjtatQoxjGR3peg=
+github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.1 h1:sCCIbinmMoh07O1GsQO5sbUF+fA/Tx3Jz6rop/FT6FE=
+github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.1/go.mod h1:6mnIS90i77LshrjcIW7NM/gnH2evwvCyfxJZxkxRXnk=
 github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2 h1:VN3Qydtdl3UlJRHVxQxSP1d8I5gtvT5zdaCCAfZST7Y=
 github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2/go.mod h1:Z3RLpIq4q49syd921XdsKeD584kPu89iKTEjluh7908=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.0 h1:vb58sKt9Z3QVVcXYchKZllS9Z0Rqk/1O0RYX1qu6Aaw=

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,8 @@ github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.1 h1:Y13JcmFg9xS3dUMvH
 github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.1/go.mod h1:Xbz+Dpc4yauZxeAWJoyamT2ckQjFwfbNj/1CUxM+XhQ=
 github.com/aws/aws-sdk-go-v2/service/sts v1.32.1 h1:q76Ig4OaJzVJGNUSGO3wjSTBS94g+EhHIbpY9rPvkxs=
 github.com/aws/aws-sdk-go-v2/service/sts v1.32.1/go.mod h1:664dajZ7uS7JMUMUG0R5bWbtN97KECNCVdFDdQ6Ipu8=
-github.com/aws/aws-sdk-go-v2/service/swf v1.27.0 h1:LSUYrSjhBj26URDk+8K7mvjS8Syx6PmdViZeOLO9iw8=
-github.com/aws/aws-sdk-go-v2/service/swf v1.27.0/go.mod h1:Yj3He6Dx5KDTnOJ0yFErYrcBtymgeI1oDTTv4U/Yx3A=
+github.com/aws/aws-sdk-go-v2/service/swf v1.27.1 h1:Fp+M3ovc3hJ8xckuS/7yF8fHm6eujS7nX+OvD2nIyDQ=
+github.com/aws/aws-sdk-go-v2/service/swf v1.27.1/go.mod h1:NBZBIHLdqCtyypd3Rkmljh+yPQNjIPlNqpzFc7o4VMs=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.0 h1:bQEQMQnZy7bJ7YnHqJMOxu+JOTfDALCGcNqymPDgiCQ=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.0/go.mod h1:EVm6DB4C55u5/gAv015al/XfTNbJC8P7oC2vC9Bsk+0=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.0 h1:m+jcCFKJjHnT28uKkiYavY7AmA14teuwCsEsUxEZtDQ=

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/aws/aws-sdk-go-v2/service/qldb v1.25.1 h1:5NC/v2lzEL975KGLTCGCK+KQgoO
 github.com/aws/aws-sdk-go-v2/service/qldb v1.25.1/go.mod h1:BgW5p6T2g9GkVBUbxvhvtriEv4vnT/L3YCe3kDBa0j0=
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.1 h1:MmT9KqFTmdbv8l/5cp76/PI+E+AqNLnaAw2RLvhN4vQ=
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.1/go.mod h1:r1BKM29D3qtTeefZlyFHlNDab2P1DSmGBmaefmrT9AU=
-github.com/aws/aws-sdk-go-v2/service/ram v1.29.0 h1:g5Nn5xdCNdxk2nU2nIXrpB3MMlqhNlhb4qnhznZxNds=
-github.com/aws/aws-sdk-go-v2/service/ram v1.29.0/go.mod h1:z5ZsiLJsbrEd4tJshS60/2HpshO6LHfeMFu0d8SqMOA=
+github.com/aws/aws-sdk-go-v2/service/ram v1.29.1 h1:cjdxjGObaYoGQ0Zt/whkpudg3NvZNRUQLWpmAKKrNaE=
+github.com/aws/aws-sdk-go-v2/service/ram v1.29.1/go.mod h1:m24XUsed393gJQDEQD2qeQYd1uYPvULjhd058dSnvBk=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.20.0 h1:nTxhnIrEDPqX61qQ5HwNGbg4uYrkudfMI/cNowh7xbA=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.20.0/go.mod h1:Wku6F7vWrPVEljMjR4l/YFOqxaAYygUwF52brnF1Lfo=
 github.com/aws/aws-sdk-go-v2/service/rds v1.87.0 h1:f7u5jzUHaIIn5F121ortA0g2yDDWiPeTw2lWrgk9+ZA=

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,8 @@ github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.1 h1:QRaE6W0KuU5GUGg
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.1/go.mod h1:OZmsLDFkBEij+uekZcbHfYUK9ixD2IKem+mqAqoHSXM=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.1 h1:LMT5ZSXxB8UlcKNraPsZ0D2LwELnoCUF3pNHRKsvrfE=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.1/go.mod h1:Pef3zWt3qUxpxVnAoaXoiZfiCaJ5jr0ys6cqSJQuEio=
-github.com/aws/aws-sdk-go-v2/service/ses v1.28.0 h1:q+uLTiRFjYikxHyKoWd93PIqUtMauFULviv2TSo9DBQ=
-github.com/aws/aws-sdk-go-v2/service/ses v1.28.0/go.mod h1:hnsZ7hRQ9ia0fw8TkGq+str440nue1tymneiXecfZFI=
+github.com/aws/aws-sdk-go-v2/service/ses v1.28.1 h1:eulUIq+v/IN4akDHBY3NFKVfJ+6Yd/Fl5fxgUL/cFiY=
+github.com/aws/aws-sdk-go-v2/service/ses v1.28.1/go.mod h1:6z25WLQt133DHJGT7S+42KFqsr7fv7J1VhLTBJIQrxc=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.0 h1:XbfGIngoLQHGGQySy9zAD3OXcJn8+rpl9im2pO6BbN4=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.0/go.mod h1:ZrKaLqQnpEHJPSRJrfWtmUdW7/O0qtdWrY1ynCwFvxw=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.33.0 h1:lSci2Dcan6foJsXv0RJNO+yOJ/mYPq7tABqy9Pm8QRc=

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,8 @@ github.com/aws/aws-sdk-go-v2/service/shield v1.29.1 h1:ycZY4cWJGgQ07knRwETVZZI3X
 github.com/aws/aws-sdk-go-v2/service/shield v1.29.1/go.mod h1:9EzkR8jfdQDQaSK4TBit+0fjztMuLUVUBUt0FuJks40=
 github.com/aws/aws-sdk-go-v2/service/signer v1.26.1 h1:hdKdIuAEHsy7zhuqX0xe2JaRYUcARdcd16LsOH9Z5PU=
 github.com/aws/aws-sdk-go-v2/service/signer v1.26.1/go.mod h1:CMDWlKzjksZLIAYXq8lyZsA3B66QeYxH6mY/cbZ37kA=
-github.com/aws/aws-sdk-go-v2/service/sns v1.33.0 h1:QuttYvND/OmttAImqJtsZXYJ6bEoUC2qLi29lhw1lss=
-github.com/aws/aws-sdk-go-v2/service/sns v1.33.0/go.mod h1:bZXJof3RK1G0NKSmE3NQGBFDIpQD/ayLu7ffN1cCW/E=
+github.com/aws/aws-sdk-go-v2/service/sns v1.33.1 h1:SBxarBZKkHCw7zAGORjjaU3KH8/PrMgzMZ3V+ntKmKk=
+github.com/aws/aws-sdk-go-v2/service/sns v1.33.1/go.mod h1:b54PFWcn1ium9LTWf+5QbPLMSVbfktXFWZtcLtxYSDQ=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.36.0 h1:t+b3U3fmUiuXyeBhp9c3BpaEQS7bzp/CoGCuj8DW6r8=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.36.0/go.mod h1:ICKQNsIj2Q6IXn5nF+ADptwAM9jX5JFWbnIfRR+6SqE=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.55.0 h1:tXrDYWutZsSAtqilgdOkn/DMLdIhTZoyA5J7NgwNfyc=

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/aws/aws-sdk-go-v2/service/transfer v1.52.1 h1:0zt9NzKWlleqdV1Q+oQGY/Z
 github.com/aws/aws-sdk-go-v2/service/transfer v1.52.1/go.mod h1:yC5F7XiU6FD8T7l3AoQX8j7PYfEu1j7mf05sA/yUA0g=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.1 h1:gnqtFuuxQq6tkp92xQQKlWjEnMm3hIGTPoTC9zyok98=
 github.com/aws/aws-sdk-go-v2/service/verifiedpermissions v1.19.1/go.mod h1:egWn3jckqtKKtcQCdnM10rpejnRjVoONDNO0Fpzl5EU=
-github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.0 h1:uV04W6WHAS/OkwHzirEOwJ6MJ4dZ58vAx7Rxi/voKkY=
-github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.0/go.mod h1:6tIKuPku+QZQS49ysax0tHHpL3BB7aCO6kYdwdwgQh8=
+github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.1 h1:VSN3StgMPSYxW8Zx4aWSJ3IaOFWxYbpmXQuHY0vhxzo=
+github.com/aws/aws-sdk-go-v2/service/vpclattice v1.12.1/go.mod h1:+YPjSOl7R2QY6n3AVkIbr2h/lfltiB8lLxF8zYNKK3Y=
 github.com/aws/aws-sdk-go-v2/service/waf v1.25.0 h1:pcXyQakScYjzkuRmppyugVxls3l+Ip17/FdOP9RNPSA=
 github.com/aws/aws-sdk-go-v2/service/waf v1.25.0/go.mod h1:r7fguRe/kcVfWLtb/7Q7IE/hOcIvLZuVL72vT7YEyW4=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.0 h1:ffGAT/6KC61oDMmvosbSsJryBbzKkHNUhicSllr4wWA=

--- a/go.sum
+++ b/go.sum
@@ -492,8 +492,8 @@ github.com/aws/aws-sdk-go-v2/service/ssm v1.55.1 h1:HqpHD/vOlIPvVSp9Gy1dSenPXmpW
 github.com/aws/aws-sdk-go-v2/service/ssm v1.55.1/go.mod h1:az8SwCal1RPwT2TBBfLXW4iMEgX0Pkdv4qXNRDQwMmA=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.1 h1:uffgV7K0W1uX7wJ0wQZQiSElKKwX+txKpNAeqBSBaTs=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.1/go.mod h1:Np9vCZ47Hp/GjNvPVy2MLNwc1oFxe86Hso2cMjHH0i0=
-github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.0 h1:0hXgMxu4vAkgPb6HVu+rOH7jQecQdtYA3MK98JOKP58=
-github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.0/go.mod h1:myzq95kUgPEjfIrcKw1Vkim53/HS/TzjZFsXLvZjYao=
+github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.1 h1:/T/vqfErQUnZgbfdqmHrt1TR61VtCSm2rkaHwi2ENJw=
+github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.1/go.mod h1:/C/iW5qZOiBDoFWFZuIA3JYJB1E6P6GB4nKVr+tJsCI=
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.0 h1:Hakxr1VEEoqdZJrzztF/7B885LTXIAigVjY9+OiW7CA=
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.0/go.mod h1:nqS9HQTVbgmhKJmYw8OlHRcODdFRTL8t0cOO8qyWQNg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.1 h1:aAIr0WhAgvKrxZtkBqne87Gjmd7/lJVTFkR2l2yuhL8=

--- a/go.sum
+++ b/go.sum
@@ -428,8 +428,8 @@ github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.1 h1:Aep8GZWLKsNy7G
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.1/go.mod h1:gqG9ZuJw0eDiKHJZLzaT5zNR9v3Iqzjwe0XFS2hKY7s=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.1 h1:ja7tjSd77ceL6V+a/87qKOeVS+dRqWYa94ZoZf5hwrQ=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.1/go.mod h1:UgHGSK9vLH9ACEQlppeJGr8DeDTk0NfADpBU60YkxeI=
-github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.0 h1:Z7Ath4jnwTlSEZrwoIlJBQ2VsmZyK2LikMyVCkbFIw0=
-github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.0/go.mod h1:PFt3nGZViJqO6OBdi2tqIg2e5WfqrXIngLCWWGudtA4=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.1 h1:7K5hiNaLCz0f/N621ySn1TKed8Iq8yqhmqsMkpoMk84=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.1/go.mod h1:Icia4XxLK8BIFOOGJk50caAqOspWxEGVHrBG4Ex2xLI=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.0 h1:6g52Jw3Kkcwapx0Zw0Sb2685agYB13/c/cI0Ug/eMvA=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.0/go.mod h1:Icyb01vb5rarCy2O62IWhC+uuUswzYy5CkDwLA1w+bY=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.45.0 h1:rwDRzOudNWFLRmpHIC6zZjGKovvgdfobPgXn/aXTdcs=

--- a/go.sum
+++ b/go.sum
@@ -464,8 +464,8 @@ github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.1 h1:5Z5aKDslmsUbIyZXJ5V1
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.1/go.mod h1:mmLGDyo4VuWb+IsAabryb/9iaCXjGTHT/j2UM1/wraw=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.1 h1:0Mi6OpfXLojFhx2sVr2jPEddQw2SVwaWXzyawSBMSRo=
 github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.1/go.mod h1:ZqIAvqEz4wsGlqthry91c6G94C3bY9tBr7GyC/G3XBg=
-github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.0 h1:YJDXIKbdPuDFzwAntG1wiIWy2+2maPmZSK5zLoxnJeg=
-github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.0/go.mod h1:e92wJ1h3L8kZQcEzj5d1lhedkBhgP5dJvKbVi+KhfPs=
+github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.1 h1:XjrcC7mlT2d6vNt4Z7YVb7vn0c2Xlrgz6K/eDKcwjkk=
+github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.1/go.mod h1:Q6LJqWYkJiGKOI6lYHdg67jWj1fGFU+O0RSV58e0qTM=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.0 h1:EqcxrBxHzdx8B/w0JOTkZEG0/t3aZaAQNqfRkiftbyA=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.0/go.mod h1:dtAAuoYbebaCBhTq2iToNHR+flXZbM+MBky8hpcMLLQ=
 github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.0 h1:u54yrJFR6ZvKpuECnnuRwHidTyGlUHOGNHtpg1Onq7I=

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,8 @@ github.com/aws/aws-sdk-go-v2/service/waf v1.25.1 h1:ARXTu3Zk2paaSkOIjwP+At5MRsga
 github.com/aws/aws-sdk-go-v2/service/waf v1.25.1/go.mod h1:kfz9Qw0tfmgiviSMRebO8VndS9nWadnMRCfRWLfdfFE=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.1 h1:UpQRGrJiUGg7LTO64ISmAQfUlYbIISKQBMRKWt73az8=
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.25.1/go.mod h1:feJTuhX73shl7IOkO60NPGLD3JqGp8tlPEoJYTQx/to=
-github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.0 h1:KX07HLsIMbFwG/Z7GEgz7BcRCIih8i9/mrVQ+as3VWU=
-github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.0/go.mod h1:HbRx9F7QUM5rREHq6Dk8htxe+8a7QWUhseIBwAtAn9M=
+github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.1 h1:1UQEx2IPoBnVd3Fue55GKwLQV91gWaX8gTeDdJlOD/4=
+github.com/aws/aws-sdk-go-v2/service/wafv2 v1.54.1/go.mod h1:czYEoDBD1goOpyeHLPK6fsqRoZH04T77pxo67YPA0g8=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.0 h1:AvCS0hEflN2PYQ7kn9s+0x6wIwLGru/wSXkBBeFRLV8=
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.0/go.mod h1:rzBMeN2c3ZF8BFRCfzJHO7ATmPsqEjtatQoxjGR3peg=
 github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2 h1:VN3Qydtdl3UlJRHVxQxSP1d8I5gtvT5zdaCCAfZST7Y=

--- a/go.sum
+++ b/go.sum
@@ -512,8 +512,8 @@ github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.1 h1:uLHm3amWf+9rZOm4NYLXU
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.1/go.mod h1:xZiTBcmY83As+lrrDK9O4/0jOwfpNbNAQq2toD6Fs0E=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.1 h1:cbZsfPVqP0EXJrcYmzBtSHzeI7Rh/T11Ldij+x4MqTw=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.1/go.mod h1:gbQKi0ClVV8cLYjVHaeuw9mYaQDMNTY/ljWfN1M20Fs=
-github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.0 h1:lCwcIvhH/pjh1yS9qmHhqahFAvw/BzJwfMcOx2X08dk=
-github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.0/go.mod h1:ntNwtSXaEI66Ih0dBCDkaGDCvKNYEp3MR5D2xvt8KOI=
+github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.1 h1:NmND1B6iw4JlL+QtdjY6wBmcu4dIgU9f2db0OeHclk8=
+github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.1/go.mod h1:2YEqAmt6JZvJPf/N7AJbXlEZxxE+O491DfLfoqUqh3U=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.0 h1:yDMWyH7Y2v4FlWyxVvphHofmDoAqteraYzgsRcIXzbo=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.0/go.mod h1:GmUujOo0WwtRAGmBCpD6sY8VcJg1xKeFEePIqwLjles=
 github.com/aws/aws-sdk-go-v2/service/transfer v1.52.0 h1:aKBQyfTYN9Yk7l9FRHZIdXCDn1EZ6t63/97H5Tl+lsA=

--- a/go.sum
+++ b/go.sum
@@ -454,8 +454,8 @@ github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.1 h1:MnaHGq7h+H1Vp4g/dSgCZ
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.28.1/go.mod h1:lu9ExP0KNREiicRRO+cAPdFHwWOADcO6rchUX0AKC18=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.1 h1:WZI/wXuY6zG1JSiOO+mritaa3rlXcnGaXYxT0jXwMHU=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.1/go.mod h1:jE/zSskmE910W52Dz9OU2X4qCV+5QQntuqcEYtZr+sg=
-github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.0 h1:Ab6KTtzTUlHCXRrFzR3VoBnDZWXJbq74SIPrJ9JPrI0=
-github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.0/go.mod h1:72FLP4wQfEC7OGz4Iwa9I4WHZUO/Fho5XvXXeF/A9xY=
+github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.1 h1:az/RRfnWVUmHcpc9OLkXIm81S9ixVYzzmqCyec4Cml8=
+github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.1/go.mod h1:vUcSJmzbhlc4bYUUexFD6sHqln4rKDvLMvhfvMAeaUY=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.28.0 h1:9YWh3m74QgbQcBfKNt2au59+vy6UYxT/ajiGBonwvUY=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.28.0/go.mod h1:PCN14vMhDnj5B+BXEgTdc1OVJ4D3M2KfVa7QGTCa6eY=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.0 h1:POvqkPd+H/B6No9py/7c//RRVbSp75wtN8nsd/LGHw0=

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.1 h1:MmT9KqFTmdbv8l/5cp76/
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.1/go.mod h1:r1BKM29D3qtTeefZlyFHlNDab2P1DSmGBmaefmrT9AU=
 github.com/aws/aws-sdk-go-v2/service/ram v1.29.1 h1:cjdxjGObaYoGQ0Zt/whkpudg3NvZNRUQLWpmAKKrNaE=
 github.com/aws/aws-sdk-go-v2/service/ram v1.29.1/go.mod h1:m24XUsed393gJQDEQD2qeQYd1uYPvULjhd058dSnvBk=
-github.com/aws/aws-sdk-go-v2/service/rbin v1.20.0 h1:nTxhnIrEDPqX61qQ5HwNGbg4uYrkudfMI/cNowh7xbA=
-github.com/aws/aws-sdk-go-v2/service/rbin v1.20.0/go.mod h1:Wku6F7vWrPVEljMjR4l/YFOqxaAYygUwF52brnF1Lfo=
+github.com/aws/aws-sdk-go-v2/service/rbin v1.20.1 h1:JUJ0hy5GGOIA1zRvPJZ0ogLstQFWdE0f//nZycMu+Gw=
+github.com/aws/aws-sdk-go-v2/service/rbin v1.20.1/go.mod h1:amSW5uKZDHYqNL68oQTj9l0gTAo/2Dp9scSFyzyGOLw=
 github.com/aws/aws-sdk-go-v2/service/rds v1.87.0 h1:f7u5jzUHaIIn5F121ortA0g2yDDWiPeTw2lWrgk9+ZA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.87.0/go.mod h1:agnQGhYbHXxPM2+zZH4WZIpki6IDU6zFGzfOlnu+1Ow=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.48.0 h1:kUEB7p3N8z/qpREJHtHdBtjCoLljXiuybWBcQgYjfuI=

--- a/go.sum
+++ b/go.sum
@@ -502,8 +502,8 @@ github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.1 h1:5utEDeHqFaLkSANGQqIo2wU
 github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.1/go.mod h1:AeSmm9JxztoCEt6gQJw0NtdUT2jM9QSnzMn6Z87B6Rc=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.1 h1:J6kIsIkgFOaU6aKjigXJoue1XEHtKIIrpSh4vKdmRTs=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.1/go.mod h1:2V2JLP7tXOmUbL3Hd1ojq+774t2KUAEQ35//shoNEL0=
-github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.0 h1:YRCmsCb/6T536pJyWQg8iKS2kL4Qlw9MhF7iBgNeJWI=
-github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.0/go.mod h1:tUV1L536ZC4vHqvhCcpSKjpT4779Q/7JSrIXbgJ+LbU=
+github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.1 h1:Y13JcmFg9xS3dUMvH91Zt9OoRk/y4EkvWDwhHVhKZ1w=
+github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.1/go.mod h1:Xbz+Dpc4yauZxeAWJoyamT2ckQjFwfbNj/1CUxM+XhQ=
 github.com/aws/aws-sdk-go-v2/service/sts v1.32.1 h1:q76Ig4OaJzVJGNUSGO3wjSTBS94g+EhHIbpY9rPvkxs=
 github.com/aws/aws-sdk-go-v2/service/sts v1.32.1/go.mod h1:664dajZ7uS7JMUMUG0R5bWbtN97KECNCVdFDdQ6Ipu8=
 github.com/aws/aws-sdk-go-v2/service/swf v1.27.0 h1:LSUYrSjhBj26URDk+8K7mvjS8Syx6PmdViZeOLO9iw8=

--- a/go.sum
+++ b/go.sum
@@ -432,8 +432,8 @@ github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.1 h1:7K5hiNa
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.1/go.mod h1:Icia4XxLK8BIFOOGJk50caAqOspWxEGVHrBG4Ex2xLI=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.1 h1:E8qmhSDhPJv/qMyVHAv76bBX8WX6wXh2vkcKzso/4EU=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.1/go.mod h1:HTvMdQF1o1l4cMIl5USp4uF93ItioP8/MX+6XRZc8iU=
-github.com/aws/aws-sdk-go-v2/service/route53 v1.45.0 h1:rwDRzOudNWFLRmpHIC6zZjGKovvgdfobPgXn/aXTdcs=
-github.com/aws/aws-sdk-go-v2/service/route53 v1.45.0/go.mod h1:NAmFsZ4aGISCGa2nX+EGxPQGukb/z+XwriLW0i+EHKs=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.45.1 h1:5TrG9eUsK9DSBgEjDBUFejVflHcO8N26hxYAip/By78=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.45.1/go.mod h1:ouWuMuHh26dNYAVQzo0IlE857OEdKzkTf6oTYdSvy+4=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.0 h1:e+u19/iuSeOCuGScwu3xnIh8BoVFioDEXYGs02fDbFI=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.0/go.mod h1:s7xQfc5XS0ZxLGI1gvJagVrh+WbgEaGaAPxYBMUTowo=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.0 h1:0beyA/a9AGG3sId10n9RJ5sHFDKnnC1Fe1CUsdA6t4I=

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.1 h1:uffgV7K0W1uX7wJ0wQZQ
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.1/go.mod h1:Np9vCZ47Hp/GjNvPVy2MLNwc1oFxe86Hso2cMjHH0i0=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.1 h1:/T/vqfErQUnZgbfdqmHrt1TR61VtCSm2rkaHwi2ENJw=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.1/go.mod h1:/C/iW5qZOiBDoFWFZuIA3JYJB1E6P6GB4nKVr+tJsCI=
-github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.0 h1:Hakxr1VEEoqdZJrzztF/7B885LTXIAigVjY9+OiW7CA=
-github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.0/go.mod h1:nqS9HQTVbgmhKJmYw8OlHRcODdFRTL8t0cOO8qyWQNg=
+github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.1 h1:cNRhbqRpKlnsXb4UwbN6c7FEmLVBxmfe+JashQ0ud6c=
+github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.1/go.mod h1:lSR5AxwEVIXpbielpsJrJfa9agreU2+zfPegDjuj+bw=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.1 h1:aAIr0WhAgvKrxZtkBqne87Gjmd7/lJVTFkR2l2yuhL8=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.1/go.mod h1:8XhxGMWUfikJuginPQl5SGZ0LSJuNX3TCEQmFWZwHTM=
 github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.0 h1:P9RiUfxhNwnW471xdobvUB4fr0OEqL1AafmkbMTehak=

--- a/go.sum
+++ b/go.sum
@@ -436,8 +436,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.45.1 h1:5TrG9eUsK9DSBgEjDBUFejVf
 github.com/aws/aws-sdk-go-v2/service/route53 v1.45.1/go.mod h1:ouWuMuHh26dNYAVQzo0IlE857OEdKzkTf6oTYdSvy+4=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.1 h1:qphFA2tBcmIkbfFv+XzTyyIQuv2dXMVRgWi8b7twbsY=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.1/go.mod h1:SMj7WSUGwV7U8QFpZxPI7kD0lRCqB905lUVDt8EtQb8=
-github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.0 h1:0beyA/a9AGG3sId10n9RJ5sHFDKnnC1Fe1CUsdA6t4I=
-github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.0/go.mod h1:4OFMwxsrRSVQ1paBt853323cxg6ZJwpLsMtjMZuBDdY=
+github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.1 h1:jRm3L87f92Z2Arf7fjBxSQkUQIrYcAfoFsv6nCCe8Z0=
+github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.1/go.mod h1:EVI9MMbDdd8XLunof1agY0v0eFvxFMZwgvu/kzO7mL0=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.0 h1:OieU9CF8Mkc/Yjg9tY+oG2y2HFJrynaZEgVl7pAuh8w=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.0/go.mod h1:qh4z11zzitV4EyEpFLTUReJA/ZxfiChkpeP4zyqUN0U=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.0 h1:d92tQ6JVqk64YvZgx/tdaknym1wmAZAuvip7Z3g5qAU=

--- a/go.sum
+++ b/go.sum
@@ -434,8 +434,8 @@ github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.1 h1:E8qmhSDhPJv/qMyVHA
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.1/go.mod h1:HTvMdQF1o1l4cMIl5USp4uF93ItioP8/MX+6XRZc8iU=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.45.1 h1:5TrG9eUsK9DSBgEjDBUFejVflHcO8N26hxYAip/By78=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.45.1/go.mod h1:ouWuMuHh26dNYAVQzo0IlE857OEdKzkTf6oTYdSvy+4=
-github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.0 h1:e+u19/iuSeOCuGScwu3xnIh8BoVFioDEXYGs02fDbFI=
-github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.0/go.mod h1:s7xQfc5XS0ZxLGI1gvJagVrh+WbgEaGaAPxYBMUTowo=
+github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.1 h1:qphFA2tBcmIkbfFv+XzTyyIQuv2dXMVRgWi8b7twbsY=
+github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.1/go.mod h1:SMj7WSUGwV7U8QFpZxPI7kD0lRCqB905lUVDt8EtQb8=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.0 h1:0beyA/a9AGG3sId10n9RJ5sHFDKnnC1Fe1CUsdA6t4I=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.0/go.mod h1:4OFMwxsrRSVQ1paBt853323cxg6ZJwpLsMtjMZuBDdY=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.0 h1:OieU9CF8Mkc/Yjg9tY+oG2y2HFJrynaZEgVl7pAuh8w=

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.1 h1:cNRhbqRpKlnsXb4UwbN6c7FEm
 github.com/aws/aws-sdk-go-v2/service/ssmsap v1.18.1/go.mod h1:lSR5AxwEVIXpbielpsJrJfa9agreU2+zfPegDjuj+bw=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.1 h1:aAIr0WhAgvKrxZtkBqne87Gjmd7/lJVTFkR2l2yuhL8=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.1/go.mod h1:8XhxGMWUfikJuginPQl5SGZ0LSJuNX3TCEQmFWZwHTM=
-github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.0 h1:P9RiUfxhNwnW471xdobvUB4fr0OEqL1AafmkbMTehak=
-github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.0/go.mod h1:q3QK/e4GiZ05aXa8rO3rYmPAGUDalq6J8TdirT7FPrE=
+github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.1 h1:5utEDeHqFaLkSANGQqIo2wUORtiy6txu8hD8AWayfzU=
+github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.29.1/go.mod h1:AeSmm9JxztoCEt6gQJw0NtdUT2jM9QSnzMn6Z87B6Rc=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.1 h1:J6kIsIkgFOaU6aKjigXJoue1XEHtKIIrpSh4vKdmRTs=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.1/go.mod h1:2V2JLP7tXOmUbL3Hd1ojq+774t2KUAEQ35//shoNEL0=
 github.com/aws/aws-sdk-go-v2/service/storagegateway v1.34.0 h1:YRCmsCb/6T536pJyWQg8iKS2kL4Qlw9MhF7iBgNeJWI=

--- a/go.sum
+++ b/go.sum
@@ -424,8 +424,8 @@ github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.1 h1:a1/NIV+lVPNmfv8V1Naq
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.1/go.mod h1:a6paTJsNFBXDDm8LAGe2RTOkG4x5hrgXU66qHuYFA3g=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.1 h1:LHg2Om8yDgFc1mHsNeGlkTMn9CkeHsQzSTVXSsi2L+I=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.1/go.mod h1:ylHgpVAjcgAhnh1diFGal0xNCLhY4AS7ofsgxweU+bI=
-github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.0 h1:rW7l5p7yFv16o+Qsh9lbn8irCNxSn+YOwpaiTxirKbs=
-github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.0/go.mod h1:0DLAN293+uvcMXXJi4IQO93kcfx+6vJsHHlNJ9AR/Oc=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.1 h1:Aep8GZWLKsNy7Gr/WT9jjmvXmGypYkOJBZS80iAiLP4=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.1/go.mod h1:gqG9ZuJw0eDiKHJZLzaT5zNR9v3Iqzjwe0XFS2hKY7s=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.0 h1:KO+o+Pw2WdwBKaHgZEFeO+HGo5/mHtWWIbg5iD42oKg=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.0/go.mod h1:oYY+rpubTuKkdfBfpGxMZMMzEgRLGuAvPyK7I1BYbR0=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.0 h1:Z7Ath4jnwTlSEZrwoIlJBQ2VsmZyK2LikMyVCkbFIw0=

--- a/go.sum
+++ b/go.sum
@@ -508,8 +508,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.32.1 h1:q76Ig4OaJzVJGNUSGO3wjSTBS94g
 github.com/aws/aws-sdk-go-v2/service/sts v1.32.1/go.mod h1:664dajZ7uS7JMUMUG0R5bWbtN97KECNCVdFDdQ6Ipu8=
 github.com/aws/aws-sdk-go-v2/service/swf v1.27.1 h1:Fp+M3ovc3hJ8xckuS/7yF8fHm6eujS7nX+OvD2nIyDQ=
 github.com/aws/aws-sdk-go-v2/service/swf v1.27.1/go.mod h1:NBZBIHLdqCtyypd3Rkmljh+yPQNjIPlNqpzFc7o4VMs=
-github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.0 h1:bQEQMQnZy7bJ7YnHqJMOxu+JOTfDALCGcNqymPDgiCQ=
-github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.0/go.mod h1:EVm6DB4C55u5/gAv015al/XfTNbJC8P7oC2vC9Bsk+0=
+github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.1 h1:uLHm3amWf+9rZOm4NYLXUSNFW4i5sZkKMtDIo2rX+2A=
+github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.1/go.mod h1:xZiTBcmY83As+lrrDK9O4/0jOwfpNbNAQq2toD6Fs0E=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.0 h1:m+jcCFKJjHnT28uKkiYavY7AmA14teuwCsEsUxEZtDQ=
 github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.0/go.mod h1:jDhWkpACdYr96xcqQKCwJcpPO+LL5KvPssHWbeKlbO8=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.0 h1:lCwcIvhH/pjh1yS9qmHhqahFAvw/BzJwfMcOx2X08dk=

--- a/go.sum
+++ b/go.sum
@@ -476,8 +476,8 @@ github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.1 h1:LMT5ZSXxB8UlcKNraP
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.1/go.mod h1:Pef3zWt3qUxpxVnAoaXoiZfiCaJ5jr0ys6cqSJQuEio=
 github.com/aws/aws-sdk-go-v2/service/ses v1.28.1 h1:eulUIq+v/IN4akDHBY3NFKVfJ+6Yd/Fl5fxgUL/cFiY=
 github.com/aws/aws-sdk-go-v2/service/ses v1.28.1/go.mod h1:6z25WLQt133DHJGT7S+42KFqsr7fv7J1VhLTBJIQrxc=
-github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.0 h1:XbfGIngoLQHGGQySy9zAD3OXcJn8+rpl9im2pO6BbN4=
-github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.0/go.mod h1:ZrKaLqQnpEHJPSRJrfWtmUdW7/O0qtdWrY1ynCwFvxw=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.1 h1:GOv1qRwi+/KU6LrLs5Q5Y7fiW33Vgwi+GzYKj8FzLak=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.1/go.mod h1:4kVGvyNjR6/irI+0VQoOZpVehKKKIZKTVryG6wK9cHw=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.33.0 h1:lSci2Dcan6foJsXv0RJNO+yOJ/mYPq7tABqy9Pm8QRc=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.33.0/go.mod h1:JUuJaZ8MuowjLVqEgCbk9kMtvap7IksP3sgXAIjmI58=
 github.com/aws/aws-sdk-go-v2/service/shield v1.29.0 h1:0SWAgFo5dKyltXcu+0YJa//R2kDIOJ4MXVJ4NSnudBI=

--- a/go.sum
+++ b/go.sum
@@ -532,8 +532,8 @@ github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.1 h1:sCCIbinmMoh07O1G
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.34.1/go.mod h1:6mnIS90i77LshrjcIW7NM/gnH2evwvCyfxJZxkxRXnk=
 github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2 h1:VN3Qydtdl3UlJRHVxQxSP1d8I5gtvT5zdaCCAfZST7Y=
 github.com/aws/aws-sdk-go-v2/service/worklink v1.23.2/go.mod h1:Z3RLpIq4q49syd921XdsKeD584kPu89iKTEjluh7908=
-github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.0 h1:vb58sKt9Z3QVVcXYchKZllS9Z0Rqk/1O0RYX1qu6Aaw=
-github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.0/go.mod h1:20HmpNqARbg7M3XuF0b+VC7+WaW6aeGmsT7Lm2bybfM=
+github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.1 h1:mPunwUzwoWt3ReX5j8pjYShsU7HXcFXcQ3/joQGU/t0=
+github.com/aws/aws-sdk-go-v2/service/workspaces v1.48.1/go.mod h1:OJXicfvTfPBmIAup2u5W22/mC3fjX5/PvqIuxG7Jrtg=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.0 h1:5FXWXn9U6xLJoKpauNaRwhGv4mfKxUUaZKl7J8RepLE=
 github.com/aws/aws-sdk-go-v2/service/workspacesweb v1.24.0/go.mod h1:uXHeCA2U0bpd9L7DZUn56gOjhmzMGZJh1QzNnMjlgdM=
 github.com/aws/aws-sdk-go-v2/service/xray v1.29.0 h1:iUFQp4OIJVY9cNVUX1NKC/lNIjR5a+53iV23rRRNY8E=

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.1 h1:LHg2Om8yDgFc1mHsNe
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.1/go.mod h1:ylHgpVAjcgAhnh1diFGal0xNCLhY4AS7ofsgxweU+bI=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.1 h1:Aep8GZWLKsNy7Gr/WT9jjmvXmGypYkOJBZS80iAiLP4=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.1/go.mod h1:gqG9ZuJw0eDiKHJZLzaT5zNR9v3Iqzjwe0XFS2hKY7s=
-github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.0 h1:KO+o+Pw2WdwBKaHgZEFeO+HGo5/mHtWWIbg5iD42oKg=
-github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.0/go.mod h1:oYY+rpubTuKkdfBfpGxMZMMzEgRLGuAvPyK7I1BYbR0=
+github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.1 h1:ja7tjSd77ceL6V+a/87qKOeVS+dRqWYa94ZoZf5hwrQ=
+github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.1/go.mod h1:UgHGSK9vLH9ACEQlppeJGr8DeDTk0NfADpBU60YkxeI=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.0 h1:Z7Ath4jnwTlSEZrwoIlJBQ2VsmZyK2LikMyVCkbFIw0=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.0/go.mod h1:PFt3nGZViJqO6OBdi2tqIg2e5WfqrXIngLCWWGudtA4=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.0 h1:6g52Jw3Kkcwapx0Zw0Sb2685agYB13/c/cI0Ug/eMvA=

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.1 h1:jRm3L87f92Z2Arf7f
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.4.1/go.mod h1:EVI9MMbDdd8XLunof1agY0v0eFvxFMZwgvu/kzO7mL0=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.1 h1:3X4GcNR+YMYpVMhdWyLkF7T/JVeGNi+VI8+OMe+BEUQ=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.1/go.mod h1:UczKD5EZACP66D69wEHkb5xtyE+Nqg7hrVmIC0Y7i+8=
-github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.0 h1:d92tQ6JVqk64YvZgx/tdaknym1wmAZAuvip7Z3g5qAU=
-github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.0/go.mod h1:qZ5z3iSFXz0tUAuO9AefVpLvaaCyK8bfxCCfGa+B6zk=
+github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.1 h1:ulttJb/snhsV6UCwRVcU7dpOQdlhRdax3mQLiNCytuA=
+github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.1/go.mod h1:5qzPKTeJWm7+jezdxx1wf3ABiQZJr6wc3IhDcPHcjpo=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.0 h1:5M/EgVtiXZGIgdoAuGc83/VwdgHpTMkRwSgvabrQopw=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.0/go.mod h1:sJHJPZc9VrEGRlrXr1hfFmidLzj6IL/UuqhcuupZFik=
 github.com/aws/aws-sdk-go-v2/service/rum v1.21.0 h1:froFlZL0sQHnS6E5mN3SuiRAl87v22gyLqMdG+Vb+3Q=

--- a/go.sum
+++ b/go.sum
@@ -404,8 +404,8 @@ github.com/aws/aws-sdk-go-v2/service/pricing v1.32.1 h1:Z9g1Xv92iFWsecXPqZWCghcy
 github.com/aws/aws-sdk-go-v2/service/pricing v1.32.1/go.mod h1:ZZKslHgGl11WsRaQXXG3b7R/IDAQ7CAjf+4TNRYh6D4=
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.1 h1:LSWNrEnNfO3/WB0nLHTYX0opxtFQRA7zw3oyZzHPREU=
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.13.1/go.mod h1:pDCTAL74HuN9jgrRMcbiCUE7+Xd6B108rvQNtn9V57M=
-github.com/aws/aws-sdk-go-v2/service/qldb v1.25.0 h1:YHAUmDQQnyrvqrb4r04JaENU/X/p7j6Epm+YaZrXwKI=
-github.com/aws/aws-sdk-go-v2/service/qldb v1.25.0/go.mod h1:R31TC0sdnEyqyd7jf+5PDOLzv5Ld3R3NrBn4tyTXn1Y=
+github.com/aws/aws-sdk-go-v2/service/qldb v1.25.1 h1:5NC/v2lzEL975KGLTCGCK+KQgoOnr+QRCo22WP7nvac=
+github.com/aws/aws-sdk-go-v2/service/qldb v1.25.1/go.mod h1:BgW5p6T2g9GkVBUbxvhvtriEv4vnT/L3YCe3kDBa0j0=
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.0 h1:DonpKyb7frAZkVQFN8QoVtWe+k4BK+FcfPOFkbRsurs=
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.76.0/go.mod h1:becAKh34jIXQ0ux2lz93ITt/AQzn+kpl/tuBi2Esxgg=
 github.com/aws/aws-sdk-go-v2/service/ram v1.29.0 h1:g5Nn5xdCNdxk2nU2nIXrpB3MMlqhNlhb4qnhznZxNds=

--- a/go.sum
+++ b/go.sum
@@ -510,8 +510,8 @@ github.com/aws/aws-sdk-go-v2/service/swf v1.27.1 h1:Fp+M3ovc3hJ8xckuS/7yF8fHm6eu
 github.com/aws/aws-sdk-go-v2/service/swf v1.27.1/go.mod h1:NBZBIHLdqCtyypd3Rkmljh+yPQNjIPlNqpzFc7o4VMs=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.1 h1:uLHm3amWf+9rZOm4NYLXUSNFW4i5sZkKMtDIo2rX+2A=
 github.com/aws/aws-sdk-go-v2/service/synthetics v1.29.1/go.mod h1:xZiTBcmY83As+lrrDK9O4/0jOwfpNbNAQq2toD6Fs0E=
-github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.0 h1:m+jcCFKJjHnT28uKkiYavY7AmA14teuwCsEsUxEZtDQ=
-github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.0/go.mod h1:jDhWkpACdYr96xcqQKCwJcpPO+LL5KvPssHWbeKlbO8=
+github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.1 h1:cbZsfPVqP0EXJrcYmzBtSHzeI7Rh/T11Ldij+x4MqTw=
+github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb v1.6.1/go.mod h1:gbQKi0ClVV8cLYjVHaeuw9mYaQDMNTY/ljWfN1M20Fs=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.0 h1:lCwcIvhH/pjh1yS9qmHhqahFAvw/BzJwfMcOx2X08dk=
 github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.29.0/go.mod h1:ntNwtSXaEI66Ih0dBCDkaGDCvKNYEp3MR5D2xvt8KOI=
 github.com/aws/aws-sdk-go-v2/service/transcribe v1.41.0 h1:yDMWyH7Y2v4FlWyxVvphHofmDoAqteraYzgsRcIXzbo=

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,8 @@ github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.1 h1:ja7tjSd77ceL6V+a/
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.1/go.mod h1:UgHGSK9vLH9ACEQlppeJGr8DeDTk0NfADpBU60YkxeI=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.1 h1:7K5hiNaLCz0f/N621ySn1TKed8Iq8yqhmqsMkpoMk84=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.25.1/go.mod h1:Icia4XxLK8BIFOOGJk50caAqOspWxEGVHrBG4Ex2xLI=
-github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.0 h1:6g52Jw3Kkcwapx0Zw0Sb2685agYB13/c/cI0Ug/eMvA=
-github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.0/go.mod h1:Icyb01vb5rarCy2O62IWhC+uuUswzYy5CkDwLA1w+bY=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.1 h1:E8qmhSDhPJv/qMyVHAv76bBX8WX6wXh2vkcKzso/4EU=
+github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.16.1/go.mod h1:HTvMdQF1o1l4cMIl5USp4uF93ItioP8/MX+6XRZc8iU=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.45.0 h1:rwDRzOudNWFLRmpHIC6zZjGKovvgdfobPgXn/aXTdcs=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.45.0/go.mod h1:NAmFsZ4aGISCGa2nX+EGxPQGukb/z+XwriLW0i+EHKs=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.27.0 h1:e+u19/iuSeOCuGScwu3xnIh8BoVFioDEXYGs02fDbFI=

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.1 h1:WZI/wXuY6zG1JSiOO+mri
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.1/go.mod h1:jE/zSskmE910W52Dz9OU2X4qCV+5QQntuqcEYtZr+sg=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.1 h1:az/RRfnWVUmHcpc9OLkXIm81S9ixVYzzmqCyec4Cml8=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.12.1/go.mod h1:vUcSJmzbhlc4bYUUexFD6sHqln4rKDvLMvhfvMAeaUY=
-github.com/aws/aws-sdk-go-v2/service/schemas v1.28.0 h1:9YWh3m74QgbQcBfKNt2au59+vy6UYxT/ajiGBonwvUY=
-github.com/aws/aws-sdk-go-v2/service/schemas v1.28.0/go.mod h1:PCN14vMhDnj5B+BXEgTdc1OVJ4D3M2KfVa7QGTCa6eY=
+github.com/aws/aws-sdk-go-v2/service/schemas v1.28.1 h1:Q9/y3bAOlDihURNAmSSiMFAkKAX3GfiKkIJxbx8X/9M=
+github.com/aws/aws-sdk-go-v2/service/schemas v1.28.1/go.mod h1:nZ1tceWvNkUA+TZG6HgT+dJQ1wOjk+RnW9lkx4oJAeg=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.0 h1:POvqkPd+H/B6No9py/7c//RRVbSp75wtN8nsd/LGHw0=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.0/go.mod h1:G2a06OQdRNbG8bfvdYSFpA9CBuaTQrmnrIyGuU6OgXU=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.0 h1:2aYy17RgJLQ/7byuUnupyG1zwOa/meg7eTQOP4NWBRM=

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.1 h1:nHj7BRE9VP5NB
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.23.1/go.mod h1:VNC+ru3vCew5IVClkwo7kqrmCH5uROBqbjPNQGZErdQ=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.1 h1:a1/NIV+lVPNmfv8V1NaqcMjNwJ/QTqyWcEwRYgOAOEg=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.45.1/go.mod h1:a6paTJsNFBXDDm8LAGe2RTOkG4x5hrgXU66qHuYFA3g=
-github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.0 h1:gINVcGi9Z6Wlw84Ovi7PVgRQKG7iy+XO6cC4swswZcU=
-github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.0/go.mod h1:omuRZH8owz4Ng2SJd6qZoJJa994Z42aeJjID+PW2TUM=
+github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.1 h1:LHg2Om8yDgFc1mHsNeGlkTMn9CkeHsQzSTVXSsi2L+I=
+github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.26.1/go.mod h1:ylHgpVAjcgAhnh1diFGal0xNCLhY4AS7ofsgxweU+bI=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.0 h1:rW7l5p7yFv16o+Qsh9lbn8irCNxSn+YOwpaiTxirKbs=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.15.0/go.mod h1:0DLAN293+uvcMXXJi4IQO93kcfx+6vJsHHlNJ9AR/Oc=
 github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.27.0 h1:KO+o+Pw2WdwBKaHgZEFeO+HGo5/mHtWWIbg5iD42oKg=

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,8 @@ github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.1 h1:3X4
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.25.1/go.mod h1:UczKD5EZACP66D69wEHkb5xtyE+Nqg7hrVmIC0Y7i+8=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.1 h1:ulttJb/snhsV6UCwRVcU7dpOQdlhRdax3mQLiNCytuA=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.21.1/go.mod h1:5qzPKTeJWm7+jezdxx1wf3ABiQZJr6wc3IhDcPHcjpo=
-github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.0 h1:5M/EgVtiXZGIgdoAuGc83/VwdgHpTMkRwSgvabrQopw=
-github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.0/go.mod h1:sJHJPZc9VrEGRlrXr1hfFmidLzj6IL/UuqhcuupZFik=
+github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.1 h1:YZ5lTsgswKaOUpBAGOJ2A5L85GwDcDOF4WG4YZUPFA0=
+github.com/aws/aws-sdk-go-v2/service/route53resolver v1.32.1/go.mod h1:c1qyH3e8KWjb+cPlKVTnr/6vjxd1kUFF/5SqCk4WL44=
 github.com/aws/aws-sdk-go-v2/service/rum v1.21.0 h1:froFlZL0sQHnS6E5mN3SuiRAl87v22gyLqMdG+Vb+3Q=
 github.com/aws/aws-sdk-go-v2/service/rum v1.21.0/go.mod h1:UKSUPazZlk9fEvAQTaHqiSYolcMnSjh2mpABvTwPY5o=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.65.1 h1:HQR79P0F0C2YQOaS2Z+90YK9DH22z9D6Neplaj0yuy4=

--- a/go.sum
+++ b/go.sum
@@ -486,8 +486,8 @@ github.com/aws/aws-sdk-go-v2/service/signer v1.26.1 h1:hdKdIuAEHsy7zhuqX0xe2JaRY
 github.com/aws/aws-sdk-go-v2/service/signer v1.26.1/go.mod h1:CMDWlKzjksZLIAYXq8lyZsA3B66QeYxH6mY/cbZ37kA=
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.1 h1:SBxarBZKkHCw7zAGORjjaU3KH8/PrMgzMZ3V+ntKmKk=
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.1/go.mod h1:b54PFWcn1ium9LTWf+5QbPLMSVbfktXFWZtcLtxYSDQ=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.36.0 h1:t+b3U3fmUiuXyeBhp9c3BpaEQS7bzp/CoGCuj8DW6r8=
-github.com/aws/aws-sdk-go-v2/service/sqs v1.36.0/go.mod h1:ICKQNsIj2Q6IXn5nF+ADptwAM9jX5JFWbnIfRR+6SqE=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.36.1 h1:8VpPO5IYvP7ODERfS59E8R+aZixH07EMb4MVENl7WUo=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.36.1/go.mod h1:FPCleXfdVS/8g4dT8ZRWGQ8hn9xrqJzqtEw6iS2rWp4=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.55.0 h1:tXrDYWutZsSAtqilgdOkn/DMLdIhTZoyA5J7NgwNfyc=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.55.0/go.mod h1:Brz7JZ/wuntsPXH0D0dgZsb/IKr1+slD0eL+k967oLo=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.0 h1:2I9B3FdEvPqsu9si4ZN4/iL0GPz22AmdA6EOk9apxrw=

--- a/go.sum
+++ b/go.sum
@@ -480,8 +480,8 @@ github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.1 h1:GOv1qRwi+/KU6LrLs5Q5Y7fiW3
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.1/go.mod h1:4kVGvyNjR6/irI+0VQoOZpVehKKKIZKTVryG6wK9cHw=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.33.1 h1:39B84msn/lmkK7OgHhvHJfbZZx9PLpqFZuSbu/ZQIrQ=
 github.com/aws/aws-sdk-go-v2/service/sfn v1.33.1/go.mod h1:5EpOKPBSOtPLqbE1rJ+RypmehSHgwpnDyrRzL3gt3yE=
-github.com/aws/aws-sdk-go-v2/service/shield v1.29.0 h1:0SWAgFo5dKyltXcu+0YJa//R2kDIOJ4MXVJ4NSnudBI=
-github.com/aws/aws-sdk-go-v2/service/shield v1.29.0/go.mod h1:dcWFJreo88UytaYe/TEdxbcjbz8v3TZPmfKkSWQUo+4=
+github.com/aws/aws-sdk-go-v2/service/shield v1.29.1 h1:ycZY4cWJGgQ07knRwETVZZI3XanU26s8LEQNbvY1CYU=
+github.com/aws/aws-sdk-go-v2/service/shield v1.29.1/go.mod h1:9EzkR8jfdQDQaSK4TBit+0fjztMuLUVUBUt0FuJks40=
 github.com/aws/aws-sdk-go-v2/service/signer v1.26.0 h1:e+/9/bl+E9GMzg4o2KuCEz4Alr1YlbCbTMe9CzKl7XI=
 github.com/aws/aws-sdk-go-v2/service/signer v1.26.0/go.mod h1:YZjxkEuuHPXjtibRIeQot92+ku++p9DtwDGi8w20C44=
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.0 h1:QuttYvND/OmttAImqJtsZXYJ6bEoUC2qLi29lhw1lss=

--- a/go.sum
+++ b/go.sum
@@ -462,8 +462,8 @@ github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.1 h1:NxhxUnLx7Bexlz0tc
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.1/go.mod h1:ZOm+hOpec53Pm14NWBDqg1oSj+FtxphlNIUrFo+fJec=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.1 h1:5Z5aKDslmsUbIyZXJ5V14OpauPFCsIBqndIB2QJHUZQ=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.54.1/go.mod h1:mmLGDyo4VuWb+IsAabryb/9iaCXjGTHT/j2UM1/wraw=
-github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.0 h1:Pzs5BqZJ/R+Dv/v4HThy8PK9yloqnHyArjyU1h2T/Ys=
-github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.0/go.mod h1:qGYvx8v5BG54w/e9gFsmZX9dvynw/DwWhYq2QJDJs/o=
+github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.1 h1:0Mi6OpfXLojFhx2sVr2jPEddQw2SVwaWXzyawSBMSRo=
+github.com/aws/aws-sdk-go-v2/service/securitylake v1.18.1/go.mod h1:ZqIAvqEz4wsGlqthry91c6G94C3bY9tBr7GyC/G3XBg=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.0 h1:YJDXIKbdPuDFzwAntG1wiIWy2+2maPmZSK5zLoxnJeg=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.0/go.mod h1:e92wJ1h3L8kZQcEzj5d1lhedkBhgP5dJvKbVi+KhfPs=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.0 h1:EqcxrBxHzdx8B/w0JOTkZEG0/t3aZaAQNqfRkiftbyA=

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,8 @@ github.com/aws/aws-sdk-go-v2/service/sns v1.33.1 h1:SBxarBZKkHCw7zAGORjjaU3KH8/P
 github.com/aws/aws-sdk-go-v2/service/sns v1.33.1/go.mod h1:b54PFWcn1ium9LTWf+5QbPLMSVbfktXFWZtcLtxYSDQ=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.36.1 h1:8VpPO5IYvP7ODERfS59E8R+aZixH07EMb4MVENl7WUo=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.36.1/go.mod h1:FPCleXfdVS/8g4dT8ZRWGQ8hn9xrqJzqtEw6iS2rWp4=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.55.0 h1:tXrDYWutZsSAtqilgdOkn/DMLdIhTZoyA5J7NgwNfyc=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.55.0/go.mod h1:Brz7JZ/wuntsPXH0D0dgZsb/IKr1+slD0eL+k967oLo=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.55.1 h1:HqpHD/vOlIPvVSp9Gy1dSenPXmpWgvcgWrNoVWW3DCg=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.55.1/go.mod h1:az8SwCal1RPwT2TBBfLXW4iMEgX0Pkdv4qXNRDQwMmA=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.0 h1:2I9B3FdEvPqsu9si4ZN4/iL0GPz22AmdA6EOk9apxrw=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.26.0/go.mod h1:zcKz8ylqpcPVWWPMN0i0dQ9TYL6ncuql3si6h9IdJaU=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.34.0 h1:0hXgMxu4vAkgPb6HVu+rOH7jQecQdtYA3MK98JOKP58=

--- a/go.sum
+++ b/go.sum
@@ -468,8 +468,8 @@ github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.1 h1:
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.1/go.mod h1:Q6LJqWYkJiGKOI6lYHdg67jWj1fGFU+O0RSV58e0qTM=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.1 h1:VBB3OMmAUHSYrbdYFXrRCZIhBuYmT0Nj+GyTGmwNaAs=
 github.com/aws/aws-sdk-go-v2/service/servicecatalog v1.32.1/go.mod h1:d240WPXwr71aheedA3e1oNn1TI0YQbST9/oRlt2grko=
-github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.0 h1:u54yrJFR6ZvKpuECnnuRwHidTyGlUHOGNHtpg1Onq7I=
-github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.0/go.mod h1:JG65e6XhAXgat+1AAv+eIfDAj6asV9XNWptNwKfBHqQ=
+github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.1 h1:LsznptbfALbXav1YX8PcxbY0r3XVIJhTrAvArud3Pio=
+github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry v1.30.1/go.mod h1:Hcw30Kzs1CBHG4wS/C90aVWNQxt48SNFyRpO8p+H394=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.0 h1:Fcrhw7pe0vahNqpBoT/crqF92RWcBb/d8umD5Am2SkA=
 github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.33.0/go.mod h1:VIPaV4ryt9Sj7Xt5+AFPGzmP9ZxjX/l9zPx0XKgnPLk=
 github.com/aws/aws-sdk-go-v2/service/servicequotas v1.25.0 h1:IS+tdlxJ7AhPTVIOJC0FDLOxrEF/Jg40J2Q+tOi3jVw=

--- a/go.sum
+++ b/go.sum
@@ -478,8 +478,8 @@ github.com/aws/aws-sdk-go-v2/service/ses v1.28.1 h1:eulUIq+v/IN4akDHBY3NFKVfJ+6Y
 github.com/aws/aws-sdk-go-v2/service/ses v1.28.1/go.mod h1:6z25WLQt133DHJGT7S+42KFqsr7fv7J1VhLTBJIQrxc=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.1 h1:GOv1qRwi+/KU6LrLs5Q5Y7fiW33Vgwi+GzYKj8FzLak=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.36.1/go.mod h1:4kVGvyNjR6/irI+0VQoOZpVehKKKIZKTVryG6wK9cHw=
-github.com/aws/aws-sdk-go-v2/service/sfn v1.33.0 h1:lSci2Dcan6foJsXv0RJNO+yOJ/mYPq7tABqy9Pm8QRc=
-github.com/aws/aws-sdk-go-v2/service/sfn v1.33.0/go.mod h1:JUuJaZ8MuowjLVqEgCbk9kMtvap7IksP3sgXAIjmI58=
+github.com/aws/aws-sdk-go-v2/service/sfn v1.33.1 h1:39B84msn/lmkK7OgHhvHJfbZZx9PLpqFZuSbu/ZQIrQ=
+github.com/aws/aws-sdk-go-v2/service/sfn v1.33.1/go.mod h1:5EpOKPBSOtPLqbE1rJ+RypmehSHgwpnDyrRzL3gt3yE=
 github.com/aws/aws-sdk-go-v2/service/shield v1.29.0 h1:0SWAgFo5dKyltXcu+0YJa//R2kDIOJ4MXVJ4NSnudBI=
 github.com/aws/aws-sdk-go-v2/service/shield v1.29.0/go.mod h1:dcWFJreo88UytaYe/TEdxbcjbz8v3TZPmfKkSWQUo+4=
 github.com/aws/aws-sdk-go-v2/service/signer v1.26.0 h1:e+/9/bl+E9GMzg4o2KuCEz4Alr1YlbCbTMe9CzKl7XI=

--- a/internal/service/securityhub/automation_rule.go
+++ b/internal/service/securityhub/automation_rule.go
@@ -201,7 +201,7 @@ func (r *automationRuleResource) Schema(ctx context.Context, request resource.Sc
 				},
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
-						names.AttrAWSAccountID:               stringFilterSchemaFramework(ctx, 100),
+						names.AttrAWSAccountID:               stringFilterSchemaFramework(ctx, 100), //nolint:mnd // 100 is the maximum number of items
 						"aws_account_name":                   stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"company_name":                       stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"compliance_associated_standards_id": stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
@@ -212,7 +212,7 @@ func (r *automationRuleResource) Schema(ctx context.Context, request resource.Sc
 						"criticality":                        numberFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						names.AttrDescription:                stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"first_observed_at":                  dateFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
-						"generator_id":                       stringFilterSchemaFramework(ctx, 100),
+						"generator_id":                       stringFilterSchemaFramework(ctx, 100), //nolint:mnd // 100 is the maximum number of items
 						names.AttrID:                         stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"last_observed_at":                   dateFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"note_text":                          stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
@@ -226,14 +226,14 @@ func (r *automationRuleResource) Schema(ctx context.Context, request resource.Sc
 						"resource_application_arn":           stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"resource_application_name":          stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"resource_details_other":             mapFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
-						names.AttrResourceID:                 stringFilterSchemaFramework(ctx, 100),
+						names.AttrResourceID:                 stringFilterSchemaFramework(ctx, 100), //nolint:mnd // 100 is the maximum number of items
 						"resource_partition":                 stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"resource_region":                    stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						names.AttrResourceTags:               mapFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						names.AttrResourceType:               stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"severity_label":                     stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"source_url":                         stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
-						"title":                              stringFilterSchemaFramework(ctx, 100),
+						"title":                              stringFilterSchemaFramework(ctx, 100), //nolint:mnd // 100 is the maximum number of items
 						names.AttrType:                       stringFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"updated_at":                         dateFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),
 						"user_defined_fields":                mapFilterSchemaFramework(ctx, defaultFilterSchemaMaxSize),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
The ``aws_securityhub_automation_rule`` resource has ``criteria``  configuration block. Here, the following stringFilter attributes

- [aws_account_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_automation_rule#aws_account_id)
- [generator_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_automation_rule#generator_id)
- [title](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_automation_rule#title)
- [resource_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_automation_rule#resource_id)

are Array Members with a max size of 100 items according to documentation but the code only allows a max of 20 items.

### Relations

Closes #39161

### References

AWS CLI Documentation : https://docs.aws.amazon.com/cli/latest/reference/securityhub/create-automation-rule.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Would require help running the Acceptance Tests.
