### PR TITLE
b: allow aws_iam_account_alias-datasource to return nil

### DIFF
--- a/internal/service/iam/account_alias_data_source.go
+++ b/internal/service/iam/account_alias_data_source.go
@@ -42,7 +42,10 @@ func dataSourceAccountAliasRead(ctx context.Context, d *schema.ResourceData, met
 
 	// 'AccountAliases': [] if there is no alias.
 	if resp == nil || len(resp.AccountAliases) == 0 {
-		return sdkdiag.AppendErrorf(diags, "reading IAM Account Alias: empty result")
+		log.Printf("[DEBUG] No Aliases Associated to Account %s.", meta.(*conns.AWSClient).AccountID)
+		d.SetId(meta.(*conns.AWSClient).AccountID)
+		d.Set("account_alias", nil)
+		return diags
 	}
 
 	alias := resp.AccountAliases[0]


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR is a small change that allows the `aws_iam_account_alias` datasource to return `nil` instead of erroring out when there's no aliases associated to an account. For me it makes sense to return the `accountID` as the ID for the datasource since it's the identifier at the time but I'm open to suggestions.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/39651

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I have a couple of questions related to Acceptance Testing:
1. Can you help me running these tests?
2. Related to the tests setup now, looks like we're executing an account alias creation and then getting it. In order to test this we will need an account without an alias and don't call the `resource "aws_iam_account_alias"` before calling `data "aws_iam_account_alias"` - is this a possibility? I'm basing off this code https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/iam/account_alias_data_source_test.go#L16-L52.

I'd like to get some advice here related to tests.


```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
