### PR TITLE
Additional Athena sweepers

### DIFF
--- a/internal/service/athena/data_catalog.go
+++ b/internal/service/athena/data_catalog.go
@@ -192,7 +192,7 @@ func resourceDataCatalogDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
-	log.Printf("[DEBUG] Deleting Athena Data Catalog: (%s)", d.Id())
+	log.Printf("[DEBUG] Deleting Athena Data Catalog (%s)", d.Id())
 	_, err := conn.DeleteDataCatalog(ctx, &athena.DeleteDataCatalogInput{
 		Name: aws.String(d.Id()),
 	})

--- a/internal/service/athena/database.go
+++ b/internal/service/athena/database.go
@@ -197,6 +197,7 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 		ResultConfiguration: expandResultConfiguration(d),
 	}
 
+	log.Printf("[DEBUG] Deleting Athena Database (%s)", d.Id())
 	output, err := conn.StartQueryExecution(ctx, input)
 
 	if err != nil {

--- a/internal/service/athena/sweep.go
+++ b/internal/service/athena/sweep.go
@@ -28,6 +28,14 @@ func RegisterSweepers() {
 		Name: "aws_athena_database",
 		F:    sweepDatabases,
 	})
+
+	resource.AddTestSweepers("aws_athena_workgroup", &resource.Sweeper{
+		Name: "aws_athena_workgroup",
+		F:    sweepWorkGroups,
+		Dependencies: []string{
+			"aws_athena_data_catalog",
+		},
+	})
 }
 
 func sweepDataCatalogs(region string) error {
@@ -37,36 +45,33 @@ func sweepDataCatalogs(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.AthenaClient(ctx)
-	input := &athena.ListDatabasesInput{
-		CatalogName: aws.String("AwsDataCatalog"),
-	}
+	input := &athena.ListDataCatalogsInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	pages := athena.NewListDatabasesPaginator(conn, input)
+	pages := athena.NewListDataCatalogsPaginator(conn, input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
 		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Athena Database sweep for %s: %s", region, err)
+			log.Printf("[WARN] Skipping Athena Data Catalog sweep for %s: %s", region, err)
 			return nil
 		}
 
 		if err != nil {
-			return fmt.Errorf("error listing Athena Databases (%s): %w", region, err)
+			return fmt.Errorf("error listing Athena DData Catalogs (%s): %w", region, err)
 		}
 
-		for _, v := range page.DatabaseList {
-			name := aws.ToString(v.Name)
+		for _, v := range page.DataCatalogsSummary {
+			name := aws.ToString(v.CatalogName)
 
-			if name == "default" {
-				log.Printf("[INFO] Skipping Athena Database %s", name)
+			if name == "AwsDataCatalog" {
+				log.Printf("[INFO] Skipping Athena Data Catalog %s", name)
 				continue
 			}
 
-			r := resourceDatabase()
+			r := resourceDataCatalog()
 			d := r.Data(nil)
 			d.SetId(name)
-			d.Set(names.AttrForceDestroy, true)
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}
@@ -75,7 +80,7 @@ func sweepDataCatalogs(region string) error {
 	err = sweep.SweepOrchestrator(ctx, sweepResources)
 
 	if err != nil {
-		return fmt.Errorf("error sweeping Athena Databases (%s): %w", region, err)
+		return fmt.Errorf("error sweeping Athena Data Catalogs (%s): %w", region, err)
 	}
 
 	return nil
@@ -127,6 +132,55 @@ func sweepDatabases(region string) error {
 
 	if err != nil {
 		return fmt.Errorf("error sweeping Athena Databases (%s): %w", region, err)
+	}
+
+	return nil
+}
+
+func sweepWorkGroups(region string) error {
+	ctx := sweep.Context(region)
+	client, err := sweep.SharedRegionalSweepClient(ctx, region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	conn := client.AthenaClient(ctx)
+	input := &athena.ListWorkGroupsInput{}
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := athena.NewListWorkGroupsPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if awsv2.SkipSweepError(err) {
+			log.Printf("[WARN] Skipping Athena WorkGroup sweep for %s: %s", region, err)
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error listing Athena WorkGroups (%s): %w", region, err)
+		}
+
+		for _, v := range page.WorkGroups {
+			name := aws.ToString(v.Name)
+
+			if name == "primary" {
+				log.Printf("[INFO] Skipping Athena WorkGroup %s", name)
+				continue
+			}
+
+			r := resourceDatabase()
+			d := r.Data(nil)
+			d.SetId(name)
+			d.Set(names.AttrForceDestroy, true)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
+	}
+
+	err = sweep.SweepOrchestrator(ctx, sweepResources)
+
+	if err != nil {
+		return fmt.Errorf("error sweeping Athena WorkGroups (%s): %w", region, err)
 	}
 
 	return nil

--- a/internal/service/athena/sweep.go
+++ b/internal/service/athena/sweep.go
@@ -182,7 +182,7 @@ func sweepWorkGroups(region string) error {
 				continue
 			}
 
-			r := resourceDatabase()
+			r := resourceWorkGroup()
 			d := r.Data(nil)
 			d.SetId(name)
 			d.Set(names.AttrForceDestroy, true)

--- a/internal/service/athena/workgroup.go
+++ b/internal/service/athena/workgroup.go
@@ -301,6 +301,7 @@ func resourceWorkGroupDelete(ctx context.Context, d *schema.ResourceData, meta i
 		input.RecursiveDeleteOption = aws.Bool(v.(bool))
 	}
 
+	log.Printf("[DEBUG] Deleting Athena WorkGroup (%s)", d.Id())
 	_, err := conn.DeleteWorkGroup(ctx, input)
 
 	if err != nil {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds sweepers for `aws_athena_data_catalog` and `aws_athena_workgroup`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SWEEPERS=aws_athena_workgroup make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.23.2 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run='aws_athena_workgroup' -timeout 360m
2024/10/11 11:58:56 [DEBUG] Running Sweepers for region (us-west-2):
2024/10/11 11:58:56 [DEBUG] Sweeper (aws_athena_workgroup) has dependency (aws_athena_data_catalog), running..
2024/10/11 11:58:56 [DEBUG] Sweeper (aws_athena_data_catalog) has dependency (aws_athena_database), running..
2024/10/11 11:58:56 [DEBUG] Running Sweeper (aws_athena_database) in region (us-west-2)
2024/10/11 11:58:56 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2
2024-10-11T11:58:56.835-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-2
2024-10-11T11:58:56.835-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2
2024-10-11T11:58:56.836-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-2
2024-10-11T11:58:56.836-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-2 tf_aws.credentials_source=EnvConfigCredentials
2024-10-11T11:58:56.836-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2
2024/10/11 11:58:56 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-west-2
2024/10/11 11:58:56 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-2
2024-10-11T11:58:56.836-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-2
2024-10-11T11:58:57.318-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-2
2024/10/11 11:58:59 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2
2024/10/11 11:58:59 [DEBUG] Completed Sweeper (aws_athena_database) in region (us-west-2) in 2.169326917s
2024/10/11 11:58:59 [DEBUG] Running Sweeper (aws_athena_data_catalog) in region (us-west-2)
2024/10/11 11:58:59 [INFO] Skipping Athena Data Catalog AwsDataCatalog
2024/10/11 11:58:59 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2
2024/10/11 11:58:59 [DEBUG] Completed Sweeper (aws_athena_data_catalog) in region (us-west-2) in 182.095834ms
2024/10/11 11:58:59 [DEBUG] Running Sweeper (aws_athena_workgroup) in region (us-west-2)
2024/10/11 11:58:59 [INFO] Skipping Athena WorkGroup primary
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-4255864663532193210-workgroup)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-4956515640533903359-workgroup)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-1814403745124472991)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-8327429029732962009)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-5775617747197163022-workgroup)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-8020875522727025474)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-3787202862043235887)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-5921867408776270298)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-5721869836086787960-workgroup)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-2998881734044891095-workgroup)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-9177635593855985624)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-8114181909443793205)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-8786676886553421504-workgroup)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-5852344544149424690-workgroup)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-4582449940096249144-workgroup)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-2995882622734649012-workgroup)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-1764195772504434705-workgroup)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-6455417231587607473-workgroup)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-6832298778787118497-workgroup)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-1649590278151210259-workgroup)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-6279773625630149655-workgroup)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-8345041259398558286-workgroup)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-1575139863715901860)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-119346054856286320)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-3981832272614734198)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-1042149029647481947)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-2027634499747307886-workgroup)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-2588752721083110573)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-1923297721291755385)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-2871707685790328060-workgroup)
2024/10/11 11:58:59 [DEBUG] Waiting for state to become: [success]
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-5084159112571987416-workgroup)
2024/10/11 11:58:59 [DEBUG] Deleting Athena WorkGroup (tf-acc-test-6879328360942497619)
2024/10/11 11:59:07 [DEBUG] Completed Sweeper (aws_athena_workgroup) in region (us-west-2) in 8.593455542s
2024/10/11 11:59:07 [DEBUG] Sweeper (aws_athena_database) already ran in region (us-west-2)
2024/10/11 11:59:07 [DEBUG] Sweeper (aws_athena_data_catalog) has dependency (aws_athena_database), running..
2024/10/11 11:59:07 [DEBUG] Sweeper (aws_athena_database) already ran in region (us-west-2)
2024/10/11 11:59:07 [DEBUG] Sweeper (aws_athena_data_catalog) already ran in region (us-west-2)
2024/10/11 11:59:07 Completed Sweepers for region (us-west-2) in 10.945146125s
2024/10/11 11:59:07 Sweeper Tests for region (us-west-2) ran successfully:
2024/10/11 11:59:07 	- aws_athena_database
2024/10/11 11:59:07 	- aws_athena_data_catalog
2024/10/11 11:59:07 	- aws_athena_workgroup
2024/10/11 11:59:07 [DEBUG] Running Sweepers for region (us-east-1):
2024/10/11 11:59:07 [DEBUG] Sweeper (aws_athena_workgroup) has dependency (aws_athena_data_catalog), running..
2024/10/11 11:59:07 [DEBUG] Sweeper (aws_athena_data_catalog) has dependency (aws_athena_database), running..
2024/10/11 11:59:07 [DEBUG] Running Sweeper (aws_athena_database) in region (us-east-1)
2024/10/11 11:59:07 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-1
2024-10-11T11:59:07.780-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-1
2024-10-11T11:59:07.780-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1
2024-10-11T11:59:07.780-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-1
2024-10-11T11:59:07.780-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-1 tf_aws.credentials_source=EnvConfigCredentials
2024-10-11T11:59:07.780-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1
2024/10/11 11:59:07 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-east-1
2024/10/11 11:59:07 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-1
2024-10-11T11:59:07.781-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-1
2024-10-11T11:59:07.894-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-1
2024/10/11 11:59:08 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1
2024/10/11 11:59:08 [DEBUG] Completed Sweeper (aws_athena_database) in region (us-east-1) in 445.874792ms
2024/10/11 11:59:08 [DEBUG] Running Sweeper (aws_athena_data_catalog) in region (us-east-1)
2024/10/11 11:59:08 [INFO] Skipping Athena Data Catalog AwsDataCatalog
2024/10/11 11:59:08 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1
2024/10/11 11:59:08 [DEBUG] Completed Sweeper (aws_athena_data_catalog) in region (us-east-1) in 47.499709ms
2024/10/11 11:59:08 [DEBUG] Running Sweeper (aws_athena_workgroup) in region (us-east-1)
2024/10/11 11:59:08 [INFO] Skipping Athena WorkGroup primary
2024/10/11 11:59:08 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1
2024/10/11 11:59:08 [DEBUG] Completed Sweeper (aws_athena_workgroup) in region (us-east-1) in 67.692292ms
2024/10/11 11:59:08 [DEBUG] Sweeper (aws_athena_database) already ran in region (us-east-1)
2024/10/11 11:59:08 [DEBUG] Sweeper (aws_athena_data_catalog) has dependency (aws_athena_database), running..
2024/10/11 11:59:08 [DEBUG] Sweeper (aws_athena_database) already ran in region (us-east-1)
2024/10/11 11:59:08 [DEBUG] Sweeper (aws_athena_data_catalog) already ran in region (us-east-1)
2024/10/11 11:59:08 Completed Sweepers for region (us-east-1) in 561.235459ms
2024/10/11 11:59:08 Sweeper Tests for region (us-east-1) ran successfully:
2024/10/11 11:59:08 	- aws_athena_data_catalog
2024/10/11 11:59:08 	- aws_athena_workgroup
2024/10/11 11:59:08 	- aws_athena_database
2024/10/11 11:59:08 [DEBUG] Running Sweepers for region (us-east-2):
2024/10/11 11:59:08 [DEBUG] Sweeper (aws_athena_workgroup) has dependency (aws_athena_data_catalog), running..
2024/10/11 11:59:08 [DEBUG] Sweeper (aws_athena_data_catalog) has dependency (aws_athena_database), running..
2024/10/11 11:59:08 [DEBUG] Running Sweeper (aws_athena_database) in region (us-east-2)
2024/10/11 11:59:08 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-2
2024-10-11T11:59:08.342-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-2
2024-10-11T11:59:08.342-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2
2024-10-11T11:59:08.342-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-2
2024-10-11T11:59:08.342-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-2 tf_aws.credentials_source=EnvConfigCredentials
2024-10-11T11:59:08.342-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2
2024/10/11 11:59:08 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-east-2
2024/10/11 11:59:08 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-2
2024-10-11T11:59:08.343-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-2
2024-10-11T11:59:08.517-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-2
2024/10/11 11:59:08 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2
2024/10/11 11:59:08 [DEBUG] Completed Sweeper (aws_athena_database) in region (us-east-2) in 525.362083ms
2024/10/11 11:59:08 [DEBUG] Running Sweeper (aws_athena_data_catalog) in region (us-east-2)
2024/10/11 11:59:08 [INFO] Skipping Athena Data Catalog AwsDataCatalog
2024/10/11 11:59:08 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2
2024/10/11 11:59:08 [DEBUG] Completed Sweeper (aws_athena_data_catalog) in region (us-east-2) in 62.654125ms
2024/10/11 11:59:08 [DEBUG] Running Sweeper (aws_athena_workgroup) in region (us-east-2)
2024/10/11 11:59:09 [INFO] Skipping Athena WorkGroup primary
2024/10/11 11:59:09 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2
2024/10/11 11:59:09 [DEBUG] Completed Sweeper (aws_athena_workgroup) in region (us-east-2) in 88.391458ms
2024/10/11 11:59:09 [DEBUG] Sweeper (aws_athena_database) already ran in region (us-east-2)
2024/10/11 11:59:09 [DEBUG] Sweeper (aws_athena_data_catalog) has dependency (aws_athena_database), running..
2024/10/11 11:59:09 [DEBUG] Sweeper (aws_athena_database) already ran in region (us-east-2)
2024/10/11 11:59:09 [DEBUG] Sweeper (aws_athena_data_catalog) already ran in region (us-east-2)
2024/10/11 11:59:09 Completed Sweepers for region (us-east-2) in 676.609583ms
2024/10/11 11:59:09 Sweeper Tests for region (us-east-2) ran successfully:
2024/10/11 11:59:09 	- aws_athena_database
2024/10/11 11:59:09 	- aws_athena_data_catalog
2024/10/11 11:59:09 	- aws_athena_workgroup
2024/10/11 11:59:09 [DEBUG] Running Sweepers for region (us-west-1):
2024/10/11 11:59:09 [DEBUG] Sweeper (aws_athena_workgroup) has dependency (aws_athena_data_catalog), running..
2024/10/11 11:59:09 [DEBUG] Sweeper (aws_athena_data_catalog) has dependency (aws_athena_database), running..
2024/10/11 11:59:09 [DEBUG] Running Sweeper (aws_athena_database) in region (us-west-1)
2024/10/11 11:59:09 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-1
2024-10-11T11:59:09.018-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-1
2024-10-11T11:59:09.018-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1
2024-10-11T11:59:09.018-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-1
2024-10-11T11:59:09.019-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-1 tf_aws.credentials_source=EnvConfigCredentials
2024-10-11T11:59:09.019-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1
2024/10/11 11:59:09 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-west-1
2024/10/11 11:59:09 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-1
2024-10-11T11:59:09.019-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-1
2024-10-11T11:59:09.504-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-1
2024/10/11 11:59:09 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-1
2024/10/11 11:59:09 [DEBUG] Completed Sweeper (aws_athena_database) in region (us-west-1) in 948.631625ms
2024/10/11 11:59:09 [DEBUG] Running Sweeper (aws_athena_data_catalog) in region (us-west-1)
2024/10/11 11:59:10 [INFO] Skipping Athena Data Catalog AwsDataCatalog
2024/10/11 11:59:10 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-1
2024/10/11 11:59:10 [DEBUG] Completed Sweeper (aws_athena_data_catalog) in region (us-west-1) in 126.557833ms
2024/10/11 11:59:10 [DEBUG] Running Sweeper (aws_athena_workgroup) in region (us-west-1)
2024/10/11 11:59:10 [INFO] Skipping Athena WorkGroup primary
2024/10/11 11:59:10 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-1
2024/10/11 11:59:10 [DEBUG] Completed Sweeper (aws_athena_workgroup) in region (us-west-1) in 173.516625ms
2024/10/11 11:59:10 [DEBUG] Sweeper (aws_athena_database) already ran in region (us-west-1)
2024/10/11 11:59:10 [DEBUG] Sweeper (aws_athena_data_catalog) has dependency (aws_athena_database), running..
2024/10/11 11:59:10 [DEBUG] Sweeper (aws_athena_database) already ran in region (us-west-1)
2024/10/11 11:59:10 [DEBUG] Sweeper (aws_athena_data_catalog) already ran in region (us-west-1)
2024/10/11 11:59:10 Completed Sweepers for region (us-west-1) in 1.2488775s
2024/10/11 11:59:10 Sweeper Tests for region (us-west-1) ran successfully:
2024/10/11 11:59:10 	- aws_athena_database
2024/10/11 11:59:10 	- aws_athena_data_catalog
2024/10/11 11:59:10 	- aws_athena_workgroup
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	18.392s
```
