### PR TITLE
docs: add missing owner to aws_s3_bucket_acl

### DIFF
--- a/website/docs/d/cloudfront_log_delivery_canonical_user_id.html.markdown
+++ b/website/docs/d/cloudfront_log_delivery_canonical_user_id.html.markdown
@@ -14,10 +14,19 @@ See the [Amazon CloudFront Developer Guide](https://docs.aws.amazon.com/AmazonCl
 ## Example Usage
 
 ```terraform
+data "aws_canonical_user_id" "current" {}
+
 data "aws_cloudfront_log_delivery_canonical_user_id" "example" {}
 
 resource "aws_s3_bucket" "example" {
   bucket = "example"
+}
+
+resource "aws_s3_bucket_ownership_controls" "example" {
+  bucket = aws_s3_bucket.example.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
 }
 
 resource "aws_s3_bucket_acl" "example" {
@@ -31,7 +40,11 @@ resource "aws_s3_bucket_acl" "example" {
       }
       permission = "FULL_CONTROL"
     }
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
   }
+  depends_on = [aws_s3_bucket_ownership_controls.example]
 }
 ```
 


### PR DESCRIPTION
### Description

- The `owner` is required as part of the `access_control_policy` provided in the example
- The example also requires to modify the ownership controls. The default value `BucketOwnerEnforced` disables ACLs.

### Relations

Closes #39667 

### References
- [`s3_bucket_acl` Documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl#access_control_policy)
- [Controlling ownership of objects and disabling ACLs for your bucket
](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)  
  Explaining that we need to move to either `Bucket owner preferred` or `Object writer`

### Output from Acceptance Testing

Not required as only documentation is updated.