### PR TITLE
Fix issue preventing replacing when ASG capacity provider 

### DIFF
--- a/internal/service/ecs/cluster_capacity_providers.go
+++ b/internal/service/ecs/cluster_capacity_providers.go
@@ -38,6 +38,7 @@ func resourceClusterCapacityProviders() *schema.Resource {
 			"capacity_providers": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				ForceNew: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This pull request resolves issue #14393.

The aws_ecs_cluster_capacity_providers resource depends on the aws_ecs_capacity_provider. Currently, when the aws_ecs_capacity_provider is force replaced due to a rename or other modification, the aws_ecs_cluster_capacity_providers is updated in-place. However, in AWS, deleting a capacity_provider via API fails if it is still associated with a cluster (which corresponds to the cluster_capacity_provider resource in Terraform). This is the root cause of issue #14393.  What this means is that the aws_ecs_cluster_capacity_providers must be deleted before the aws_ecs_capacity_provider can be deleted.

The solution is to enable force new on the capacity_providers argument within the aws_ecs_cluster_capacity_providers. This ensures that when a aws_ecs_capacity_provider is force replaced, the aws_ecs_cluster_capacity_providers is also force replaced, allowing the association with the cluster to be removed before the aws_ecs_capacity_provider is deleted. This resolves the issue.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #14393 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

The test case TestAccECSClusterCapacityProviders_destroy is failing, but as reported in issue #38408, this is a failing test even in the latest main branch, and is not caused by this pull request.

```console
% make testacc TESTS=TestAccECSClusterCapacityProviders_* PKG=ecs

    cluster_capacity_providers_test.go:120: Step 1/2 error: Check failed: Check 2/2 error: RegisteredContainerInstancesCount = 0, want 2
--- PASS: TestAccECSClusterCapacityProviders_defaults (59.27s)
--- PASS: TestAccECSClusterCapacityProviders_basic (59.30s)
--- PASS: TestAccECSClusterCapacityProviders_disappears (63.42s)
--- PASS: TestAccECSClusterCapacityProviders_Rename_CapacityProvider (109.37s)
--- PASS: TestAccECSClusterCapacityProviders_Update_defaultStrategy (125.55s)
--- PASS: TestAccECSClusterCapacityProviders_Update_capacityProviders (157.86s)
--- FAIL: TestAccECSClusterCapacityProviders_destroy (168.53s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ecs        177.279s
FAIL
make: *** [testacc] Error 1

```
