### PR TITLE
remove capacity_provider_strategy validation for aws_ecs_service resource

### DIFF
--- a/.changelog/39706.txt
+++ b/.changelog/39706.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecs_service: Remove zero check for weight and base fields in capacity_provider_strategy block.
+```

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1938,19 +1938,8 @@ func triggersCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta inter
 }
 
 func capacityProviderStrategyCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	// to be backward compatible, should ForceNew almost always (previous behavior), unless:
-	//   force_new_deployment is true and
-	//   neither the old set nor new set is 0 length
+	// to be backward compatible, should ForceNew almost always (previous behavior), unless force_new_deployment is true
 	if v := d.Get("force_new_deployment").(bool); !v {
-		return capacityProviderStrategyForceNew(d)
-	}
-
-	old, new := d.GetChange(names.AttrCapacityProviderStrategy)
-
-	ol := old.(*schema.Set).Len()
-	nl := new.(*schema.Set).Len()
-
-	if (ol == 0 && nl > 0) || (ol > 0 && nl == 0) {
 		return capacityProviderStrategyForceNew(d)
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
When updating `capacity_provider_strategy`, update should happen in-place and not require recreate.

AWS provider Terraform docs mention a partial solution:
```
[capacity_provider_strategy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#capacity_provider_strategy)

(Optional) Capacity provider strategies to use for the service. Can be one or more.
These can be updated without destroying and recreating the service only if force_new_deployment = true
and not changing from 0 capacity_provider_strategy blocks to greater than 0, or vice versa.
See below.
Conflicts with launch_type.
```

The solution isn’t complete as changing base or weight to 0 triggers a recreate, but on AWS Console it can be updated without recreation.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/37848
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22823
Relates https://github.com/hashicorp/terraform-provider-aws/issues/22408

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
This [comment](https://github.com/hashicorp/terraform-provider-aws/issues/22408#issuecomment-1028734039) provides a good description why this line should be removed.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
