### PR TITLE
Update record.go allow ttl to be 0

### DIFF
--- a/.changelog/39728.txt
+++ b/.changelog/39728.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_route53_record: Fix to allow creation of records witth ttl=0
+resource/aws_route53_record: Allow creation of records with `ttl=0`
 ```

--- a/.changelog/39728.txt
+++ b/.changelog/39728.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_record: Fix to allow creation of records witth ttl=0
+```

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -616,7 +616,7 @@ func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	if v, _ := d.GetChange("ttl"); v.(int) != 0 {
+	if v, _ := d.GetChange("ttl"); v != nil {
 		oldRec.TTL = aws.Int64(int64(v.(int)))
 	}
 

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -904,8 +904,9 @@ func expandResourceRecordSet(d *schema.ResourceData, zoneName string) *awstypes.
 		Type: rrType,
 	}
 
-	if v, ok := d.GetOk("ttl"); ok {
-		apiObject.TTL = aws.Int64(int64(v.(int)))
+	if v := d.GetRawConfig().GetAttr("ttl"); v.IsKnown() && !v.IsNull() {
+		v, _ := v.AsBigFloat().Int64()
+		apiObject.TTL = aws.Int64(v)
 	}
 
 	// Resource records

--- a/internal/service/route53/record.go
+++ b/internal/service/route53/record.go
@@ -616,14 +616,16 @@ func resourceRecordUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	if v, _ := d.GetChange("ttl"); v != nil {
-		oldRec.TTL = aws.Int64(int64(v.(int)))
-	}
-
 	// Resource records
 	if v, _ := d.GetChange("records"); v != nil {
 		if v.(*schema.Set).Len() > 0 {
 			oldRec.ResourceRecords = expandResourceRecords(flex.ExpandStringValueSet(v.(*schema.Set)), awstypes.RRType(oldRRType.(string)))
+
+			// TTL and ResourceRecords
+			if v := d.GetRawState().GetAttr("ttl"); !v.IsNull() {
+				v, _ := v.AsBigFloat().Int64()
+				oldRec.TTL = aws.Int64(v)
+			}
 		}
 	}
 
@@ -904,14 +906,15 @@ func expandResourceRecordSet(d *schema.ResourceData, zoneName string) *awstypes.
 		Type: rrType,
 	}
 
-	if v := d.GetRawConfig().GetAttr("ttl"); v.IsKnown() && !v.IsNull() {
-		v, _ := v.AsBigFloat().Int64()
-		apiObject.TTL = aws.Int64(v)
-	}
-
 	// Resource records
 	if v, ok := d.GetOk("records"); ok {
 		apiObject.ResourceRecords = expandResourceRecords(flex.ExpandStringValueSet(v.(*schema.Set)), rrType)
+
+		// TTL and ResourceRecords
+		if v := d.GetRawPlan().GetAttr("ttl"); v.IsKnown() && !v.IsNull() {
+			v, _ := v.AsBigFloat().Int64()
+			apiObject.TTL = aws.Int64(v)
+		}
 	}
 
 	// Alias record


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updated route53/record.go to allow creation of record with ttl = 0.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36411

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://github.com/hashicorp/terraform-provider-aws/issues/36411

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
terraform-provider-aws % go test ./internal/service/route53/...
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53 
```
