### PR TITLE
r/aws_iam_role_policy_attachments_exclusive(test): fix test configuration

### DIFF
--- a/internal/service/iam/role_policy_attachments_exclusive_test.go
+++ b/internal/service/iam/role_policy_attachments_exclusive_test.go
@@ -273,7 +273,7 @@ func TestAccIAMRolePolicyAttachmentsExclusive_outOfBandAddition(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccRolePolicyAttachmentsExclusiveConfig_basic(rName),
+				Config: testAccRolePolicyAttachmentsExclusiveConfig_outOfBandAddition(rName, oobPolicyName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleExists(ctx, roleResourceName, &role),
 					testAccCheckRolePolicyAttachmentsExclusiveExists(ctx, resourceName),


### PR DESCRIPTION




<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
During a refactor of the initial implementation, the `Config` field was updated during the first test step but not the second. This introduced a race condition between detachment and deletion of the out of band policy, resulting in intermittent failures deleting the policy. The impacted test now appropriately uses the same configuration throughout all test steps.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #39718


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=iam TESTS=TestAccIAMRolePolicyAttachmentsExclusive_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRolePolicyAttachmentsExclusive_'  -timeout 360m
2024/10/15 13:56:16 Initializing Terraform AWS Provider...

--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_empty (15.49s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_disappears_Role (17.15s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_disappears_Policy (17.45s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_basic (17.85s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_outOfBandAddition (25.47s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_outOfBandRemoval (25.58s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_multiple (25.99s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        31.059s
```
