### PR TITLE
B leaking vpc related resources issue fix

### DIFF
--- a/internal/service/ec2/vpc_network_acl_rule.go
+++ b/internal/service/ec2/vpc_network_acl_rule.go
@@ -178,11 +178,11 @@ func resourceNetworkACLRuleCreate(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("[DEBUG] Creating EC2 Network ACL Rule: %#v", input)
 	_, err = conn.CreateNetworkAclEntry(ctx, input)
 
+	d.SetId(networkACLRuleCreateResourceID(naclID, ruleNumber, egress, protocol))
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating EC2 Network ACL (%s) Rule (egress: %t)(%d): %s", naclID, egress, ruleNumber, err)
 	}
-
-	d.SetId(networkACLRuleCreateResourceID(naclID, ruleNumber, egress, protocol))
 
 	return append(diags, resourceNetworkACLRuleRead(ctx, d, meta)...)
 }

--- a/internal/service/ec2/vpc_security_group_rule.go
+++ b/internal/service/ec2/vpc_security_group_rule.go
@@ -174,6 +174,8 @@ func resourceSecurityGroupRuleCreate(ctx context.Context, d *schema.ResourceData
 	ruleType := securityGroupRuleType(d.Get(names.AttrType).(string))
 	id := securityGroupRuleCreateID(securityGroupID, string(ruleType), &ipPermission)
 
+	d.SetId(id)
+
 	switch ruleType {
 	case securityGroupRuleTypeIngress:
 		input := &ec2.AuthorizeSecurityGroupIngressInput{
@@ -249,8 +251,6 @@ information and instructions for recovery. Error: %s`, securityGroupID, err)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for Security Group (%s) Rule (%s) create: %s", securityGroupID, id, err)
 	}
-
-	d.SetId(id)
 
 	return diags
 }

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -196,11 +196,11 @@ func resourceSubnetCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	output, err := conn.CreateSubnet(ctx, input)
 
+	d.SetId(aws.ToString(output.Subnet.SubnetId))
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating EC2 Subnet: %s", err)
 	}
-
-	d.SetId(aws.ToString(output.Subnet.SubnetId))
 
 	subnet, err := waitSubnetAvailable(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 

--- a/internal/service/ec2/vpc_subnet_cidr_reservation.go
+++ b/internal/service/ec2/vpc_subnet_cidr_reservation.go
@@ -93,11 +93,11 @@ func resourceSubnetCIDRReservationCreate(ctx context.Context, d *schema.Resource
 	log.Printf("[DEBUG] Creating EC2 Subnet CIDR Reservation: %s", aws.ToString(input.SubnetId))
 	output, err := conn.CreateSubnetCidrReservation(ctx, input)
 
+	d.SetId(aws.ToString(output.SubnetCidrReservation.SubnetCidrReservationId))
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating EC2 Subnet CIDR Reservation: %s", err)
 	}
-
-	d.SetId(aws.ToString(output.SubnetCidrReservation.SubnetCidrReservationId))
 
 	return append(diags, resourceSubnetCIDRReservationRead(ctx, d, meta)...)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This PR fixes the issue described in  #39741 for :
  - aws_subnet
  - aws_ec2_subnet_cidr_reservation
  - aws_security_group_rule
  - aws_network_acl_rule
  
  



### Relations

Closes #39741

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing


#### TestAccVPCSubnetCIDRReservation
```console
❯ make testacc PKG=ec2 TESTS=TestAccVPCSubnetCIDRReservation
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCSubnetCIDRReservation'  -timeout 360m
2024/10/16 08:47:23 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCSubnetCIDRReservation_basic
=== PAUSE TestAccVPCSubnetCIDRReservation_basic
=== RUN   TestAccVPCSubnetCIDRReservation_ipv6
=== PAUSE TestAccVPCSubnetCIDRReservation_ipv6
=== RUN   TestAccVPCSubnetCIDRReservation_disappears
=== PAUSE TestAccVPCSubnetCIDRReservation_disappears
=== CONT  TestAccVPCSubnetCIDRReservation_basic
=== CONT  TestAccVPCSubnetCIDRReservation_disappears
=== CONT  TestAccVPCSubnetCIDRReservation_ipv6
--- PASS: TestAccVPCSubnetCIDRReservation_disappears (26.91s)
--- PASS: TestAccVPCSubnetCIDRReservation_basic (29.57s)
--- PASS: TestAccVPCSubnetCIDRReservation_ipv6 (40.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2 
```


#### TestAccVPCNetworkACLRule

```console
❯ make testacc PKG=ec2 TESTS=TestAccVPCNetworkACLRule
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkACLRule'  -timeout 360m
2024/10/16 08:49:44 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCNetworkACLRule_basic
=== PAUSE TestAccVPCNetworkACLRule_basic
=== RUN   TestAccVPCNetworkACLRule_disappears
=== PAUSE TestAccVPCNetworkACLRule_disappears
=== RUN   TestAccVPCNetworkACLRule_Disappears_networkACL
=== PAUSE TestAccVPCNetworkACLRule_Disappears_networkACL
=== RUN   TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber
=== PAUSE TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber
=== RUN   TestAccVPCNetworkACLRule_ipv6
=== PAUSE TestAccVPCNetworkACLRule_ipv6
=== RUN   TestAccVPCNetworkACLRule_ipv6ICMP
=== PAUSE TestAccVPCNetworkACLRule_ipv6ICMP
=== RUN   TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate
=== PAUSE TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate
=== RUN   TestAccVPCNetworkACLRule_allProtocol
=== PAUSE TestAccVPCNetworkACLRule_allProtocol
=== RUN   TestAccVPCNetworkACLRule_tcpProtocol
=== PAUSE TestAccVPCNetworkACLRule_tcpProtocol
=== RUN   TestAccVPCNetworkACLRule_duplicate
=== PAUSE TestAccVPCNetworkACLRule_duplicate
=== CONT  TestAccVPCNetworkACLRule_basic
=== CONT  TestAccVPCNetworkACLRule_ipv6ICMP
=== CONT  TestAccVPCNetworkACLRule_tcpProtocol
=== CONT  TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber
=== CONT  TestAccVPCNetworkACLRule_ipv6
=== CONT  TestAccVPCNetworkACLRule_Disappears_networkACL
=== CONT  TestAccVPCNetworkACLRule_disappears
=== CONT  TestAccVPCNetworkACLRule_allProtocol
=== CONT  TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate
=== CONT  TestAccVPCNetworkACLRule_duplicate
--- PASS: TestAccVPCNetworkACLRule_duplicate (18.92s)
--- PASS: TestAccVPCNetworkACLRule_Disappears_ingressEgressSameNumber (32.74s)
--- PASS: TestAccVPCNetworkACLRule_disappears (34.06s)
--- PASS: TestAccVPCNetworkACLRule_ipv6ICMP (35.22s)
--- PASS: TestAccVPCNetworkACLRule_Disappears_networkACL (35.42s)
--- PASS: TestAccVPCNetworkACLRule_ipv6 (35.51s)
--- PASS: TestAccVPCNetworkACLRule_allProtocol (39.27s)
--- PASS: TestAccVPCNetworkACLRule_tcpProtocol (39.30s)
--- PASS: TestAccVPCNetworkACLRule_basic (45.66s)
--- PASS: TestAccVPCNetworkACLRule_ipv6VPCAssignGeneratedIPv6CIDRBlockUpdate (62.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        62.689s
```

#### TestSecurityGroupRule
```console
❯ make testacc PKG=ec2 TESTS=TestSecurityGroupRule
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestSecurityGroupRule'  -timeout 360m
2024/10/16 08:55:13 Initializing Terraform AWS Provider...
=== RUN   TestSecurityGroupRuleMigrateState
=== PAUSE TestSecurityGroupRuleMigrateState
=== RUN   TestSecurityGroupRuleCreateID
=== PAUSE TestSecurityGroupRuleCreateID
=== CONT  TestSecurityGroupRuleMigrateState
2024/10/16 08:55:13 [INFO] Found AWS Security Group State v0; migrating to v1
=== CONT  TestSecurityGroupRuleCreateID
2024/10/16 08:55:13 [DEBUG] Attributes before migration: map[string]string{"cidr_blocks.#":"0", "from_port":"0", "protocol":"-1", "security_group_id":"sg-13877277", "self":"false", "source_security_group_id":"sg-11877275", "to_port":"0", "type":"ingress"}
2024/10/16 08:55:13 [DEBUG] Attributes after migration: map[string]string{"cidr_blocks.#":"0", "from_port":"0", "id":"sgrule-2889201120", "protocol":"-1", "security_group_id":"sg-13877277", "self":"false", "source_security_group_id":"sg-11877275", "to_port":"0", "type":"ingress"}, new id: sgrule-2889201120
2024/10/16 08:55:13 [INFO] Found AWS Security Group State v0; migrating to v1
--- PASS: TestSecurityGroupRuleCreateID (0.00s)
2024/10/16 08:55:13 [DEBUG] Attributes before migration: map[string]string{"cidr_blocks.#":"4", "cidr_blocks.0":"172.16.1.0/24", "cidr_blocks.1":"172.16.2.0/24", "cidr_blocks.2":"172.16.3.0/24", "cidr_blocks.3":"172.16.4.0/24", "from_port":"0", "protocol":"-1", "security_group_id":"sg-0981746d", "self":"false", "to_port":"0", "type":"ingress"}
2024/10/16 08:55:13 [DEBUG] Attributes after migration: map[string]string{"cidr_blocks.#":"4", "cidr_blocks.0":"172.16.1.0/24", "cidr_blocks.1":"172.16.2.0/24", "cidr_blocks.2":"172.16.3.0/24", "cidr_blocks.3":"172.16.4.0/24", "from_port":"0", "id":"sgrule-1826358977", "protocol":"-1", "security_group_id":"sg-0981746d", "self":"false", "to_port":"0", "type":"ingress"}, new id: sgrule-1826358977
--- PASS: TestSecurityGroupRuleMigrateState (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        0.139s
```

#### TestAccVPCSubnet
```console
❯ make testacc PKG=ec2 TESTS=TestAccVPCSubnet
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/ec2/... -v -count 1 -parallel 3 -run='TestAccVPCSubnet'  -timeout 360m
2024/10/16 09:09:27 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCSubnetCIDRReservation_basic
=== PAUSE TestAccVPCSubnetCIDRReservation_basic
=== RUN   TestAccVPCSubnetCIDRReservation_ipv6
=== PAUSE TestAccVPCSubnetCIDRReservation_ipv6
=== RUN   TestAccVPCSubnetCIDRReservation_disappears
=== PAUSE TestAccVPCSubnetCIDRReservation_disappears
=== RUN   TestAccVPCSubnetDataSource_basic
=== PAUSE TestAccVPCSubnetDataSource_basic
=== RUN   TestAccVPCSubnetDataSource_ipv6ByIPv6Filter
=== PAUSE TestAccVPCSubnetDataSource_ipv6ByIPv6Filter
=== RUN   TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock
=== PAUSE TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock
=== RUN   TestAccVPCSubnetDataSource_enableLniAtDeviceIndex
=== PAUSE TestAccVPCSubnetDataSource_enableLniAtDeviceIndex
=== RUN   TestAccVPCSubnet_tags
=== PAUSE TestAccVPCSubnet_tags
=== RUN   TestAccVPCSubnet_tags_null
=== PAUSE TestAccVPCSubnet_tags_null
=== RUN   TestAccVPCSubnet_tags_EmptyMap
=== PAUSE TestAccVPCSubnet_tags_EmptyMap
=== RUN   TestAccVPCSubnet_tags_AddOnUpdate
=== PAUSE TestAccVPCSubnet_tags_AddOnUpdate
=== RUN   TestAccVPCSubnet_tags_EmptyTag_OnCreate
=== PAUSE TestAccVPCSubnet_tags_EmptyTag_OnCreate
=== RUN   TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccVPCSubnet_tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCSubnet_tags_DefaultTags_providerOnly
=== RUN   TestAccVPCSubnet_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCSubnet_tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCSubnet_tags_DefaultTags_overlapping
=== PAUSE TestAccVPCSubnet_tags_DefaultTags_overlapping
=== RUN   TestAccVPCSubnet_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCSubnet_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCSubnet_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCSubnet_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCSubnet_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCSubnet_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCSubnet_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCSubnet_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCSubnet_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCSubnet_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCSubnet_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCSubnet_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCSubnet_tags_ComputedTag_OnCreate
=== PAUSE TestAccVPCSubnet_tags_ComputedTag_OnCreate
=== RUN   TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPCSubnet_tags_defaultAndIgnoreTags
=== PAUSE TestAccVPCSubnet_tags_defaultAndIgnoreTags
=== RUN   TestAccVPCSubnet_tags_ignoreTags
=== PAUSE TestAccVPCSubnet_tags_ignoreTags
=== RUN   TestAccVPCSubnet_ipv6
=== PAUSE TestAccVPCSubnet_ipv6
=== RUN   TestAccVPCSubnet_enableIPv6
=== PAUSE TestAccVPCSubnet_enableIPv6
=== RUN   TestAccVPCSubnet_availabilityZoneID
=== PAUSE TestAccVPCSubnet_availabilityZoneID
=== RUN   TestAccVPCSubnet_disappears
=== PAUSE TestAccVPCSubnet_disappears
=== RUN   TestAccVPCSubnet_customerOwnedIPv4Pool
=== PAUSE TestAccVPCSubnet_customerOwnedIPv4Pool
=== RUN   TestAccVPCSubnet_mapCustomerOwnedIPOnLaunch
=== PAUSE TestAccVPCSubnet_mapCustomerOwnedIPOnLaunch
=== RUN   TestAccVPCSubnet_mapPublicIPOnLaunch
=== PAUSE TestAccVPCSubnet_mapPublicIPOnLaunch
=== RUN   TestAccVPCSubnet_outpost
=== PAUSE TestAccVPCSubnet_outpost
=== RUN   TestAccVPCSubnet_enableDNS64
=== PAUSE TestAccVPCSubnet_enableDNS64
=== RUN   TestAccVPCSubnet_ipv4ToIPv6
=== PAUSE TestAccVPCSubnet_ipv4ToIPv6
=== RUN   TestAccVPCSubnet_enableLNIAtDeviceIndex
=== PAUSE TestAccVPCSubnet_enableLNIAtDeviceIndex
=== RUN   TestAccVPCSubnet_privateDNSNameOptionsOnLaunch
=== PAUSE TestAccVPCSubnet_privateDNSNameOptionsOnLaunch
=== RUN   TestAccVPCSubnet_ipv6Native
=== PAUSE TestAccVPCSubnet_ipv6Native
=== RUN   TestAccVPCSubnetsDataSource_basic
=== PAUSE TestAccVPCSubnetsDataSource_basic
=== RUN   TestAccVPCSubnetsDataSource_filter
=== PAUSE TestAccVPCSubnetsDataSource_filter
=== CONT  TestAccVPCSubnetCIDRReservation_basic
=== CONT  TestAccVPCSubnet_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccVPCSubnet_tags_EmptyTag_OnCreate
--- PASS: TestAccVPCSubnetCIDRReservation_basic (29.97s)
=== CONT  TestAccVPCSubnet_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccVPCSubnet_tags_DefaultTags_nullNonOverlappingResourceTag (31.01s)
=== CONT  TestAccVPCSubnet_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCSubnet_tags_EmptyTag_OnCreate (53.46s)
=== CONT  TestAccVPCSubnet_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCSubnet_tags_DefaultTags_nullOverlappingResourceTag (30.58s)
=== CONT  TestAccVPCSubnet_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCSubnet_tags_DefaultTags_emptyProviderOnlyTag (30.19s)
=== CONT  TestAccVPCSubnet_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCSubnet_tags_DefaultTags_emptyResourceTag (30.13s)
=== CONT  TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccVPCSubnet_tags_DefaultTags_updateToResourceOnly (50.80s)
=== CONT  TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccVPCSubnet_tags_DefaultTags_updateToProviderOnly (50.52s)
=== CONT  TestAccVPCSubnetDataSource_enableLniAtDeviceIndex
    vpc_subnet_data_source_test.go:197: skipping since no Outposts found
--- SKIP: TestAccVPCSubnetDataSource_enableLniAtDeviceIndex (0.61s)
=== CONT  TestAccVPCSubnet_tags_AddOnUpdate
--- PASS: TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Replace (48.71s)
=== CONT  TestAccVPCSubnet_tags_EmptyMap
--- PASS: TestAccVPCSubnet_tags_AddOnUpdate (48.67s)
=== CONT  TestAccVPCSubnet_tags_null
--- PASS: TestAccVPCSubnet_tags_EmptyMap (37.65s)
=== CONT  TestAccVPCSubnet_tags
--- PASS: TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add (72.75s)
=== CONT  TestAccVPCSubnetDataSource_basic
--- PASS: TestAccVPCSubnet_tags_null (38.12s)
=== CONT  TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock
--- PASS: TestAccVPCSubnetDataSource_basic (26.42s)
=== CONT  TestAccVPCSubnetDataSource_ipv6ByIPv6Filter
--- PASS: TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock (48.28s)
=== CONT  TestAccVPCSubnet_tags_DefaultTags_overlapping
--- PASS: TestAccVPCSubnetDataSource_ipv6ByIPv6Filter (48.01s)
=== CONT  TestAccVPCSubnet_tags_DefaultTags_providerOnly
--- PASS: TestAccVPCSubnet_tags (98.94s)
=== CONT  TestAccVPCSubnet_customerOwnedIPv4Pool
    vpc_subnet_test.go:285: skipping since no Outposts found
--- SKIP: TestAccVPCSubnet_customerOwnedIPv4Pool (0.60s)
=== CONT  TestAccVPCSubnet_tags_DefaultTags_nonOverlapping
--- PASS: TestAccVPCSubnet_tags_DefaultTags_overlapping (79.06s)
=== CONT  TestAccVPCSubnet_tags_ignoreTags
--- PASS: TestAccVPCSubnet_tags_DefaultTags_nonOverlapping (79.84s)
=== CONT  TestAccVPCSubnet_disappears
--- PASS: TestAccVPCSubnet_tags_DefaultTags_providerOnly (105.41s)
=== CONT  TestAccVPCSubnet_availabilityZoneID
--- PASS: TestAccVPCSubnet_tags_ignoreTags (40.73s)
=== CONT  TestAccVPCSubnet_enableIPv6
--- PASS: TestAccVPCSubnet_disappears (25.52s)
=== CONT  TestAccVPCSubnet_ipv6
--- PASS: TestAccVPCSubnet_availabilityZoneID (29.03s)
=== CONT  TestAccVPCSubnetCIDRReservation_disappears
--- PASS: TestAccVPCSubnetCIDRReservation_disappears (25.61s)
=== CONT  TestAccVPCSubnetCIDRReservation_ipv6
--- PASS: TestAccVPCSubnetCIDRReservation_ipv6 (38.63s)
=== CONT  TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccVPCSubnet_enableIPv6 (94.14s)
=== CONT  TestAccVPCSubnet_tags_defaultAndIgnoreTags
--- PASS: TestAccVPCSubnet_ipv6 (93.53s)
=== CONT  TestAccVPCSubnet_basic
--- PASS: TestAccVPCSubnet_basic (27.38s)
=== CONT  TestAccVPCSubnet_ipv6Native
--- PASS: TestAccVPCSubnet_tags_defaultAndIgnoreTags (40.96s)
=== CONT  TestAccVPCSubnetsDataSource_basic
--- PASS: TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Replace (51.90s)
=== CONT  TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccVPCSubnet_ipv6Native (38.67s)
=== CONT  TestAccVPCSubnet_privateDNSNameOptionsOnLaunch
--- PASS: TestAccVPCSubnetsDataSource_basic (38.92s)
=== CONT  TestAccVPCSubnet_ipv4ToIPv6
--- PASS: TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Add (51.45s)
=== CONT  TestAccVPCSubnet_enableLNIAtDeviceIndex
    vpc_subnet_test.go:490: skipping since no Outposts found
--- SKIP: TestAccVPCSubnet_enableLNIAtDeviceIndex (0.60s)
=== CONT  TestAccVPCSubnet_outpost
    vpc_subnet_test.go:384: skipping since no Outposts found
--- SKIP: TestAccVPCSubnet_outpost (0.24s)
=== CONT  TestAccVPCSubnet_enableDNS64
--- PASS: TestAccVPCSubnet_ipv4ToIPv6 (83.71s)
=== CONT  TestAccVPCSubnet_mapPublicIPOnLaunch
--- PASS: TestAccVPCSubnet_enableDNS64 (112.54s)
=== CONT  TestAccVPCSubnet_mapCustomerOwnedIPOnLaunch
    vpc_subnet_test.go:313: skipping since no Outposts found
--- SKIP: TestAccVPCSubnet_mapCustomerOwnedIPOnLaunch (0.62s)
=== CONT  TestAccVPCSubnet_tags_ComputedTag_OnCreate
--- PASS: TestAccVPCSubnet_privateDNSNameOptionsOnLaunch (166.17s)
=== CONT  TestAccVPCSubnetsDataSource_filter
--- PASS: TestAccVPCSubnet_tags_ComputedTag_OnCreate (31.57s)
--- PASS: TestAccVPCSubnet_mapPublicIPOnLaunch (92.41s)
--- PASS: TestAccVPCSubnetsDataSource_filter (26.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        727.082s
```
