### PR TITLE
r/dynamodb_table: fix crash when table is updated without GSI updates

### DIFF
--- a/.changelog/39752.txt
+++ b/.changelog/39752.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix crash when `billing_mode` is set to `PAY_PER_REQUEST` without `global_secondary_index` updates
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -272,9 +272,10 @@ func resourceTable() *schema.Resource {
 				ForceNew: true,
 			},
 			"read_capacity": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeInt,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"on_demand_throughput"},
 			},
 			"replica": {
 				Type:     schema.TypeSet,
@@ -483,9 +484,10 @@ func resourceTable() *schema.Resource {
 				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
 			},
 			"write_capacity": {
-				Type:     schema.TypeInt,
-				Computed: true,
-				Optional: true,
+				Type:          schema.TypeInt,
+				Computed:      true,
+				Optional:      true,
+				ConflictsWith: []string{"on_demand_throughput"},
 			},
 		},
 	}
@@ -1079,7 +1081,7 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	// update only on-demand throughput indexes when switching to PAY_PER_REQUEST
 	if newBillingMode == awstypes.BillingModePayPerRequest {
 		for _, gsiUpdate := range gsiUpdates {
-			if gsiUpdate.Update.OnDemandThroughput == nil {
+			if gsiUpdate.Update == nil || (gsiUpdate.Update != nil && gsiUpdate.Update.OnDemandThroughput == nil) {
 				continue
 			}
 
@@ -1736,7 +1738,7 @@ func updateDiffGSI(oldGsi, newGsi []interface{}, billingMode awstypes.BillingMod
 			}
 			otherAttributesChanged := nonKeyAttributesChanged || !reflect.DeepEqual(oldAttributes, newAttributes)
 
-			if capacityChanged && !otherAttributesChanged {
+			if capacityChanged && !otherAttributesChanged && billingMode == awstypes.BillingModeProvisioned {
 				update := awstypes.GlobalSecondaryIndexUpdate{
 					Update: &awstypes.UpdateGlobalSecondaryIndexAction{
 						IndexName:             aws.String(idxName),
@@ -1744,7 +1746,7 @@ func updateDiffGSI(oldGsi, newGsi []interface{}, billingMode awstypes.BillingMod
 					},
 				}
 				ops = append(ops, update)
-			} else if onDemandThroughputChanged && !otherAttributesChanged {
+			} else if onDemandThroughputChanged && !otherAttributesChanged && billingMode == awstypes.BillingModePayPerRequest {
 				update := awstypes.GlobalSecondaryIndexUpdate{
 					Update: &awstypes.UpdateGlobalSecondaryIndexAction{
 						IndexName:          aws.String(idxName),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #37799
Closes #39747

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

### Before

```console
% make testacc TESTARGS='-run=TestAccDynamoDBTable_BillingMode_payPerRequestBasic' PKG=dynamodb

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20  -run=TestAccDynamoDBTable_BillingMode_payPerRequestBasic -timeout 360m
2024/10/16 09:01:53 Initializing Terraform AWS Provider...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x114f376cc]
```

### After

```console
% make testacc TESTARGS='-run=TestAccDynamoDBTable_' PKG=dynamodb

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20  -run=TestAccDynamoDBTable_ -timeout 360m
2024/10/16 10:32:29 Initializing Terraform AWS Provider...
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (4.34s)
--- PASS: TestAccDynamoDBTable_TTL_validate (12.33s)
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (12.36s)
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (42.88s)
--- PASS: TestAccDynamoDBTable_tableClass_migrate (44.03s)
--- PASS: TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Replace (71.02s)
--- PASS: TestAccDynamoDBTable_gsiOnDemandThroughput (74.98s)
--- PASS: TestAccDynamoDBTable_streamSpecification (75.92s)
--- PASS: TestAccDynamoDBTable_onDemandThroughput (77.87s)
--- PASS: TestAccDynamoDBTable_lsiUpdate (78.25s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (73.01s)
--- PASS: TestAccDynamoDBTable_disappears (26.14s)
--- PASS: TestAccDynamoDBTable_tags (117.48s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (47.29s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (55.15s)
--- PASS: TestAccDynamoDBTable_encryption (128.24s)
--- PASS: TestAccDynamoDBTable_basic (25.97s)
--- PASS: TestAccDynamoDBTable_deletion_protection (33.12s)
--- PASS: TestAccDynamoDBTable_enablePITR (70.30s)
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (149.92s)
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (86.52s)
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (45.82s)
--- PASS: TestAccDynamoDBTable_tags_ComputedTag_OnCreate (29.56s)
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (41.20s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_nullNonOverlappingResourceTag (25.99s)
--- PASS: TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Add (45.93s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_nullOverlappingResourceTag (28.04s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_emptyProviderOnlyTag (23.97s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_emptyResourceTag (30.87s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_overlapping (77.45s)
--- PASS: TestAccDynamoDBTable_Replica_singleStreamSpecification (226.01s)
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (228.41s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (38.27s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_updateToProviderOnly (44.65s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_updateToResourceOnly (37.22s)
--- PASS: TestAccDynamoDBTable_TTL_update (42.61s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (32.32s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (31.39s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (30.82s)
--- PASS: TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Replace (43.33s)
--- PASS: TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Add (63.32s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_nonOverlapping (67.19s)
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (58.07s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_providerOnly (84.66s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (109.07s)
--- PASS: TestAccDynamoDBTable_extended (262.20s)
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestBasic (340.34s)
--- PASS: TestAccDynamoDBTable_tags_AddOnUpdate (41.19s)
--- PASS: TestAccDynamoDBTable_tags_EmptyTag_OnCreate (44.48s)
--- PASS: TestAccDynamoDBTable_Replica_tagsUpdate (410.62s)
--- PASS: TestAccDynamoDBTable_tags_EmptyMap (30.68s)
--- PASS: TestAccDynamoDBTable_tags_null (33.13s)
--- PASS: TestAccDynamoDBTable_Replica_single (486.06s)
--- PASS: TestAccDynamoDBTable_importTable (183.10s)
--- PASS: TestAccDynamoDBTable_Replica_singleCMK (295.98s)
--- PASS: TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned (304.55s)
--- PASS: TestAccDynamoDBTable_Replica_multiple (649.81s)
--- PASS: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (359.43s)
--- PASS: TestAccDynamoDBTable_Replica_tagsOneOfTwo (357.50s)
--- PASS: TestAccDynamoDBTable_Replica_pitrKMS (395.88s)
--- PASS: TestAccDynamoDBTable_Replica_pitr (315.15s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (434.69s)
--- PASS: TestAccDynamoDBTable_attributeUpdate (671.06s)
--- PASS: TestAccDynamoDBTable_restoreCrossRegion (839.65s)
--- PASS: TestAccDynamoDBTable_Replica_tagsNext (579.02s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (846.49s)
--- PASS: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (866.31s)
--- PASS: TestAccDynamoDBTable_backupEncryption (835.07s)
--- PASS: TestAccDynamoDBTable_backup_overrideEncryption (862.95s)
--- PASS: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (1171.97s)
--- PASS: TestAccDynamoDBTable_Replica_doubleAddCMK (896.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	1233.211s
```
