### PR TITLE
Fix GovCloud `imagebuilder` sweepers

### DIFF
--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -37,6 +37,10 @@ func SkipSweepError(err error) bool {
 	if tfawserr.ErrMessageContains(err, "BadRequestException", "not supported") {
 		return true
 	}
+	// Example (GovCloud): ForbiddenException: HTTP status code 403: Access forbidden. You do not have permission to perform this operation. Check your credentials and try your request again
+	if tfawserr.ErrCodeEquals(err, "ForbiddenException") {
+		return true
+	}
 	// Example: InvalidAction: InvalidAction: Operation (ListPlatformApplications) is not supported in this region
 	if tfawserr.ErrMessageContains(err, "InvalidAction", "is not supported") {
 		return true


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes

```
2024/10/17 08:02:39 [DEBUG] Running Sweeper (aws_imagebuilder_lifecycle_policy) in region (us-gov-east-1)
2024/10/17 08:02:39 [DEBUG] Completed Sweeper (aws_imagebuilder_lifecycle_policy) in region (us-gov-east-1) in 307.255416ms
2024/10/17 08:02:39 [ERROR] Error running Sweeper (aws_imagebuilder_lifecycle_policy) in region (us-gov-east-1): error listing Image Builder Lifecycle Policies (us-gov-east-1): operation error imagebuilder: ListLifecyclePolicies, https response error StatusCode: 403, RequestID: 4220474b-da8b-44ed-afd4-edd4c36bd0d8, ForbiddenException: HTTP status code 403: Access forbidden. You do not have permission to perform this operation. Check your credentials and try your request again.
FAIL	github.com/hashicorp/terraform-provider-aws/internal/sweep	32.242s
FAIL
make: *** [sweep] Error 1
```