### PR TITLE
Update Verified Access Group SSE Config Example

### DIFF
--- a/website/docs/r/verifiedaccess_group.html.markdown
+++ b/website/docs/r/verifiedaccess_group.html.markdown
@@ -30,7 +30,7 @@ resource "aws_kms_key" "test_key" {
 resource "aws_verifiedaccess_group" "test" {
   verifiedaccess_instance_id = aws_verifiedaccess_instance_trust_provider_attachment.test.verifiedaccess_instance_id
 
-  server_side_encryption_configuration {
+  sse_configuration {
     kms_key_arn = aws_kms_key.test_key.arn
   }
 }


### PR DESCRIPTION
The example for verified access group set with SSE encryption was mentioned incorrectly.

Referred Doc : https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/verifiedaccess_group

Open Issue: #39769  
