### PR TITLE
Fix #33114

### DIFF
--- a/.changelog/39778.txt
+++ b/.changelog/39778.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_data_set: Fix `InvalidParameterValueException: Invalid RowLevelPermissionDataSet. Namespace parameter should not be specified for Version 2` errors on Create and Update
+```

--- a/internal/service/quicksight/schema/data_set.go
+++ b/internal/service/quicksight/schema/data_set.go
@@ -1352,21 +1352,19 @@ func ExpandRowLevelPermissionDataSet(tfList []interface{}) *awstypes.RowLevelPer
 
 	apiObject := &awstypes.RowLevelPermissionDataSet{}
 
-	if v, ok := tfMap[names.AttrARN].(string); ok {
+	if v, ok := tfMap[names.AttrARN].(string); ok && v != "" {
 		apiObject.Arn = aws.String(v)
 	}
-	if v, ok := tfMap["permission_policy"].(string); ok {
-		apiObject.PermissionPolicy = awstypes.RowLevelPermissionPolicy(v)
-	}
-	if v, ok := tfMap["format_version"].(string); ok {
+	if v, ok := tfMap["format_version"].(string); ok && v != "" {
 		apiObject.FormatVersion = awstypes.RowLevelPermissionFormatVersion(v)
 	}
-	if apiObject.FormatVersion == awstypes.RowLevelPermissionFormatVersionVersion1 {
-		if v, ok := tfMap[names.AttrNamespace].(string); ok {
-			apiObject.Namespace = aws.String(v)
-		}
+	if v, ok := tfMap[names.AttrNamespace].(string); ok && v != "" {
+		apiObject.Namespace = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrStatus].(string); ok {
+	if v, ok := tfMap["permission_policy"].(string); ok && v != "" {
+		apiObject.PermissionPolicy = awstypes.RowLevelPermissionPolicy(v)
+	}
+	if v, ok := tfMap[names.AttrStatus].(string); ok && v != "" {
 		apiObject.Status = awstypes.Status(v)
 	}
 

--- a/internal/service/quicksight/schema/data_set.go
+++ b/internal/service/quicksight/schema/data_set.go
@@ -1361,8 +1361,10 @@ func ExpandRowLevelPermissionDataSet(tfList []interface{}) *awstypes.RowLevelPer
 	if v, ok := tfMap["format_version"].(string); ok {
 		apiObject.FormatVersion = awstypes.RowLevelPermissionFormatVersion(v)
 	}
-	if v, ok := tfMap[names.AttrNamespace].(string); ok {
-		apiObject.Namespace = aws.String(v)
+	if apiObject.FormatVersion == awstypes.RowLevelPermissionFormatVersionVersion1 {
+		if v, ok := tfMap[names.AttrNamespace].(string); ok {
+			apiObject.Namespace = aws.String(v)
+		}
 	}
 	if v, ok := tfMap[names.AttrStatus].(string); ok {
 		apiObject.Status = awstypes.Status(v)


### PR DESCRIPTION
### Description

Currently trying to apply any Quicksight data set with a `row_level_permission_data_set` block with `format_version = VERSION_2` will fail with:

> Error: updating QuickSight Data Set (...): operation error QuickSight: UpdateDataSet, https response error StatusCode: 400, InvalidParameterValueException: Invalid RowLevelPermissionDataSet. Namespace parameter should not be specified for Version 2

The AWS [documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-quicksight/Interface/RowLevelPermissionDataSet/) states that the `Namespace` parameter must not exist if format VERSION_2 is passed.

The fix is fairly trivial; i.e. it prevents setting the `Namespace` parameter in the request body if the format version is not 1.

### Relations

Fixes #33114

### Testing

The existing code has no test coverage for the `row_level_permission_data_set` block that I can extend.