### PR TITLE
docs: add ARN for new CIS benchmark to resource description

### DIFF
--- a/website/docs/r/securityhub_standards_subscription.html.markdown
+++ b/website/docs/r/securityhub_standards_subscription.html.markdown
@@ -42,6 +42,7 @@ Currently available standards (remember to replace `${var.partition}` and `${var
 | AWS Resource Tagging Standard            | `arn:${var.partition}:securityhub:${var.region}::standards/aws-resource-tagging-standard/v/1.0.0`            |
 | CIS AWS Foundations Benchmark v1.2.0     | `arn:${var.partition}:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0`                           |
 | CIS AWS Foundations Benchmark v1.4.0     | `arn:${var.partition}:securityhub:${var.region}::standards/cis-aws-foundations-benchmark/v/1.4.0`            |
+| CIS AWS Foundations Benchmark v3.0.0     | `arn:${var.partition}:securityhub:${var.region}::standards/cis-aws-foundations-benchmark/v/3.0.0`            |
 | NIST SP 800-53 Rev. 5                    | `arn:${var.partition}:securityhub:${var.region}::standards/nist-800-53/v/5.0.0`                              |
 | PCI DSS                                  | `arn:${var.partition}:securityhub:${var.region}::standards/pci-dss/v/3.2.1`                                  |
 


### PR DESCRIPTION
### Description

The documentation for the resoure `aws_securityhub_standards_subscription` contains a table showing standards and their ARN. This pull requests adds the entry for the CIS 3.0.0 benchmark.

In general the ARN can be found by executing `aws securityhub describe-standards`. Below is the relevant entry for the mentioned benchmark

```shell
STANDARDS       The Center for Internet Security (CIS) AWS Foundations Benchmark v3.0.0 is a set of security configuration best practices for AWS. This Security Hub standard automatically checks for your compliance readiness against a subset of CIS requirements.  False   CIS AWS Foundations Benchmark v3.0.0    arn:aws:securityhub:eu-central-1::standards/cis-aws-foundations-benchmark/v/3.0.0

```
### Relations

Closes #39740 

### References


### Output from Acceptance Testing

Not applicable. Only documentation is updated.
