### PR TITLE
Update the name of the resource to be more accurate.

### DIFF
--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -23,7 +23,7 @@ data "aws_subnet" "selected" {
   id = var.subnet_id
 }
 
-resource "aws_security_group" "subnet" {
+resource "aws_security_group" "subnet_security_group" {
   vpc_id = data.aws_subnet.selected.vpc_id
 
   ingress {


### PR DESCRIPTION
The resource name `subnet` is misleading in this example, because it's returning a security group, not the subnet. It makes more sense to call this `subnet_security_group` to indicate that this is the security group attached to the subnet.