### PR TITLE
r/aws_dynamodb_table: ignore go default value when expanding `on_demand_throughput`

### DIFF
--- a/.changelog/39784.txt
+++ b/.changelog/39784.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Fix validation error when optional attribute in `on_demand_throughput` is excluded
+```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -2436,11 +2436,11 @@ func expandOnDemandThroughput(tfMap map[string]interface{}) *awstypes.OnDemandTh
 
 	apiObject := &awstypes.OnDemandThroughput{}
 
-	if v, ok := tfMap["max_read_request_units"].(int); ok {
+	if v, ok := tfMap["max_read_request_units"].(int); ok && v != 0 {
 		apiObject.MaxReadRequestUnits = aws.Int64(int64(v))
 	}
 
-	if v, ok := tfMap["max_write_request_units"].(int); ok {
+	if v, ok := tfMap["max_write_request_units"].(int); ok && v != 0 {
 		apiObject.MaxWriteRequestUnits = aws.Int64(int64(v))
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

During expansion the Go `int` default value `0` is being included in the request. This happens when either optional attribute `max_read_request_units` or `max_write_request_units` is omitted.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #39760

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccDynamoDBTable_gsi\|TestAccDynamoDBTable_onDemandThroughput\|TestAccDynamoDBTable_basic\|TestAccDynamoDBTable_disappears' PKG=dynamodb

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20  -run=TestAccDynamoDBTable_gsi\|TestAccDynamoDBTable_onDemandThroughput\|TestAccDynamoDBTable_basic\|TestAccDynamoDBTable_disappears -timeout 360m
2024/10/17 15:42:16 Initializing Terraform AWS Provider...
--- PASS: TestAccDynamoDBTable_disappears (22.84s)
--- PASS: TestAccDynamoDBTable_basic (23.83s)
--- PASS: TestAccDynamoDBTable_onDemandThroughput (50.64s)
--- PASS: TestAccDynamoDBTable_gsiOnDemandThroughput (56.10s)
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (56.16s)
--- PASS: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (384.45s)
--- PASS: TestAccDynamoDBTable_gsiUpdateOtherAttributes (715.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	721.810s
```
