### PR TITLE
docs: add argument description to resource aws_ami_copy

### DIFF
--- a/website/docs/r/ami_copy.html.markdown
+++ b/website/docs/r/ami_copy.html.markdown
@@ -40,6 +40,7 @@ resource "aws_ami_copy" "example" {
 This resource supports the following arguments:
 
 * `name` - (Required) Region-unique name for the AMI.
+* `description` - (Optional) Longer, human-readable description for the AMI in the destination region.
 * `source_ami_id` - (Required) Id of the AMI to copy. This id must be valid in the region
   given by `source_ami_region`.
 * `source_ami_region` - (Required) Region from which the AMI will be copied. This may be the

--- a/website/docs/r/ami_copy.html.markdown
+++ b/website/docs/r/ami_copy.html.markdown
@@ -25,7 +25,6 @@ block until the new AMI is available for use on new instances.
 ```terraform
 resource "aws_ami_copy" "example" {
   name              = "terraform-example"
-  description       = "A copy of ami-xxxxxxxx"
   source_ami_id     = "ami-xxxxxxxx"
   source_ami_region = "us-west-1"
 
@@ -40,7 +39,6 @@ resource "aws_ami_copy" "example" {
 This resource supports the following arguments:
 
 * `name` - (Required) Region-unique name for the AMI.
-* `description` - (Optional) Longer, human-readable description for the AMI in the destination region.
 * `source_ami_id` - (Required) Id of the AMI to copy. This id must be valid in the region
   given by `source_ami_region`.
 * `source_ami_region` - (Required) Region from which the AMI will be copied. This may be the


### PR DESCRIPTION
### Description

The example in resource `aws_ami_copy` contains a `description` field that is not documented in the _Arguments_ section.

```hcl
resource "aws_ami_copy" "example" {
  name              = "terraform-example"
  description       = "A copy of ami-xxxxxxxx"
  source_ami_id     = "ami-xxxxxxxx"
  source_ami_region = "us-west-1"

  tags = {
    Name = "HelloWorld"
  }
}
```

This PR added the missing field.

Please note: The resource documentation contains the statement below

> This resource also exposes the full set of arguments from the [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ami) resource.

So, it may be the case that adding the  `description` field is not required, but it helps readers as they to not need to open another documentation page for getting details on `description` . 

### Relations

Closes #39794 

### References

- [Link to resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ami_copy)
- [Usage of description in AWS Go SDK v2](https://github.com/aws/aws-sdk-go-v2/blob/6a30b3f71b8aaf38fef1816652f5b8847471681c/service/ec2/api_op_CopyImage.go#L84)


### Output from Acceptance Testing

Not required. Only documentation is updated.