### PR TITLE
r/sagemaker_app_image and image_version - log errors better

### DIFF
--- a/internal/service/sagemaker/image.go
+++ b/internal/service/sagemaker/image.go
@@ -104,7 +104,7 @@ func resourceImageCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.SetId(name)
 
-	if _, err := waitImageCreated(ctx, conn, d.Id()); err != nil {
+	if err := waitImageCreated(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker Image (%s) to be created: %s", d.Id(), err)
 	}
 
@@ -174,7 +174,7 @@ func resourceImageUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			return sdkdiag.AppendErrorf(diags, "updating SageMaker Image: %s", err)
 		}
 
-		if _, err := waitImageCreated(ctx, conn, d.Id()); err != nil {
+		if err := waitImageCreated(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for SageMaker Image (%s) to update: %s", d.Id(), err)
 		}
 	}
@@ -197,7 +197,7 @@ func resourceImageDelete(ctx context.Context, d *schema.ResourceData, meta inter
 		return sdkdiag.AppendErrorf(diags, "deleting SageMaker Image (%s): %s", d.Id(), err)
 	}
 
-	if _, err := waitImageDeleted(ctx, conn, d.Id()); err != nil {
+	if err := waitImageDeleted(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker Image (%s) to delete: %s", d.Id(), err)
 	}
 

--- a/internal/service/sagemaker/image.go
+++ b/internal/service/sagemaker/image.go
@@ -104,7 +104,7 @@ func resourceImageCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.SetId(name)
 
-	if err := waitImageCreated(ctx, conn, d.Id()); err != nil {
+	if _, err := waitImageCreated(ctx, conn, d.Id()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker Image (%s) to be created: %s", d.Id(), err)
 	}
 
@@ -174,7 +174,7 @@ func resourceImageUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			return sdkdiag.AppendErrorf(diags, "updating SageMaker Image: %s", err)
 		}
 
-		if err := waitImageCreated(ctx, conn, d.Id()); err != nil {
+		if _, err := waitImageCreated(ctx, conn, d.Id()); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for SageMaker Image (%s) to update: %s", d.Id(), err)
 		}
 	}

--- a/internal/service/sagemaker/wait.go
+++ b/internal/service/sagemaker/wait.go
@@ -170,7 +170,7 @@ func waitModelPackageGroupDeleted(ctx context.Context, conn *sagemaker.Client, n
 	return nil, err
 }
 
-func waitImageCreated(ctx context.Context, conn *sagemaker.Client, name string) error {
+func waitImageCreated(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeImageOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ImageStatusCreating, awstypes.ImageStatusUpdating),
 		Target:  enum.Slice(awstypes.ImageStatusCreated),
@@ -178,9 +178,17 @@ func waitImageCreated(ctx context.Context, conn *sagemaker.Client, name string) 
 		Timeout: imageCreatedTimeout,
 	}
 
-	_, err := stateConf.WaitForStateContext(ctx)
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
-	return err
+	if output, ok := outputRaw.(*sagemaker.DescribeImageOutput); ok {
+		if status, reason := output.ImageStatus, aws.ToString(output.FailureReason); (status == awstypes.ImageStatusCreateFailed || status == awstypes.ImageStatusUpdateFailed) && reason != "" {
+			tfresource.SetLastError(err, errors.New(reason))
+		}
+
+		return output, err
+	}
+
+	return nil, err
 }
 
 func waitImageDeleted(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeImageOutput, error) {
@@ -194,6 +202,10 @@ func waitImageDeleted(ctx context.Context, conn *sagemaker.Client, name string) 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*sagemaker.DescribeImageOutput); ok {
+		if status, reason := output.ImageStatus, aws.ToString(output.FailureReason); status == awstypes.ImageStatusDeleteFailed && reason != "" {
+			tfresource.SetLastError(err, errors.New(reason))
+		}
+
 		return output, err
 	}
 
@@ -211,6 +223,10 @@ func waitImageVersionCreated(ctx context.Context, conn *sagemaker.Client, name s
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*sagemaker.DescribeImageVersionOutput); ok {
+		if status, reason := output.ImageVersionStatus, aws.ToString(output.FailureReason); status == awstypes.ImageVersionStatusCreateFailed && reason != "" {
+			tfresource.SetLastError(err, errors.New(reason))
+		}
+
 		return output, err
 	}
 
@@ -228,6 +244,10 @@ func waitImageVersionDeleted(ctx context.Context, conn *sagemaker.Client, name s
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
 
 	if output, ok := outputRaw.(*sagemaker.DescribeImageVersionOutput); ok {
+		if status, reason := output.ImageVersionStatus, aws.ToString(output.FailureReason); status == awstypes.ImageVersionStatusDeleteFailed && reason != "" {
+			tfresource.SetLastError(err, errors.New(reason))
+		}
+
 		return output, err
 	}
 

--- a/internal/service/sagemaker/wait.go
+++ b/internal/service/sagemaker/wait.go
@@ -170,7 +170,7 @@ func waitModelPackageGroupDeleted(ctx context.Context, conn *sagemaker.Client, n
 	return nil, err
 }
 
-func waitImageCreated(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeImageOutput, error) {
+func waitImageCreated(ctx context.Context, conn *sagemaker.Client, name string) error {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ImageStatusCreating, awstypes.ImageStatusUpdating),
 		Target:  enum.Slice(awstypes.ImageStatusCreated),
@@ -185,13 +185,13 @@ func waitImageCreated(ctx context.Context, conn *sagemaker.Client, name string) 
 			tfresource.SetLastError(err, errors.New(reason))
 		}
 
-		return output, err
+		return err
 	}
 
-	return nil, err
+	return err
 }
 
-func waitImageDeleted(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeImageOutput, error) {
+func waitImageDeleted(ctx context.Context, conn *sagemaker.Client, name string) error {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ImageStatusDeleting),
 		Target:  []string{},
@@ -206,10 +206,10 @@ func waitImageDeleted(ctx context.Context, conn *sagemaker.Client, name string) 
 			tfresource.SetLastError(err, errors.New(reason))
 		}
 
-		return output, err
+		return err
 	}
 
-	return nil, err
+	return err
 }
 
 func waitImageVersionCreated(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeImageVersionOutput, error) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccSageMakerImage_basic  PKG=sagemaker

--- PASS: TestAccSageMakerImage_basic (77.43s)
```
