### PR TITLE
fix: update validation for image builder workflow type

### DIFF
--- a/.changelog/39810.txt
+++ b/.changelog/39810.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_imagebuilder_workflow: Fix validation of workflow type. Exclude DISTRIBUTION from allowed values.
+```

--- a/internal/service/imagebuilder/workflow.go
+++ b/internal/service/imagebuilder/workflow.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -87,10 +86,10 @@ func resourceWorkflow() *schema.Resource {
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			names.AttrType: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: enum.Validate[awstypes.WorkflowType](),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{string(awstypes.WorkflowTypeBuild), string(awstypes.WorkflowTypeTest)}, false),
 			},
 			names.AttrURI: {
 				Type:         schema.TypeString,

--- a/website/docs/r/imagebuilder_workflow.html.markdown
+++ b/website/docs/r/imagebuilder_workflow.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 Terraform resource for managing an AWS EC2 Image Builder Workflow.
 
+-> The Image Builder workflow framework also includes a distribution stage. However, Image Builder handles the workflows for that stage, so that workflow type `DISTRIBUTION` is not supported by this resource.
+
 ## Example Usage
 
 ### Basic Usage
@@ -55,7 +57,7 @@ resource "aws_imagebuilder_workflow" "example" {
 The following arguments are required:
 
 * `name` - (Required) Name of the workflow.
-* `type` - (Required) Type of the workflow. Valid values: `BUILD`, `TEST`, `DISTRIBUTION`.
+* `type` - (Required) Type of the workflow. Valid values: `BUILD`, `TEST`.
 * `version` - (Required) Version of the workflow.
 
 The following arguments are optional:


### PR DESCRIPTION
### Description

The documentation of the resource [`ami_imagebuilder_workflow`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/imagebuilder_workflow)  mentions for the argument `type`
>  Valid values: BUILD, TEST, DISTRIBUTION.

Image Builder handles the  workflow type DISTRIBUTION, it cannot be configured by users.
When trying to do so, for example using the code snippet provided as part of #39785 

```hcl
resource aws_imagebuilder_workflow codebuild-projects {
  name = "CodeBuildProjectsDistributionWorkflow"
  version = "1.0.0"
  type = "DISTRIBUTION"
  data = file("${path.module}/codebuild-projects-distribution.workflow.yaml")
}
```

the API returns the error ` The value supplied for parameter 'type' is not valid. Custom distribution workflows are not supported.`

This pull request is to update the documentation for the resource as well as the validation for the argument.
Two points from my side:

- For the validation I was not sure on the correct approach: I changed `ValidateDiagFunc` to `ValidateFunc`, typically it should be the other, right? Feedback is appreciated. 
- How would I test the change in the validation?  At the moment we do not have a test for attribute `type`, but adding one would also not cover the change.

### Relations


Closes #39785 

### References

[Here](https://github.com/hashicorp/terraform-provider-aws/issues/39785#issuecomment-2424187935) I explained the current situation.

### Output from Acceptance Testing
```console
❯ make testacc TESTS=TestAccImageBuilderWorkflow PKG=imagebuilder
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderWorkflow'  -timeout 360m
2024/10/20 21:04:19 Initializing Terraform AWS Provider...
=== RUN   TestAccImageBuilderWorkflow_basic
=== PAUSE TestAccImageBuilderWorkflow_basic
=== RUN   TestAccImageBuilderWorkflow_disappears
=== PAUSE TestAccImageBuilderWorkflow_disappears
=== RUN   TestAccImageBuilderWorkflow_changeDescription
=== PAUSE TestAccImageBuilderWorkflow_changeDescription
=== RUN   TestAccImageBuilderWorkflow_description
=== PAUSE TestAccImageBuilderWorkflow_description
=== RUN   TestAccImageBuilderWorkflow_kmsKeyID
=== PAUSE TestAccImageBuilderWorkflow_kmsKeyID
=== RUN   TestAccImageBuilderWorkflow_tags
=== PAUSE TestAccImageBuilderWorkflow_tags
=== RUN   TestAccImageBuilderWorkflow_uri
=== PAUSE TestAccImageBuilderWorkflow_uri
=== CONT  TestAccImageBuilderWorkflow_basic
=== CONT  TestAccImageBuilderWorkflow_kmsKeyID
=== CONT  TestAccImageBuilderWorkflow_uri
=== CONT  TestAccImageBuilderWorkflow_tags
=== CONT  TestAccImageBuilderWorkflow_changeDescription
=== CONT  TestAccImageBuilderWorkflow_description
=== CONT  TestAccImageBuilderWorkflow_disappears
--- PASS: TestAccImageBuilderWorkflow_disappears (42.21s)
--- PASS: TestAccImageBuilderWorkflow_basic (47.48s)
--- PASS: TestAccImageBuilderWorkflow_changeDescription (47.56s)
--- PASS: TestAccImageBuilderWorkflow_description (47.66s)
--- PASS: TestAccImageBuilderWorkflow_kmsKeyID (49.77s)
--- PASS: TestAccImageBuilderWorkflow_uri (55.30s)
--- PASS: TestAccImageBuilderWorkflow_tags (85.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       85.434s
...
```
