### PR TITLE
internal/verify: handle policy parsing errors of state content 

### DIFF
--- a/.changelog/39842.txt
+++ b/.changelog/39842.txt
@@ -1,0 +1,19 @@
+```release-note:bug
+resource/aws_iam_policy: Fix persistent validation errors when malformed `policy` content is written to state
+```
+```release-note:bug
+resource/aws_iam_role_policy: Fix persistent validation errors when malformed `policy` content is written to state
+```
+```release-note:bug
+resource/aws_ecr_repository_policy: Fix persistent validation errors when malformed `policy` content is written to state
+```
+```release-note:bug
+resource/aws_secretsmanager_secret: Fix persistent validation errors when malformed `policy` content is written to state
+```
+```release-note:bug
+resource/aws_s3_bucket_policy: Fix persistent validation errors when malformed `policy` content is written to state
+```
+```release-note:bug
+resource/aws_kms_key: Fix persistent validation errors when malformed `policy` content is written to state
+```
+

--- a/internal/service/iam/policy_test.go
+++ b/internal/service/iam/policy_test.go
@@ -349,6 +349,57 @@ func TestAccIAMPolicy_policyDuplicateKeys(t *testing.T) {
 	})
 }
 
+// TestAccIAMPolicy_malformedCondition verifies that malformed policy content
+// that is stored in state does not prevent subsequent plan and apply operations
+// from proceeding.
+//
+// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/39833
+func TestAccIAMPolicy_malformedCondition(t *testing.T) {
+	ctx := acctest.Context(t)
+	var out awstypes.Policy
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_iam_policy.test"
+	expectedPolicyText1 := `{"Statement":[{"Action":["s3:ListBucket"],"Effect":"Allow","Resource":"*"}],"Version":"2012-10-17"}`
+	expectedPolicyText2 := `{"Statement":[{"Action":["s3:ListBucket"],"Condition":{"StringLike":["demo-prefix/"]}",Effect":"Allow","Resource":"*"}],"Version":"2012-10-17"}`
+	expectedPolicyText3 := `{"Statement":[{"Action":["s3:ListBucket"],"Condition":{"StringLike":{"s3:prefix":["demo-prefix/"]}},"Effect":"Allow","Resource":"*"}],"Version":"2012-10-17"}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyConfig_MalformedCondition_setup(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(ctx, resourceName, &out),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPolicy, expectedPolicyText1),
+				),
+			},
+			{
+				Config:      testAccPolicyConfig_MalformedCondition_failure(rName),
+				ExpectError: regexache.MustCompile(`MalformedPolicyDocument: Syntax errors in policy`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(ctx, resourceName, &out),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					// Because this is a Plugin SDK V2-based resource, the malformed content
+					// is stored in state despite the failed update.
+					resource.TestCheckResourceAttr(resourceName, names.AttrPolicy, expectedPolicyText2),
+				),
+			},
+			{
+				Config: testAccPolicyConfig_MalformedCondition_fix(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(ctx, resourceName, &out),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPolicy, expectedPolicyText3),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPolicyExists(ctx context.Context, n string, v *awstypes.Policy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -621,6 +672,77 @@ resource "aws_iam_policy" "test" {
   ]
 }
 EOF
+}
+`, rName)
+}
+
+func testAccPolicyConfig_MalformedCondition_setup(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_policy" "test" {
+  name = %q
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Resource = "*"
+        Action = [
+          "s3:ListBucket",
+        ]
+      },
+    ]
+  })
+}
+`, rName)
+}
+
+func testAccPolicyConfig_MalformedCondition_failure(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_policy" "test" {
+  name = %q
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Resource = "*"
+        Action = [
+          "s3:ListBucket",
+        ]
+        "Condition" : {
+          "StringLike" : ["demo-prefix/"]
+        }
+      },
+    ]
+  })
+}
+`, rName)
+}
+
+func testAccPolicyConfig_MalformedCondition_fix(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_policy" "test" {
+  name = %q
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Resource = "*"
+        Action = [
+          "s3:ListBucket",
+        ]
+        "Condition" : {
+          "StringLike" : {
+            "s3:prefix" : ["demo-prefix/"]
+          }
+        }
+      },
+    ]
+  })
 }
 `, rName)
 }

--- a/internal/verify/json.go
+++ b/internal/verify/json.go
@@ -15,6 +15,7 @@ import (
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 )
 
 // SuppressEquivalentPolicyDiffs returns a difference suppression function that compares
@@ -156,7 +157,7 @@ func SecondJSONUnlessEquivalent(old, new string) (string, error) {
 		// read directly from the remote resource instead.
 		//
 		// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/39833
-		if strings.Contains(err.Error(), "parsing policy 1") {
+		if errs.Contains(err, "parsing policy 1") {
 			return new, nil
 		}
 

--- a/internal/verify/json.go
+++ b/internal/verify/json.go
@@ -126,6 +126,11 @@ func JSONBytesEqual(b1, b2 []byte) bool {
 	return reflect.DeepEqual(o1, o2)
 }
 
+// SecondJSONUnlessEquivalent returns the second JSON string unless
+// the AWS policy content is deemed equivalent.
+//
+// If parsing of the policy content from the first argument fails, the
+// second is returned and no error is raised.
 func SecondJSONUnlessEquivalent(old, new string) (string, error) {
 	// valid empty JSON is "{}" not "" so handle special case to avoid
 	// Error unmarshaling policy: unexpected end of JSON input
@@ -144,6 +149,17 @@ func SecondJSONUnlessEquivalent(old, new string) (string, error) {
 	equivalent, err := awspolicy.PoliciesAreEquivalent(old, new)
 
 	if err != nil {
+		// Plugin SDK V2 based resources can set malformed policy content in state
+		// despite a failed update. In these cases, parsing the "old" content
+		// will fail. Surfacing this error during read operations causes a
+		// persistent plan-time validation error, so return the "new" content
+		// read directly from the remote resource instead.
+		//
+		// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/39833
+		if strings.Contains(err.Error(), "parsing policy 1") {
+			return new, nil
+		}
+
 		return "", err
 	}
 

--- a/internal/verify/json_test.go
+++ b/internal/verify/json_test.go
@@ -354,6 +354,48 @@ func TestSecondJSONUnlessEquivalent(t *testing.T) {
 			newPolicy: "",
 			want:      "",
 		},
+		{
+			name: "malformed old",
+			oldPolicy: `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Condition" : {
+        "StringLike" : ["demo-prefix/"]
+      },
+      "Resource": "*"
+    }
+  ]
+}`,
+			newPolicy: `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "*"
+    }
+  ]
+}`,
+			want: `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "*"
+    }
+  ]
+}`,
+		},
 	}
 
 	for _, v := range testCases {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Plugin SDK V2 based resources can set malformed policy content in state despite a failed update. In these cases, parsing the old content will fail (it is still malformed). Surfacing parsing errors during read operations causes a persistent plan-time validation error, so this changes the behavior to return the "new" content read directly from the remote resource instead.

This fix is applied as far down in the provider codebase as possible, directly after calling the `PoliciesAreEquivalent` function from `github.com/hashicorp/awspolicyequivalence`. The `SecondJSONUnlessEquivalent` function is called across a variety of services which have arguments that expect IAM policy JSON, as well by other upstream functions within `internal/verify` which apply additional normalization on top of the output. As such, this fix may apply to more resources than are explicitly included in the CHANGELOG entry. For now I've limited entries only to those with open bug reports (that I could easily find).

This change also includes a test case reproducing this previously broken workflow for an IAM policy resource. Before the changes to `internal/verify`:

```console
make testacc PKG=iam TESTS=TestAccIAMPolicy_malformedCondition
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicy_malformedCondition'  -timeout 360m
2024/10/22 14:34:52 Initializing Terraform AWS Provider...

    policy_test.go:366: Step 3/3 error: Error running pre-apply plan: exit status 1

        Error: while setting policy (), encountered: while checking equivalency of existing policy ({"Statement":[{"Action":["s3:ListBucket"],"Condition":{"StringLike":["demo-prefix/"]},"Effect":"Allow","Resource":"*"}],"Version":"2012-10-17"}) and new policy ({"Statement":[{"Action":["s3:ListBucket"],"Effect":"Allow","Resource":"*"}],"Version":"2012-10-17"}), encountered: parsing policy 1: parsing statement 1: 1 error(s) decoding:

        * '[0].Condition[StringLike]' expected a map, got 'slice'

          with aws_iam_policy.test,
          on terraform_plugin_test.tf line 12, in resource "aws_iam_policy" "test":
          12: resource "aws_iam_policy" "test" {

--- FAIL: TestAccIAMPolicy_malformedCondition (14.38s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/iam        20.852s
```

After:

```console
% make testacc PKG=iam TESTS=TestAccIAMPolicy_malformedCondition
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicy_malformedCondition'  -timeout 360m
2024/10/22 14:33:06 Initializing Terraform AWS Provider...

--- PASS: TestAccIAMPolicy_malformedCondition (21.43s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        27.884s
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39833
Closes #39202
Closes #29185
Closes #28609


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=iam TESTS=TestAccIAMPolicy_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMPolicy_'  -timeout 360m
2024/10/22 14:47:49 Initializing Terraform AWS Provider...

--- PASS: TestAccIAMPolicy_policyDuplicateKeys (3.93s)
=== CONT  TestAccIAMPolicy_whitespace
--- PASS: TestAccIAMPolicy_disappears (33.95s)
=== CONT  TestAccIAMPolicy_description
--- PASS: TestAccIAMPolicy_path (39.26s)
=== CONT  TestAccIAMPolicy_basic
--- PASS: TestAccIAMPolicy_namePrefix (40.36s)
=== CONT  TestAccIAMPolicy_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nullOverlappingResourceTag (47.05s)
=== CONT  TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nullNonOverlappingResourceTag (47.31s)
=== CONT  TestAccIAMPolicy_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccIAMPolicy_tags_DefaultTags_emptyResourceTag (48.16s)
=== CONT  TestAccIAMPolicy_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccIAMPolicy_tags_ComputedTag_OnCreate (48.91s)
=== CONT  TestAccIAMPolicy_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccIAMPolicy_tags_EmptyMap (60.04s)
=== CONT  TestAccIAMPolicy_tags_null
--- PASS: TestAccIAMPolicy_malformedCondition (66.86s)
=== CONT  TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccIAMPolicy_policy (69.03s)
=== CONT  TestAccIAMPolicy_tags_DefaultTags_overlapping
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Replace (71.84s)
--- PASS: TestAccIAMPolicy_description (40.11s)
--- PASS: TestAccIAMPolicy_tags_AddOnUpdate (76.91s)
--- PASS: TestAccIAMPolicy_basic (37.69s)
--- PASS: TestAccIAMPolicy_whitespace (76.92s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_emptyProviderOnlyTag (45.17s)
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnCreate (85.62s)
--- PASS: TestAccIAMPolicy_tags_IgnoreTags_Overlap_ResourceTag (100.60s)
--- PASS: TestAccIAMPolicy_tags_null (42.53s)
--- PASS: TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Add (103.00s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_updateToProviderOnly (56.55s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_updateToResourceOnly (56.36s)
--- PASS: TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Replace (58.95s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_nonOverlapping (107.66s)
--- PASS: TestAccIAMPolicy_tags_IgnoreTags_Overlap_DefaultTag (64.80s)
--- PASS: TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Add (48.12s)
--- PASS: TestAccIAMPolicy_tags (119.83s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_providerOnly (120.47s)
--- PASS: TestAccIAMPolicy_tags_DefaultTags_overlapping (59.19s)
--- PASS: TestAccIAMPolicy_diffs (133.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        139.894s
```
