### PR TITLE
f/aws_firehose_delivery_stream iceberg destination

### DIFF
--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -38,6 +38,7 @@ const (
 	destinationTypeElasticsearch        destinationType = "elasticsearch"
 	destinationTypeExtendedS3           destinationType = "extended_s3"
 	destinationTypeHTTPEndpoint         destinationType = "http_endpoint"
+	destinationTypeIceberg              destinationType = "iceberg"
 	destinationTypeOpenSearch           destinationType = "opensearch"
 	destinationTypeOpenSearchServerless destinationType = "opensearchserverless"
 	destinationTypeRedshift             destinationType = "redshift"
@@ -50,6 +51,7 @@ func (destinationType) Values() []destinationType {
 		destinationTypeElasticsearch,
 		destinationTypeExtendedS3,
 		destinationTypeHTTPEndpoint,
+		destinationTypeIceberg,
 		destinationTypeOpenSearch,
 		destinationTypeOpenSearchServerless,
 		destinationTypeRedshift,
@@ -61,7 +63,7 @@ func (destinationType) Values() []destinationType {
 // @SDKResource("aws_kinesis_firehose_delivery_stream", name="Delivery Stream")
 // @Tags(identifierAttribute="name")
 func resourceDeliveryStream() *schema.Resource {
-	//lintignore:R011
+	// lintignore:R011
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDeliveryStreamCreate,
 		ReadWithoutTimeout:   resourceDeliveryStreamRead,
@@ -113,6 +115,35 @@ func resourceDeliveryStream() *schema.Resource {
 							"log_stream_name": {
 								Type:     schema.TypeString,
 								Optional: true,
+							},
+						},
+					},
+				}
+			}
+			destinationTableConfigurationSchema := func() *schema.Schema {
+				return &schema.Schema{
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"database_name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"table_name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"s3_error_output_prefix": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringLenBetween(0, 1024),
+							},
+							"unique_keys": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
 							},
 						},
 					},
@@ -821,6 +852,52 @@ func resourceDeliveryStream() *schema.Resource {
 						},
 					},
 				},
+				"iceberg_configuration": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"buffering_interval": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  300,
+							},
+							"buffering_size": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Default:  5,
+							},
+							"catalog_arn": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"cloudwatch_logging_options":      cloudWatchLoggingOptionsSchema(),
+							"destination_table_configuration": destinationTableConfigurationSchema(),
+							"processing_configuration":        processingConfigurationSchema(),
+							"retry_duration": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								Default:      300,
+								ValidateFunc: validation.IntBetween(0, 7200),
+							},
+							names.AttrRoleARN: {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: verify.ValidARN,
+							},
+							"s3_backup_mode": {
+								Type:             schema.TypeString,
+								Optional:         true,
+								Default:          types.IcebergS3BackupModeFailedDataOnly,
+								ValidateDiagFunc: enum.Validate[types.IcebergS3BackupMode](),
+							},
+							"s3_configuration": s3ConfigurationSchema(),
+						},
+					},
+				},
 				"kinesis_source_configuration": {
 					Type:          schema.TypeList,
 					ForceNew:      true,
@@ -1376,6 +1453,7 @@ func resourceDeliveryStream() *schema.Resource {
 					destinationTypeElasticsearch:        "elasticsearch_configuration",
 					destinationTypeExtendedS3:           "extended_s3_configuration",
 					destinationTypeHTTPEndpoint:         "http_endpoint_configuration",
+					destinationTypeIceberg:              "iceberg_configuration",
 					destinationTypeOpenSearch:           "opensearch_configuration",
 					destinationTypeOpenSearchServerless: "opensearchserverless_configuration",
 					destinationTypeRedshift:             "redshift_configuration",
@@ -1425,6 +1503,10 @@ func resourceDeliveryStreamCreate(ctx context.Context, d *schema.ResourceData, m
 		if v, ok := d.GetOk("http_endpoint_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			input.HttpEndpointDestinationConfiguration = expandHTTPEndpointDestinationConfiguration(v.([]interface{})[0].(map[string]interface{}))
 		}
+	case destinationTypeIceberg:
+		if v, ok := d.GetOk("iceberg_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			input.IcebergDestinationConfiguration = expandIcebergDestinationConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		}
 	case destinationTypeOpenSearch:
 		if v, ok := d.GetOk("opensearch_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			input.AmazonopensearchserviceDestinationConfiguration = expandAmazonopensearchserviceDestinationConfiguration(v.([]interface{})[0].(map[string]interface{}))
@@ -1450,13 +1532,11 @@ func resourceDeliveryStreamCreate(ctx context.Context, d *schema.ResourceData, m
 	_, err := retryDeliveryStreamOp(ctx, func() (interface{}, error) {
 		return conn.CreateDeliveryStream(ctx, input)
 	})
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Kinesis Firehose Delivery Stream (%s): %s", sn, err)
 	}
 
 	output, err := waitDeliveryStreamCreated(ctx, conn, sn, d.Timeout(schema.TimeoutCreate))
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for Kinesis Firehose Delivery Stream (%s) create: %s", sn, err)
 	}
@@ -1470,7 +1550,6 @@ func resourceDeliveryStreamCreate(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		_, err := conn.StartDeliveryStreamEncryption(ctx, input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "starting Kinesis Firehose Delivery Stream (%s) encryption: %s", sn, err)
 		}
@@ -1546,6 +1625,11 @@ func resourceDeliveryStreamRead(ctx context.Context, d *schema.ResourceData, met
 			if err := d.Set("http_endpoint_configuration", flattenHTTPEndpointDestinationDescription(destination.HttpEndpointDestinationDescription, configuredAccessKey)); err != nil {
 				return sdkdiag.AppendErrorf(diags, "setting http_endpoint_configuration: %s", err)
 			}
+		case destination.IcebergDestinationDescription != nil:
+			d.Set(names.AttrDestination, destinationTypeIceberg)
+			if err := d.Set("iceberg_configuration", flattenIcebergDestinationDescription(destination.IcebergDestinationDescription)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "setting iceberg_configuration: %s", err)
+			}
 		case destination.AmazonopensearchserviceDestinationDescription != nil:
 			d.Set(names.AttrDestination, destinationTypeOpenSearch)
 			if err := d.Set("opensearch_configuration", flattenAmazonopensearchserviceDestinationDescription(destination.AmazonopensearchserviceDestinationDescription)); err != nil {
@@ -1612,6 +1696,10 @@ func resourceDeliveryStreamUpdate(ctx context.Context, d *schema.ResourceData, m
 			if v, ok := d.GetOk("http_endpoint_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 				input.HttpEndpointDestinationUpdate = expandHTTPEndpointDestinationUpdate(v.([]interface{})[0].(map[string]interface{}))
 			}
+		case destinationTypeIceberg:
+			if v, ok := d.GetOk("iceberg_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+				input.IcebergDestinationUpdate = expandIcebergDestinationUpdate(v.([]interface{})[0].(map[string]interface{}))
+			}
 		case destinationTypeOpenSearch:
 			if v, ok := d.GetOk("opensearch_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 				input.AmazonopensearchserviceDestinationUpdate = expandAmazonopensearchserviceDestinationUpdate(v.([]interface{})[0].(map[string]interface{}))
@@ -1637,7 +1725,6 @@ func resourceDeliveryStreamUpdate(ctx context.Context, d *schema.ResourceData, m
 		_, err := retryDeliveryStreamOp(ctx, func() (interface{}, error) {
 			return conn.UpdateDestination(ctx, input)
 		})
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Kinesis Firehose Delivery Stream (%s): %s", sn, err)
 		}
@@ -1651,7 +1738,6 @@ func resourceDeliveryStreamUpdate(ctx context.Context, d *schema.ResourceData, m
 			}
 
 			_, err := conn.StopDeliveryStreamEncryption(ctx, input)
-
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "stopping Kinesis Firehose Delivery Stream (%s) encryption: %s", sn, err)
 			}
@@ -1666,7 +1752,6 @@ func resourceDeliveryStreamUpdate(ctx context.Context, d *schema.ResourceData, m
 			}
 
 			_, err := conn.StartDeliveryStreamEncryption(ctx, input)
-
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "starting Kinesis Firehose Delivery Stream (%s) encryption: %s", sn, err)
 			}
@@ -1817,7 +1902,6 @@ func waitDeliveryStreamDeleted(ctx context.Context, conn *firehose.Client, name 
 
 func findDeliveryStreamEncryptionConfigurationByName(ctx context.Context, conn *firehose.Client, name string) (*types.DeliveryStreamEncryptionConfiguration, error) {
 	output, err := findDeliveryStreamByName(ctx, conn, name)
-
 	if err != nil {
 		return nil, err
 	}
@@ -2432,6 +2516,86 @@ func expandPrefix(s3 map[string]interface{}) *string {
 	}
 
 	return nil
+}
+
+func expandIcebergDestinationConfiguration(tfMap map[string]interface{}) *types.IcebergDestinationConfiguration {
+	roleARN := tfMap[names.AttrRoleARN].(string)
+	apiObject := &types.IcebergDestinationConfiguration{
+		CatalogConfiguration: &types.CatalogConfiguration{
+			CatalogARN: aws.String(tfMap["catalog_arn"].(string)),
+		},
+		RoleARN: aws.String(roleARN),
+		BufferingHints: &types.BufferingHints{
+			IntervalInSeconds: aws.Int32(int32(tfMap["buffering_interval"].(int))),
+			SizeInMBs:         aws.Int32(int32(tfMap["buffering_size"].(int))),
+		},
+		S3Configuration: expandS3DestinationConfiguration(tfMap["s3_configuration"].([]interface{})),
+	}
+
+	if _, ok := tfMap["cloudwatch_logging_options"]; ok {
+		apiObject.CloudWatchLoggingOptions = expandCloudWatchLoggingOptions(tfMap)
+	}
+
+	if _, ok := tfMap["destination_table_configuration"]; ok {
+		apiObject.DestinationTableConfigurationList = expandDestinationTableConfigurationList(tfMap)
+	}
+
+	if _, ok := tfMap["processing_configuration"]; ok {
+		apiObject.ProcessingConfiguration = expandProcessingConfiguration(tfMap, destinationTypeIceberg, roleARN)
+	}
+
+	if _, ok := tfMap["retry_duration"]; ok {
+		apiObject.RetryOptions = expandIcebergRetryOptions(tfMap)
+	}
+
+	if v, ok := tfMap["s3_backup_mode"]; ok {
+		apiObject.S3BackupMode = types.IcebergS3BackupMode(v.(string))
+	}
+
+	return apiObject
+}
+
+func expandIcebergDestinationUpdate(tfMap map[string]interface{}) *types.IcebergDestinationUpdate {
+	roleARN := tfMap[names.AttrRoleARN].(string)
+	apiObject := &types.IcebergDestinationUpdate{
+		RoleARN: aws.String(roleARN),
+		BufferingHints: &types.BufferingHints{
+			IntervalInSeconds: aws.Int32(int32(tfMap["buffering_interval"].(int))),
+			SizeInMBs:         aws.Int32(int32(tfMap["buffering_size"].(int))),
+		},
+	}
+
+	if catalogARN, ok := tfMap["catalog_arn"].(string); ok {
+		apiObject.CatalogConfiguration = &types.CatalogConfiguration{
+			CatalogARN: aws.String(catalogARN),
+		}
+	}
+
+	if _, ok := tfMap["cloudwatch_logging_options"]; ok {
+		apiObject.CloudWatchLoggingOptions = expandCloudWatchLoggingOptions(tfMap)
+	}
+
+	if _, ok := tfMap["destination_table_configuration"]; ok {
+		apiObject.DestinationTableConfigurationList = expandDestinationTableConfigurationList(tfMap)
+	}
+
+	if _, ok := tfMap["processing_configuration"]; ok {
+		apiObject.ProcessingConfiguration = expandProcessingConfiguration(tfMap, destinationTypeIceberg, roleARN)
+	}
+
+	if _, ok := tfMap["retry_duration"]; ok {
+		apiObject.RetryOptions = expandIcebergRetryOptions(tfMap)
+	}
+
+	if v, ok := tfMap["s3_backup_mode"]; ok {
+		apiObject.S3BackupMode = types.IcebergS3BackupMode(v.(string))
+	}
+
+	if v, ok := tfMap["s3_configuration"]; ok {
+		apiObject.S3Configuration = expandS3DestinationConfiguration(v.([]interface{}))
+	}
+
+	return apiObject
 }
 
 func expandRedshiftDestinationConfiguration(tfMap map[string]interface{}) *types.RedshiftDestinationConfiguration {
@@ -3123,6 +3287,16 @@ func expandAmazonOpenSearchServerlessBufferingHints(es map[string]interface{}) *
 	return bufferingHints
 }
 
+func expandIcebergRetryOptions(iceberg map[string]interface{}) *types.RetryOptions {
+	retryOptions := &types.RetryOptions{}
+
+	if retryDuration, ok := iceberg["retry_duration"].(int); ok {
+		retryOptions.DurationInSeconds = aws.Int32(int32(retryDuration))
+	}
+
+	return retryOptions
+}
+
 func expandElasticsearchRetryOptions(es map[string]interface{}) *types.ElasticsearchRetryOptions {
 	retryOptions := &types.ElasticsearchRetryOptions{}
 
@@ -3228,6 +3402,37 @@ func expandSplunkRetryOptions(splunk map[string]interface{}) *types.SplunkRetryO
 	}
 
 	return retryOptions
+}
+
+func expandDestinationTableConfigurationList(tfMap map[string]interface{}) []types.DestinationTableConfiguration {
+	config := tfMap["destination_table_configuration"].([]interface{})
+	if len(config) == 0 {
+		return nil
+	}
+
+	tableConfigurations := make([]types.DestinationTableConfiguration, 0, len(config))
+	for _, table := range config {
+		tableConfigurations = append(tableConfigurations, expandDestinationTableConfiguration(table.(map[string]interface{})))
+	}
+
+	return tableConfigurations
+}
+
+func expandDestinationTableConfiguration(tfMap map[string]interface{}) types.DestinationTableConfiguration {
+	destinationTable := types.DestinationTableConfiguration{
+		DestinationDatabaseName: aws.String(tfMap["database_name"].(string)),
+		DestinationTableName:    aws.String(tfMap["table_name"].(string)),
+	}
+
+	if v, ok := tfMap["s3_error_output_prefix"].(string); ok {
+		destinationTable.S3ErrorOutputPrefix = aws.String(v)
+	}
+
+	if v, ok := tfMap["unique_keys"].([]interface{}); ok {
+		destinationTable.UniqueKeys = flex.ExpandStringValueList(v)
+	}
+
+	return destinationTable
 }
 
 func expandCopyCommand(redshift map[string]interface{}) *types.CopyCommand {
@@ -4007,6 +4212,54 @@ func flattenHTTPEndpointDestinationDescription(apiObject *types.HttpEndpointDest
 
 	if apiObject.RetryOptions != nil {
 		tfMap["retry_duration"] = int(aws.ToInt32(apiObject.RetryOptions.DurationInSeconds))
+	}
+
+	return []interface{}{tfMap}
+}
+
+func flattenIcebergDestinationDescription(apiObject *types.IcebergDestinationDescription) []interface{} {
+	if apiObject == nil {
+		return []interface{}{}
+	}
+
+	tfMap := map[string]interface{}{
+		"catalog_arn":      aws.ToString(apiObject.CatalogConfiguration.CatalogARN),
+		"s3_configuration": flattenS3DestinationDescription(apiObject.S3DestinationDescription),
+		names.AttrRoleARN:  aws.ToString(apiObject.RoleARN),
+	}
+
+	if apiObject.BufferingHints != nil {
+		tfMap["buffering_interval"] = int(aws.ToInt32(apiObject.BufferingHints.IntervalInSeconds))
+		tfMap["buffering_size"] = int(aws.ToInt32(apiObject.BufferingHints.SizeInMBs))
+	}
+
+	if apiObject.CloudWatchLoggingOptions != nil {
+		tfMap["cloudwatch_logging_options"] = flattenCloudWatchLoggingOptions(apiObject.CloudWatchLoggingOptions)
+	}
+
+	if apiObject.DestinationTableConfigurationList != nil {
+		tableConfigurations := make([]map[string]interface{}, 0, len(apiObject.DestinationTableConfigurationList))
+		for _, table := range apiObject.DestinationTableConfigurationList {
+			tableConfigurations = append(tableConfigurations, map[string]interface{}{
+				"database_name":          aws.ToString(table.DestinationDatabaseName),
+				"table_name":             aws.ToString(table.DestinationTableName),
+				"s3_error_output_prefix": table.S3ErrorOutputPrefix,
+				"unique_keys":            table.UniqueKeys,
+			})
+		}
+		tfMap["destination_table_configuration"] = tableConfigurations
+	}
+
+	if apiObject.ProcessingConfiguration != nil {
+		tfMap["processing_configuration"] = flattenProcessingConfiguration(apiObject.ProcessingConfiguration, destinationTypeIceberg, aws.ToString(apiObject.RoleARN))
+	}
+
+	if apiObject.RetryOptions != nil {
+		tfMap["retry_duration"] = int(aws.ToInt32(apiObject.RetryOptions.DurationInSeconds))
+	}
+
+	if apiObject.S3BackupMode != "" {
+		tfMap["s3_backup_mode"] = apiObject.S3BackupMode
 	}
 
 	return []interface{}{tfMap}

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -526,6 +526,84 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
 }
 ```
 
+### Iceberg Destination
+
+```terraform
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket        = "test-bucket"
+  force_destroy = true
+}
+
+resource "aws_glue_catalog_database" "test" {
+  name = "test"
+}
+
+resource "aws_glue_catalog_table" "test" {
+  name          = "test"
+  database_name = aws_glue_catalog_database.test.name
+  parameters = {
+    format = "parquet"
+  }
+
+  table_type = "EXTERNAL_TABLE"
+
+  open_table_format_input {
+    iceberg_input {
+      metadata_operation = "CREATE"
+      version            = 2
+    }
+  }
+
+  storage_descriptor {
+    location = "s3://${aws_s3_bucket.bucket.id}"
+
+    columns {
+      name    = "my_column_1"
+      type    = "int"
+    }
+  }
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
+  name        = "terraform-kinesis-firehose-test-stream"
+  destination = "iceberg"
+
+  iceberg_configuration {
+    role_arn            = aws_iam_role.firehose_role.arn
+    catalog_arn         = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"
+    buffering_size     = 10
+    buffering_interval = 400
+
+    s3_configuration {
+      role_arn           = aws_iam_role.firehose_role.arn
+      bucket_arn         = aws_s3_bucket.bucket.arn
+    }
+
+    destination_table_configuration {
+      database_name = aws_glue_catalog_database.test.name
+      table_name    = aws_glue_catalog_table.test.name
+    }
+
+    processing_configuration {
+      enabled = "true"
+
+      processors {
+        type = "Lambda"
+
+        parameters {
+          parameter_name  = "LambdaArn"
+          parameter_value = "${aws_lambda_function.lambda_processor.arn}:$LATEST"
+        }
+      }
+    }
+  }
+}
+```
+
 ### Splunk Destination
 
 ```terraform
@@ -636,6 +714,7 @@ This resource supports the following arguments:
 * `elasticsearch_configuration` - (Optional) Configuration options when `destination` is `elasticsearch`. See [`elasticsearch_configuration` block](#elasticsearch_configuration-block) below for details.
 * `extended_s3_configuration` - (Optional, only Required when `destination` is `extended_s3`) Enhanced configuration options for the s3 destination. See [`extended_s3_configuration` block](#extended_s3_configuration-block) below for details.
 * `http_endpoint_configuration` - (Optional) Configuration options when `destination` is `http_endpoint`. Requires the user to also specify an `s3_configuration` block.  See [`http_endpoint_configuration` block](#http_endpoint_configuration-block) below for details.
+* `iceberg_configuration` - (Optional) Configuration options when `destination` is `iceberg`. See [`iceberg_configuration` block](#iceberg_configuration-block) below for details.
 * `opensearch_configuration` - (Optional) Configuration options when `destination` is `opensearch`. See [`opensearch_configuration` block](#opensearch_configuration-block) below for details.
 * `opensearchserverless_configuration` - (Optional) Configuration options when `destination` is `opensearchserverless`. See [`opensearchserverless_configuration` block](#opensearchserverless_configuration-block) below for details.
 * `redshift_configuration` - (Optional) Configuration options when `destination` is `redshift`. Requires the user to also specify an `s3_configuration` block. See [`redshift_configuration` block](#redshift_configuration-block) below for details.
@@ -721,6 +800,20 @@ The `elasticsearch_configuration` configuration block supports the following arg
 * `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. See [`cloudwatch_logging_options` block](#cloudwatch_logging_options-block) below for details.
 * `vpc_config` - (Optional) The VPC configuration for the delivery stream to connect to Elastic Search associated with the VPC. See [`vpc_config` block](#vpc_config-block) below for details.
 * `processing_configuration` - (Optional) The data processing configuration.  See [`processing_configuration` block](#processing_configuration-block) below for details.
+
+### `iceberg_configuration` block
+
+The `iceberg_configuration` configuration block supports the following arguments:
+
+* `buffering_interval` - (Optional) Buffer incoming data for the specified period of time, in seconds between 0 and 900, before delivering it to the destination. The default value is 300.
+* `buffering_size` - (Optional) Buffer incoming data to the specified size, in MBs between 1 and 128, before delivering it to the destination. The default value is 5.
+* `catalog_arn` - (Required) Glue catalog ARN identifier of the destination Apache Iceberg Tables. You must specify the ARN in the format `arn:aws:glue:region:account-id:catalog`
+* `cloudwatch_logging_options` - (Optional) The CloudWatch Logging Options for the delivery stream. See [`cloudwatch_logging_options` block](#cloudwatch_logging_options-block) below for details.
+* `destination_table_configuration` - (Optional) Destination table configurations which Firehose uses to deliver data to Apache Iceberg Tables. Firehose will write data with insert if table specific configuration is not provided. See [`destination_table_configuration` block](#destination_table_configuration-block) below for details.
+* `processing_configuration` - (Optional) The data processing configuration.  See [`processing_configuration` block](#processing_configuration-block) below for details.
+* `role_arn` - (Required) The ARN of the IAM role to be assumed by Firehose for calling Apache Iceberg Tables.
+* `retry_duration` - (Optional) The period of time, in seconds between 0 to 7200, during which Firehose retries to deliver data to the specified destination.
+* `s3_configuration` - (Required) The S3 Configuration. See [`s3_configuration` block](#s3_configuration-block) below for details.
 
 ### `opensearch_configuration` block
 
@@ -1023,6 +1116,15 @@ The `schema_configuration` configuration block supports the following arguments:
 * `catalog_id` - (Optional) The ID of the AWS Glue Data Catalog. If you don't supply this, the AWS account ID is used by default.
 * `region` - (Optional) If you don't specify an AWS Region, the default is the current region.
 * `version_id` - (Optional) Specifies the table version for the output data schema. Defaults to `LATEST`.
+
+### `destination_table_configuration` block
+
+The `destination_table_configuration` configuration block supports the following arguments:
+
+* `database_name` - (Required) The name of the Apache Iceberg database.
+* `table_name` - (Required) The name of the Apache Iceberg Table.
+* `s3_error_output_prefix` - (Optional) The table specific S3 error output prefix. All the errors that occurred while delivering to this table will be prefixed with this value in S3 destination.
+* `unique_keys` - (Optional) A list of unique keys for a given Apache Iceberg table. Firehose will use these for running Create, Update, or Delete operations on the given Iceberg table.
 
 ### `dynamic_partitioning_configuration` block
 


### PR DESCRIPTION
### Description

This commit adds an initial implementation of the `iceberg` destination type for Firehose delivery streams.

Some notes
* My team would really like to have this feature ASAP, so I hope to be as helpful as possible
* I tried to follow conventions for ordering things, but I didn't quite figure out the conventions for function ordering so I made some arbitrary guesses which may or may not make sense
* I updated one of the markdown files for documentation, but there are several and I'm not sure which one(s) should be updated
* Some formatting changes were added by gofumpt. I can remove them if necessary
* It looks like I might not have the option to check "allow maintainers to make changes" - I can reopen this under my own account if needed

### Relations

Proposal for addressing #38753

### References

* AWS API reference for [IcebergDestinationConfiguration](https://docs.aws.amazon.com/firehose/latest/APIReference/API_IcebergDestinationConfiguration.html)

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccFirehoseDeliveryStream_icebergUpdates PKG=firehose
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/firehose/... -v -count 1 -parallel 20 -run='TestAccFirehoseDeliveryStream_icebergUpdates'  -timeout 360m
2024/10/22 22:11:44 Initializing Terraform AWS Provider...
=== RUN   TestAccFirehoseDeliveryStream_icebergUpdates
=== PAUSE TestAccFirehoseDeliveryStream_icebergUpdates
=== CONT  TestAccFirehoseDeliveryStream_icebergUpdates
--- PASS: TestAccFirehoseDeliveryStream_icebergUpdates (153.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/firehose   157.535s
```
