### PR TITLE
fix: adjust `enable_machine_learning` default configuration

### DIFF
--- a/.changelog/39858.txt
+++ b/.changelog/39858.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_wafv2_web_acl: `rule.statement.managed_rule_group_statement.managed_rule_group_configs.aws_managed_rules_bot_control_rule_set.enable_machine_learning` now defaults to `false`
+```

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -1285,7 +1285,7 @@ func managedRuleGroupConfigSchema() *schema.Schema {
 							"enable_machine_learning": {
 								Type:     schema.TypeBool,
 								Optional: true,
-								Default:  true,
+								Default:  false,
 							},
 							"inspection_level": {
 								Type:             schema.TypeString,

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -738,7 +738,8 @@ func TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig(t *testing.T) {
 						"statement.0.managed_rule_group_statement.0.name":                                                     "AWSManagedRulesATPRuleSet",
 						"statement.0.managed_rule_group_statement.0.rule_action_override.#":                                   "0",
 						"statement.0.managed_rule_group_statement.0.scope_down_statement.#":                                   "0",
-						"statement.0.managed_rule_group_statement.0.vendor_name":                                              "AWS"}),
+						"statement.0.managed_rule_group_statement.0.vendor_name":                                              "AWS",
+					}),
 				),
 			},
 			{
@@ -1002,7 +1003,7 @@ func TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl(t *te
 						"statement.0.managed_rule_group_statement.0.name":        "AWSManagedRulesBotControlRuleSet",
 						"statement.0.managed_rule_group_statement.0.vendor_name": "AWS",
 						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.0.aws_managed_rules_bot_control_rule_set.0.inspection_level":        "TARGETED",
-						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.0.aws_managed_rules_bot_control_rule_set.0.enable_machine_learning": acctest.CtFalse,
+						"statement.0.managed_rule_group_statement.0.managed_rule_group_configs.0.aws_managed_rules_bot_control_rule_set.0.enable_machine_learning": acctest.CtTrue,
 					}),
 				),
 			},
@@ -2487,7 +2488,6 @@ func TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation(t *testing.T) {
 
 						return !lastPage
 					})
-
 					if err != nil {
 						t.Fatalf("finding WebACL (%s): %s", webACLName, err)
 					}
@@ -2516,7 +2516,6 @@ func TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation(t *testing.T) {
 
 						return !lastPage
 					})
-
 					if err != nil {
 						t.Fatalf("finding rule group (%s): %s", webACLName, err)
 					}
@@ -3378,7 +3377,6 @@ func testAccCheckWebACLExists(ctx context.Context, n string, v *awstypes.WebACL)
 		conn := acctest.Provider.Meta().(*conns.AWSClient).WAFV2Client(ctx)
 
 		output, err := tfwafv2.FindWebACLByThreePartKey(ctx, conn, rs.Primary.ID, rs.Primary.Attributes[names.AttrName], rs.Primary.Attributes[names.AttrScope])
-
 		if err != nil {
 			return err
 		}
@@ -5020,7 +5018,7 @@ resource "aws_wafv2_web_acl" "test" {
         managed_rule_group_configs {
           aws_managed_rules_bot_control_rule_set {
             inspection_level        = "TARGETED"
-            enable_machine_learning = false
+            enable_machine_learning = true
           }
         }
       }

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -65,6 +65,7 @@ Upgrade topics:
 - [resource/aws_spot_instance_request](#resourceaws_spot_instance_request)
 - [resource/aws_ssm_association](#resourceaws_ssm_association)
 - [resource/aws_verifiedpermissions_schema](#resourceaws_verifiedpermissions_schema)
+- [resource/aws_wafv2_web_acl](#resourceaws_wafv2_web_acl)
 
 <!-- /TOC -->
 
@@ -455,3 +456,8 @@ Remove `instance_id` from configuration—it no longer exists. Use `targets` ins
 The `definition` argument is now a list nested block instead of a single nested block.
 When referencing this argument, the index must now be included in the attribute address.
 For example, `definition.value` would now be referenced as `definition[0].value`.
+
+## resource/aws_wafv2_web_acl
+
+The default value for `rule.statement.managed_rule_group_statement.managed_rule_group_configs.aws_managed_rules_bot_control_rule_set.enable_machine_learning` is now `false`.
+To retain the previous behavior in configurations which omit this argument, explicitly set the value to `true`.


### PR DESCRIPTION
### Description

- The Bot Control managed rule group offers two inspection levels: `COMMON` and `TARGETED`. While there's no default inspection level, enabling `enable_machine_learning = true` forces the inspection level to be set to `TARGETED`, which is nine times more expensive than `COMMON`. This configuration mismatch has led to continual drift in our setup.

### Relations

- Closes #39825

### References

- [AWS WAF Bot Control rule group Docs](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html)

### Output from Acceptance Testing

```console
❯ make testacc TESTS=TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl'  -timeout 360m
2024/10/23 11:44:22 Initializing Terraform AWS Provider...
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (18.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      23.593s
```
