### PR TITLE
docs: remove non-usable workflow type in ami_imagebuilder_workflow resource

### DIFF
--- a/website/docs/r/imagebuilder_workflow.html.markdown
+++ b/website/docs/r/imagebuilder_workflow.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 Terraform resource for managing an AWS EC2 Image Builder Workflow.
 
+-> Image Builder manages the workflows for the distribution stage. Therefore, using the DISTRIBUTION workflow type results in an error.
+
 ## Example Usage
 
 ### Basic Usage
@@ -55,7 +57,7 @@ resource "aws_imagebuilder_workflow" "example" {
 The following arguments are required:
 
 * `name` - (Required) Name of the workflow.
-* `type` - (Required) Type of the workflow. Valid values: `BUILD`, `TEST`, `DISTRIBUTION`.
+* `type` - (Required) Type of the workflow. Valid values: `BUILD`, `TEST`.
 * `version` - (Required) Version of the workflow.
 
 The following arguments are optional:


### PR DESCRIPTION
### Description

The documentation of the resource [`ami_imagebuilder_workflow`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/imagebuilder_workflow)  mentions for the argument `type`
>  Valid values: BUILD, TEST, DISTRIBUTION.

Image Builder handles the  workflow type DISTRIBUTION, it cannot be configured by users. When trying to do so, for example using the code snippet provided as part of #39785 

```hcl
resource aws_imagebuilder_workflow codebuild-projects {
  name = "CodeBuildProjectsDistributionWorkflow"
  version = "1.0.0"
  type = "DISTRIBUTION"
  data = file("${path.module}/codebuild-projects-distribution.workflow.yaml")
}
```

the API returns the error ` The value supplied for parameter 'type' is not valid. Custom distribution workflows are not supported.`

This pull request is to update the documentation for the resource. Jared Baker provided an idea for the required change:
 > Removing the DISTRIBUTION valid value from the docs, or explicitly stating it is only for internal Image Builder workflows provides guidance that it’s not usable. I

### Relations

* Closes #39785  (original issue)
* #39810 (my first try, updating also the validation function), already closed.
### References

[Here](https://github.com/hashicorp/terraform-provider-aws/issues/39785#issuecomment-2424187935) I explained the current situation.

### Output from Acceptance Testing

Not required. Only documentation changed.