### PR TITLE
docs: update `aws_networkmanager_core_network_policy_document`

### DIFF
--- a/website/docs/d/networkmanager_core_network_policy_document.html.markdown
+++ b/website/docs/d/networkmanager_core_network_policy_document.html.markdown
@@ -181,7 +181,6 @@ The following arguments are available:
 * `conditions` (Required) - A block argument. Detailed Below.
 * `description` (Optional) - A user-defined description that further helps identify the rule.
 * `rule_number` (Required) - An integer from `1` to `65535` indicating the rule's order number. Rules are processed in order from the lowest numbered rule to the highest. Rules stop processing when a rule is matched. It's important to make sure that you number your rules in the exact order that you want them processed.
-* `add_to_network_function_group` (Optional) - The name of the network function group to attach to the attachment policy.
 
 ### `action`
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Updating the documentation for `data.aws_networkmanager_core_network_policy_document` to remove `add_to_network_function_group` from the `attachment_policies` block. 

Based on [AWS docs](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policies-json.html#cloudwan-attach-policies-json) and [the code](https://github.com/hashicorp/terraform-provider-aws/blob/aa3208fef4f4b80e37333362f60118ee29cd44aa/internal/service/networkmanager/core_network_policy_document_data_source.go#L376) for this data resource, `add_to_network_function_group` should only be available under the `action` block. 


### Relations

n/a

### References
[Code](https://github.com/hashicorp/terraform-provider-aws/blob/aa3208fef4f4b80e37333362f60118ee29cd44aa/internal/service/networkmanager/core_network_policy_document_data_source.go#L376) for this data resource

[AWS docs](https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-policies-json.html#cloudwan-attach-policies-json) for the policy object


### Output from Acceptance Testing

I'm do not have the means to run acceptance testing on my own