### PR TITLE
feat: Add support for `efa-only` interface types

### DIFF
--- a/.changelog/39882.txt
+++ b/.changelog/39882.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_launch_template: Add `efa-only` as supported value for `interface_type`
+```

--- a/.changelog/39882.txt
+++ b/.changelog/39882.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_launch_template: Add `efa-only` as supported value for `interface_type`
+resource/aws_launch_template: Add `efa-only` as a valid value for `network_interfaces.interface_type`
 ```

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -771,7 +771,7 @@ func resourceLaunchTemplate() *schema.Resource {
 						"interface_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"efa", "interface"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"efa", "efa-only", "interface"}, false),
 						},
 						"ipv4_address_count": {
 							Type:     schema.TypeInt,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
- Add support for `efa-only` interface types
  - Ref https://aws.amazon.com/about-aws/whats-new/2024/10/aws-efa-updates-scalability-ai-ml-applications/

From [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html):

![image](https://github.com/user-attachments/assets/32670f3d-d22c-4046-812e-16cfceb39b36)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/39891.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
