### PR TITLE
chore/Remove leftover comments

### DIFF
--- a/internal/service/pinpoint/email_template.go
+++ b/internal/service/pinpoint/email_template.go
@@ -47,7 +47,7 @@ const (
 
 type resourceEmailTemplate struct {
 	framework.ResourceWithConfigure
-	// framework.WithImportByID
+	framework.WithImportByID
 	framework.WithTimeouts
 }
 
@@ -147,11 +147,6 @@ func (r *resourceEmailTemplate) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	// resp.Diagnostics.Append(flex.Flatten(ctx, out, &plan)...)
-	// if resp.Diagnostics.HasError() {
-	// 	return
-	// }
-
 	plan.Arn = flex.StringToFramework(ctx, out.CreateTemplateMessageBody.Arn)
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
@@ -199,9 +194,8 @@ func (r *resourceEmailTemplate) Update(ctx context.Context, req resource.UpdateR
 	if !old.TemplateName.Equal(new.TemplateName) ||
 		!old.Arn.Equal(new.Arn) ||
 		!old.EmailTemplate.Equal(new.EmailTemplate) {
-		in := &pinpoint.UpdateEmailTemplateInput{
-			// TemplateName: aws.String(old.TemplateName.ValueString()),
-		}
+		in := &pinpoint.UpdateEmailTemplateInput{}
+
 		resp.Diagnostics.Append(flex.Expand(ctx, &old, in, flex.WithFieldNameSuffix("Request"))...)
 		if resp.Diagnostics.HasError() {
 			return

--- a/internal/service/pinpoint/email_template_test.go
+++ b/internal/service/pinpoint/email_template_test.go
@@ -97,13 +97,6 @@ func TestAccPinpointEmailTemplate_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "email_template.0.subject", "update"),
 				),
 			},
-			// {
-			// 	ResourceName:                         resourceName,
-			// 	ImportState:                          true,
-			// 	ImportStateIdFunc:                    testAccEmailtemplateImportStateIDFunc(resourceName),
-			// 	ImportStateVerifyIdentifierAttribute: "template_name",
-			// 	ImportStateVerify:                    true,
-			// },
 		},
 	})
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Remove leftover comments from previous PR.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #33266

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTARGS='-run=TestAccPinpointEmailTemplate_' PKG=pinpoint
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/pinpoint/... -v -count 1 -parallel 20  -run=TestAccPinpointEmailTemplate_ -timeout 360m
2024/10/25 11:39:57 Initializing Terraform AWS Provider...
=== RUN   TestAccPinpointEmailTemplate_basic
=== PAUSE TestAccPinpointEmailTemplate_basic
=== RUN   TestAccPinpointEmailTemplate_update
=== PAUSE TestAccPinpointEmailTemplate_update
=== RUN   TestAccPinpointEmailTemplate_tags
=== PAUSE TestAccPinpointEmailTemplate_tags
=== CONT  TestAccPinpointEmailTemplate_basic
=== CONT  TestAccPinpointEmailTemplate_tags
=== CONT  TestAccPinpointEmailTemplate_update
--- PASS: TestAccPinpointEmailTemplate_basic (13.62s)
--- PASS: TestAccPinpointEmailTemplate_tags (13.62s)
--- PASS: TestAccPinpointEmailTemplate_update (20.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint   25.785s

...
```
