### PR TITLE
Replaces `sort.Slice` and `sort.SliceStable` with `slices.SortFunc` and `slices.SortStableFunc`

### DIFF
--- a/.ci/semgrep/stdlib/sort.yml
+++ b/.ci/semgrep/stdlib/sort.yml
@@ -1,0 +1,12 @@
+rules:
+  - id: prefer-slices-sortfunc
+    languages: [go]
+    message: Prefer slices.SortFunc to sort.Slice
+    pattern: sort.Slice(...)
+    severity: WARNING
+
+  - id: prefer-slices-sortstablefunc
+    languages: [go]
+    message: Prefer slices.SortStableFunc to sort.SliceStable
+    pattern: sort.SliceStable(...)
+    severity: WARNING

--- a/internal/generate/acctestconsts/main.go
+++ b/internal/generate/acctestconsts/main.go
@@ -7,8 +7,9 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
@@ -23,14 +24,14 @@ var constOrQuoteTmpl string
 //go:embed semgrep.gtpl
 var semgrepTmpl string
 
-type ConstantDatum struct {
+type constantDatum struct {
 	Constant   string
 	Literal    string
 	AltLiteral string
 }
 
 type TemplateData struct {
-	Constants []ConstantDatum
+	Constants []constantDatum
 }
 
 func main() {
@@ -91,21 +92,21 @@ func main() {
 	}
 }
 
-func readConstants(filename string) ([]ConstantDatum, error) {
+func readConstants(filename string) ([]constantDatum, error) {
 	constants, err := common.ReadAllCSVData(filename)
 
 	if err != nil {
 		return nil, err
 	}
 
-	var constantList []ConstantDatum
+	var constantList []constantDatum
 
 	for _, row := range constants {
 		if row[0] == "" {
 			continue
 		}
 
-		cd := ConstantDatum{
+		cd := constantDatum{
 			Literal:  row[0],
 			Constant: row[1],
 		}
@@ -128,8 +129,8 @@ func readConstants(filename string) ([]ConstantDatum, error) {
 		constantList = append(constantList, cd)
 	}
 
-	sort.SliceStable(constantList, func(i, j int) bool {
-		return constantList[j].Constant > constantList[i].Constant
+	slices.SortStableFunc(constantList, func(a, b constantDatum) int {
+		return cmp.Compare(a.Constant, b.Constant)
 	})
 
 	return constantList, nil

--- a/internal/generate/allowsubcats/main.go
+++ b/internal/generate/allowsubcats/main.go
@@ -7,8 +7,9 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
@@ -55,8 +56,8 @@ func main() {
 		td.Services = append(td.Services, sd)
 	}
 
-	sort.SliceStable(td.Services, func(i, j int) bool {
-		return td.Services[i].HumanFriendly < td.Services[j].HumanFriendly
+	slices.SortStableFunc(td.Services, func(a, b ServiceDatum) int {
+		return cmp.Compare(a.HumanFriendly, b.HumanFriendly)
 	})
 
 	d := g.NewUnformattedFileDestination(filename)

--- a/internal/generate/attrconsts/main.go
+++ b/internal/generate/attrconsts/main.go
@@ -7,8 +7,9 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
@@ -27,13 +28,13 @@ var constOrQuoteTmpl string
 //go:embed semgrep.gtpl
 var semgrepTmpl string
 
-type ConstantDatum struct {
+type constantDatum struct {
 	Constant string
 	Literal  string
 }
 
 type TemplateData struct {
-	Constants []ConstantDatum
+	Constants []constantDatum
 }
 
 func main() {
@@ -94,28 +95,28 @@ func main() {
 	}
 }
 
-func readConstants(filename string) ([]ConstantDatum, error) {
+func readConstants(filename string) ([]constantDatum, error) {
 	constants, err := common.ReadAllCSVData(filename)
 
 	if err != nil {
 		return nil, err
 	}
 
-	var constantList []ConstantDatum
+	var constantList []constantDatum
 
 	for _, row := range constants {
 		if row[0] == "" {
 			continue
 		}
 
-		constantList = append(constantList, ConstantDatum{
+		constantList = append(constantList, constantDatum{
 			Literal:  row[0],
 			Constant: row[1],
 		})
 	}
 
-	sort.SliceStable(constantList, func(i, j int) bool {
-		return constantList[j].Constant > constantList[i].Constant
+	slices.SortStableFunc(constantList, func(a, b constantDatum) int {
+		return cmp.Compare(a.Constant, b.Constant)
 	})
 
 	return constantList, nil

--- a/internal/generate/awsclient/main.go
+++ b/internal/generate/awsclient/main.go
@@ -7,8 +7,9 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
 	"github.com/hashicorp/terraform-provider-aws/names/data"
@@ -59,8 +60,8 @@ func main() {
 		td.Services = append(td.Services, s)
 	}
 
-	sort.SliceStable(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderNameUpper < td.Services[j].ProviderNameUpper
+	slices.SortStableFunc(td.Services, func(a, b ServiceDatum) int {
+		return cmp.Compare(a.ProviderNameUpper, b.ProviderNameUpper)
 	})
 
 	d := g.NewGoFileDestination(filename)

--- a/internal/generate/customends/main.go
+++ b/internal/generate/customends/main.go
@@ -7,8 +7,9 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
@@ -72,8 +73,8 @@ func main() {
 		td.Services = append(td.Services, sd)
 	}
 
-	sort.Slice(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderPackage < td.Services[j].ProviderPackage
+	slices.SortFunc(td.Services, func(a, b serviceDatum) int {
+		return cmp.Compare(a.ProviderPackage, b.ProviderPackage)
 	})
 
 	d := g.NewUnformattedFileDestination(filename)

--- a/internal/generate/customendsfwschema/main.go
+++ b/internal/generate/customendsfwschema/main.go
@@ -7,8 +7,9 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
@@ -56,8 +57,8 @@ func main() {
 		td.Services = append(td.Services, sd)
 	}
 
-	sort.Slice(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderPackage < td.Services[j].ProviderPackage
+	slices.SortFunc(td.Services, func(a, b serviceDatum) int {
+		return cmp.Compare(a.ProviderPackage, b.ProviderPackage)
 	})
 
 	d := g.NewGoFileDestination(filename)

--- a/internal/generate/customendsschema/main.go
+++ b/internal/generate/customendsschema/main.go
@@ -7,8 +7,9 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
@@ -62,8 +63,8 @@ func main() {
 		td.Services = append(td.Services, sd)
 	}
 
-	sort.Slice(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderPackage < td.Services[j].ProviderPackage
+	slices.SortFunc(td.Services, func(a, b serviceDatum) int {
+		return cmp.Compare(a.ProviderPackage, b.ProviderPackage)
 	})
 
 	d := g.NewGoFileDestination(filename)

--- a/internal/generate/issuelabels/main.go
+++ b/internal/generate/issuelabels/main.go
@@ -7,8 +7,9 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
@@ -57,8 +58,8 @@ func main() {
 		td.Services = append(td.Services, s)
 	}
 
-	sort.SliceStable(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderPackage < td.Services[j].ProviderPackage
+	slices.SortStableFunc(td.Services, func(a, b ServiceDatum) int {
+		return cmp.Compare(a.ProviderPackage, b.ProviderPackage)
 	})
 
 	d := g.NewUnformattedFileDestination(filename)

--- a/internal/generate/namescapslist/main.go
+++ b/internal/generate/namescapslist/main.go
@@ -7,9 +7,10 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
@@ -91,11 +92,12 @@ func readBadCaps(filename string) ([]CapsDatum, error) {
 		})
 	}
 
-	sort.SliceStable(capsList, func(i, j int) bool {
-		if len(capsList[i].Wrong) == len(capsList[j].Wrong) {
-			return capsList[i].Wrong < capsList[j].Wrong
-		}
-		return len(capsList[j].Wrong) < len(capsList[i].Wrong)
+	slices.SortStableFunc(capsList, func(a, b CapsDatum) int {
+		return cmp.Or(
+			// Reverse length order
+			cmp.Compare(len(b.Wrong), len(a.Wrong)),
+			cmp.Compare(a.Wrong, b.Wrong),
+		)
 	})
 
 	onChunk := -1
@@ -108,11 +110,11 @@ func readBadCaps(filename string) ([]CapsDatum, error) {
 		capsList[i].Test = fmt.Sprintf(`%s%d`, "caps", onChunk)
 	}
 
-	sort.SliceStable(capsList, func(i, j int) bool {
-		if strings.EqualFold(capsList[i].Wrong, capsList[j].Wrong) {
-			return capsList[i].Wrong < capsList[j].Wrong
-		}
-		return strings.ToLower(capsList[i].Wrong) < strings.ToLower(capsList[j].Wrong)
+	slices.SortStableFunc(capsList, func(a, b CapsDatum) int {
+		return cmp.Or(
+			cmp.Compare(strings.ToLower(a.Wrong), strings.ToLower(b.Wrong)),
+			cmp.Compare(a.Wrong, b.Wrong),
+		)
 	})
 
 	return capsList, nil

--- a/internal/generate/namesconsts/main.go
+++ b/internal/generate/namesconsts/main.go
@@ -7,18 +7,19 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
 	"github.com/hashicorp/terraform-provider-aws/names/data"
 )
 
 type TemplateData struct {
-	Services []ServiceDatum
+	Services []serviceDatum
 }
 
-type ServiceDatum struct {
+type serviceDatum struct {
 	ProviderPackage   string
 	ProviderNameUpper string
 	SDKID             string
@@ -49,7 +50,7 @@ func main() {
 			continue
 		}
 
-		sd := ServiceDatum{
+		sd := serviceDatum{
 			ProviderPackage:   l.ProviderPackage(),
 			ProviderNameUpper: l.ProviderNameUpper(),
 			SDKID:             l.SDKID(),
@@ -58,8 +59,8 @@ func main() {
 		td.Services = append(td.Services, sd)
 	}
 
-	sort.Slice(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderNameUpper < td.Services[j].ProviderNameUpper
+	slices.SortFunc(td.Services, func(a, b serviceDatum) int {
+		return cmp.Compare(a.ProviderNameUpper, b.ProviderNameUpper)
 	})
 
 	d := g.NewGoFileDestination(filename)

--- a/internal/generate/prlabels/main.go
+++ b/internal/generate/prlabels/main.go
@@ -7,8 +7,9 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
@@ -65,8 +66,8 @@ func main() {
 		td.Services = append(td.Services, s)
 	}
 
-	sort.SliceStable(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderPackage < td.Services[j].ProviderPackage
+	slices.SortStableFunc(td.Services, func(a, b ServiceDatum) int {
+		return cmp.Compare(a.ProviderPackage, b.ProviderPackage)
 	})
 
 	d := g.NewUnformattedFileDestination(filename)

--- a/internal/generate/servicelabels/main.go
+++ b/internal/generate/servicelabels/main.go
@@ -7,8 +7,9 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
@@ -53,8 +54,8 @@ func main() {
 		td.Services = append(td.Services, s)
 	}
 
-	sort.SliceStable(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderPackage < td.Services[j].ProviderPackage
+	slices.SortStableFunc(td.Services, func(a, b ServiceDatum) int {
+		return cmp.Compare(a.ProviderPackage, b.ProviderPackage)
 	})
 
 	d := g.NewUnformattedFileDestination(filename)

--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -15,7 +16,6 @@ import (
 	"go/token"
 	"os"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/YakDriver/regexache"
@@ -82,11 +82,11 @@ func main() {
 			SDKResources:         v.sdkResources,
 		}
 
-		sort.SliceStable(s.FrameworkDataSources, func(i, j int) bool {
-			return s.FrameworkDataSources[i].FactoryName < s.FrameworkDataSources[j].FactoryName
+		slices.SortStableFunc(s.FrameworkDataSources, func(a, b ResourceDatum) int {
+			return cmp.Compare(a.FactoryName, b.FactoryName)
 		})
-		sort.SliceStable(s.FrameworkResources, func(i, j int) bool {
-			return s.FrameworkResources[i].FactoryName < s.FrameworkResources[j].FactoryName
+		slices.SortStableFunc(s.FrameworkResources, func(a, b ResourceDatum) int {
+			return cmp.Compare(a.FactoryName, b.FactoryName)
 		})
 
 		d := g.NewGoFileDestination(filename)

--- a/internal/generate/servicepackages/main.go
+++ b/internal/generate/servicepackages/main.go
@@ -7,11 +7,12 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
 	"flag"
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
 	"github.com/hashicorp/terraform-provider-aws/names/data"
@@ -59,8 +60,8 @@ func main() {
 		td.Services = append(td.Services, s)
 	}
 
-	sort.SliceStable(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderPackage < td.Services[j].ProviderPackage
+	slices.SortStableFunc(td.Services, func(a, b ServiceDatum) int {
+		return cmp.Compare(a.ProviderPackage, b.ProviderPackage)
 	})
 
 	d := g.NewGoFileDestination(filename)

--- a/internal/generate/sweeperregistration/main.go
+++ b/internal/generate/sweeperregistration/main.go
@@ -7,12 +7,13 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
-	"sort"
+	"slices"
 
 	"github.com/hashicorp/terraform-provider-aws/internal/generate/common"
 	"github.com/hashicorp/terraform-provider-aws/names/data"
@@ -70,8 +71,8 @@ func main() {
 		td.Services = append(td.Services, s)
 	}
 
-	sort.SliceStable(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderPackage < td.Services[j].ProviderPackage
+	slices.SortStableFunc(td.Services, func(a, b ServiceDatum) int {
+		return cmp.Compare(a.ProviderPackage, b.ProviderPackage)
 	})
 
 	d := g.NewGoFileDestination(filename)

--- a/internal/generate/teamcity/services.go
+++ b/internal/generate/teamcity/services.go
@@ -7,13 +7,14 @@
 package main
 
 import (
+	"cmp"
 	_ "embed"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsimple"
@@ -94,8 +95,8 @@ func main() {
 		td.Services = append(td.Services, sd)
 	}
 
-	sort.SliceStable(td.Services, func(i, j int) bool {
-		return td.Services[i].ProviderPackage < td.Services[j].ProviderPackage
+	slices.SortStableFunc(td.Services, func(a, b ServiceDatum) int {
+		return cmp.Compare(a.ProviderPackage, b.ProviderPackage)
 	})
 
 	d := g.NewUnformattedFileDestination(servicesAllFile)

--- a/internal/service/batch/container_properties.go
+++ b/internal/service/batch/container_properties.go
@@ -4,7 +4,8 @@
 package batch
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	_ "unsafe" // Required for go:linkname
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -107,8 +108,8 @@ func (cp *containerProperties) reduce() {
 
 func (cp *containerProperties) sortEnvironment() {
 	// Deal with Environment objects which may be re-ordered in the API.
-	sort.Slice(cp.Environment, func(i, j int) bool {
-		return aws.ToString(cp.Environment[i].Name) < aws.ToString(cp.Environment[j].Name)
+	slices.SortFunc(cp.Environment, func(a, b awstypes.KeyValuePair) int {
+		return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
 	})
 }
 

--- a/internal/service/batch/ecs_properties.go
+++ b/internal/service/batch/ecs_properties.go
@@ -4,7 +4,8 @@
 package batch
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	_ "unsafe" // Required for go:linkname
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -69,8 +70,8 @@ func (ep *ecsProperties) reduce() {
 
 func (ep *ecsProperties) orderContainers() {
 	for i, taskProps := range ep.TaskProperties {
-		sort.Slice(taskProps.Containers, func(i, j int) bool {
-			return aws.ToString(taskProps.Containers[i].Name) < aws.ToString(taskProps.Containers[j].Name)
+		slices.SortFunc(taskProps.Containers, func(a, b awstypes.TaskContainerProperties) int {
+			return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
 		})
 
 		ep.TaskProperties[i].Containers = taskProps.Containers
@@ -85,8 +86,8 @@ func (ep *ecsProperties) orderEnvironmentVariables() {
 				return aws.ToString(kvp.Value) != ""
 			})
 
-			sort.Slice(container.Environment, func(i, j int) bool {
-				return aws.ToString(container.Environment[i].Name) < aws.ToString(container.Environment[j].Name)
+			slices.SortFunc(container.Environment, func(a, b awstypes.KeyValuePair) int {
+				return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
 			})
 
 			ep.TaskProperties[i].Containers[j].Environment = container.Environment
@@ -97,8 +98,8 @@ func (ep *ecsProperties) orderEnvironmentVariables() {
 func (ep *ecsProperties) orderSecrets() {
 	for i, taskProps := range ep.TaskProperties {
 		for j, container := range taskProps.Containers {
-			sort.Slice(container.Secrets, func(i, j int) bool {
-				return aws.ToString(container.Secrets[i].Name) < aws.ToString(container.Secrets[j].Name)
+			slices.SortFunc(container.Secrets, func(a, b awstypes.Secret) int {
+				return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
 			})
 
 			ep.TaskProperties[i].Containers[j].Secrets = container.Secrets

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -4,10 +4,11 @@
 package batch
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -589,8 +590,8 @@ func expandComputeEnvironments(ctx context.Context, tfList types.List) []awstype
 }
 
 func flattenComputeEnvironments(ctx context.Context, apiObjects []awstypes.ComputeEnvironmentOrder) types.List {
-	sort.Slice(apiObjects, func(i, j int) bool {
-		return aws.ToInt32(apiObjects[i].Order) < aws.ToInt32(apiObjects[j].Order)
+	slices.SortFunc(apiObjects, func(a, b awstypes.ComputeEnvironmentOrder) int {
+		return cmp.Compare(aws.ToInt32(a.Order), aws.ToInt32(b.Order))
 	})
 
 	return fwflex.FlattenFrameworkStringListLegacy(ctx, tfslices.ApplyToAll(apiObjects, func(v awstypes.ComputeEnvironmentOrder) *string {

--- a/internal/service/ec2/ebs_snapshot_data_source.go
+++ b/internal/service/ec2/ebs_snapshot_data_source.go
@@ -6,12 +6,13 @@ package ec2
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -151,18 +152,16 @@ func dataSourceEBSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "Your query returned no results. Please change your search criteria and try again.")
 	}
 
-	if len(snapshots) > 1 {
-		if !d.Get(names.AttrMostRecent).(bool) {
-			return sdkdiag.AppendErrorf(diags, "Your query returned more than one result. Please try a more "+
-				"specific search criteria, or set `most_recent` attribute to true.")
-		}
-
-		sort.Slice(snapshots, func(i, j int) bool {
-			return aws.ToTime(snapshots[i].StartTime).Unix() > aws.ToTime(snapshots[j].StartTime).Unix()
-		})
+	if len(snapshots) > 1 && !d.Get(names.AttrMostRecent).(bool) {
+		return sdkdiag.AppendErrorf(diags, "Your query returned more than one result. Please try a more "+
+			"specific search criteria, or set `most_recent` attribute to true.")
 	}
 
-	snapshot := snapshots[0]
+	sortSnapshotsDescending(snapshots)
+
+	snapshot := slices.MaxFunc(snapshots, func(a, b awstypes.Snapshot) int {
+		return aws.ToTime(a.StartTime).Compare(aws.ToTime(b.StartTime))
+	})
 
 	d.SetId(aws.ToString(snapshot.SnapshotId))
 	arn := arn.ARN{

--- a/internal/service/ec2/ebs_snapshot_ids_data_source.go
+++ b/internal/service/ec2/ebs_snapshot_ids_data_source.go
@@ -5,11 +5,12 @@ package ec2
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -76,9 +77,7 @@ func dataSourceEBSSnapshotIDsRead(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "reading EBS Snapshots: %s", err)
 	}
 
-	sort.Slice(snapshots, func(i, j int) bool {
-		return aws.ToTime(snapshots[i].StartTime).Unix() > aws.ToTime(snapshots[j].StartTime).Unix()
-	})
+	sortSnapshotsDescending(snapshots)
 
 	var snapshotIDs []string
 
@@ -90,4 +89,10 @@ func dataSourceEBSSnapshotIDsRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set(names.AttrIDs, snapshotIDs)
 
 	return diags
+}
+
+func sortSnapshotsDescending(snapshots []awstypes.Snapshot) {
+	slices.SortFunc(snapshots, func(a, b awstypes.Snapshot) int {
+		return aws.ToTime(b.StartTime).Compare(aws.ToTime(a.StartTime))
+	})
 }

--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -6,7 +6,7 @@ package ec2
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -280,19 +280,16 @@ func dataSourceAMIRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return sdkdiag.AppendErrorf(diags, "Your query returned no results. Please change your search criteria and try again.")
 	}
 
-	if len(filteredImages) > 1 {
-		if !d.Get(names.AttrMostRecent).(bool) {
-			return sdkdiag.AppendErrorf(diags, "Your query returned more than one result. Please try a more "+
-				"specific search criteria, or set `most_recent` attribute to true.")
-		}
-		sort.Slice(filteredImages, func(i, j int) bool {
-			itime, _ := time.Parse(time.RFC3339, aws.ToString(filteredImages[i].CreationDate))
-			jtime, _ := time.Parse(time.RFC3339, aws.ToString(filteredImages[j].CreationDate))
-			return itime.Unix() > jtime.Unix()
-		})
+	if len(filteredImages) > 1 && !d.Get(names.AttrMostRecent).(bool) {
+		return sdkdiag.AppendErrorf(diags, "Your query returned more than one result. Please try a more "+
+			"specific search criteria, or set `most_recent` attribute to true.")
 	}
 
-	image := filteredImages[0]
+	image := slices.MaxFunc(filteredImages, func(a, b awstypes.Image) int {
+		atime, _ := time.Parse(time.RFC3339, aws.ToString(a.CreationDate))
+		btime, _ := time.Parse(time.RFC3339, aws.ToString(b.CreationDate))
+		return atime.Compare(btime)
+	})
 
 	d.SetId(aws.ToString(image.ImageId))
 	d.Set("architecture", image.Architecture)

--- a/internal/service/ec2/ec2_availability_zones_data_source.go
+++ b/internal/service/ec2/ec2_availability_zones_data_source.go
@@ -4,9 +4,10 @@
 package ec2
 
 import (
+	"cmp"
 	"context"
 	"log"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -107,8 +108,8 @@ func dataSourceAvailabilityZonesRead(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "fetching Availability Zones: %s", err)
 	}
 
-	sort.Slice(resp.AvailabilityZones, func(i, j int) bool {
-		return aws.ToString(resp.AvailabilityZones[i].ZoneName) < aws.ToString(resp.AvailabilityZones[j].ZoneName)
+	slices.SortFunc(resp.AvailabilityZones, func(a, b awstypes.AvailabilityZone) int {
+		return cmp.Compare(aws.ToString(a.ZoneName), aws.ToString(b.ZoneName))
 	})
 
 	excludeNames := d.Get("exclude_names").(*schema.Set)

--- a/internal/service/ec2/ec2_availability_zones_data_source_test.go
+++ b/internal/service/ec2/ec2_availability_zones_data_source_test.go
@@ -10,75 +10,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
-
-func TestAvailabilityZonesSort(t *testing.T) {
-	t.Parallel()
-
-	azs := []*awstypes.AvailabilityZone{
-		{
-			ZoneName: aws.String("name_YYY"),
-			ZoneId:   aws.String("id_YYY"),
-		},
-		{
-			ZoneName: aws.String("name_AAA"),
-			ZoneId:   aws.String("id_AAA"),
-		},
-		{
-			ZoneName: aws.String("name_ZZZ"),
-			ZoneId:   aws.String("id_ZZZ"),
-		},
-		{
-			ZoneName: aws.String("name_BBB"),
-			ZoneId:   aws.String("id_BBB"),
-		},
-	}
-	sort.Slice(azs, func(i, j int) bool {
-		return aws.ToString(azs[i].ZoneName) < aws.ToString(azs[j].ZoneName)
-	})
-
-	cases := []struct {
-		Index    int
-		ZoneName string
-		ZoneId   string
-	}{
-		{
-			Index:    0,
-			ZoneName: "name_AAA",
-			ZoneId:   "id_AAA",
-		},
-		{
-			Index:    1,
-			ZoneName: "name_BBB",
-			ZoneId:   "id_BBB",
-		},
-		{
-			Index:    2,
-			ZoneName: "name_YYY",
-			ZoneId:   "id_YYY",
-		},
-		{
-			Index:    3,
-			ZoneName: "name_ZZZ",
-			ZoneId:   "id_ZZZ",
-		},
-	}
-	for _, tc := range cases {
-		az := azs[tc.Index]
-		if aws.ToString(az.ZoneName) != tc.ZoneName {
-			t.Fatalf("AvailabilityZones index %d got zone name %s, expected %s", tc.Index, aws.ToString(az.ZoneName), tc.ZoneName)
-		}
-		if aws.ToString(az.ZoneId) != tc.ZoneId {
-			t.Fatalf("AvailabilityZones index %d got zone ID %s, expected %s", tc.Index, aws.ToString(az.ZoneId), tc.ZoneId)
-		}
-	}
-}
 
 func TestAccEC2AvailabilityZonesDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)

--- a/internal/service/ecr/lifecycle_policy.go
+++ b/internal/service/ecr/lifecycle_policy.go
@@ -4,9 +4,10 @@
 package ecr
 
 import (
+	"cmp"
 	"context"
 	"log"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -198,8 +199,8 @@ type lifecyclePolicy struct {
 }
 
 func (lp *lifecyclePolicy) reduce() {
-	sort.Slice(lp.Rules, func(i, j int) bool {
-		return aws.ToInt64(lp.Rules[i].RulePriority) < aws.ToInt64(lp.Rules[j].RulePriority)
+	slices.SortFunc(lp.Rules, func(a, b *lifecyclePolicyRule) int {
+		return cmp.Compare(aws.ToInt64(a.RulePriority), aws.ToInt64(b.RulePriority))
 	})
 
 	for _, rule := range lp.Rules {
@@ -208,16 +209,16 @@ func (lp *lifecyclePolicy) reduce() {
 }
 
 func (lprs *lifecyclePolicyRuleSelection) reduce() {
-	sort.Slice(lprs.TagPatternList, func(i, j int) bool {
-		return aws.ToString(lprs.TagPatternList[i]) < aws.ToString(lprs.TagPatternList[j])
+	slices.SortFunc(lprs.TagPatternList, func(a, b *string) int {
+		return cmp.Compare(aws.ToString(a), aws.ToString(b))
 	})
 
 	if len(lprs.TagPatternList) == 0 {
 		lprs.TagPatternList = nil
 	}
 
-	sort.Slice(lprs.TagPrefixList, func(i, j int) bool {
-		return aws.ToString(lprs.TagPrefixList[i]) < aws.ToString(lprs.TagPrefixList[j])
+	slices.SortFunc(lprs.TagPrefixList, func(a, b *string) int {
+		return cmp.Compare(aws.ToString(a), aws.ToString(b))
 	})
 
 	if len(lprs.TagPrefixList) == 0 {

--- a/internal/service/ecs/container_definitions.go
+++ b/internal/service/ecs/container_definitions.go
@@ -4,8 +4,9 @@
 package ecs
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	_ "unsafe" // Required for go:linkname
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -145,8 +146,8 @@ func (cd containerDefinitions) reduce(isAWSVPC bool) {
 
 func (cd containerDefinitions) orderEnvironmentVariables() {
 	for i, def := range cd {
-		sort.Slice(def.Environment, func(i, j int) bool {
-			return aws.ToString(def.Environment[i].Name) < aws.ToString(def.Environment[j].Name)
+		slices.SortFunc(def.Environment, func(a, b awstypes.KeyValuePair) int {
+			return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
 		})
 		cd[i].Environment = def.Environment
 	}
@@ -154,16 +155,16 @@ func (cd containerDefinitions) orderEnvironmentVariables() {
 
 func (cd containerDefinitions) orderSecrets() {
 	for i, def := range cd {
-		sort.Slice(def.Secrets, func(i, j int) bool {
-			return aws.ToString(def.Secrets[i].Name) < aws.ToString(def.Secrets[j].Name)
+		slices.SortFunc(def.Secrets, func(a, b awstypes.Secret) int {
+			return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
 		})
 		cd[i].Secrets = def.Secrets
 	}
 }
 
 func (cd containerDefinitions) orderContainers() {
-	sort.Slice(cd, func(i, j int) bool {
-		return aws.ToString(cd[i].Name) < aws.ToString(cd[j].Name)
+	slices.SortFunc(cd, func(a, b awstypes.ContainerDefinition) int {
+		return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
 	})
 }
 

--- a/internal/service/kafka/broker_nodes_data_source.go
+++ b/internal/service/kafka/broker_nodes_data_source.go
@@ -4,12 +4,13 @@
 package kafka
 
 import (
+	"cmp"
 	"context"
-	"sort"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
-	"github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -74,7 +75,7 @@ func dataSourceBrokerNodesRead(ctx context.Context, d *schema.ResourceData, meta
 	input := &kafka.ListNodesInput{
 		ClusterArn: aws.String(clusterARN),
 	}
-	var nodeInfos []types.NodeInfo
+	var nodeInfos []awstypes.NodeInfo
 
 	pages := kafka.NewListNodesPaginator(conn, input)
 	for pages.HasMorePages() {
@@ -91,11 +92,9 @@ func dataSourceBrokerNodesRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	// node list is returned unsorted sort on broker id
-	sort.Slice(nodeInfos, func(i, j int) bool {
-		iBrokerId := aws.ToFloat64(nodeInfos[i].BrokerNodeInfo.BrokerId)
-		jBrokerId := aws.ToFloat64(nodeInfos[j].BrokerNodeInfo.BrokerId)
-		return iBrokerId < jBrokerId
+	// node list is returned unsorted, sort on broker id
+	slices.SortFunc(nodeInfos, func(a, b awstypes.NodeInfo) int {
+		return cmp.Compare(aws.ToFloat64(a.BrokerNodeInfo.BrokerId), aws.ToFloat64(b.BrokerNodeInfo.BrokerId))
 	})
 
 	tfList := []interface{}{}

--- a/internal/service/rds/engine_version_data_source.go
+++ b/internal/service/rds/engine_version_data_source.go
@@ -428,7 +428,7 @@ func sortEngineVersions(engineVersions []awstypes.DBEngineVersion) {
 		return
 	}
 
-	sort.Slice(engineVersions, func(i, j int) bool {
+	sort.Slice(engineVersions, func(i, j int) bool { // nosemgrep:ci.semgrep.stdlib.prefer-slices-sortfunc
 		return version.LessThanWithTime(engineVersions[i].CreateTime, engineVersions[j].CreateTime, aws.ToString(engineVersions[i].EngineVersion), aws.ToString(engineVersions[j].EngineVersion))
 	})
 }

--- a/internal/service/rds/orderable_instance_data_source.go
+++ b/internal/service/rds/orderable_instance_data_source.go
@@ -477,7 +477,7 @@ func sortInstanceClassesByVersion(ic []awstypes.OrderableDBInstanceOption) {
 		return
 	}
 
-	sort.Slice(ic, func(i, j int) bool {
+	sort.Slice(ic, func(i, j int) bool { // nosemgrep:ci.semgrep.stdlib.prefer-slices-sortfunc
 		return version.LessThan(aws.ToString(ic[i].EngineVersion), aws.ToString(ic[j].EngineVersion))
 	})
 }

--- a/internal/service/servicecatalog/product.go
+++ b/internal/service/servicecatalog/product.go
@@ -6,7 +6,7 @@ package servicecatalog
 import (
 	"context"
 	"log"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -371,11 +371,9 @@ func resourceProductImport(ctx context.Context, d *schema.ResourceData, meta int
 
 	// import the last entry in the summary
 	if len(productData.ProvisioningArtifactSummaries) > 0 {
-		sort.Slice(productData.ProvisioningArtifactSummaries, func(i, j int) bool {
-			return aws.ToTime(productData.ProvisioningArtifactSummaries[i].CreatedTime).Before(aws.ToTime(productData.ProvisioningArtifactSummaries[j].CreatedTime))
+		provisioningArtifact := slices.MaxFunc(productData.ProvisioningArtifactSummaries, func(a, b awstypes.ProvisioningArtifactSummary) int {
+			return aws.ToTime(a.CreatedTime).Compare(aws.ToTime(b.CreatedTime))
 		})
-
-		provisioningArtifact := productData.ProvisioningArtifactSummaries[len(productData.ProvisioningArtifactSummaries)-1]
 		in := &servicecatalog.DescribeProvisioningArtifactInput{
 			ProductId:              aws.String(d.Id()),
 			ProvisioningArtifactId: provisioningArtifact.Id,

--- a/internal/service/ssmcontacts/planmodifiers.go
+++ b/internal/service/ssmcontacts/planmodifiers.go
@@ -4,22 +4,23 @@
 package ssmcontacts
 
 import (
+	"cmp"
 	"context"
-	"sort"
+	"slices"
 
-	"github.com/google/go-cmp/cmp"
+	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
-var _ planmodifier.List = shiftCoveragesPlanModifier{}
+var _ planmodifier.List = shiftCoveragesModifier{}
 
-func ShiftCoveragesPlanModifier() planmodifier.List {
-	return &shiftCoveragesPlanModifier{}
+func shiftCoveragesPlanModifier() planmodifier.List {
+	return &shiftCoveragesModifier{}
 }
 
-type shiftCoveragesPlanModifier struct{}
+type shiftCoveragesModifier struct{}
 
-func (s shiftCoveragesPlanModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+func (s shiftCoveragesModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
 	if req.PlanValue.IsNull() {
 		return
 	}
@@ -41,25 +42,23 @@ func (s shiftCoveragesPlanModifier) PlanModifyList(ctx context.Context, req plan
 		return
 	}
 
-	sort.Slice(plan, func(i, j int) bool {
-		return plan[i].MapBlockKey.ValueString() < plan[j].MapBlockKey.ValueString()
+	slices.SortFunc(plan, func(a, b shiftCoveragesData) int {
+		return cmp.Compare(a.MapBlockKey.ValueString(), b.MapBlockKey.ValueString())
 	})
 
-	sort.Slice(state, func(i, j int) bool {
-		return state[i].MapBlockKey.ValueString() < state[j].MapBlockKey.ValueString()
+	slices.SortFunc(state, func(a, b shiftCoveragesData) int {
+		return cmp.Compare(a.MapBlockKey.ValueString(), b.MapBlockKey.ValueString())
 	})
 
-	isEqual := cmp.Diff(plan, state) == ""
-
-	if isEqual {
+	if gocmp.Equal(plan, state) {
 		resp.PlanValue = req.StateValue
 	}
 }
 
-func (s shiftCoveragesPlanModifier) Description(_ context.Context) string {
+func (s shiftCoveragesModifier) Description(_ context.Context) string {
 	return "Suppress diff for shift_coverages"
 }
 
-func (s shiftCoveragesPlanModifier) MarkdownDescription(ctx context.Context) string {
+func (s shiftCoveragesModifier) MarkdownDescription(ctx context.Context) string {
 	return s.Description(ctx)
 }

--- a/internal/service/ssmcontacts/rotation.go
+++ b/internal/service/ssmcontacts/rotation.go
@@ -111,7 +111,7 @@ func (r *resourceRotation) Schema(ctx context.Context, request resource.SchemaRe
 						"shift_coverages": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[shiftCoveragesData](ctx),
 							PlanModifiers: []planmodifier.List{
-								ShiftCoveragesPlanModifier(),
+								shiftCoveragesPlanModifier(),
 								listplanmodifier.UseStateForUnknown(),
 							},
 							NestedObject: schema.NestedBlockObject{

--- a/tools/literally/main.go
+++ b/tools/literally/main.go
@@ -326,7 +326,7 @@ func (v *visitor) orderLiterals(scores map[string][]float64) []string {
 	}
 
 	// Sort the keys based on the scores
-	sort.Slice(keys, func(i, j int) bool {
+	sort.Slice(keys, func(i, j int) bool { // nosemgrep:ci.semgrep.stdlib.prefer-slices-sortfunc
 		if scores[keys[i]][0] != scores[keys[j]][0] {
 			return scores[keys[i]][0] > scores[keys[j]][0]
 		}


### PR DESCRIPTION
### Description

Replaces `sort.Slice` and `sort.SliceStable` with `slices.SortFunc` and `slices.SortStableFunc`. The syntax is more clear and in most cases, the `slices` functions are more performant.

Adds Semgrep rules