### PR TITLE
feat: add aws_glue_catalog_tables data source

### DIFF
--- a/internal/service/glue/catalog_tables_data_source.go
+++ b/internal/service/glue/catalog_tables_data_source.go
@@ -1,0 +1,76 @@
+package glue
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/glue"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// Define AttrIDs as a string constant
+const AttrIDs = "ids"
+
+// @SDKDataSource("aws_glue_catalog_tables")
+func DataSourceCatalogTables() *schema.Resource {
+
+	return &schema.Resource{
+		ReadWithoutTimeout: DataSourceCatalogTablesRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			names.AttrDatabaseName: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			names.AttrIDs: {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			names.AttrCatalogID: {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func DataSourceCatalogTablesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).GlueClient(ctx)
+
+	dbName := d.Get(names.AttrDatabaseName).(string)
+	catalogID := createCatalogID(d, meta.(*conns.AWSClient).AccountID)
+
+	input := &glue.GetTablesInput{
+		DatabaseName: aws.String(dbName),
+		CatalogId:    aws.String(catalogID),
+	}
+
+	output, err := conn.GetTables(ctx, input)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "getting Glue tables: %s", err)
+	}
+
+	var tableIDs []string
+	for _, table := range output.TableList {
+		tableIDs = append(tableIDs, *table.Name)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", catalogID, dbName))
+	d.Set(AttrIDs, tableIDs)
+	d.Set("catalog_id", catalogID)
+
+	return diags
+}

--- a/internal/service/glue/catalog_tables_data_source_test.go
+++ b/internal/service/glue/catalog_tables_data_source_test.go
@@ -1,0 +1,95 @@
+package glue_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDataSourceCatalogTables_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "data.aws_glue_catalog_tables.test"
+	databaseName := "test_db"
+	tableName1 := "table1"
+	tableName2 := "table2"
+	fmt.Println("Starting")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCatalogTablesDataSourceConfig_basic(databaseName, tableName1, tableName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "database_name", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "ids.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ids.0", tableName1),
+					resource.TestCheckResourceAttr(resourceName, "ids.1", tableName2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCatalogTablesDataSourceConfig_basic(databaseName, tableName1, tableName2 string) string {
+	return fmt.Sprintf(`
+resource "aws_glue_catalog_database" "test" {
+  name = %[1]q
+}
+
+resource "aws_glue_catalog_table" "test1" {
+  name          = %[2]q
+  database_name = aws_glue_catalog_database.test.name
+
+  storage_descriptor {
+    columns {
+      name = "col1"
+      type = "string"
+    }
+
+    location = "s3://my-bucket/test1/"
+    input_format = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+    compressed = false
+    number_of_buckets = -1
+    ser_de_info {
+      name = "test1"
+      serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+    }
+    stored_as_sub_directories = false
+  }
+}
+
+resource "aws_glue_catalog_table" "test2" {
+  name          = %[3]q
+  database_name = aws_glue_catalog_database.test.name
+
+  storage_descriptor {
+    columns {
+      name = "col1"
+      type = "string"
+    }
+
+    location = "s3://my-bucket/test2/"
+    input_format = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+    compressed = false
+    number_of_buckets = -1
+    ser_de_info {
+      name = "test2"
+      serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+    }
+    stored_as_sub_directories = false
+  }
+}
+
+data "aws_glue_catalog_tables" "test" {
+  database_name = aws_glue_catalog_database.test.name
+  depends_on = [aws_glue_catalog_table.test1, aws_glue_catalog_table.test2]
+}
+`, databaseName, tableName1, tableName2)
+}

--- a/internal/service/glue/service_package_gen.go
+++ b/internal/service/glue/service_package_gen.go
@@ -39,6 +39,10 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			TypeName: "aws_glue_catalog_table",
 		},
 		{
+			Factory:  DataSourceCatalogTables,
+			TypeName: "aws_glue_catalog_tables",
+		},
+		{
 			Factory:  DataSourceConnection,
 			TypeName: "aws_glue_connection",
 		},

--- a/website/docs/d/glue_catalog_tables..html.markdown
+++ b/website/docs/d/glue_catalog_tables..html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "Glue"
+layout: "aws"
+page_title: "AWS: aws_glue_catalog_table"
+description: |-
+  Get information on AWS Glue Data Catalog Table
+---
+
+# Data Source: aws_glue_catalog_tables
+
+This data source can be used to fetch table names from an AWS Glue Data Catalog Database.
+
+## Example Usage
+
+```terraform
+data "aws_glue_catalog_tables" "example" {
+  database_name          = "MyCatalogTable"
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `database_name` - (Required) Name of the table.
+* `catalog_id` - (Optional) ID of the Glue Catalog and database where the table metadata resides. If omitted, this defaults to the current AWS Account ID.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - Catalog ID and Database name of the tables separated by `:`.
+* `ids` - List of table names in the database.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Added a new data source aws_glue_catalog_tables which outputs all tables within a specified catalog and database. If no catalog is specified, the account_id is taken. The database_name is a mandatory field and needs to be provided. 
The output contains the database name, catalog id and id's containing all the table names within the specified database. 


### References

Data Source can be used for Glue Tables created by crawlers to ensure custom actions can be applied (e.g. data quality checks).
References to [this](https://docs.aws.amazon.com/cli/latest/reference/glue/get-tables.html) AWS CLI call



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccDataSourceCatalogTables PKG=glue
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccDataSourceCatalogTables'  -timeout 360m
2024/10/28 09:50:01 Initializing Terraform AWS Provider...
=== RUN   TestAccDataSourceCatalogTables_basic
Starting
=== PAUSE TestAccDataSourceCatalogTables_basic
=== CONT  TestAccDataSourceCatalogTables_basic
--- PASS: TestAccDataSourceCatalogTables_basic (18.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       18.539s

...
```
