### PR TITLE
Add Valkey engine support for memorydb resources

### DIFF
--- a/internal/service/memorydb/cluster.go
+++ b/internal/service/memorydb/cluster.go
@@ -80,6 +80,14 @@ func resourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrEngine: {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"redis",
+					"valkey",
+				}, false),
+			},
 			names.AttrEngineVersion: {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -282,6 +290,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		ACLName:                 aws.String(d.Get("acl_name").(string)),
 		AutoMinorVersionUpgrade: aws.Bool(d.Get(names.AttrAutoMinorVersionUpgrade).(bool)),
 		ClusterName:             aws.String(name),
+		Engine:                  aws.String(d.Get(names.AttrEngine).(string)),
 		NodeType:                aws.String(d.Get("node_type").(string)),
 		NumReplicasPerShard:     aws.Int32(int32(d.Get("num_replicas_per_shard").(int))),
 		NumShards:               aws.Int32(int32(d.Get("num_shards").(int))),
@@ -375,6 +384,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		input := &memorydb.UpdateClusterInput{
 			ClusterName: aws.String(d.Id()),
+			Engine:      aws.String(d.Get(names.AttrEngine).(string)),
 		}
 
 		if d.HasChange("acl_name") {
@@ -513,6 +523,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.Set(names.AttrDescription, cluster.Description)
 	d.Set("engine_patch_version", cluster.EnginePatchVersion)
+	d.Set(names.AttrEngine, cluster.Engine)
 	d.Set(names.AttrEngineVersion, cluster.EngineVersion)
 	d.Set(names.AttrKMSKeyARN, cluster.KmsKeyId) // KmsKeyId is actually an ARN here.
 	d.Set("maintenance_window", cluster.MaintenanceWindow)

--- a/internal/service/memorydb/cluster_data_source.go
+++ b/internal/service/memorydb/cluster_data_source.go
@@ -49,6 +49,10 @@ func dataSourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrEngine: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrEngineVersion: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -200,6 +204,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	d.Set(names.AttrDescription, cluster.Description)
 	d.Set("engine_patch_version", cluster.EnginePatchVersion)
+	d.Set(names.AttrEngine, cluster.Engine)
 	d.Set(names.AttrEngineVersion, cluster.EngineVersion)
 	d.Set(names.AttrKMSKeyARN, cluster.KmsKeyId) // KmsKeyId is actually an ARN here.
 	d.Set("maintenance_window", cluster.MaintenanceWindow)

--- a/internal/service/memorydb/cluster_data_source_test.go
+++ b/internal/service/memorydb/cluster_data_source_test.go
@@ -35,6 +35,7 @@ func TestAccMemoryDBClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "data_tiering", resourceName, "data_tiering"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDescription, resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttrPair(dataSourceName, "engine_patch_version", resourceName, "engine_patch_version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrEngine, resourceName, names.AttrEngine),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrEngineVersion, resourceName, names.AttrEngineVersion),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrKMSKeyARN, resourceName, names.AttrKMSKeyARN),
 					resource.TestCheckResourceAttrPair(dataSourceName, "maintenance_window", resourceName, "maintenance_window"),
@@ -87,6 +88,7 @@ resource "aws_memorydb_cluster" "test" {
   auto_minor_version_upgrade = false
   kms_key_arn                = aws_kms_key.test.arn
   name                       = %[1]q
+  engine                     = "valkey"
   node_type                  = "db.t4g.small"
   num_shards                 = 2
   security_group_ids         = [aws_security_group.test.id]

--- a/internal/service/memorydb/snapshot.go
+++ b/internal/service/memorydb/snapshot.go
@@ -57,6 +57,10 @@ func resourceSnapshot() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						names.AttrEngine: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						names.AttrEngineVersion: {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -248,6 +252,7 @@ func flattenClusterConfiguration(v *awstypes.ClusterConfiguration) []interface{}
 
 	m := map[string]interface{}{
 		names.AttrDescription:        aws.ToString(v.Description),
+		names.AttrEngine:             aws.ToString(v.Engine),
 		names.AttrEngineVersion:      aws.ToString(v.EngineVersion),
 		"maintenance_window":         aws.ToString(v.MaintenanceWindow),
 		names.AttrName:               aws.ToString(v.Name),

--- a/internal/service/memorydb/snapshot_test.go
+++ b/internal/service/memorydb/snapshot_test.go
@@ -35,6 +35,7 @@ func TestAccMemoryDBSnapshot_basic(t *testing.T) {
 					testAccCheckSnapshotExists(ctx, resourceName),
 					acctest.CheckResourceAttrRegionalARN(resourceName, names.AttrARN, "memorydb", "snapshot/"+rName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.description", "aws_memorydb_cluster.test", names.AttrDescription),
+					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.engine", "aws_memorydb_cluster.test", names.AttrEngine),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.engine_version", "aws_memorydb_cluster.test", names.AttrEngineVersion),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.maintenance_window", "aws_memorydb_cluster.test", "maintenance_window"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "cluster_configuration.0.name", "aws_memorydb_cluster.test", names.AttrName),
@@ -295,6 +296,7 @@ resource "aws_memorydb_cluster" "test" {
   acl_name                 = "open-access"
   name                     = %[1]q
   node_type                = "db.t4g.small"
+  engine                   = "redis"
   num_replicas_per_shard   = 0
   num_shards               = 1
   security_group_ids       = [aws_security_group.test.id]

--- a/website/docs/d/memorydb_cluster.html.markdown
+++ b/website/docs/d/memorydb_cluster.html.markdown
@@ -38,6 +38,7 @@ This data source exports the following attributes in addition to the arguments a
 * `data_tiering` - True when data tiering is enabled.
 * `description` - Description for the cluster.
 * `engine_patch_version` - Patch version number of the Redis engine used by the cluster.
+* `engine` - The engine that will run on cluster nodes.
 * `engine_version` - Version number of the Redis engine used by the cluster.
 * `final_snapshot_name` - Name of the final cluster snapshot to be created when this resource is deleted. If omitted, no final snapshot will be made.
 * `kms_key_arn` - ARN of the KMS key used to encrypt the cluster at rest.

--- a/website/docs/r/memorydb_cluster.html.markdown
+++ b/website/docs/r/memorydb_cluster.html.markdown
@@ -19,6 +19,7 @@ resource "aws_memorydb_cluster" "example" {
   acl_name                 = "open-access"
   name                     = "my-cluster"
   node_type                = "db.t4g.small"
+  engine                   = "redis"
   num_shards               = 2
   security_group_ids       = [aws_security_group.example.id]
   snapshot_retention_limit = 7
@@ -31,6 +32,7 @@ resource "aws_memorydb_cluster" "example" {
 The following arguments are required:
 
 * `acl_name` - (Required) The name of the Access Control List to associate with the cluster.
+* `engine` - (Required) The engine that will run on your nodes. Supported values are `redis` and `valkey`.
 * `node_type` - (Required) The compute and memory capacity of the nodes in the cluster. See AWS documentation on [supported node types](https://docs.aws.amazon.com/memorydb/latest/devguide/nodes.supportedtypes.html) as well as [vertical scaling](https://docs.aws.amazon.com/memorydb/latest/devguide/cluster-vertical-scaling.html).
 
 The following arguments are optional:

--- a/website/docs/r/memorydb_snapshot.html.markdown
+++ b/website/docs/r/memorydb_snapshot.html.markdown
@@ -39,6 +39,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - The ARN of the snapshot.
 * `cluster_configuration` - The configuration of the cluster from which the snapshot was taken.
     * `description` - Description for the cluster.
+    * `engine` - The engine that will run on cluster nodes.
     * `engine_version` - Version number of the Redis engine used by the cluster.
     * `maintenance_window` - The weekly time range during which maintenance on the cluster is performed.
     * `name` - Name of the cluster.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adding support for the newly introduced Valkey engine in AWS MemoryDB.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39644

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccMemoryDBSnapshot_basic PKG=memorydb
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/memorydb/... -v -count 1 -parallel 20 -run='TestAccMemoryDBSnapshot_basic'  -timeout 360m
=== RUN   TestAccMemoryDBSnapshot_basic
=== PAUSE TestAccMemoryDBSnapshot_basic
=== CONT  TestAccMemoryDBSnapshot_basic
--- PASS: TestAccMemoryDBSnapshot_basic (2894.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/memorydb	2898.408s

make testacc TESTS=TestAccMemoryDBClusterDataSource_basic PKG=memorydb
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/memorydb/... -v -count 1 -parallel 20 -run='TestAccMemoryDBClusterDataSource_basic'  -timeout 360m
=== RUN   TestAccMemoryDBClusterDataSource_basic
=== PAUSE TestAccMemoryDBClusterDataSource_basic
=== CONT  TestAccMemoryDBClusterDataSource_basic
--- PASS: TestAccMemoryDBClusterDataSource_basic (1996.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/memorydb	2001.265s

make testacc TESTS=TestAccMemoryDBCluster_basic PKG=memorydb 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/memorydb/... -v -count 1 -parallel 20 -run='TestAccMemoryDBCluster_basic'  -timeout 360m
=== RUN   TestAccMemoryDBCluster_basic
=== PAUSE TestAccMemoryDBCluster_basic
=== CONT  TestAccMemoryDBCluster_basic
--- PASS: TestAccMemoryDBCluster_basic (1975.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/memorydb	1979.363s
make testacc TESTS=TestAccMemoryDBCluster_valkey PKG=memorydb
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.22.7 test ./internal/service/memorydb/... -v -count 1 -parallel 20 -run='TestAccMemoryDBCluster_valkey'  -timeout 360m
=== RUN   TestAccMemoryDBCluster_valkey
=== PAUSE TestAccMemoryDBCluster_valkey
=== CONT  TestAccMemoryDBCluster_valkey
--- PASS: TestAccMemoryDBCluster_valkey (2033.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/memorydb	2037.697s
```
