### PR TITLE
fix: update approve_after_days validation in ssm patch baseline resource

### DIFF
--- a/.changelog/39949.txt
+++ b/.changelog/39949.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ssm_patch_baseline: Fix validation error when `approve_after_days` exceeds value of `100`.
+```

--- a/.changelog/39949.txt
+++ b/.changelog/39949.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ssm_patch_baseline: Fix validation error when `approve_after_days` exceeds value of `100`.
+resource/aws_ssm_patch_baseline: Update `approval_rule.approve_after_days` validation to allow a maximum value of `360`
 ```

--- a/internal/service/ssm/patch_baseline.go
+++ b/internal/service/ssm/patch_baseline.go
@@ -54,7 +54,7 @@ func resourcePatchBaseline() *schema.Resource {
 						"approve_after_days": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(0, 100),
+							ValidateFunc: validation.IntBetween(0, 360),
 						},
 						"approve_until_date": {
 							Type:         schema.TypeString,

--- a/internal/service/ssm/patch_baseline_test.go
+++ b/internal/service/ssm/patch_baseline_test.go
@@ -221,6 +221,31 @@ func TestAccSSMPatchBaseline_approveUntilDateParam(t *testing.T) {
 	})
 }
 
+func TestAccSSMPatchBaseline_approveAfterDaysParam(t *testing.T) {
+	ctx := acctest.Context(t)
+	var before ssm.GetPatchBaselineOutput
+	name := sdkacctest.RandString(10)
+	resourceName := "aws_ssm_patch_baseline.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPatchBaselineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPatchBaselineConfig_approve_after_days(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPatchBaselineExists(ctx, resourceName, &before),
+					resource.TestCheckResourceAttr(resourceName, "approval_rule.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "approval_rule.0.approve_after_days", "360"),
+					resource.TestCheckResourceAttr(resourceName, "approval_rule.0.patch_filter.#", acctest.Ct2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSSMPatchBaseline_sources(t *testing.T) {
 	ctx := acctest.Context(t)
 	var before, after ssm.GetPatchBaselineOutput
@@ -598,6 +623,36 @@ resource "aws_ssm_patch_baseline" "test" {
 
   approval_rule {
     approve_until_date  = "2020-02-02"
+    enable_non_security = true
+    compliance_level    = "CRITICAL"
+
+    patch_filter {
+      key    = "PRODUCT"
+      values = ["AmazonLinux2016.03", "AmazonLinux2016.09", "AmazonLinux2017.03", "AmazonLinux2017.09"]
+    }
+
+    patch_filter {
+      key    = "SEVERITY"
+      values = ["Critical", "Important"]
+    }
+  }
+}
+`, rName)
+}
+
+func testAccPatchBaselineConfig_approve_after_days(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_patch_baseline" "test" {
+  name             = "patch-baseline-%[1]s"
+  operating_system = "AMAZON_LINUX"
+  description      = "Baseline containing all updates approved for production systems"
+
+  tags = {
+    Name = "My Patch Baseline"
+  }
+
+  approval_rule {
+    approve_after_days  = 360
     enable_non_security = true
     compliance_level    = "CRITICAL"
 

--- a/internal/service/ssm/patch_baseline_test.go
+++ b/internal/service/ssm/patch_baseline_test.go
@@ -237,9 +237,9 @@ func TestAccSSMPatchBaseline_approveAfterDaysParam(t *testing.T) {
 				Config: testAccPatchBaselineConfig_approve_after_days(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPatchBaselineExists(ctx, resourceName, &before),
-					resource.TestCheckResourceAttr(resourceName, "approval_rule.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(resourceName, "approval_rule.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "approval_rule.0.approve_after_days", "360"),
-					resource.TestCheckResourceAttr(resourceName, "approval_rule.0.patch_filter.#", acctest.Ct2),
+					resource.TestCheckResourceAttr(resourceName, "approval_rule.0.patch_filter.#", "2"),
 				),
 			},
 		},

--- a/internal/service/ssm/patch_baseline_test.go
+++ b/internal/service/ssm/patch_baseline_test.go
@@ -221,9 +221,9 @@ func TestAccSSMPatchBaseline_approveUntilDateParam(t *testing.T) {
 	})
 }
 
-func TestAccSSMPatchBaseline_approveAfterDaysParam(t *testing.T) {
+func TestAccSSMPatchBaseline_approveAfterDays(t *testing.T) {
 	ctx := acctest.Context(t)
-	var before ssm.GetPatchBaselineOutput
+	var baseline ssm.GetPatchBaselineOutput
 	name := sdkacctest.RandString(10)
 	resourceName := "aws_ssm_patch_baseline.test"
 
@@ -234,9 +234,9 @@ func TestAccSSMPatchBaseline_approveAfterDaysParam(t *testing.T) {
 		CheckDestroy:             testAccCheckPatchBaselineDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPatchBaselineConfig_approve_after_days(name),
+				Config: testAccPatchBaselineConfig_approveAfterDays(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPatchBaselineExists(ctx, resourceName, &before),
+					testAccCheckPatchBaselineExists(ctx, resourceName, &baseline),
 					resource.TestCheckResourceAttr(resourceName, "approval_rule.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "approval_rule.0.approve_after_days", "360"),
 					resource.TestCheckResourceAttr(resourceName, "approval_rule.0.patch_filter.#", "2"),
@@ -640,16 +640,12 @@ resource "aws_ssm_patch_baseline" "test" {
 `, rName)
 }
 
-func testAccPatchBaselineConfig_approve_after_days(rName string) string {
+func testAccPatchBaselineConfig_approveAfterDays(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_ssm_patch_baseline" "test" {
-  name             = "patch-baseline-%[1]s"
+  name             = %[1]q
   operating_system = "AMAZON_LINUX"
   description      = "Baseline containing all updates approved for production systems"
-
-  tags = {
-    Name = "My Patch Baseline"
-  }
 
   approval_rule {
     approve_after_days  = 360

--- a/website/docs/r/ssm_patch_baseline.html.markdown
+++ b/website/docs/r/ssm_patch_baseline.html.markdown
@@ -180,7 +180,7 @@ The following arguments are optional:
 
 The `approval_rule` block supports:
 
-* `approve_after_days` - (Optional) Number of days after the release date of each patch matched by the rule the patch is marked as approved in the patch baseline. Valid Range: 0 to 100. Conflicts with `approve_until_date`.
+* `approve_after_days` - (Optional) Number of days after the release date of each patch matched by the rule the patch is marked as approved in the patch baseline. Valid Range: 0 to 360. Conflicts with `approve_until_date`.
 * `approve_until_date` - (Optional) Cutoff date for auto approval of released patches. Any patches released on or before this date are installed automatically. Date is formatted as `YYYY-MM-DD`. Conflicts with `approve_after_days`
 * `compliance_level` - (Optional) Compliance level for patches approved by this rule. Valid values are `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `INFORMATIONAL`, and `UNSPECIFIED`. The default value is `UNSPECIFIED`.
 * `enable_non_security` - (Optional) Boolean enabling the application of non-security updates. The default value is `false`. Valid for Linux instances only.


### PR DESCRIPTION
### Description

As described in #39917 the validation range for the `approve_after_days`  setting is not matching the range described in the official docs (see `References` section).

The PR updates the range from 0-100 to 0-360. In addition, the documentation for the resource is updated.

### Relations

Closes #39917 

### References

- [API Reference](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_PatchRule.html)


### Output from Acceptance Testing
```console
❯ make testacc TESTS=TestAccSSMPatchBaseline PKG=ssm
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/ssm/... -v -count 1 -parallel 5 -run='TestAccSSMPatchBaseline'  -timeout 360m
2024/10/30 19:58:29 Initializing Terraform AWS Provider...
=== RUN   TestAccSSMPatchBaselineDataSource_existingBaseline
=== PAUSE TestAccSSMPatchBaselineDataSource_existingBaseline
=== RUN   TestAccSSMPatchBaselineDataSource_newBaseline
=== PAUSE TestAccSSMPatchBaselineDataSource_newBaseline
=== RUN   TestAccSSMPatchBaseline_tags
=== PAUSE TestAccSSMPatchBaseline_tags
=== RUN   TestAccSSMPatchBaseline_tags_null
=== PAUSE TestAccSSMPatchBaseline_tags_null
=== RUN   TestAccSSMPatchBaseline_tags_EmptyMap
=== PAUSE TestAccSSMPatchBaseline_tags_EmptyMap
=== RUN   TestAccSSMPatchBaseline_tags_AddOnUpdate
=== PAUSE TestAccSSMPatchBaseline_tags_AddOnUpdate
=== RUN   TestAccSSMPatchBaseline_tags_EmptyTag_OnCreate
=== PAUSE TestAccSSMPatchBaseline_tags_EmptyTag_OnCreate
=== RUN   TestAccSSMPatchBaseline_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccSSMPatchBaseline_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccSSMPatchBaseline_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccSSMPatchBaseline_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccSSMPatchBaseline_tags_DefaultTags_providerOnly
=== PAUSE TestAccSSMPatchBaseline_tags_DefaultTags_providerOnly
=== RUN   TestAccSSMPatchBaseline_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccSSMPatchBaseline_tags_DefaultTags_nonOverlapping
=== RUN   TestAccSSMPatchBaseline_tags_DefaultTags_overlapping
=== PAUSE TestAccSSMPatchBaseline_tags_DefaultTags_overlapping
=== RUN   TestAccSSMPatchBaseline_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccSSMPatchBaseline_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccSSMPatchBaseline_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccSSMPatchBaseline_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccSSMPatchBaseline_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccSSMPatchBaseline_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccSSMPatchBaseline_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccSSMPatchBaseline_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccSSMPatchBaseline_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccSSMPatchBaseline_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccSSMPatchBaseline_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccSSMPatchBaseline_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccSSMPatchBaseline_tags_ComputedTag_OnCreate
=== PAUSE TestAccSSMPatchBaseline_tags_ComputedTag_OnCreate
=== RUN   TestAccSSMPatchBaseline_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccSSMPatchBaseline_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccSSMPatchBaseline_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccSSMPatchBaseline_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccSSMPatchBaseline_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccSSMPatchBaseline_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccSSMPatchBaseline_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccSSMPatchBaseline_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccSSMPatchBaseline_basic
=== PAUSE TestAccSSMPatchBaseline_basic
=== RUN   TestAccSSMPatchBaseline_disappears
=== PAUSE TestAccSSMPatchBaseline_disappears
=== RUN   TestAccSSMPatchBaseline_operatingSystem
=== PAUSE TestAccSSMPatchBaseline_operatingSystem
=== RUN   TestAccSSMPatchBaseline_approveUntilDateParam
=== PAUSE TestAccSSMPatchBaseline_approveUntilDateParam
=== RUN   TestAccSSMPatchBaseline_approveAfterDaysParam
=== PAUSE TestAccSSMPatchBaseline_approveAfterDaysParam
=== RUN   TestAccSSMPatchBaseline_sources
=== PAUSE TestAccSSMPatchBaseline_sources
=== RUN   TestAccSSMPatchBaseline_approvedPatchesNonSec
=== PAUSE TestAccSSMPatchBaseline_approvedPatchesNonSec
=== RUN   TestAccSSMPatchBaseline_approvalRuleEmpty
=== PAUSE TestAccSSMPatchBaseline_approvalRuleEmpty
=== RUN   TestAccSSMPatchBaseline_rejectPatchesAction
=== PAUSE TestAccSSMPatchBaseline_rejectPatchesAction
=== CONT  TestAccSSMPatchBaselineDataSource_existingBaseline
=== CONT  TestAccSSMPatchBaseline_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccSSMPatchBaseline_rejectPatchesAction
=== CONT  TestAccSSMPatchBaseline_approvalRuleEmpty
=== CONT  TestAccSSMPatchBaseline_approvedPatchesNonSec
--- PASS: TestAccSSMPatchBaselineDataSource_existingBaseline (26.55s)
=== CONT  TestAccSSMPatchBaseline_sources
--- PASS: TestAccSSMPatchBaseline_rejectPatchesAction (40.97s)
=== CONT  TestAccSSMPatchBaseline_approveAfterDaysParam
--- PASS: TestAccSSMPatchBaseline_approvedPatchesNonSec (41.16s)
=== CONT  TestAccSSMPatchBaseline_approveUntilDateParam
--- PASS: TestAccSSMPatchBaseline_tags_DefaultTags_nullOverlappingResourceTag (44.28s)
=== CONT  TestAccSSMPatchBaseline_operatingSystem
--- PASS: TestAccSSMPatchBaseline_approvalRuleEmpty (66.80s)
=== CONT  TestAccSSMPatchBaseline_disappears
--- PASS: TestAccSSMPatchBaseline_approveAfterDaysParam (27.67s)
=== CONT  TestAccSSMPatchBaseline_basic
--- PASS: TestAccSSMPatchBaseline_sources (57.52s)
=== CONT  TestAccSSMPatchBaseline_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccSSMPatchBaseline_disappears (30.80s)
=== CONT  TestAccSSMPatchBaseline_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccSSMPatchBaseline_approveUntilDateParam (57.90s)
=== CONT  TestAccSSMPatchBaseline_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccSSMPatchBaseline_operatingSystem (58.78s)
=== CONT  TestAccSSMPatchBaseline_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccSSMPatchBaseline_basic (63.93s)
=== CONT  TestAccSSMPatchBaseline_tags_ComputedTag_OnCreate
--- PASS: TestAccSSMPatchBaseline_tags_ComputedTag_OnUpdate_Replace (71.66s)
=== CONT  TestAccSSMPatchBaseline_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccSSMPatchBaseline_tags_ComputedTag_OnUpdate_Add (71.36s)
=== CONT  TestAccSSMPatchBaseline_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccSSMPatchBaseline_tags_ComputedTag_OnCreate (47.84s)
=== CONT  TestAccSSMPatchBaseline_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccSSMPatchBaseline_tags_IgnoreTags_Overlap_DefaultTag (84.05s)
=== CONT  TestAccSSMPatchBaseline_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccSSMPatchBaseline_tags_IgnoreTags_Overlap_ResourceTag (101.62s)
=== CONT  TestAccSSMPatchBaseline_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccSSMPatchBaseline_tags_DefaultTags_nullNonOverlappingResourceTag (42.52s)
=== CONT  TestAccSSMPatchBaseline_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccSSMPatchBaseline_tags_DefaultTags_emptyProviderOnlyTag (40.61s)
=== CONT  TestAccSSMPatchBaseline_tags_DefaultTags_overlapping
--- PASS: TestAccSSMPatchBaseline_tags_DefaultTags_emptyResourceTag (41.04s)
=== CONT  TestAccSSMPatchBaseline_tags_DefaultTags_nonOverlapping
--- PASS: TestAccSSMPatchBaseline_tags_EmptyTag_OnUpdate_Replace (71.59s)
=== CONT  TestAccSSMPatchBaseline_tags_DefaultTags_providerOnly
--- PASS: TestAccSSMPatchBaseline_tags_DefaultTags_updateToResourceOnly (65.44s)
=== CONT  TestAccSSMPatchBaseline_tags_EmptyMap
--- PASS: TestAccSSMPatchBaseline_tags_DefaultTags_updateToProviderOnly (68.72s)
=== CONT  TestAccSSMPatchBaseline_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccSSMPatchBaseline_tags_EmptyMap (52.11s)
=== CONT  TestAccSSMPatchBaseline_tags_EmptyTag_OnCreate
--- PASS: TestAccSSMPatchBaseline_tags_DefaultTags_overlapping (113.59s)
=== CONT  TestAccSSMPatchBaseline_tags_AddOnUpdate
--- PASS: TestAccSSMPatchBaseline_tags_DefaultTags_nonOverlapping (115.61s)
=== CONT  TestAccSSMPatchBaseline_tags
--- PASS: TestAccSSMPatchBaseline_tags_EmptyTag_OnCreate (77.39s)
=== CONT  TestAccSSMPatchBaseline_tags_null
--- PASS: TestAccSSMPatchBaseline_tags_EmptyTag_OnUpdate_Add (103.65s)
=== CONT  TestAccSSMPatchBaselineDataSource_newBaseline
--- PASS: TestAccSSMPatchBaseline_tags_DefaultTags_providerOnly (149.91s)
--- PASS: TestAccSSMPatchBaseline_tags_AddOnUpdate (69.21s)
--- PASS: TestAccSSMPatchBaselineDataSource_newBaseline (29.46s)
--- PASS: TestAccSSMPatchBaseline_tags_null (46.43s)
--- PASS: TestAccSSMPatchBaseline_tags (132.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        471.222s
```
