### PR TITLE
Fix invalid terraform drifting to redis in global replication groups

### DIFF
--- a/.changelog/39950.txt
+++ b/.changelog/39950.txt
@@ -1,0 +1,4 @@
+
+```release-note:bug
+resource/aws_elasticache_replication_group: Fix invalid drifting to redis engine in global replication groups
+```


### PR DESCRIPTION
### Description

This change follows-up on https://github.com/hashicorp/terraform-provider-aws/pull/39745 and fixes a bug which causes drift for ElastiCache Global Datastore in Valkey.

This is due to the current hard-coded default value for the `engine` argument, which inevitably causes the drift even in a `terraform plan` in an empty state importing an existing `aws_elasticache_replication_group` resource with the `global_replication_group_id` argument set (if this argument is set, the `redis` value in `engine` argument should **not** be passed).

```terraform
      ~ engine                         = "valkey" -> "redis" # forces replacement
```

The API parameter in AWS for `Engine` is [not required](https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateReplicationGroup.html) and has a default value, which brings the Terraform provider in line with AWS API behaviour.

### Relations

Relates #39745 

### References

### Output from Acceptance Testing

As per the [contributor guide](https://hashicorp.github.io/terraform-provider-aws/#4-write-tests) I would prefer the tests run on HashiCorp side.