### PR TITLE
aws_rds_global_cluster: Add `endpoint` attribute for DB writer endpoint

### DIFF
--- a/.changelog/39960.txt
+++ b/.changelog/39960.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_global_cluster: Add `endpoint` argument to point to the writer DB instance in the current primary cluster
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,6 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* resource/aws_rds_global_cluster: Add new `Endpoint` output attribute ([#39862](https://github.com/hashicorp/terraform-provider-aws/issues/39862))
 * data-source/aws_imagebuilder_distribution_configuration: Add `distribution.s3_export_configuration` attribute ([#35492](https://github.com/hashicorp/terraform-provider-aws/issues/35492))
 * data-source/aws_imagebuilder_image_recipe: Fix `block_device_mapping.0.ebs.0.delete_on_termination: '' expected type 'bool', got unconvertible type 'string'` errors ([#39928](https://github.com/hashicorp/terraform-provider-aws/issues/39928))
 * resource/aws_codedeploy_deployment_group: Add `termination_hook_enabled` argument ([#35482](https://github.com/hashicorp/terraform-provider-aws/issues/35482))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ FEATURES:
 
 ENHANCEMENTS:
 
-
+* resource/aws_rds_global_cluster: Add new `Endpoint` output attribute ([#39862](https://github.com/hashicorp/terraform-provider-aws/issues/39862))
 * data-source/aws_imagebuilder_distribution_configuration: Add `distribution.s3_export_configuration` attribute ([#35492](https://github.com/hashicorp/terraform-provider-aws/issues/35492))
 * data-source/aws_imagebuilder_image_recipe: Fix `block_device_mapping.0.ebs.0.delete_on_termination: '' expected type 'bool', got unconvertible type 'string'` errors ([#39928](https://github.com/hashicorp/terraform-provider-aws/issues/39928))
 * resource/aws_codedeploy_deployment_group: Add `termination_hook_enabled` argument ([#35482](https://github.com/hashicorp/terraform-provider-aws/issues/35482))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ FEATURES:
 
 ENHANCEMENTS:
 
+
 * data-source/aws_imagebuilder_distribution_configuration: Add `distribution.s3_export_configuration` attribute ([#35492](https://github.com/hashicorp/terraform-provider-aws/issues/35492))
 * data-source/aws_imagebuilder_image_recipe: Fix `block_device_mapping.0.ebs.0.delete_on_termination: '' expected type 'bool', got unconvertible type 'string'` errors ([#39928](https://github.com/hashicorp/terraform-provider-aws/issues/39928))
 * resource/aws_codedeploy_deployment_group: Add `termination_hook_enabled` argument ([#35482](https://github.com/hashicorp/terraform-provider-aws/issues/35482))

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -61,7 +61,7 @@ func resourceGlobalCluster() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
-			"endpoint": {
+			names.AttrEndpoint: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -214,6 +214,7 @@ func resourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(names.AttrARN, globalCluster.GlobalClusterArn)
 	d.Set(names.AttrDatabaseName, globalCluster.DatabaseName)
 	d.Set(names.AttrDeletionProtection, globalCluster.DeletionProtection)
+	d.Set(names.AttrEndpoint, globalCluster.Endpoint)
 	d.Set(names.AttrEngine, globalCluster.Engine)
 	d.Set("engine_lifecycle_support", globalCluster.EngineLifecycleSupport)
 	d.Set("global_cluster_identifier", globalCluster.GlobalClusterIdentifier)
@@ -222,11 +223,6 @@ func resourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 	d.Set("global_cluster_resource_id", globalCluster.GlobalClusterResourceId)
 	d.Set(names.AttrStorageEncrypted, globalCluster.StorageEncrypted)
-
-	// Set the endpoint attribute
-	if err := d.Set("endpoint", globalCluster.Endpoint); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting endpoint: %s", err)
-	}
 
 	oldEngineVersion, newEngineVersion := d.Get(names.AttrEngineVersion).(string), aws.ToString(globalCluster.EngineVersion)
 

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -61,6 +61,10 @@ func resourceGlobalCluster() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrEngine: {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -127,10 +131,6 @@ func resourceGlobalCluster() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-			},
-			"endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
 			},
 		},
 	}

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -128,6 +128,10 @@ func resourceGlobalCluster() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -218,6 +222,11 @@ func resourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 	d.Set("global_cluster_resource_id", globalCluster.GlobalClusterResourceId)
 	d.Set(names.AttrStorageEncrypted, globalCluster.StorageEncrypted)
+
+	// Set the endpoint attribute
+	if err := d.Set("endpoint", globalCluster.Endpoint); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting endpoint: %s", err)
+	}
 
 	oldEngineVersion, newEngineVersion := d.Get(names.AttrEngineVersion).(string), aws.ToString(globalCluster.EngineVersion)
 

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -124,6 +124,7 @@ func TestAccRDSGlobalCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "global_cluster_identifier", rName),
 					resource.TestMatchResourceAttr(resourceName, "global_cluster_resource_id", regexache.MustCompile(`cluster-.+`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStorageEncrypted, acctest.CtFalse),
+					resource.TestCheckResourceAttrSet(resourceName, "endpoint"),
 				),
 			},
 			{

--- a/internal/service/rds/global_cluster_test.go
+++ b/internal/service/rds/global_cluster_test.go
@@ -124,7 +124,7 @@ func TestAccRDSGlobalCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "global_cluster_identifier", rName),
 					resource.TestMatchResourceAttr(resourceName, "global_cluster_resource_id", regexache.MustCompile(`cluster-.+`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrStorageEncrypted, acctest.CtFalse),
-					resource.TestCheckResourceAttrSet(resourceName, "endpoint"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrEndpoint),
 				),
 			},
 			{

--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -217,6 +217,7 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - RDS Global Cluster Amazon Resource Name (ARN)
+* `endpoint` - Writer endpoint for the new global database cluster. This endpoint always points to the writer DB instance in the current primary cluster.
 * `global_cluster_members` - Set of objects containing Global Cluster members.
     * `db_cluster_arn` - Amazon Resource Name (ARN) of member DB Cluster
     * `is_writer` - Whether the member is the primary DB Cluster


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
AWS Started supporting [global endpoint](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database-connecting.html) for global aurora clusters. This PR is to basically add the new endpoint attribute as a new output attribute. 

This basically solves https://github.com/hashicorp/terraform-provider-aws/issues/39862
<!---

--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #39862
--->

Closes #39862

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
