### PR TITLE
Add support for engineValkey in the ValidateFunc

### DIFF
--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -142,7 +142,7 @@ func resourceCluster() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ExactlyOneOf: []string{names.AttrEngine, "replication_group_id"},
-				ValidateFunc: validation.StringInSlice([]string{engineMemcached, engineRedis}, false),
+				ValidateFunc: validation.StringInSlice([]string{engineMemcached, engineRedis, engineValkey}, false),
 			},
 			names.AttrEngineVersion: {
 				Type:     schema.TypeString,

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -117,6 +117,50 @@ func TestAccElastiCacheCluster_Engine_redis(t *testing.T) {
 	})
 }
 
+func TestAccElastiCacheCluster_Engine_valkey(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var ec awstypes.CacheCluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_engineValkey(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &ec),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "cache_nodes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cache_nodes.0.id", "0001"),
+					resource.TestCheckResourceAttr(resourceName, "cache_nodes.0.outpost_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "valkey"),
+					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^7\.[[:digit:]]+\.[[:digit:]]+$`)),
+					resource.TestCheckResourceAttr(resourceName, "ip_discovery", "ipv4"),
+					resource.TestCheckResourceAttr(resourceName, "network_type", "ipv4"),
+					resource.TestCheckNoResourceAttr(resourceName, "outpost_mode"),
+					resource.TestCheckResourceAttr(resourceName, "preferred_outpost_arn", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					names.AttrApplyImmediately,
+				},
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheCluster_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -1555,6 +1599,17 @@ func testAccClusterConfig_engineMemcached(rName string) string {
 resource "aws_elasticache_cluster" "test" {
   cluster_id      = %[1]q
   engine          = "memcached"
+  node_type       = "cache.t3.small"
+  num_cache_nodes = 1
+}
+`, rName)
+}
+
+func testAccClusterConfig_engineValkey(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_cluster" "test" {
+  cluster_id      = %[1]q
+  engine          = "valkey"
   node_type       = "cache.t3.small"
   num_cache_nodes = 1
 }


### PR DESCRIPTION
This MR adds `valkey` as option in the validation function for the allowed engines.
I also added a testcase with best effort, but unfortunately I cannot really run the test as I have no default subnet in my VPC which would be required by the test.

### Relations

Closes #39905

### Output from Acceptance Testing

```console
make testacc TESTS=TestAccElastiCacheCluster_Engine_valkey PKG=elasticache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheCluster_Engine_valkey'  -timeout 360m
2024/10/31 17:49:09 Initializing Terraform AWS Provider...
=== RUN   TestAccElastiCacheCluster_Engine_valkey
=== PAUSE TestAccElastiCacheCluster_Engine_valkey
=== CONT  TestAccElastiCacheCluster_Engine_valkey
    cluster_test.go:130: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating ElastiCache Cache Cluster (tf-acc-test-6418033427746438838): operation error ElastiCache: CreateCacheCluster, https response error StatusCode: 400, RequestID: 42f6496b-2635-4932-824b-206cc9ae2a84, InvalidParameterValue: The account does not have any default subnets.
        
          with aws_elasticache_cluster.test,
          on terraform_plugin_test.tf line 12, in resource "aws_elasticache_cluster" "test":
          12: resource "aws_elasticache_cluster" "test" {
        
--- FAIL: TestAccElastiCacheCluster_Engine_valkey (6.93s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	10.909s
FAIL
make: *** [testacc] Error 1
```
