### PR TITLE
Bypass iops check on unknown ebs volume types

### DIFF
--- a/.changelog/39838.txt
+++ b/.changelog/39838.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ebs_volume: Allow iops to be set on unknown volume types
+```

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -343,6 +343,21 @@ func resourceEBSVolumeCustomizeDiff(_ context.Context, diff *schema.ResourceDiff
 	throughput := diff.Get(names.AttrThroughput).(int)
 	volumeType := awstypes.VolumeType(diff.Get(names.AttrType).(string))
 
+	var isKnownType bool
+	for _, v := range volumeType.Values() {
+		if volumeType == v {
+			isKnownType = true
+			break
+		}
+	}
+
+	if !isKnownType {
+		// if the volume type is not known to this provider then we can't
+		// assume that rules about iops, multi-attach, etc apply to it
+		// so just return
+		return nil
+	}
+
 	if diff.Id() == "" {
 		// Create.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change will allow `aws_ebs_volume` resources to be created with `iops`  regardless of the volume type, whenever the volume type is not one of `awstypes.VolumeType`.  This allows the provider to be used to create volumes in AWS-compatible backends that offer additional volume types not found in AWS.  It also allows the `aws_ebs_resource` to support any potential new AWS volume types that would allow `iops`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39838

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I don't think it's possible to run acceptance tests for this since it would involve using a volume type that AWS doesn't consider valid.  I didn't see any unit tests for `aws_ebs_volume` but if unit tests are needed for this I can add them.
