### PR TITLE
add listTag condition to allow for failed sagemaker app

### DIFF
--- a/internal/provider/intercept.go
+++ b/internal/provider/intercept.go
@@ -349,6 +349,12 @@ func (r tagsResourceInterceptor) run(ctx context.Context, d schemaResourceData, 
 							}
 						}
 
+						if inContext.ServicePackageName == names.SageMaker && inContext.ResourceName == "App" && err != nil {
+							if tfawserr.ErrMessageContains(err, "ValidationException", "UnknownError") {
+								err = nil
+							}
+						}
+
 						if err != nil {
 							return ctx, sdkdiag.AppendErrorf(diags, "listing tags for %s %s (%s): %s", serviceName, resourceName, identifier, err)
 						}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add a condition to the listing of tags for a SageMaker App. If a SageMaker App is in a failed state due to a startup failure (i.e. lifecycle script) terraform (and aws cli) is unable to list tags and the action will continue to fail until the app is manually cleaned up.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
