### PR TITLE
feat: Add task_mode attr for aws_datasync_task

### DIFF
--- a/.changelog/39979.txt
+++ b/.changelog/39979.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_datasync_task: Add `task_mode` argument
+```

--- a/internal/service/datasync/location_s3_test.go
+++ b/internal/service/datasync/location_s3_test.go
@@ -211,6 +211,53 @@ func testAccCheckLocationS3Exists(ctx context.Context, n string, v *datasync.Des
 	}
 }
 
+func testAccLocationS3Config_base2(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test2" {
+  name = %[1]q
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "datasync.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "test2" {
+  role   = aws_iam_role.test2.id
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Action": [
+      "s3:*"
+    ],
+    "Effect": "Allow",
+    "Resource": [
+      "${aws_s3_bucket.test2.arn}",
+      "${aws_s3_bucket.test2.arn}/*"
+    ]
+  }]
+}
+POLICY
+}
+
+resource "aws_s3_bucket" "test2" {
+  bucket        = %[1]q
+  force_destroy = true
+}
+`, rName)
+}
+
 func testAccLocationS3Config_base(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {

--- a/internal/service/datasync/task.go
+++ b/internal/service/datasync/task.go
@@ -227,8 +227,8 @@ func resourceTask() *schema.Resource {
 			"task_mode": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Computed:         true,
 				ForceNew:         true,
-				Default:          awstypes.TaskModeBasic,
 				ValidateDiagFunc: enum.Validate[awstypes.TaskMode](),
 			},
 			"task_report_config": {

--- a/internal/service/datasync/task.go
+++ b/internal/service/datasync/task.go
@@ -224,6 +224,13 @@ func resourceTask() *schema.Resource {
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"task_mode": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Default:          awstypes.TaskModeBasic,
+				ValidateDiagFunc: enum.Validate[awstypes.TaskMode](),
+			},
 			"task_report_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -339,6 +346,10 @@ func resourceTaskCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 		input.Schedule = expandTaskSchedule(v.([]any))
 	}
 
+	if v, ok := d.GetOk("task_mode"); ok {
+		input.TaskMode = awstypes.TaskMode(v.(string))
+	}
+
 	output, err := conn.CreateTask(ctx, input)
 
 	if err != nil {
@@ -386,6 +397,7 @@ func resourceTaskRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 	if err := d.Set(names.AttrSchedule, flattenTaskSchedule(output.Schedule)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting schedule: %s", err)
 	}
+	d.Set("task_mode", output.TaskMode)
 	if err := d.Set("task_report_config", flattenTaskReportConfig(output.TaskReportConfig)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting task_report_config: %s", err)
 	}

--- a/internal/service/datasync/task_test.go
+++ b/internal/service/datasync/task_test.go
@@ -66,6 +66,7 @@ func TestAccDataSyncTask_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "schedule.#", "0"),
 					resource.TestCheckResourceAttrPair(resourceName, "source_location_arn", dataSyncSourceLocationResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+					resource.TestCheckResourceAttr(resourceName, "task_mode", "BASIC"),
 				),
 			},
 			{
@@ -807,6 +808,47 @@ func TestAccDataSyncTask_DefaultSyncOptions_verifyMode(t *testing.T) {
 	})
 }
 
+func TestAccDataSyncTask_taskMode(t *testing.T) {
+	ctx := acctest.Context(t)
+	var task1, task2 datasync.DescribeTaskOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_datasync_task.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DataSyncServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTaskDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskConfig_taskMode_enhanced(rName, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTaskExists(ctx, resourceName, &task1),
+					resource.TestCheckResourceAttr(resourceName, "options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.verify_mode", "ONLY_FILES_TRANSFERRED"),
+					resource.TestCheckResourceAttr(resourceName, "task_mode", "ENHANCED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccTaskConfig_taskMode_basic(rName, rName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTaskExists(ctx, resourceName, &task2),
+					testAccCheckTaskRecreated(&task1, &task2),
+					resource.TestCheckResourceAttr(resourceName, "options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "options.0.verify_mode", "POINT_IN_TIME_CONSISTENT"),
+					resource.TestCheckResourceAttr(resourceName, "task_mode", "BASIC"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSyncTask_taskReportConfig(t *testing.T) {
 	ctx := acctest.Context(t)
 	var task1 datasync.DescribeTaskOutput
@@ -947,6 +989,16 @@ func testAccCheckTaskExists(ctx context.Context, resourceName string, task *data
 	}
 }
 
+func testAccCheckTaskRecreated(i, j *datasync.DescribeTaskOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.ToString(i.TaskArn) == aws.ToString(j.TaskArn) {
+			return errors.New("DataSync Task was not recreated")
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckTaskNotRecreated(i, j *datasync.DescribeTaskOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if aws.ToString(i.TaskArn) != aws.ToString(j.TaskArn) {
@@ -986,6 +1038,21 @@ resource "aws_datasync_location_s3" "test" {
   }
 
   depends_on = [aws_iam_role_policy.test]
+}
+`)
+}
+
+func testAccTaskConfig_baseLocationS3_2(rName string) string {
+	return acctest.ConfigCompose(testAccLocationS3Config_base2(rName), `
+resource "aws_datasync_location_s3" "test2" {
+  s3_bucket_arn = aws_s3_bucket.test2.arn
+  subdirectory  = "/test2"
+
+  s3_config {
+    bucket_access_role_arn = aws_iam_role.test2.arn
+  }
+
+  depends_on = [aws_iam_role_policy.test2]
 }
 `)
 }
@@ -1583,4 +1650,45 @@ resource "aws_datasync_task" "test" {
   }
 }
 `, rName))
+}
+
+func testAccTaskConfig_taskMode_basic(rName, rName2 string) string {
+	return acctest.ConfigCompose(
+		testAccTaskConfig_baseLocationS3(rName),
+		testAccTaskConfig_baseLocationS3_2(rName2),
+		fmt.Sprintf(`
+resource "aws_datasync_task" "test" {
+  destination_location_arn = aws_datasync_location_s3.test2.arn
+  name                     = %[1]q
+  source_location_arn      = aws_datasync_location_s3.test.arn
+  task_mode                = "BASIC"
+
+  options {
+    gid               = "NONE"
+    posix_permissions = "NONE"
+    uid               = "NONE"
+  }
+}
+`, rName, rName2))
+}
+
+func testAccTaskConfig_taskMode_enhanced(rName, rName2 string) string {
+	return acctest.ConfigCompose(
+		testAccTaskConfig_baseLocationS3(rName),
+		testAccTaskConfig_baseLocationS3_2(rName2),
+		fmt.Sprintf(`
+resource "aws_datasync_task" "test" {
+  destination_location_arn = aws_datasync_location_s3.test2.arn
+  name                     = %[1]q
+  source_location_arn      = aws_datasync_location_s3.test.arn
+  task_mode                = "ENHANCED"
+
+  options {
+    gid               = "NONE"
+    posix_permissions = "NONE"
+    uid               = "NONE"
+    verify_mode       = "ONLY_FILES_TRANSFERRED"
+  }
+}
+`, rName, rName2))
 }

--- a/website/docs/r/datasync_task.html.markdown
+++ b/website/docs/r/datasync_task.html.markdown
@@ -40,7 +40,7 @@ resource "aws_datasync_task" "example" {
 
 ## Example Usage with Filtering
 
-```hcl
+```terraform
 resource "aws_datasync_task" "example" {
   destination_location_arn = aws_datasync_location_s3.destination.arn
   name                     = "example"
@@ -58,6 +58,24 @@ resource "aws_datasync_task" "example" {
 }
 ```
 
+## Example Usage with Enhanced Task Mode
+
+```terraform
+resource "aws_datasync_task" "example" {
+  destination_location_arn = aws_datasync_location_s3.destination.arn
+  name                     = "example"
+  source_location_arn      = aws_datasync_location_s3.source.arn
+  task_mode                = "ENHANCED"
+
+  options {
+    gid               = "NONE"
+    posix_permissions = "NONE"
+    uid               = "NONE"
+    verify_mode       = "ONLY_FILES_TRANSFERRED"
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -71,6 +89,9 @@ This resource supports the following arguments:
 * `options` - (Optional) Configuration block containing option that controls the default behavior when you start an execution of this DataSync Task. For each individual task execution, you can override these options by specifying an overriding configuration in those executions.
 * `schedule` - (Optional) Specifies a schedule used to periodically transfer files from a source to a destination location.
 * `tags` - (Optional) Key-value pairs of resource tags to assign to the DataSync Task. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `task_mode` - (Optional) One of the following task modes for your data transfer:
+    * `BASIC` (default) - Transfer files or objects between Amazon Web Services storage and on-premises, edge, or other cloud storage.
+    * `ENHANCED` - Transfer virtually unlimited numbers of objects with enhanced metrics, more detailed logs, and higher performance than Basic mode. Currently available for transfers between Amazon S3 locations.
 * `task_report_config` - (Optional) Configuration block containing the configuration of a DataSync Task Report. See [`task_report_config`](#task_report_config-argument-reference) below.
 
 ### options Argument Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the recently released (enhanced) task mode feature to the `aws_datasync_task` resource. Note that enhanced task mode currently only supports transfer between S3 locations, and once set it cannot be changed (hence force new on this new argument).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39965

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateTask](https://docs.aws.amazon.com/datasync/latest/userguide/API_CreateTask.html#API_CreateTask_RequestSyntax) for specs and wordings. Also referred to [Choosing a task mode for your data transfer](https://docs.aws.amazon.com/datasync/latest/userguide/choosing-task-mode.html) to confirm that task mode can only be set during task creation and not update.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccDataSyncTask_basic|TestAccDataSyncTask_taskMode" PKG=datasync
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/datasync/... -v -count 1 -parallel 20 -run='TestAccDataSyncTask_basic|TestAccDataSyncTask_taskMode'  -timeout 360m -vet=off
2025/03/23 01:56:02 Initializing Terraform AWS Provider...
=== RUN   TestAccDataSyncTask_basic
=== PAUSE TestAccDataSyncTask_basic
=== RUN   TestAccDataSyncTask_taskMode
=== PAUSE TestAccDataSyncTask_taskMode
=== CONT  TestAccDataSyncTask_basic
=== CONT  TestAccDataSyncTask_taskMode
--- PASS: TestAccDataSyncTask_taskMode (38.15s)
--- PASS: TestAccDataSyncTask_basic (180.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   180.614s

$
```
