### PR TITLE
feat: Add description arg/attr for aws_cloudwatch_event_bus resource and data source

### DIFF
--- a/.changelog/39980.txt
+++ b/.changelog/39980.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+resource/aws_cloudwatch_event_bus: Add `description` argument
+```
+```release-note:enhancement
+data-source/aws_cloudwatch_event_bus: Add `description` attribute
+```

--- a/internal/service/events/bus.go
+++ b/internal/service/events/bus.go
@@ -41,6 +41,11 @@ func resourceBus() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrDescription: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 512),
+			},
 			"event_source_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -74,6 +79,10 @@ func resourceBusCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	input := &eventbridge.CreateEventBusInput{
 		Name: aws.String(eventBusName),
 		Tags: getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk(names.AttrDescription); ok {
+		input.Description = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("event_source_name"); ok {
@@ -133,6 +142,7 @@ func resourceBusRead(ctx context.Context, d *schema.ResourceData, meta interface
 	}
 
 	d.Set(names.AttrARN, output.Arn)
+	d.Set(names.AttrDescription, output.Description)
 	d.Set("kms_key_identifier", output.KmsKeyIdentifier)
 	d.Set(names.AttrName, output.Name)
 
@@ -143,9 +153,16 @@ func resourceBusUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EventsClient(ctx)
 
-	if d.HasChange("kms_key_identifier") {
+	if d.HasChanges(names.AttrDescription, "kms_key_identifier") {
 		input := &eventbridge.UpdateEventBusInput{
 			Name: aws.String(d.Get(names.AttrName).(string)),
+		}
+
+		// To unset the description, the only way is to explicitly set it to the empty string
+		if v, ok := d.GetOk(names.AttrDescription); ok {
+			input.Description = aws.String(v.(string))
+		} else {
+			input.Description = aws.String("")
 		}
 
 		if v, ok := d.GetOk("kms_key_identifier"); ok {

--- a/internal/service/events/bus_data_source.go
+++ b/internal/service/events/bus_data_source.go
@@ -23,6 +23,10 @@ func dataSourceBus() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrDescription: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"kms_key_identifier": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -48,6 +52,7 @@ func dataSourceBusRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	d.SetId(eventBusName)
 	d.Set(names.AttrARN, output.Arn)
+	d.Set(names.AttrDescription, output.Description)
 	d.Set("kms_key_identifier", output.KmsKeyIdentifier)
 	d.Set(names.AttrName, output.Name)
 

--- a/internal/service/events/bus_data_source_test.go
+++ b/internal/service/events/bus_data_source_test.go
@@ -49,6 +49,7 @@ func TestAccEventsBusDataSource_kmsKeyIdentifier(t *testing.T) {
 			{
 				Config: testAccBusDataSourceConfig_kmsKeyIdentifier(busName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDescription, resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttrPair(dataSourceName, "kms_key_identifier", resourceName, "kms_key_identifier"),
 				),
 			},
@@ -124,6 +125,7 @@ resource "aws_kms_key_policy" "test" {
 
 resource "aws_cloudwatch_event_bus" "test" {
   name               = %[1]q
+  description        = "Test event bus"
   kms_key_identifier = aws_kms_key.test.arn
 }
 

--- a/internal/service/events/bus_test.go
+++ b/internal/service/events/bus_test.go
@@ -24,10 +24,11 @@ import (
 
 func TestAccEventsBus_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var v1, v2, v3 eventbridge.DescribeEventBusOutput
+	var v1, v2, v3, v4, v5 eventbridge.DescribeEventBusOutput
 	busName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	busNameModified := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_event_bus.test"
+	description := "Test event bus"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -40,6 +41,7 @@ func TestAccEventsBus_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBusExists(ctx, resourceName, &v1),
 					acctest.CheckResourceAttrRegionalARN(resourceName, names.AttrARN, "events", fmt.Sprintf("event-bus/%s", busName)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckNoResourceAttr(resourceName, "event_source_name"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, busName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
@@ -51,11 +53,28 @@ func TestAccEventsBus_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBusConfig_basic(busNameModified),
+				Config: testAccBusConfig_description(busName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBusExists(ctx, resourceName, &v2),
-					testAccCheckBusRecreated(&v1, &v2),
+					testAccCheckBusNotRecreated(&v1, &v2),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
+				),
+			},
+			{
+				Config: testAccBusConfig_basic(busName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBusExists(ctx, resourceName, &v3),
+					testAccCheckBusNotRecreated(&v2, &v3),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
+				),
+			},
+			{
+				Config: testAccBusConfig_basic(busNameModified),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBusExists(ctx, resourceName, &v4),
+					testAccCheckBusRecreated(&v3, &v4),
 					acctest.CheckResourceAttrRegionalARN(resourceName, names.AttrARN, "events", fmt.Sprintf("event-bus/%s", busNameModified)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckNoResourceAttr(resourceName, "event_source_name"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, busNameModified),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
@@ -64,8 +83,9 @@ func TestAccEventsBus_basic(t *testing.T) {
 			{
 				Config: testAccBusConfig_tags1(busNameModified, names.AttrKey, names.AttrValue),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBusExists(ctx, resourceName, &v3),
-					testAccCheckBusNotRecreated(&v2, &v3),
+					testAccCheckBusExists(ctx, resourceName, &v5),
+					testAccCheckBusNotRecreated(&v4, &v5),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", names.AttrValue),
 				),
@@ -300,6 +320,15 @@ resource "aws_cloudwatch_event_bus" "test" {
   name = %[1]q
 }
 `, name)
+}
+
+func testAccBusConfig_description(name, description string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_bus" "test" {
+  name        = %[1]q
+  description = %[2]q
+}
+`, name, description)
 }
 
 func testAccBusConfig_tags1(name, key, value string) string {

--- a/website/docs/d/cloudwatch_event_bus.html.markdown
+++ b/website/docs/d/cloudwatch_event_bus.html.markdown
@@ -22,11 +22,13 @@ data "aws_cloudwatch_event_bus" "example" {
 
 ## Argument Reference
 
-* `name` - (Required) Friendly EventBridge event bus name.
+* `name` - (Required) Name of the event bus.
 
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN.
-* `kms_key_identifier` - The identifier of the AWS KMS customer managed key for EventBridge to use to encrypt events on this event bus, if one has been specified.
+* `arn` - ARN of the event bus.
+* `description` - Event bus description.
+* `id` - Name of the event bus.
+* `kms_key_identifier` - Identifier of the AWS KMS customer managed key for EventBridge to use to encrypt events on this event bus, if one has been specified.

--- a/website/docs/r/cloudwatch_event_bus.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus.html.markdown
@@ -27,6 +27,7 @@ data "aws_cloudwatch_event_source" "examplepartner" {
 
 resource "aws_cloudwatch_event_bus" "examplepartner" {
   name              = data.aws_cloudwatch_event_source.examplepartner.name
+  description       = "Event bus for example partner events"
   event_source_name = data.aws_cloudwatch_event_source.examplepartner.name
 }
 ```
@@ -35,17 +36,24 @@ resource "aws_cloudwatch_event_bus" "examplepartner" {
 
 This resource supports the following arguments:
 
-* `name` - (Required) The name of the new event bus. The names of custom event buses can't contain the / character. To create a partner event bus, ensure the `name` matches the `event_source_name`.
-* `event_source_name` - (Optional) The partner event source that the new event bus will be matched with. Must match `name`.
-* `kms_key_identifier` - (Optional) The identifier of the AWS KMS customer managed key for EventBridge to use, if you choose to use a customer managed key to encrypt events on this event bus. The identifier can be the key Amazon Resource Name (ARN), KeyId, key alias, or key alias ARN.
-* `tags` - (Optional)  A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+The following arguments are required:
+
+* `name` - (Required) Name of the new event bus. The names of custom event buses can't contain the / character. To create a partner event bus, ensure that the `name` matches the `event_source_name`.
+
+The following arguments are optional:
+
+* `description` - (Optional) Event bus description.
+* `event_source_name` - (Optional) Partner event source that the new event bus will be matched with. Must match `name`.
+* `kms_key_identifier` - (Optional) Identifier of the AWS KMS customer managed key for EventBridge to use, if you choose to use a customer managed key to encrypt events on this event bus. The identifier can be the key Amazon Resource Name (ARN), KeyId, key alias, or key alias ARN.
+* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - The Amazon Resource Name (ARN) of the event bus.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `arn` - ARN of the event bus.
+* `id` - Name of the event bus.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import
 
@@ -58,7 +66,7 @@ import {
 }
 ```
 
-Using `terraform import`, import EventBridge event buses using the `name` (which can also be a partner event source name). For example:
+Using `terraform import`, import EventBridge event buses using the name of the event bus (which can also be a partner event source name). For example:
 
 ```console
 % terraform import aws_cloudwatch_event_bus.messenger chat-messages


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `description` argument/attribute to the `aws_cloudwatch_event_bus` resource and data source.

Note that there is a quirk with the AWS API where you cannot unset the description on update when it is previously set. The only way is to set the description to am empty string, which is coincidentally mapped to the zero string value. So in the state, the value is never null, only empty string for now.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39900

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateTask](https://docs.aws.amazon.com/datasync/latest/userguide/API_CreateTask.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
For the `aws_cloudwatch_event_bus` resource:
```console
$ make testacc TESTS=TestAccEventsBus_basic PKG=events
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBus_basic'  -timeout 360m
2024/10/31 23:46:42 Initializing Terraform AWS Provider...
=== RUN   TestAccEventsBus_basic
=== PAUSE TestAccEventsBus_basic
=== CONT  TestAccEventsBus_basic
--- PASS: TestAccEventsBus_basic (50.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     50.394s

$
```

For the `aws_cloudwatch_event_bus` data source:
```console
$ make testacc TESTS=TestAccEventsBusDataSource_kmsKeyIdentifier PKG=events
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsBusDataSource_kmsKeyIdentifier'  -timeout 360m
2024/10/31 23:58:15 Initializing Terraform AWS Provider...
=== RUN   TestAccEventsBusDataSource_kmsKeyIdentifier
=== PAUSE TestAccEventsBusDataSource_kmsKeyIdentifier
=== CONT  TestAccEventsBusDataSource_kmsKeyIdentifier
--- PASS: TestAccEventsBusDataSource_kmsKeyIdentifier (25.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     25.392s

$
```