### PR TITLE
r/aws_iam_role: refine `managed_policy_arns` deprecation message

### DIFF
--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -132,7 +132,10 @@ func resourceRole() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				Deprecated: "The managed_policy_arns argument is deprecated. " +
-					"Use the aws_iam_role_policy_attachments_exclusive resource instead.",
+					"Use the aws_iam_role_policy_attachment resource instead. If Terraform should" +
+					"exclusively manage all managed policy attachments (the current " +
+					"behavior of this argument), use the aws_iam_role_policy_attachments_exclusive " +
+					"resource as well.",
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: verify.ValidARN,

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -124,7 +124,7 @@ resource "aws_iam_role" "example" {
 
 ### Example of Exclusive Managed Policies
 
-~> The `managed_policy_arns` argument is deprecated. Use the [`aws_iam_role_policy_attachments_exclusive`](./iam_role_policy_attachments_exclusive.html.markdown) resource instead.
+~> The `managed_policy_arns` argument is deprecated. Use the [`aws_iam_role_policy_attachment`](./iam_role_policy_attachment.html.markdown) resource instead. If Terraform should exclusively manage all managed policy attachments (the current behavior of this argument), use the [`aws_iam_role_policy_attachments_exclusive`](./iam_role_policy_attachments_exclusive.html.markdown) resource as well.
 
 This example creates an IAM role and attaches two managed IAM policies. If someone attaches another managed policy out-of-band, on the next apply, Terraform will detach that policy. If someone detaches these policies out-of-band, Terraform will attach them again.
 
@@ -168,7 +168,7 @@ resource "aws_iam_policy" "policy_two" {
 
 ### Example of Removing Managed Policies
 
-~> The `managed_policy_arns` argument is deprecated. Use the [`aws_iam_role_policy_attachments_exclusive`](./iam_role_policy_attachments_exclusive.html.markdown) resource instead.
+~> The `managed_policy_arns` argument is deprecated. Use the [`aws_iam_role_policy_attachment`](./iam_role_policy_attachment.html.markdown) resource instead. If Terraform should exclusively manage all managed policy attachments (the current behavior of this argument), use the [`aws_iam_role_policy_attachments_exclusive`](./iam_role_policy_attachments_exclusive.html.markdown) resource as well.
 
 This example creates an IAM role with an empty `managed_policy_arns` argument. If someone attaches a policy out-of-band, on the next apply, Terraform will detach that policy.
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The message has been updated to reflect that attachments migrated from this argument should be moved to the `aws_iam_role_policy_attachment` resource, with the optional adoption of `aws_iam_role_policy_attachments_exclusive` for use cases which prefer Terraform to retain exclusive management of all managed policies attached to the role.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/39818#issuecomment-2452349035
Relates #39718

