### PR TITLE
fix: set cluster address in redis

### DIFF
--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -527,9 +527,11 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if c.ConfigurationEndpoint != nil {
 		d.Set(names.AttrPort, c.ConfigurationEndpoint.Port)
 		d.Set("configuration_endpoint", aws.String(fmt.Sprintf("%s:%d", aws.ToString(c.ConfigurationEndpoint.Address), aws.ToInt32(c.ConfigurationEndpoint.Port))))
-		d.Set("cluster_address", c.ConfigurationEndpoint.Address)
-	} else if len(c.CacheNodes) > 0 {
+	}
+
+	if len(c.CacheNodes) > 0 {
 		d.Set(names.AttrPort, c.CacheNodes[0].Endpoint.Port)
+		d.Set("cluster_address", aws.String(fmt.Sprintf("%s:%d", aws.ToString(c.CacheNodes[0].Endpoint.Address), aws.ToInt32(c.CacheNodes[0].Endpoint.Port))))
 	}
 
 	d.Set("replication_group_id", c.ReplicationGroupId)

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -101,6 +101,7 @@ func TestAccElastiCacheCluster_Engine_redis(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^7\.[[:digit:]]+\.[[:digit:]]+$`)),
 					resource.TestCheckResourceAttr(resourceName, "ip_discovery", "ipv4"),
 					resource.TestCheckResourceAttr(resourceName, "network_type", "ipv4"),
+					resource.TestCheckResourceAttrSet(resourceName, "cluster_address"),
 					resource.TestCheckNoResourceAttr(resourceName, "outpost_mode"),
 					resource.TestCheckResourceAttr(resourceName, "preferred_outpost_arn", ""),
 				),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Set the Elasticache `cluster_address` output for Redis. Currently it is only set for Memcached.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates [#0000](https://github.com/hashicorp/terraform-provider-aws/issues/20394)
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/20394

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
lawrenceaiello@Lawrences-MacBook-Pro-2 ~/Development/aiell0/terraform-provider-aws (b-elasticache-redis-endpoint) $ make testacc TESTS=TestAccElastiCacheCluster_Engine_redis PKG=elasticache                                                <aws:default>
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheCluster_Engine_redis'  -timeout 360m
2024/11/03 20:23:41 Initializing Terraform AWS Provider...
=== RUN   TestAccElastiCacheCluster_Engine_redis
=== PAUSE TestAccElastiCacheCluster_Engine_redis
=== RUN   TestAccElastiCacheCluster_Engine_redis_v5
=== PAUSE TestAccElastiCacheCluster_Engine_redis_v5
=== CONT  TestAccElastiCacheCluster_Engine_redis
=== CONT  TestAccElastiCacheCluster_Engine_redis_v5
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (713.34s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (775.40s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        779.310s

...
```
