### PR TITLE
resource/aws_api_gateway_account: Properly support unregistration

### DIFF
--- a/.changelog/40004.txt
+++ b/.changelog/40004.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_api_gateway_account: Supports unregistering account settings.
+resource/aws_api_gateway_account: Add attribute `reset_on_delete` to properly reset CloudWatch Role ARN on deletion.
 ```

--- a/.changelog/40004.txt
+++ b/.changelog/40004.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_api_gateway_account: Supports unregistering account settings.
+```

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -684,6 +684,8 @@ func (flattener autoFlattener) struct_(ctx context.Context, sourcePath path.Path
 		return diags
 	}
 
+	tflog.SubsystemError(ctx, subsystemName, "Flattening incompatible types")
+
 	return diags
 }
 

--- a/internal/service/apigateway/account.go
+++ b/internal/service/apigateway/account.go
@@ -5,158 +5,262 @@ package apigateway
 
 import (
 	"context"
-	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_api_gateway_account", name="Account")
-func resourceAccount() *schema.Resource {
-	return &schema.Resource{
-		CreateWithoutTimeout: resourceAccountUpdate,
-		ReadWithoutTimeout:   resourceAccountRead,
-		UpdateWithoutTimeout: resourceAccountUpdate,
-		DeleteWithoutTimeout: resourceAccountDelete,
+// @FrameworkResource("aws_api_gateway_account")
+func newResourceAccount(context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceAccount{}
 
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Schema: map[string]*schema.Schema{
-			"api_key_version": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"cloudwatch_role_arn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: verify.ValidARN,
-			},
-			"features": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Computed: true,
-			},
-			"throttle_settings": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"burst_limit": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"rate_limit": {
-							Type:     schema.TypeFloat,
-							Computed: true,
-						},
-					},
-				},
-			},
-		},
-	}
+	return r, nil
 }
 
-func resourceAccountUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).APIGatewayClient(ctx)
+type resourceAccount struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceAccount) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "aws_api_gateway_account"
+}
+
+func (r *resourceAccount) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	s := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"api_key_version": schema.StringAttribute{
+				Computed: true,
+			},
+			"cloudwatch_role_arn": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.Any(
+						validators.ARN(),
+						stringvalidator.OneOf(""),
+					),
+				},
+				Default: stringdefault.StaticString(""), // Needed for backwards compatibility with SDK resource
+			},
+			"features": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			names.AttrID: schema.StringAttribute{
+				Computed:           true,
+				DeprecationMessage: "This attribute will be removed in a future version.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"throttle_settings": framework.DataSourceComputedListOfObjectAttribute[throttleSettingsModel](ctx),
+		},
+	}
+
+	response.Schema = s
+}
+
+func (r *resourceAccount) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data resourceAccountModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().APIGatewayClient(ctx)
 
 	input := &apigateway.UpdateAccountInput{}
 
-	if v, ok := d.GetOk("cloudwatch_role_arn"); ok {
-		input.PatchOperations = []types.PatchOperation{{
-			Op:    types.OpReplace,
-			Path:  aws.String("/cloudwatchRoleArn"),
-			Value: aws.String(v.(string)),
-		}}
+	if data.CloudwatchRoleARN.IsNull() || data.CloudwatchRoleARN.ValueString() == "" {
+		input.PatchOperations = []awstypes.PatchOperation{
+			{
+				Op:    awstypes.OpReplace,
+				Path:  aws.String("/cloudwatchRoleArn"),
+				Value: nil,
+			},
+		}
 	} else {
-		input.PatchOperations = []types.PatchOperation{{
-			Op:    types.OpReplace,
-			Path:  aws.String("/cloudwatchRoleArn"),
-			Value: nil,
-		}}
+		input.PatchOperations = []awstypes.PatchOperation{
+			{
+				Op:    awstypes.OpReplace,
+				Path:  aws.String("/cloudwatchRoleArn"),
+				Value: aws.String(data.CloudwatchRoleARN.ValueString()),
+			},
+		}
 	}
 
-	_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (any, error) {
+	output, err := tfresource.RetryGWhen(ctx, propagationTimeout,
+		func() (*apigateway.UpdateAccountOutput, error) {
 			return conn.UpdateAccount(ctx, input)
 		},
 		func(err error) (bool, error) {
-			if errs.IsAErrorMessageContains[*types.BadRequestException](err, "The role ARN does not have required permissions") {
+			if errs.IsAErrorMessageContains[*awstypes.BadRequestException](err, "The role ARN does not have required permissions") {
 				return true, err
 			}
-
-			if errs.IsAErrorMessageContains[*types.BadRequestException](err, "API Gateway could not successfully write to CloudWatch Logs using the ARN specified") {
+			if errs.IsAErrorMessageContains[*awstypes.BadRequestException](err, "API Gateway could not successfully write to CloudWatch Logs using the ARN specified") {
 				return true, err
 			}
-
 			return false, err
 		},
 	)
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating API Gateway Account: %s", err)
+		response.Diagnostics.AddError("creating API Gateway Account", err.Error())
+		return
 	}
 
-	if d.IsNewResource() {
-		d.SetId("api-gateway-account")
-	}
+	response.Diagnostics.Append(flex.Flatten(ctx, output, &data)...)
+	data.ID = types.StringValue("api-gateway-account")
 
-	return append(diags, resourceAccountRead(ctx, d, meta)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
-func resourceAccountRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).APIGatewayClient(ctx)
+func (r *resourceAccount) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data resourceAccountModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().APIGatewayClient(ctx)
 
 	account, err := findAccount(ctx, conn)
-
-	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] API Gateway Account (%s) not found, removing from state", d.Id())
-		d.SetId("")
-		return diags
+	if tfresource.NotFound(err) {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+		return
 	}
 
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading API Gateway Account: %s", err)
-	}
+	response.Diagnostics.Append(flex.Flatten(ctx, account, &data)...)
 
-	d.Set("api_key_version", account.ApiKeyVersion)
-	d.Set("cloudwatch_role_arn", account.CloudwatchRoleArn)
-	d.Set("features", account.Features)
-	if err := d.Set("throttle_settings", flattenThrottleSettings(account.ThrottleSettings)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting throttle_settings: %s", err)
-	}
-
-	return diags
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
-func resourceAccountDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).APIGatewayClient(ctx)
+func (r *resourceAccount) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var state, plan resourceAccountModel
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	diff, d := flex.Calculate(ctx, plan, state)
+	response.Diagnostics.Append(d...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if diff.HasChanges() {
+		conn := r.Meta().APIGatewayClient(ctx)
+
+		input := &apigateway.UpdateAccountInput{}
+
+		if plan.CloudwatchRoleARN.IsNull() || plan.CloudwatchRoleARN.ValueString() == "" {
+			input.PatchOperations = []awstypes.PatchOperation{
+				{
+					Op:    awstypes.OpReplace,
+					Path:  aws.String("/cloudwatchRoleArn"),
+					Value: nil,
+				},
+			}
+		} else {
+			input.PatchOperations = []awstypes.PatchOperation{
+				{
+					Op:    awstypes.OpReplace,
+					Path:  aws.String("/cloudwatchRoleArn"),
+					Value: aws.String(plan.CloudwatchRoleARN.ValueString()),
+				},
+			}
+		}
+
+		output, err := tfresource.RetryGWhen(ctx, propagationTimeout,
+			func() (*apigateway.UpdateAccountOutput, error) {
+				return conn.UpdateAccount(ctx, input)
+			},
+			func(err error) (bool, error) {
+				if errs.IsAErrorMessageContains[*awstypes.BadRequestException](err, "The role ARN does not have required permissions") {
+					return true, err
+				}
+				if errs.IsAErrorMessageContains[*awstypes.BadRequestException](err, "API Gateway could not successfully write to CloudWatch Logs using the ARN specified") {
+					return true, err
+				}
+				return false, err
+			},
+		)
+		if err != nil {
+			response.Diagnostics.AddError("updating API Gateway Account", err.Error())
+			return
+		}
+
+		response.Diagnostics.Append(flex.Flatten(ctx, output, &plan)...)
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceAccount) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data resourceAccountModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().APIGatewayClient(ctx)
 
 	input := &apigateway.UpdateAccountInput{}
 
-	input.PatchOperations = []types.PatchOperation{{
-		Op:    types.OpReplace,
+	input.PatchOperations = []awstypes.PatchOperation{{
+		Op:    awstypes.OpReplace,
 		Path:  aws.String("/cloudwatchRoleArn"),
 		Value: nil,
 	}}
 
 	_, err := conn.UpdateAccount(ctx, input)
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "resetting API Gateway Account: %s", err)
+		response.Diagnostics.AddError("resetting API Gateway Account", err.Error())
 	}
-	return diags
+}
+
+// ImportState is called when the provider must import the state of a resource instance.
+// This method must return enough state so the Read method can properly refresh the full resource.
+//
+// If setting an attribute with the import identifier, it is recommended to use the ImportStatePassthroughID() call in this method.
+func (r *resourceAccount) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), request, response)
+}
+
+type resourceAccountModel struct {
+	ApiKeyVersion     types.String                                           `tfsdk:"api_key_version"`
+	CloudwatchRoleARN types.String                                           `tfsdk:"cloudwatch_role_arn" autoflex:",legacy"`
+	Features          types.Set                                              `tfsdk:"features"`
+	ID                types.String                                           `tfsdk:"id"`
+	ThrottleSettings  fwtypes.ListNestedObjectValueOf[throttleSettingsModel] `tfsdk:"throttle_settings"`
+}
+
+type throttleSettingsModel struct {
+	BurstLimit types.Int32   `tfsdk:"burst_limit"`
+	RateLimit  types.Float64 `tfsdk:"rate_limit"`
 }
 
 func findAccount(ctx context.Context, conn *apigateway.Client) (*apigateway.GetAccountOutput, error) {

--- a/internal/service/apigateway/account.go
+++ b/internal/service/apigateway/account.go
@@ -67,7 +67,7 @@ func (r *resourceAccount) Schema(ctx context.Context, request resource.SchemaReq
 			},
 			names.AttrID: schema.StringAttribute{
 				Computed:           true,
-				DeprecationMessage: "This attribute is unused and will be removed in a future version of the provider",
+				DeprecationMessage: `The "id" attribute is unused and will be removed in a future version of the provider`,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -77,7 +77,7 @@ func (r *resourceAccount) Schema(ctx context.Context, request resource.SchemaReq
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
-				DeprecationMessage: "This attribute will be removed in a future version of the provider",
+				DeprecationMessage: `The "reset_on_delete" attribute will be removed in a future version of the provider`,
 			},
 			"throttle_settings": framework.DataSourceComputedListOfObjectAttribute[throttleSettingsModel](ctx),
 		},

--- a/internal/service/apigateway/account.go
+++ b/internal/service/apigateway/account.go
@@ -263,10 +263,6 @@ func (r *resourceAccount) Delete(ctx context.Context, request resource.DeleteReq
 	}
 }
 
-// ImportState is called when the provider must import the state of a resource instance.
-// This method must return enough state so the Read method can properly refresh the full resource.
-//
-// If setting an attribute with the import identifier, it is recommended to use the ImportStatePassthroughID() call in this method.
 func (r *resourceAccount) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrID), request, response)
 }

--- a/internal/service/apigateway/account.go
+++ b/internal/service/apigateway/account.go
@@ -110,7 +110,7 @@ func (r *resourceAccount) Create(ctx context.Context, request resource.CreateReq
 			{
 				Op:    awstypes.OpReplace,
 				Path:  aws.String("/cloudwatchRoleArn"),
-				Value: aws.String(data.CloudwatchRoleARN.ValueString()),
+				Value: data.CloudwatchRoleARN.ValueStringPointer(),
 			},
 		}
 	}
@@ -155,6 +155,10 @@ func (r *resourceAccount) Read(ctx context.Context, request resource.ReadRequest
 		response.State.RemoveResource(ctx)
 		return
 	}
+	if err != nil {
+		response.Diagnostics.AddError("reading API Gateway Account", err.Error())
+		return
+	}
 
 	response.Diagnostics.Append(flex.Flatten(ctx, account, &data)...)
 
@@ -197,7 +201,7 @@ func (r *resourceAccount) Update(ctx context.Context, request resource.UpdateReq
 				{
 					Op:    awstypes.OpReplace,
 					Path:  aws.String("/cloudwatchRoleArn"),
-					Value: aws.String(plan.CloudwatchRoleARN.ValueString()),
+					Value: plan.CloudwatchRoleARN.ValueStringPointer(),
 				},
 			}
 		}
@@ -264,7 +268,7 @@ func (r *resourceAccount) Delete(ctx context.Context, request resource.DeleteReq
 //
 // If setting an attribute with the import identifier, it is recommended to use the ImportStatePassthroughID() call in this method.
 func (r *resourceAccount) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), request, response)
+	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrID), request, response)
 }
 
 type resourceAccountModel struct {

--- a/internal/service/apigateway/account_test.go
+++ b/internal/service/apigateway/account_test.go
@@ -314,7 +314,7 @@ func testAccCheckAccountNotDestroyed(ctx context.Context) resource.TestCheckFunc
 			return nil
 		}
 
-		return errors.New("API Gateway Account still exists")
+		return errors.New("API Gateway Account was reset")
 	}
 }
 

--- a/internal/service/apigateway/account_test.go
+++ b/internal/service/apigateway/account_test.go
@@ -27,11 +27,13 @@ import (
 
 func testAccAccount_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Cleanup(accountCleanup(ctx, t))
 	resourceName := "aws_api_gateway_account.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			t.Cleanup(accountCleanup(ctx, t))
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAccountDestroy(ctx),
@@ -63,12 +65,14 @@ func testAccAccount_basic(t *testing.T) {
 
 func testAccAccount_cloudwatchRoleARN_value(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Cleanup(accountCleanup(ctx, t))
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_account.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			t.Cleanup(accountCleanup(ctx, t))
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAccountDestroy(ctx),
@@ -120,11 +124,13 @@ func testAccAccount_cloudwatchRoleARN_value(t *testing.T) {
 
 func testAccAccount_cloudwatchRoleARN_empty(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Cleanup(accountCleanup(ctx, t))
 	resourceName := "aws_api_gateway_account.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			t.Cleanup(accountCleanup(ctx, t))
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAccountDestroy(ctx),
@@ -146,12 +152,14 @@ func testAccAccount_cloudwatchRoleARN_empty(t *testing.T) {
 
 func testAccAccount_resetOnDelete_false(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Cleanup(accountCleanup(ctx, t))
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_account.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			t.Cleanup(accountCleanup(ctx, t))
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAccountNotDestroyed(ctx),
@@ -181,12 +189,14 @@ func testAccAccount_resetOnDelete_false(t *testing.T) {
 
 func testAccAccount_resetOnDelete_true(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Cleanup(accountCleanup(ctx, t))
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_account.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			t.Cleanup(accountCleanup(ctx, t))
+		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAccountDestroy(ctx),
@@ -216,11 +226,13 @@ func testAccAccount_resetOnDelete_true(t *testing.T) {
 
 func testAccAccount_frameworkMigration_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Cleanup(accountCleanup(ctx, t))
 	resourceName := "aws_api_gateway_account.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			t.Cleanup(accountCleanup(ctx, t))
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAccountDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -247,12 +259,14 @@ func testAccAccount_frameworkMigration_basic(t *testing.T) {
 
 func testAccAccount_frameworkMigration_cloudwatchRoleARN(t *testing.T) {
 	ctx := acctest.Context(t)
-	t.Cleanup(accountCleanup(ctx, t))
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_account.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			t.Cleanup(accountCleanup(ctx, t))
+		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAccountNotDestroyed(ctx),
 		Steps: []resource.TestStep{

--- a/internal/service/apigateway/account_test.go
+++ b/internal/service/apigateway/account_test.go
@@ -307,7 +307,6 @@ func testAccCheckAccountDestroy(ctx context.Context) resource.TestCheckFunc {
 		if account.CloudwatchRoleArn == nil {
 			// Settings have been reset
 			return nil
-
 		}
 
 		return errors.New("API Gateway Account still exists")

--- a/internal/service/apigateway/apigateway_test.go
+++ b/internal/service/apigateway/apigateway_test.go
@@ -25,8 +25,11 @@ func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 func TestAccAPIGateway_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Account": {
-			acctest.CtBasic:     testAccAccount_basic,
-			"CloudwatchRoleARN": testAccAccount_cloudwatchRoleARN,
+			acctest.CtBasic:                        testAccAccount_basic,
+			"CloudwatchRoleARN_Value":              testAccAccount_cloudwatchRoleARN_value,
+			"CloudwatchRoleARN_Empty":              testAccAccount_cloudwatchRoleARN_empty,
+			"FrameworkMigration_Basic":             testAccAccount_frameworkMigration_basic,
+			"FrameworkMigration_CloudwatchRoleARN": testAccAccount_frameworkMigration_cloudwatchRoleARN,
 		},
 		// Some aws_api_gateway_method_settings tests require the account-level CloudWatch Logs role ARN to be set.
 		// Serialize all this resource's acceptance tests.

--- a/internal/service/apigateway/apigateway_test.go
+++ b/internal/service/apigateway/apigateway_test.go
@@ -30,6 +30,8 @@ func TestAccAPIGateway_serial(t *testing.T) {
 			"CloudwatchRoleARN_Empty":              testAccAccount_cloudwatchRoleARN_empty,
 			"FrameworkMigration_Basic":             testAccAccount_frameworkMigration_basic,
 			"FrameworkMigration_CloudwatchRoleARN": testAccAccount_frameworkMigration_cloudwatchRoleARN,
+			"ResetOnDelete_false":                  testAccAccount_resetOnDelete_false,
+			"ResetOnDelete_true":                   testAccAccount_resetOnDelete_true,
 		},
 		// Some aws_api_gateway_method_settings tests require the account-level CloudWatch Logs role ARN to be set.
 		// Serialize all this resource's acceptance tests.

--- a/internal/service/apigateway/apigateway_test.go
+++ b/internal/service/apigateway/apigateway_test.go
@@ -25,7 +25,8 @@ func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 func TestAccAPIGateway_serial(t *testing.T) {
 	testCases := map[string]map[string]func(t *testing.T){
 		"Account": {
-			acctest.CtBasic: testAccAccount_basic,
+			acctest.CtBasic:     testAccAccount_basic,
+			"CloudwatchRoleARN": testAccAccount_cloudwatchRoleARN,
 		},
 		// Some aws_api_gateway_method_settings tests require the account-level CloudWatch Logs role ARN to be set.
 		// Serialize all this resource's acceptance tests.

--- a/internal/service/apigateway/exports_test.go
+++ b/internal/service/apigateway/exports_test.go
@@ -5,7 +5,6 @@ package apigateway
 
 // Exports for use in tests only.
 var (
-	ResourceAccount              = resourceAccount
 	ResourceAPIKey               = resourceAPIKey
 	ResourceAuthorizer           = resourceAuthorizer
 	ResourceBasePathMapping      = resourceBasePathMapping

--- a/internal/service/apigateway/exports_test.go
+++ b/internal/service/apigateway/exports_test.go
@@ -31,6 +31,7 @@ var (
 	ResourceVPCLink              = resourceVPCLink
 
 	DefaultAuthorizerTTL                 = defaultAuthorizerTTL
+	FindAccount                          = findAccount
 	FindAPIKeyByID                       = findAPIKeyByID
 	FindAuthorizerByTwoPartKey           = findAuthorizerByTwoPartKey
 	FindBasePathMappingByTwoPartKey      = findBasePathMappingByTwoPartKey

--- a/internal/service/apigateway/method_settings_test.go
+++ b/internal/service/apigateway/method_settings_test.go
@@ -619,7 +619,9 @@ func testAccMethodSettingsImportStateIdFunc(resourceName string) resource.Import
 }
 
 func testAccMethodSettingsConfig_base(rName string) string {
-	return acctest.ConfigCompose(testAccAccountConfig_role0(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccAccountConfig_resetOnDelete(rName, true),
+		fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name = %[1]q
 }

--- a/internal/service/apigateway/service_package_gen.go
+++ b/internal/service/apigateway/service_package_gen.go
@@ -17,7 +17,11 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory: newResourceAccount,
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
@@ -76,11 +80,6 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 
 func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePackageSDKResource {
 	return []*types.ServicePackageSDKResource{
-		{
-			Factory:  resourceAccount,
-			TypeName: "aws_api_gateway_account",
-			Name:     "Account",
-		},
 		{
 			Factory:  resourceAPIKey,
 			TypeName: "aws_api_gateway_api_key",

--- a/internal/service/apigateway/stage_test.go
+++ b/internal/service/apigateway/stage_test.go
@@ -551,7 +551,9 @@ func testAccStageImportStateIdFunc(resourceName string) resource.ImportStateIdFu
 }
 
 func testAccStageConfig_base(rName string) string {
-	return acctest.ConfigCompose(testAccAccountConfig_role0(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccAccountConfig_resetOnDelete(rName, true),
+		fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name = %[1]q
 }
@@ -672,6 +674,10 @@ resource "aws_api_gateway_stage" "test" {
     destination_arn = aws_cloudwatch_log_group.test.arn
     format          = %[2]q
   }
+
+  depends_on = [
+    aws_api_gateway_account.test
+  ]
 }
 `, rName, format))
 }

--- a/internal/service/apigateway/sweep.go
+++ b/internal/service/apigateway/sweep.go
@@ -59,7 +59,9 @@ func RegisterSweepers() {
 
 func sweepAccounts(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	return []sweep.Sweepable{
-		framework.NewSweepResource(newResourceAccount, client),
+		framework.NewSweepResource(newResourceAccount, client,
+			framework.NewAttribute("reset_on_delete", true),
+		),
 	}, nil
 }
 

--- a/internal/service/apigateway/sweep.go
+++ b/internal/service/apigateway/sweep.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
-	"github.com/hashicorp/terraform-provider-aws/internal/sweep/sdk"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
 )
 
 func RegisterSweepers() {
@@ -58,11 +58,8 @@ func RegisterSweepers() {
 }
 
 func sweepAccounts(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
-	r := resourceAccount()
-	d := r.Data(nil)
-
 	return []sweep.Sweepable{
-		sdk.NewSweepResource(r, d, client),
+		framework.NewSweepResource(newResourceAccount, client),
 	}, nil
 }
 

--- a/internal/service/apigateway/sweep.go
+++ b/internal/service/apigateway/sweep.go
@@ -4,6 +4,7 @@
 package apigateway
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -11,11 +12,17 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/sdk"
 )
 
 func RegisterSweepers() {
+	awsv2.Register("aws_api_gateway_account", sweepAccounts,
+		"aws_api_gateway_rest_api",
+	)
+
 	resource.AddTestSweepers("aws_api_gateway_rest_api", &resource.Sweeper{
 		Name: "aws_api_gateway_rest_api",
 		F:    sweepRestAPIs,
@@ -48,6 +55,15 @@ func RegisterSweepers() {
 		Name: "aws_api_gateway_domain_name",
 		F:    sweepDomainNames,
 	})
+}
+
+func sweepAccounts(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	r := resourceAccount()
+	d := r.Data(nil)
+
+	return []sweep.Sweepable{
+		sdk.NewSweepResource(r, d, client),
+	}, nil
 }
 
 func sweepRestAPIs(region string) error {

--- a/tools/tfsdk2fw/main.go
+++ b/tools/tfsdk2fw/main.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/website/docs/r/api_gateway_account.html.markdown
+++ b/website/docs/r/api_gateway_account.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Provides a settings of an API Gateway Account. Settings is applied region-wide per `provider` block.
 
--> **Note:** As there is no API method for deleting account settings or resetting it to defaults, destroying this resource will keep your account settings intact
-
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/api_gateway_account.html.markdown
+++ b/website/docs/r/api_gateway_account.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a settings of an API Gateway Account. Settings is applied region-wide per `provider` block.
 
--> **Note:** By default, destroying this resource will keep your account settings intact. Set `reset_on_delete` to `true` to reset the account setttings to default. In a future version, destroying the resource will reset account settings.
+-> **Note:** By default, destroying this resource will keep your account settings intact. Set `reset_on_delete` to `true` to reset the account setttings to default. In a future major version of the provider, destroying the resource will reset account settings.
 
 ## Example Usage
 
@@ -68,7 +68,7 @@ This resource supports the following arguments:
 * `cloudwatch_role_arn` - (Optional) ARN of an IAM role for CloudWatch (to allow logging & monitoring). See more [in AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-stage-settings.html#how-to-stage-settings-console). Logging & monitoring can be enabled/disabled and otherwise tuned on the API Gateway Stage level.
 * `reset_on_delete` - (Optional) If `true`, destroying the resource will reset account settings to default, otherwise account settings are not modified.
   Defaults to `false`.
-  Will be removed in a future version.
+  Will be removed in a future major version of the provider.
 
 ## Attribute Reference
 

--- a/website/docs/r/api_gateway_account.html.markdown
+++ b/website/docs/r/api_gateway_account.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a settings of an API Gateway Account. Settings is applied region-wide per `provider` block.
 
+-> **Note:** By default, destroying this resource will keep your account settings intact. Set `reset_on_delete` to `true` to reset the account setttings to default. In a future version, destroying the resource will reset account settings.
+
 ## Example Usage
 
 ```terraform
@@ -64,6 +66,9 @@ resource "aws_iam_role_policy" "cloudwatch" {
 This resource supports the following arguments:
 
 * `cloudwatch_role_arn` - (Optional) ARN of an IAM role for CloudWatch (to allow logging & monitoring). See more [in AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-stage-settings.html#how-to-stage-settings-console). Logging & monitoring can be enabled/disabled and otherwise tuned on the API Gateway Stage level.
+* `reset_on_delete` - (Optional) If `true`, destroying the resource will reset account settings to default, otherwise account settings are not modified.
+  Defaults to `false`.
+  Will be removed in a future version.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

An `aws_api_gateway_account` can be unregistered by clearing the `cloudwatch_role_arn`. Do that and add sweeper.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apigateway TESTS='TestAccAPIGateway_serial/Account'

--- PASS: TestAccAPIGateway_serial (178.47s)
    --- PASS: TestAccAPIGateway_serial/Account (178.47s)
        --- PASS: TestAccAPIGateway_serial/Account/basic (178.47s)
```
