### PR TITLE
[Docs]: Describe the destroy behavior of `_exclusive` IAM policy attachment resources

### DIFF
--- a/website/docs/r/iam_group_policies_exclusive.html.markdown
+++ b/website/docs/r/iam_group_policies_exclusive.html.markdown
@@ -11,6 +11,8 @@ Terraform resource for maintaining exclusive management of inline policies assig
 
 !> This resource takes exclusive ownership over inline policies assigned to a group. This includes removal of inline policies which are not explicitly configured. To prevent persistent drift, ensure any `aws_iam_group_policy` resources managed alongside this resource are included in the `policy_names` argument.
 
+~> Destruction of this resource means Terraform will no longer manage reconciliation of the configured inline policy assignments. It __will not__ delete the configured policies from the group.
+
 ## Example Usage
 
 ### Basic Usage

--- a/website/docs/r/iam_group_policy_attachments_exclusive.html.markdown
+++ b/website/docs/r/iam_group_policy_attachments_exclusive.html.markdown
@@ -9,7 +9,9 @@ description: |-
 
 Terraform resource for maintaining exclusive management of customer managed policies assigned to an AWS IAM (Identity & Access Management) group.
 
-!> This resource takes exclusive ownership over customer managed policies assigned to a group. This includes removal of customer managed policies which are not explicitly configured. To prevent persistent drift, ensure any `aws_iam_group_policy_attachment` resources managed alongside this resource are included in the `policy_arns` argument.
+!> This resource takes exclusive ownership over customer managed policies attached to a group. This includes removal of customer managed policies which are not explicitly configured. To prevent persistent drift, ensure any `aws_iam_group_policy_attachment` resources managed alongside this resource are included in the `policy_arns` argument.
+
+~> Destruction of this resource means Terraform will no longer manage reconciliation of the configured policy attachments. It __will not__ detach the configured policies from the group.
 
 ## Example Usage
 

--- a/website/docs/r/iam_role_policies_exclusive.html.markdown
+++ b/website/docs/r/iam_role_policies_exclusive.html.markdown
@@ -11,6 +11,8 @@ Terraform resource for maintaining exclusive management of inline policies assig
 
 !> This resource takes exclusive ownership over inline policies assigned to a role. This includes removal of inline policies which are not explicitly configured. To prevent persistent drift, ensure any `aws_iam_role_policy` resources managed alongside this resource are included in the `policy_names` argument.
 
+~> Destruction of this resource means Terraform will no longer manage reconciliation of the configured inline policy assignments. It __will not__ delete the configured policies from the role.
+
 ## Example Usage
 
 ### Basic Usage

--- a/website/docs/r/iam_role_policy_attachments_exclusive.html.markdown
+++ b/website/docs/r/iam_role_policy_attachments_exclusive.html.markdown
@@ -9,7 +9,9 @@ description: |-
 
 Terraform resource for maintaining exclusive management of customer managed policies assigned to an AWS IAM (Identity & Access Management) role.
 
-!> This resource takes exclusive ownership over customer managed policies assigned to a role. This includes removal of customer managed policies which are not explicitly configured. To prevent persistent drift, ensure any `aws_iam_role_policy_attachment` resources managed alongside this resource are included in the `policy_arns` argument.
+!> This resource takes exclusive ownership over customer managed policies attached to a role. This includes removal of customer managed policies which are not explicitly configured. To prevent persistent drift, ensure any `aws_iam_role_policy_attachment` resources managed alongside this resource are included in the `policy_arns` argument.
+
+~> Destruction of this resource means Terraform will no longer manage reconciliation of the configured policy attachments. It __will not__ detach the configured policies from the role.
 
 ## Example Usage
 

--- a/website/docs/r/iam_user_policies_exclusive.html.markdown
+++ b/website/docs/r/iam_user_policies_exclusive.html.markdown
@@ -11,6 +11,8 @@ Terraform resource for maintaining exclusive management of inline policies assig
 
 !> This resource takes exclusive ownership over inline policies assigned to a user. This includes removal of inline policies which are not explicitly configured. To prevent persistent drift, ensure any `aws_iam_user_policy` resources managed alongside this resource are included in the `policy_names` argument.
 
+~> Destruction of this resource means Terraform will no longer manage reconciliation of the configured inline policy assignments. It __will not__ delete the configured policies from the user.
+
 ## Example Usage
 
 ### Basic Usage

--- a/website/docs/r/iam_user_policy_attachments_exclusive.html.markdown
+++ b/website/docs/r/iam_user_policy_attachments_exclusive.html.markdown
@@ -9,7 +9,9 @@ description: |-
 
 Terraform resource for maintaining exclusive management of customer managed policies assigned to an AWS IAM (Identity & Access Management) user.
 
-!> This resource takes exclusive ownership over customer managed policies assigned to a user. This includes removal of customer managed policies which are not explicitly configured. To prevent persistent drift, ensure any `aws_iam_user_policy_attachment` resources managed alongside this resource are included in the `policy_arns` argument.
+!> This resource takes exclusive ownership over customer managed policies attached to a user. This includes removal of customer managed policies which are not explicitly configured. To prevent persistent drift, ensure any `aws_iam_user_policy_attachment` resources managed alongside this resource are included in the `policy_arns` argument.
+
+~> Destruction of this resource means Terraform will no longer manage reconciliation of the configured policy attachments. It __will not__ detach the configured policies from the user.
 
 ## Example Usage
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change adds a note section to each of the role, user, and policy exclusive IAM policy attachment resources to clarify the behavior of resource destruction. For these resources, destroy is a no-op as the intent is simply for Terraform to no longer own reconciliation of the attached policies going forward.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #39818 


