### PR TITLE
internal/framework/types: surface ARN validation errors

### DIFF
--- a/.changelog/40008.txt
+++ b/.changelog/40008.txt
@@ -1,0 +1,3 @@
+```release-note:note
+provider: validation of arguments implementing the custom `ARNType` will properly surface validation errors
+```

--- a/internal/framework/types/arn.go
+++ b/internal/framework/types/arn.go
@@ -52,12 +52,9 @@ func (t arnType) ValueFromString(_ context.Context, in types.String) (basetypes.
 		return ARNUnknown(), diags
 	}
 
-	valueString := in.ValueString()
-	if _, err := arn.Parse(valueString); err != nil {
-		return ARNUnknown(), diags // Must not return validation errors.
-	}
-
-	return ARNValue(valueString), diags
+	// The ValidateAttribute method will surface errors if the value is an invalid
+	// ARN. This method simply passes the value through.
+	return ARNValue(in.ValueString()), diags
 }
 
 func (t arnType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {

--- a/internal/framework/types/arn_test.go
+++ b/internal/framework/types/arn_test.go
@@ -36,7 +36,7 @@ func TestARNTypeValueFromTerraform(t *testing.T) {
 		},
 		"invalid ARN": {
 			val:      tftypes.NewValue(tftypes.String, "not ok"),
-			expected: fwtypes.ARNUnknown(),
+			expected: fwtypes.ARNValue("not ok"),
 		},
 	}
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously the `ARNType`s `ValueFromString` method parsed the string value and set the value to Unknown in cases where validation failed. This caused a plan time failure indicating a difference between the planned value (unknown) and config value (known string). This obfuscated the underlying error which is actually an invalid ARN value.

Invalid ARNs provided in a configuration will now produce errors similar to the following:

```
│ Error: Invalid ARN Value
│
│   with aws_bedrockagent_agent.test,
│   on main.tf line 16, in resource "aws_bedrockagent_agent" "test":
│   16:   agent_resource_role_arn = "INVALID-ARN"
│
│ The provided value cannot be parsed as an ARN.
│
│ Path: agent_resource_role_arn
│ Value: INVALID-ARN
```


```console
% go test ./internal/framework/types/...
ok      github.com/hashicorp/terraform-provider-aws/internal/framework/types    0.631s
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39227



