### PR TITLE
website/docs/functions: remove required version note

### DIFF
--- a/website/docs/functions/arn_build.html.markdown
+++ b/website/docs/functions/arn_build.html.markdown
@@ -8,8 +8,6 @@ description: |-
 
 # Function: arn_build
 
-~> Provider-defined functions are supported in Terraform 1.8 and later.
-
 Builds an ARN from its constituent parts.
 
 See the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) for additional information on Amazon Resource Names.

--- a/website/docs/functions/arn_parse.html.markdown
+++ b/website/docs/functions/arn_parse.html.markdown
@@ -8,8 +8,6 @@ description: |-
 
 # Function: arn_parse
 
-~> Provider-defined functions are supported in Terraform 1.8 and later.
-
 Parses an ARN into its constituent parts.
 
 See the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) for additional information on Amazon Resource Names.

--- a/website/docs/functions/trim_iam_role_path.html.markdown
+++ b/website/docs/functions/trim_iam_role_path.html.markdown
@@ -8,8 +8,6 @@ description: |-
 
 # Function: trim_iam_role_path
 
-~> Provider-defined functions are supported in Terraform 1.8 and later.
-
 Trims the path prefix from an IAM role Amazon Resource Name (ARN).
 This function can be used when services require role ARNs to be passed without a path.
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The registry now includes a banner above all functions pages indicating that provider defined functions are only supported in Terraform 1.8 and later. This now makes the notes embedded in the pages themselves redundant.

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/19e93ed0-49c3-40b6-a1be-1f880dc8f438">


