### PR TITLE
autoflex: Allow []byte-string conversion

### DIFF
--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -460,6 +460,15 @@ func (expander autoExpander) string(ctx context.Context, vFrom basetypes.StringV
 		vTo.SetString(v.ValueString())
 		return diags
 
+	case reflect.Slice:
+		if tTo.Elem().Kind() == reflect.Uint8 {
+			//
+			// types.String -> []byte (or []uint8).
+			//
+			vTo.Set(reflect.ValueOf([]byte(v.ValueString())))
+			return diags
+		}
+
 	case reflect.Struct:
 		//
 		// timetypes.RFC3339 --> time.Time

--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -28,6 +28,9 @@ func TestExpand(t *testing.T) {
 	testString := "test"
 	testStringResult := "a"
 
+	testByteSlice := []byte("test")
+	testByteSliceResult := []byte("a")
+
 	var (
 		typedNilSource *emptyStruct
 		typedNilTarget *emptyStruct
@@ -127,6 +130,15 @@ func TestExpand(t *testing.T) {
 				infoConverting(reflect.TypeFor[types.String](), reflect.TypeFor[string]()),
 			},
 		},
+		"types.String to byte slice": {
+			Source:     types.StringValue("a"),
+			Target:     &testByteSlice,
+			WantTarget: &testByteSliceResult,
+			expectedLogLines: []map[string]any{
+				infoExpanding(reflect.TypeFor[types.String](), reflect.TypeFor[*[]byte]()),
+				infoConverting(reflect.TypeFor[types.String](), reflect.TypeFor[[]byte]()),
+			},
+		},
 		"empty struct Source and Target": {
 			Source:     emptyStruct{},
 			Target:     &emptyStruct{},
@@ -178,6 +190,17 @@ func TestExpand(t *testing.T) {
 				infoConverting(reflect.TypeFor[tfSingleStringField](), reflect.TypeFor[*awsSingleStringValue]()),
 				traceMatchedFields("Field1", reflect.TypeFor[tfSingleStringField](), "Field1", reflect.TypeFor[*awsSingleStringValue]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[string]()),
+			},
+		},
+		"single string Source and byte slice Target": {
+			Source:     &tfSingleStringField{Field1: types.StringValue("a")},
+			Target:     &awsSingleByteSliceValue{},
+			WantTarget: &awsSingleByteSliceValue{Field1: []byte("a")},
+			expectedLogLines: []map[string]any{
+				infoExpanding(reflect.TypeFor[*tfSingleStringField](), reflect.TypeFor[*awsSingleByteSliceValue]()),
+				infoConverting(reflect.TypeFor[tfSingleStringField](), reflect.TypeFor[*awsSingleByteSliceValue]()),
+				traceMatchedFields("Field1", reflect.TypeFor[tfSingleStringField](), "Field1", reflect.TypeFor[*awsSingleByteSliceValue]()),
+				infoConvertingWithPath("Field1", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[[]byte]()),
 			},
 		},
 		"single string Source and single *string Target": {

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -145,6 +145,7 @@ func (flattener autoFlattener) convert(ctx context.Context, sourcePath path.Path
 
 	tflog.SubsystemInfo(ctx, subsystemName, "Converting")
 
+	// main control flow
 	tTo := valTo.Type(ctx)
 	switch k := vFrom.Kind(); k {
 	case reflect.Bool:
@@ -168,6 +169,7 @@ func (flattener autoFlattener) convert(ctx context.Context, sourcePath path.Path
 		return diags
 
 	case reflect.String:
+		// []byte (or []uint8) is also handled like string but in flattener.slice()
 		diags.Append(flattener.string(ctx, vFrom, false, tTo, vTo, fieldOpts)...)
 		return diags
 
@@ -737,6 +739,17 @@ func (flattener autoFlattener) slice(ctx context.Context, sourcePath path.Path, 
 			// []string -> types.Set(OfString).
 			//
 			diags.Append(flattener.sliceOfPrimitiveToSet(ctx, vFrom, tTo, vTo, elementType, attrValueFromReflectValue, fieldOpts)...)
+			return diags
+		}
+
+	case reflect.Uint8:
+		switch tTo := tTo.(type) {
+		case basetypes.StringTypable:
+			//
+			// []byte (or []uint8) -> types.String.
+			//
+			vFrom = reflect.ValueOf(string(vFrom.Bytes()))
+			diags.Append(flattener.string(ctx, vFrom, false, tTo, vTo, fieldOpts)...)
 			return diags
 		}
 

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -119,7 +119,6 @@ func TestFlatten(t *testing.T) {
 				errorTargetDoesNotImplementAttrValue("", reflect.TypeFor[emptyStruct](), "", reflect.TypeFor[string]()),
 			},
 		},
-
 		"empty struct Source and Target": {
 			Source:     emptyStruct{},
 			Target:     &emptyStruct{},
@@ -181,6 +180,17 @@ func TestFlatten(t *testing.T) {
 				infoConverting(reflect.TypeFor[awsSingleStringValue](), reflect.TypeFor[*tfSingleStringField]()),
 				traceMatchedFields("Field1", reflect.TypeFor[awsSingleStringValue](), "Field1", reflect.TypeFor[*tfSingleStringField]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[string](), "Field1", reflect.TypeFor[types.String]()),
+			},
+		},
+		"single byte slice Source and single string Target": {
+			Source:     &awsSingleByteSliceValue{Field1: []byte("a")},
+			Target:     &tfSingleStringField{},
+			WantTarget: &tfSingleStringField{Field1: types.StringValue("a")},
+			expectedLogLines: []map[string]any{
+				infoFlattening(reflect.TypeFor[*awsSingleByteSliceValue](), reflect.TypeFor[*tfSingleStringField]()),
+				infoConverting(reflect.TypeFor[awsSingleByteSliceValue](), reflect.TypeFor[*tfSingleStringField]()),
+				traceMatchedFields("Field1", reflect.TypeFor[awsSingleByteSliceValue](), "Field1", reflect.TypeFor[*tfSingleStringField]()),
+				infoConvertingWithPath("Field1", reflect.TypeFor[[]byte](), "Field1", reflect.TypeFor[types.String]()),
 			},
 		},
 		"single nil *string Source and single string Target": {

--- a/internal/framework/flex/autoflex_test.go
+++ b/internal/framework/flex/autoflex_test.go
@@ -242,6 +242,10 @@ type awsSingleStringPointer struct {
 	Field1 *string
 }
 
+type awsSingleByteSliceValue struct {
+	Field1 []byte
+}
+
 type awsSingleFloat64Value struct {
 	Field1 float64
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #39988 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% cd internal/framework/flex
% go test ./...
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/flex	0.272s
```
