### PR TITLE
:sparkles: add additional properties on eks job definition

### DIFF
--- a/.changelog/40019.txt
+++ b/.changelog/40019.txt
@@ -1,7 +1,9 @@
 ```release-note:enhancement
-resource/aws_batch_job_definition: Adds `init_containers` and `share_process_namespace`. Increases containers limit to 10.
+resource/aws_batch_job_definition: Add `init_containers` and `share_process_namespace` arguments
 ```
-
 ```release-note:enhancement
-datasource/aws_batch_job_definition: Adds `init_containers`, `share_process_namespace`, `image_pull_secrets`
+resource/aws_batch_job_definition: Increase maximum number of `containers` arguments to 10
+```
+```release-note:enhancement
+data-source/aws_batch_job_definition: Add `init_containers`, `share_process_namespace`, and `image_pull_secrets` attributes
 ```

--- a/.changelog/40019.txt
+++ b/.changelog/40019.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_batch_job_definition: Adds `init_containers` and `share_process_namespace`. Increases containers limit to 10.
+```
+
+```release-note:enhancement
+datasource/aws_batch_job_definition: Adds `init_containers`, `share_process_namespace`, `image_pull_secrets`
+```

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -107,7 +107,7 @@ func resourceJobDefinition() *schema.Resource {
 									"containers": {
 										Type:     schema.TypeList,
 										Required: true,
-										MaxItems: 1,
+										MaxItems: 10,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"args": {
@@ -242,6 +242,122 @@ func resourceJobDefinition() *schema.Resource {
 											},
 										},
 									},
+									"init_containers": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 10,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"args": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"command": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"env": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															names.AttrName: {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															names.AttrValue: {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+														},
+													},
+												},
+												"image": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"image_pull_policy": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice(imagePullPolicy_Values(), false),
+												},
+												names.AttrName: {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												names.AttrResources: {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"limits": {
+																Type:     schema.TypeMap,
+																Optional: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"requests": {
+																Type:     schema.TypeMap,
+																Optional: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+														},
+													},
+												},
+												"security_context": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"privileged": {
+																Type:     schema.TypeBool,
+																Optional: true,
+															},
+															"read_only_root_file_system": {
+																Type:     schema.TypeBool,
+																Optional: true,
+															},
+															"run_as_group": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+															"run_as_non_root": {
+																Type:     schema.TypeBool,
+																Optional: true,
+															},
+															"run_as_user": {
+																Type:     schema.TypeInt,
+																Optional: true,
+															},
+														},
+													},
+												},
+												"volume_mounts": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"mount_path": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															names.AttrName: {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															"read_only": {
+																Type:     schema.TypeBool,
+																Optional: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
 									"metadata": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -258,6 +374,10 @@ func resourceJobDefinition() *schema.Resource {
 									},
 									"service_account_name": {
 										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"share_process_namespace": {
+										Type:     schema.TypeBool,
 										Optional: true,
 									},
 									"volumes": {
@@ -1186,6 +1306,10 @@ func expandEKSPodProperties(tfMap map[string]interface{}) *awstypes.EksPodProper
 		apiObject.ImagePullSecrets = expandImagePullSecrets(v.([]interface{}))
 	}
 
+	if v, ok := tfMap["init_containers"]; ok {
+		apiObject.InitContainers = expandContainers(v.([]interface{}))
+	}
+
 	if v, ok := tfMap["metadata"].([]interface{}); ok && len(v) > 0 {
 		if v, ok := v[0].(map[string]interface{})["labels"]; ok {
 			apiObject.Metadata = &awstypes.EksMetadata{
@@ -1196,6 +1320,10 @@ func expandEKSPodProperties(tfMap map[string]interface{}) *awstypes.EksPodProper
 
 	if v, ok := tfMap["service_account_name"].(string); ok && v != "" {
 		apiObject.ServiceAccountName = aws.String(v)
+	}
+
+	if v, ok := tfMap["share_process_namespace"]; ok {
+		apiObject.ShareProcessNamespace = aws.Bool(v.(bool))
 	}
 
 	if v, ok := tfMap["volumes"]; ok {
@@ -1432,6 +1560,10 @@ func flattenEKSPodProperties(apiObject *awstypes.EksPodProperties) []interface{}
 		tfMap["image_pull_secret"] = flattenImagePullSecrets(v)
 	}
 
+	if v := apiObject.InitContainers; v != nil {
+		tfMap["init_containers"] = flattenEKSContainers(v)
+	}
+
 	if v := apiObject.Metadata; v != nil {
 		metadata := make([]map[string]interface{}, 0)
 
@@ -1446,6 +1578,10 @@ func flattenEKSPodProperties(apiObject *awstypes.EksPodProperties) []interface{}
 
 	if v := apiObject.ServiceAccountName; v != nil {
 		tfMap["service_account_name"] = aws.ToString(v)
+	}
+
+	if v := apiObject.ShareProcessNamespace; v != nil {
+		tfMap["share_process_namespace"] = aws.ToBool(v)
 	}
 
 	if v := apiObject.Volumes; v != nil {

--- a/internal/service/batch/job_definition_data_source.go
+++ b/internal/service/batch/job_definition_data_source.go
@@ -236,12 +236,19 @@ type eksPropertiesModel struct {
 }
 
 type eksPodPropertiesModel struct {
-	Containers         fwtypes.ListNestedObjectValueOf[eksContainerModel] `tfsdk:"containers"`
-	DNSPolicy          types.String                                       `tfsdk:"dns_policy"`
-	HostNetwork        types.Bool                                         `tfsdk:"host_network"`
-	Metadata           fwtypes.ListNestedObjectValueOf[eksMetadataModel]  `tfsdk:"metadata"`
-	ServiceAccountName types.Bool                                         `tfsdk:"service_account_name"`
-	Volumes            fwtypes.ListNestedObjectValueOf[eksVolumeModel]    `tfsdk:"volumes"`
+	Containers            fwtypes.ListNestedObjectValueOf[eksContainerModel]   `tfsdk:"containers"`
+	DNSPolicy             types.String                                         `tfsdk:"dns_policy"`
+	HostNetwork           types.Bool                                           `tfsdk:"host_network"`
+	ImagePullSecrets      fwtypes.ListNestedObjectValueOf[eksImagePullSecrets] `tfsdk:"image_pull_secrets"`
+	InitContainers        fwtypes.ListNestedObjectValueOf[eksContainerModel]   `tfsdk:"init_containers"`
+	Metadata              fwtypes.ListNestedObjectValueOf[eksMetadataModel]    `tfsdk:"metadata"`
+	ServiceAccountName    types.String                                         `tfsdk:"service_account_name"`
+	ShareProcessNamespace types.Bool                                           `tfsdk:"share_process_namespace"`
+	Volumes               fwtypes.ListNestedObjectValueOf[eksVolumeModel]      `tfsdk:"volumes"`
+}
+
+type eksImagePullSecrets struct {
+	Name types.String `tfsdk:"name"`
 }
 
 type eksContainerModel struct {

--- a/internal/service/batch/job_definition_data_source_test.go
+++ b/internal/service/batch/job_definition_data_source_test.go
@@ -128,7 +128,7 @@ func TestAccBatchJobDefinitionDataSource_basicARN_EKSProperties(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "eks_properties.0.pod_properties.0.init_containers.0.image", "public.ecr.aws/amazonlinux/amazonlinux:1"),
 					resource.TestCheckResourceAttr(dataSourceName, "eks_properties.0.pod_properties.0.containers.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "eks_properties.0.pod_properties.0.containers.0.image", "public.ecr.aws/amazonlinux/amazonlinux:1"),
-					resource.TestCheckResourceAttr(dataSourceName, "eks_properties.0.pod_properties.0.share_process_namespace", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "eks_properties.0.pod_properties.0.share_process_namespace", acctest.CtFalse),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrType, "container"),
 				),
 			},

--- a/internal/service/batch/job_definition_data_source_test.go
+++ b/internal/service/batch/job_definition_data_source_test.go
@@ -124,8 +124,11 @@ func TestAccBatchJobDefinitionDataSource_basicARN_EKSProperties(t *testing.T) {
 			{
 				Config: testAccJobDefinitionDataSourceConfig_basicARNEKS(rName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "eks_properties.0.pod_properties.0.init_containers.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "eks_properties.0.pod_properties.0.init_containers.0.image", "public.ecr.aws/amazonlinux/amazonlinux:1"),
 					resource.TestCheckResourceAttr(dataSourceName, "eks_properties.0.pod_properties.0.containers.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "eks_properties.0.pod_properties.0.containers.0.image", "public.ecr.aws/amazonlinux/amazonlinux:1"),
+					resource.TestCheckResourceAttr(dataSourceName, "eks_properties.0.pod_properties.0.share_process_namespace", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrType, "container"),
 				),
 			},

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -1852,7 +1852,7 @@ resource "aws_batch_job_definition" "test" {
     pod_properties {
       host_network = true
       containers {
-	    name  = "container1"
+        name  = "container1"
         image = "public.ecr.aws/amazonlinux/amazonlinux:1"
         command = [
           "sleep",
@@ -1865,8 +1865,8 @@ resource "aws_batch_job_definition" "test" {
           }
         }
       }
-	  containers {
-	    name  = "container2"
+      containers {
+        name  = "container2"
         image = "public.ecr.aws/amazonlinux/amazonlinux:1"
         command = [
           "sleep",

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -792,7 +792,9 @@ func TestAccBatchJobDefinition_EKSProperties_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
 					resource.TestCheckResourceAttr(resourceName, "eks_properties.0.pod_properties.0.containers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "eks_properties.0.pod_properties.0.init_containers.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "eks_properties.0.pod_properties.0.containers.0.image_pull_policy", ""),
+					resource.TestCheckResourceAttr(resourceName, "eks_properties.0.pod_properties.0.init_containers.0.image_pull_policy", ""),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "container"),
 				),
@@ -877,6 +879,37 @@ func TestAccBatchJobDefinition_EKSProperties_imagePullSecrets(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "eks_properties.*.pod_properties.*.image_pull_secret.*", map[string]string{
 						names.AttrName: "haku",
 					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinition_EKSProperties_multiContainers(t *testing.T) {
+	ctx := acctest.Context(t)
+	var jd awstypes.JobDefinition
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_batch_job_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobDefinitionConfig_EKSProperties_multiContainer(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
+					resource.TestCheckResourceAttr(resourceName, "eks_properties.0.pod_properties.0.containers.#", "2"),
 				),
 			},
 			{
@@ -1730,7 +1763,22 @@ resource "aws_batch_job_definition" "test" {
   type = "container"
   eks_properties {
     pod_properties {
-      host_network = true
+      host_network            = true
+      share_process_namespace = false
+      init_containers {
+        name  = "init0"
+        image = "public.ecr.aws/amazonlinux/amazonlinux:1"
+        command = [
+          "sleep",
+          "60"
+        ]
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "1024Mi"
+          }
+        }
+      }
       containers {
         image = "public.ecr.aws/amazonlinux/amazonlinux:1"
         command = [
@@ -1765,6 +1813,60 @@ resource "aws_batch_job_definition" "test" {
     pod_properties {
       host_network = true
       containers {
+        image = "public.ecr.aws/amazonlinux/amazonlinux:1"
+        command = [
+          "sleep",
+          "60"
+        ]
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "1024Mi"
+          }
+        }
+      }
+      image_pull_secret {
+        name = "chihiro"
+      }
+      image_pull_secret {
+        name = "haku"
+      }
+      metadata {
+        labels = {
+          environment = "test"
+          name        = %[1]q
+        }
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccJobDefinitionConfig_EKSProperties_multiContainer(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_batch_job_definition" "test" {
+  name = %[1]q
+  type = "container"
+  eks_properties {
+    pod_properties {
+      host_network = true
+      containers {
+	    name  = "container1"
+        image = "public.ecr.aws/amazonlinux/amazonlinux:1"
+        command = [
+          "sleep",
+          "60"
+        ]
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "1024Mi"
+          }
+        }
+      }
+	  containers {
+	    name  = "container2"
         image = "public.ecr.aws/amazonlinux/amazonlinux:1"
         command = [
           "sleep",

--- a/website/docs/d/batch_job_definition.html.markdown
+++ b/website/docs/d/batch_job_definition.html.markdown
@@ -56,10 +56,12 @@ This data source exports the following attributes in addition to the arguments a
 
 ### pod_properties
 
+* `containers` - The properties of the container that's used on the Amazon EKS pod. Array of [EksContainer](#container) objects.
 * `dns_policy` - The DNS policy for the pod. The default value is ClusterFirst. If the hostNetwork parameter is not specified, the default is ClusterFirstWithHostNet. ClusterFirst indicates that any DNS query that does not match the configured cluster domain suffix is forwarded to the upstream nameserver inherited from the node.
 * `host_network` - Indicates if the pod uses the hosts' network IP address. The default value is true. Setting this to false enables the Kubernetes pod networking model. Most AWS Batch workloads are egress-only and don't require the overhead of IP allocation for each pod for incoming connections.
+* `init_containers` - Properties of the container that's used on the Amazon EKS pod. See [containers](#container) below.
 * `service_account_name` - The name of the service account that's used to run the pod.
-* `containers` - The properties of the container that's used on the Amazon EKS pod. Array of [EksContainer](#container) objects.
+* `share_process_namespace` - (Optional) Indicates if the processes in a container are shared, or visible, to other containers in the same pod.
 * `metadata` - [Metadata](#eks_metadata) about the Kubernetes pod.
 * `volumes` -  Specifies the volumes for a job definition that uses Amazon EKS resources. Array of [EksVolume](#eks_volumes) objects.
 

--- a/website/docs/d/batch_job_definition.html.markdown
+++ b/website/docs/d/batch_job_definition.html.markdown
@@ -56,10 +56,10 @@ This data source exports the following attributes in addition to the arguments a
 
 ### pod_properties
 
-* `containers` - The properties of the container that's used on the Amazon EKS pod. Array of [EksContainer](#container) objects.
+* `containers` - The properties of the container that's used on the Amazon EKS pod. See [containers](#container) below.
 * `dns_policy` - The DNS policy for the pod. The default value is ClusterFirst. If the hostNetwork parameter is not specified, the default is ClusterFirstWithHostNet. ClusterFirst indicates that any DNS query that does not match the configured cluster domain suffix is forwarded to the upstream nameserver inherited from the node.
 * `host_network` - Indicates if the pod uses the hosts' network IP address. The default value is true. Setting this to false enables the Kubernetes pod networking model. Most AWS Batch workloads are egress-only and don't require the overhead of IP allocation for each pod for incoming connections.
-* `init_containers` - Properties of the container that's used on the Amazon EKS pod. See [containers](#container) below.
+* `init_containers` - Containers which run before application containers, always runs to completion, and must complete successfully before the next container starts. These containers are registered with the Amazon EKS Connector agent and persists the registration information in the Kubernetes backend data store. See [containers](#container) below.
 * `service_account_name` - The name of the service account that's used to run the pod.
 * `share_process_namespace` - (Optional) Indicates if the processes in a container are shared, or visible, to other containers in the same pod.
 * `metadata` - [Metadata](#eks_metadata) about the Kubernetes pod.

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -303,9 +303,12 @@ The following arguments are optional:
 * `containers` - (Optional) Properties of the container that's used on the Amazon EKS pod. See [containers](#containers) below.
 * `dns_policy` - (Optional) DNS policy for the pod. The default value is `ClusterFirst`. If the `host_network` argument is not specified, the default is `ClusterFirstWithHostNet`. `ClusterFirst` indicates that any DNS query that does not match the configured cluster domain suffix is forwarded to the upstream nameserver inherited from the node. For more information, see Pod's DNS policy in the Kubernetes documentation.
 * `host_network` - (Optional) Whether the pod uses the hosts' network IP address. The default value is `true`. Setting this to `false` enables the Kubernetes pod networking model. Most AWS Batch workloads are egress-only and don't require the overhead of IP allocation for each pod for incoming connections.
+* `init_containers` - (Optional) Properties of the container that's used on the Amazon EKS pod. See [containers](#containers) below.
 * `image_pull_secret` - (Optional) List of Kubernetes secret resources. See [`image_pull_secret`](#image_pull_secret) below.
 * `metadata` - (Optional) Metadata about the Kubernetes pod.
 * `service_account_name` - (Optional) Name of the service account that's used to run the pod.
+* `share_process_namespace` - (Optional) Indicates if the processes in a container are shared, or visible, to other containers in the same pod.
+* `metadata` - [Metadata](#eks_metadata) about the Kubernetes pod.
 * `volumes` - (Optional) Volumes for a job definition that uses Amazon EKS resources. AWS Batch supports [emptyDir](#eks_empty_dir), [hostPath](#eks_host_path), and [secret](#eks_secret) volume types.
 
 #### `containers`
@@ -337,6 +340,10 @@ The following arguments are optional:
 #### `eks_host_path`
 
 * `path` - (Optional) Path of the file or directory on the host to mount into containers on the pod.
+
+#### eks_metadata
+
+* `labels` - Key-value pairs used to identify, sort, and organize cube resources.
 
 #### `eks_secret`
 

--- a/website/docs/r/batch_job_definition.html.markdown
+++ b/website/docs/r/batch_job_definition.html.markdown
@@ -303,7 +303,7 @@ The following arguments are optional:
 * `containers` - (Optional) Properties of the container that's used on the Amazon EKS pod. See [containers](#containers) below.
 * `dns_policy` - (Optional) DNS policy for the pod. The default value is `ClusterFirst`. If the `host_network` argument is not specified, the default is `ClusterFirstWithHostNet`. `ClusterFirst` indicates that any DNS query that does not match the configured cluster domain suffix is forwarded to the upstream nameserver inherited from the node. For more information, see Pod's DNS policy in the Kubernetes documentation.
 * `host_network` - (Optional) Whether the pod uses the hosts' network IP address. The default value is `true`. Setting this to `false` enables the Kubernetes pod networking model. Most AWS Batch workloads are egress-only and don't require the overhead of IP allocation for each pod for incoming connections.
-* `init_containers` - (Optional) Properties of the container that's used on the Amazon EKS pod. See [containers](#containers) below.
+* `init_containers` - (Optional) Containers which run before application containers, always runs to completion, and must complete successfully before the next container starts. These containers are registered with the Amazon EKS Connector agent and persists the registration information in the Kubernetes backend data store. See [containers](#container) below.
 * `image_pull_secret` - (Optional) List of Kubernetes secret resources. See [`image_pull_secret`](#image_pull_secret) below.
 * `metadata` - (Optional) Metadata about the Kubernetes pod.
 * `service_account_name` - (Optional) Name of the service account that's used to run the pod.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
- ✨ Adds support for `initContainers` `shareProcessNamespace` on resource/data source
- ✨ Adds support for `imagePullSecrets` on data source. 
- 🔧 Increases max containers/init Containers to 10, as defined in [docs](https://docs.aws.amazon.com/batch/latest/APIReference/API_EksPodProperties.html). 
- 📝 Adds doc support for metadata (pre-existing attribute)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38606 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TF_ACC=1 make testacc TESTS=TestAccBatchJobDefinitionDataSource_ PKG=batch                                                                                                              <aws:provider> <region:us-east-2>
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchJobDefinitionDataSource_'  -timeout 360m
2024/11/05 17:43:35 Initializing Terraform AWS Provider...
=== RUN   TestAccBatchJobDefinitionDataSource_tags
=== PAUSE TestAccBatchJobDefinitionDataSource_tags
=== RUN   TestAccBatchJobDefinitionDataSource_tags_NullMap
=== PAUSE TestAccBatchJobDefinitionDataSource_tags_NullMap
=== RUN   TestAccBatchJobDefinitionDataSource_tags_EmptyMap
=== PAUSE TestAccBatchJobDefinitionDataSource_tags_EmptyMap
=== RUN   TestAccBatchJobDefinitionDataSource_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccBatchJobDefinitionDataSource_tags_DefaultTags_nonOverlapping
=== RUN   TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccBatchJobDefinitionDataSource_basicName
=== PAUSE TestAccBatchJobDefinitionDataSource_basicName
=== RUN   TestAccBatchJobDefinitionDataSource_basicARN
=== PAUSE TestAccBatchJobDefinitionDataSource_basicARN
=== RUN   TestAccBatchJobDefinitionDataSource_basicARN_NodeProperties
=== PAUSE TestAccBatchJobDefinitionDataSource_basicARN_NodeProperties
=== RUN   TestAccBatchJobDefinitionDataSource_basicARN_EKSProperties
=== PAUSE TestAccBatchJobDefinitionDataSource_basicARN_EKSProperties
=== CONT  TestAccBatchJobDefinitionDataSource_tags
=== CONT  TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccBatchJobDefinitionDataSource_basicARN_NodeProperties
=== CONT  TestAccBatchJobDefinitionDataSource_tags_DefaultTags_nonOverlapping
=== CONT  TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== CONT  TestAccBatchJobDefinitionDataSource_basicARN
=== CONT  TestAccBatchJobDefinitionDataSource_basicARN_EKSProperties
=== CONT  TestAccBatchJobDefinitionDataSource_tags_EmptyMap
=== CONT  TestAccBatchJobDefinitionDataSource_basicName
=== CONT  TestAccBatchJobDefinitionDataSource_tags_NullMap
--- PASS: TestAccBatchJobDefinitionDataSource_basicARN_NodeProperties (15.37s)
--- PASS: TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_DefaultTag (15.58s)
--- PASS: TestAccBatchJobDefinitionDataSource_basicARN_EKSProperties (15.80s)
--- PASS: TestAccBatchJobDefinitionDataSource_tags_DefaultTags_nonOverlapping (16.54s)
--- PASS: TestAccBatchJobDefinitionDataSource_tags_NullMap (17.72s)
--- PASS: TestAccBatchJobDefinitionDataSource_tags_EmptyMap (18.12s)
--- PASS: TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_ResourceTag (18.49s)
--- PASS: TestAccBatchJobDefinitionDataSource_tags (20.32s)
--- PASS: TestAccBatchJobDefinitionDataSource_basicName (25.11s)
--- PASS: TestAccBatchJobDefinitionDataSource_basicARN (29.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      37.646s

% TF_ACC=1 make testacc TESTS=TestAccBatchJobDefinition_ PKG=batch                                                                                                                        <aws:provider> <region:us-east-2>
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchJobDefinition_'  -timeout 360m
2024/11/05 17:44:23 Initializing Terraform AWS Provider...
=== RUN   TestAccBatchJobDefinition_tags
=== PAUSE TestAccBatchJobDefinition_tags
=== RUN   TestAccBatchJobDefinition_tags_null
=== PAUSE TestAccBatchJobDefinition_tags_null
=== RUN   TestAccBatchJobDefinition_tags_EmptyMap
=== PAUSE TestAccBatchJobDefinition_tags_EmptyMap
=== RUN   TestAccBatchJobDefinition_tags_AddOnUpdate
=== PAUSE TestAccBatchJobDefinition_tags_AddOnUpdate
=== RUN   TestAccBatchJobDefinition_tags_EmptyTag_OnCreate
=== PAUSE TestAccBatchJobDefinition_tags_EmptyTag_OnCreate
=== RUN   TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccBatchJobDefinition_tags_DefaultTags_providerOnly
=== PAUSE TestAccBatchJobDefinition_tags_DefaultTags_providerOnly
=== RUN   TestAccBatchJobDefinition_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccBatchJobDefinition_tags_DefaultTags_nonOverlapping
=== RUN   TestAccBatchJobDefinition_tags_DefaultTags_overlapping
=== PAUSE TestAccBatchJobDefinition_tags_DefaultTags_overlapping
=== RUN   TestAccBatchJobDefinition_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccBatchJobDefinition_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccBatchJobDefinition_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccBatchJobDefinition_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccBatchJobDefinition_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccBatchJobDefinition_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccBatchJobDefinition_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccBatchJobDefinition_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccBatchJobDefinition_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccBatchJobDefinition_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccBatchJobDefinition_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccBatchJobDefinition_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccBatchJobDefinition_tags_ComputedTag_OnCreate
=== PAUSE TestAccBatchJobDefinition_tags_ComputedTag_OnCreate
=== RUN   TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccBatchJobDefinition_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccBatchJobDefinition_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccBatchJobDefinition_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccBatchJobDefinition_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccBatchJobDefinition_basic
=== PAUSE TestAccBatchJobDefinition_basic
=== RUN   TestAccBatchJobDefinition_attributes
=== PAUSE TestAccBatchJobDefinition_attributes
=== RUN   TestAccBatchJobDefinition_disappears
=== PAUSE TestAccBatchJobDefinition_disappears
=== RUN   TestAccBatchJobDefinition_PlatformCapabilities_ec2
=== PAUSE TestAccBatchJobDefinition_PlatformCapabilities_ec2
=== RUN   TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDefaults
=== PAUSE TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDefaults
=== RUN   TestAccBatchJobDefinition_PlatformCapabilities_fargate
=== PAUSE TestAccBatchJobDefinition_PlatformCapabilities_fargate
=== RUN   TestAccBatchJobDefinition_ContainerProperties_advanced
=== PAUSE TestAccBatchJobDefinition_ContainerProperties_advanced
=== RUN   TestAccBatchJobDefinition_ContainerProperties_minorUpdate
=== PAUSE TestAccBatchJobDefinition_ContainerProperties_minorUpdate
=== RUN   TestAccBatchJobDefinition_propagateTags
=== PAUSE TestAccBatchJobDefinition_propagateTags
=== RUN   TestAccBatchJobDefinition_ContainerProperties_EmptyField
=== PAUSE TestAccBatchJobDefinition_ContainerProperties_EmptyField
=== RUN   TestAccBatchJobDefinition_NodeProperties_basic
=== PAUSE TestAccBatchJobDefinition_NodeProperties_basic
=== RUN   TestAccBatchJobDefinition_NodeProperties_advanced
=== PAUSE TestAccBatchJobDefinition_NodeProperties_advanced
=== RUN   TestAccBatchJobDefinition_EKSProperties_basic
=== PAUSE TestAccBatchJobDefinition_EKSProperties_basic
=== RUN   TestAccBatchJobDefinition_EKSProperties_update
=== PAUSE TestAccBatchJobDefinition_EKSProperties_update
=== RUN   TestAccBatchJobDefinition_EKSProperties_imagePullSecrets
=== PAUSE TestAccBatchJobDefinition_EKSProperties_imagePullSecrets
=== RUN   TestAccBatchJobDefinition_createTypeContainerWithNodeProperties
=== PAUSE TestAccBatchJobDefinition_createTypeContainerWithNodeProperties
=== RUN   TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties
=== PAUSE TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties
=== RUN   TestAccBatchJobDefinition_schedulingPriority
=== PAUSE TestAccBatchJobDefinition_schedulingPriority
=== RUN   TestAccBatchJobDefinition_emptyRetryStrategy
=== PAUSE TestAccBatchJobDefinition_emptyRetryStrategy
=== RUN   TestAccBatchJobDefinition_ECSProperties_update
=== PAUSE TestAccBatchJobDefinition_ECSProperties_update
=== RUN   TestAccBatchJobDefinition_updateWithTags
=== PAUSE TestAccBatchJobDefinition_updateWithTags
=== CONT  TestAccBatchJobDefinition_tags
=== CONT  TestAccBatchJobDefinition_basic
=== CONT  TestAccBatchJobDefinition_EKSProperties_basic
=== CONT  TestAccBatchJobDefinition_ContainerProperties_advanced
=== CONT  TestAccBatchJobDefinition_PlatformCapabilities_ec2
=== CONT  TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDefaults
=== CONT  TestAccBatchJobDefinition_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccBatchJobDefinition_disappears
=== CONT  TestAccBatchJobDefinition_updateWithTags
=== CONT  TestAccBatchJobDefinition_ECSProperties_update
=== CONT  TestAccBatchJobDefinition_emptyRetryStrategy
=== CONT  TestAccBatchJobDefinition_schedulingPriority
=== CONT  TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties
=== CONT  TestAccBatchJobDefinition_createTypeContainerWithNodeProperties
=== CONT  TestAccBatchJobDefinition_EKSProperties_imagePullSecrets
=== CONT  TestAccBatchJobDefinition_PlatformCapabilities_fargate
=== CONT  TestAccBatchJobDefinition_attributes
=== CONT  TestAccBatchJobDefinition_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccBatchJobDefinition_NodeProperties_advanced
=== CONT  TestAccBatchJobDefinition_EKSProperties_update
--- PASS: TestAccBatchJobDefinition_createTypeMultiNodeWithContainerProperties (8.54s)
=== CONT  TestAccBatchJobDefinition_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccBatchJobDefinition_createTypeContainerWithNodeProperties (8.98s)
=== CONT  TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccBatchJobDefinition_disappears (24.92s)
=== CONT  TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccBatchJobDefinition_schedulingPriority (26.48s)
=== CONT  TestAccBatchJobDefinition_tags_ComputedTag_OnCreate
--- PASS: TestAccBatchJobDefinition_emptyRetryStrategy (27.32s)
=== CONT  TestAccBatchJobDefinition_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccBatchJobDefinition_EKSProperties_basic (29.66s)
=== CONT  TestAccBatchJobDefinition_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccBatchJobDefinition_PlatformCapabilities_ec2 (29.88s)
=== CONT  TestAccBatchJobDefinition_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccBatchJobDefinition_EKSProperties_imagePullSecrets (30.26s)
=== CONT  TestAccBatchJobDefinition_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccBatchJobDefinition_PlatformCapabilitiesFargate_containerPropertiesDefaults (30.78s)
=== CONT  TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccBatchJobDefinition_basic (30.98s)
=== CONT  TestAccBatchJobDefinition_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccBatchJobDefinition_PlatformCapabilities_fargate (32.33s)
=== CONT  TestAccBatchJobDefinition_tags_DefaultTags_overlapping
--- PASS: TestAccBatchJobDefinition_ECSProperties_update (43.08s)
=== CONT  TestAccBatchJobDefinition_tags_DefaultTags_nonOverlapping
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_updateToResourceOnly (43.45s)
=== CONT  TestAccBatchJobDefinition_tags_DefaultTags_providerOnly
--- PASS: TestAccBatchJobDefinition_updateWithTags (45.73s)
=== CONT  TestAccBatchJobDefinition_ContainerProperties_EmptyField
--- PASS: TestAccBatchJobDefinition_NodeProperties_advanced (46.06s)
=== CONT  TestAccBatchJobDefinition_NodeProperties_basic
--- PASS: TestAccBatchJobDefinition_EKSProperties_update (47.07s)
=== CONT  TestAccBatchJobDefinition_tags_AddOnUpdate
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_nullNonOverlappingResourceTag (32.32s)
=== CONT  TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_nullOverlappingResourceTag (31.60s)
=== CONT  TestAccBatchJobDefinition_tags_EmptyTag_OnCreate
--- PASS: TestAccBatchJobDefinition_tags_ComputedTag_OnCreate (35.21s)
=== CONT  TestAccBatchJobDefinition_propagateTags
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_emptyProviderOnlyTag (32.86s)
=== CONT  TestAccBatchJobDefinition_tags_EmptyMap
--- PASS: TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Replace (54.02s)
=== CONT  TestAccBatchJobDefinition_tags_null
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_emptyResourceTag (33.30s)
=== CONT  TestAccBatchJobDefinition_ContainerProperties_minorUpdate
--- PASS: TestAccBatchJobDefinition_tags_IgnoreTags_Overlap_DefaultTag (61.68s)
--- PASS: TestAccBatchJobDefinition_tags_IgnoreTags_Overlap_ResourceTag (74.14s)
--- PASS: TestAccBatchJobDefinition_NodeProperties_basic (29.48s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_EmptyField (30.90s)
--- PASS: TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Add (52.62s)
--- PASS: TestAccBatchJobDefinition_attributes (79.41s)
--- PASS: TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Replace (49.18s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_updateToProviderOnly (50.16s)
--- PASS: TestAccBatchJobDefinition_propagateTags (19.65s)
--- PASS: TestAccBatchJobDefinition_tags_AddOnUpdate (42.02s)
--- PASS: TestAccBatchJobDefinition_tags_EmptyMap (28.54s)
--- PASS: TestAccBatchJobDefinition_tags_null (28.51s)
--- PASS: TestAccBatchJobDefinition_tags (92.94s)
--- PASS: TestAccBatchJobDefinition_tags_EmptyTag_OnCreate (37.65s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_overlapping (67.48s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_nonOverlapping (60.34s)
--- PASS: TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Add (48.89s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_advanced (110.19s)
--- PASS: TestAccBatchJobDefinition_tags_DefaultTags_providerOnly (74.40s)
--- PASS: TestAccBatchJobDefinition_ContainerProperties_minorUpdate (76.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      144.776s
```
