### PR TITLE
Add SageMaker notebook support for Jupyter 4

### DIFF
--- a/internal/service/sagemaker/notebook_instance.go
+++ b/internal/service/sagemaker/notebook_instance.go
@@ -124,7 +124,7 @@ func resourceNotebookInstance() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^(notebook-al1-v1|notebook-al2-v1|notebook-al2-v2)$`), ""),
+				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^(notebook-al1-v1|notebook-al2-v1|notebook-al2-v2|notebook-al2-v3)$`), ""),
 			},
 			names.AttrRoleARN: {
 				Type:         schema.TypeString,

--- a/internal/service/sagemaker/notebook_instance_test.go
+++ b/internal/service/sagemaker/notebook_instance_test.go
@@ -428,6 +428,13 @@ func TestAccSageMakerNotebookInstance_Platform_identifier(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "platform_identifier", "notebook-al2-v2"),
 				),
 			},
+			{
+				Config: testAccNotebookInstanceConfig_platformIdentifier(rName, "notebook-al2-v3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotebookInstanceExists(ctx, resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "platform_identifier", "notebook-al2-v3"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/cdktf/python/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/cdktf/python/r/sagemaker_notebook_instance.html.markdown
@@ -77,7 +77,7 @@ This resource supports the following arguments:
 * `name` - (Required) The name of the notebook instance (must be unique).
 * `role_arn` - (Required) The ARN of the IAM role to be used by the notebook instance which allows SageMaker to call other services on your behalf.
 * `instance_type` - (Required) The name of ML compute instance type.
-* `platform_identifier` - (Optional) The platform identifier of the notebook instance runtime environment. This value can be either `notebook-al1-v1`, `notebook-al2-v1`, or  `notebook-al2-v2`, depending on which version of Amazon Linux you require.
+* `platform_identifier` - (Optional) The platform identifier of the notebook instance runtime environment. This value can be either `notebook-al1-v1`, `notebook-al2-v1`, `notebook-al2-v2`, or `notebook-al2-v3`, depending on which version of Amazon Linux and JupyterLab you require.
 * `volume_size` - (Optional) The size, in GB, of the ML storage volume to attach to the notebook instance. The default value is 5 GB.
 * `subnet_id` - (Optional) The VPC subnet ID.
 * `security_groups` - (Optional) The associated security groups.

--- a/website/docs/cdktf/typescript/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/cdktf/typescript/r/sagemaker_notebook_instance.html.markdown
@@ -84,7 +84,7 @@ This resource supports the following arguments:
 * `name` - (Required) The name of the notebook instance (must be unique).
 * `roleArn` - (Required) The ARN of the IAM role to be used by the notebook instance which allows SageMaker to call other services on your behalf.
 * `instanceType` - (Required) The name of ML compute instance type.
-* `platformIdentifier` - (Optional) The platform identifier of the notebook instance runtime environment. This value can be either `notebook-al1-v1`, `notebook-al2-v1`, or  `notebook-al2-v2`, depending on which version of Amazon Linux you require.
+* `platformIdentifier` - (Optional) The platform identifier of the notebook instance runtime environment. This value can be either `notebook-al1-v1`, `notebook-al2-v1`, `notebook-al2-v2`, or `notebook-al2-v3`, depending on which version of Amazon Linux and JupyterLab you require.
 * `volumeSize` - (Optional) The size, in GB, of the ML storage volume to attach to the notebook instance. The default value is 5 GB.
 * `subnetId` - (Optional) The VPC subnet ID.
 * `securityGroups` - (Optional) The associated security groups.

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -56,7 +56,7 @@ This resource supports the following arguments:
 * `name` - (Required) The name of the notebook instance (must be unique).
 * `role_arn` - (Required) The ARN of the IAM role to be used by the notebook instance which allows SageMaker to call other services on your behalf.
 * `instance_type` - (Required) The name of ML compute instance type.
-* `platform_identifier` - (Optional) The platform identifier of the notebook instance runtime environment. This value can be either `notebook-al1-v1`, `notebook-al2-v1`, or  `notebook-al2-v2`, depending on which version of Amazon Linux you require.
+* `platform_identifier` - (Optional) The platform identifier of the notebook instance runtime environment. This value can be either `notebook-al1-v1`, `notebook-al2-v1`, `notebook-al2-v2`, or `notebook-al2-v3` depending on which version of Amazon Linux and JupyterLab you require.
 * `volume_size` - (Optional) The size, in GB, of the ML storage volume to attach to the notebook instance. The default value is 5 GB.
 * `subnet_id` - (Optional) The VPC subnet ID.
 * `security_groups` - (Optional) The associated security groups.


### PR DESCRIPTION
### Description
Adds support for SageMaker Notebook Jupyter 4.

### References

https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-sagemaker-notebook-instances-jupyterlab-4-notebooks/

Platform identifier: Amazon Linux 2, Jupyter Lab 4 (notebook-al2-v3)


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccSageMakerNotebookInstance_Platform_identifier PKG=sagemaker
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerNotebookInstance_Platform_identifier'  -timeout 360m
2024/11/06 08:33:56 Initializing Terraform AWS Provider...
=== RUN   TestAccSageMakerNotebookInstance_Platform_identifier
=== PAUSE TestAccSageMakerNotebookInstance_Platform_identifier
=== CONT  TestAccSageMakerNotebookInstance_Platform_identifier
--- PASS: TestAccSageMakerNotebookInstance_Platform_identifier (1145.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	1149.133s
```
