### PR TITLE
Add missing `shared_accounts` parameter to `db_snapshot_copy` documentation

### DIFF
--- a/website/docs/r/db_snapshot_copy.html.markdown
+++ b/website/docs/r/db_snapshot_copy.html.markdown
@@ -47,6 +47,7 @@ This resource supports the following arguments:
 * `kms_key_id` - (Optional) KMS key ID.
 * `option_group_name`- (Optional) The name of an option group to associate with the copy of the snapshot.
 * `presigned_url` - (Optional) he URL that contains a Signature Version 4 signed request.
+* `shared_accounts` - (Optional) List of AWS Account IDs to share the snapshot with. Use `all` to make the snapshot public.
 * `source_db_snapshot_identifier` - (Required) Snapshot identifier of the source snapshot.
 * `target_custom_availability_zone` - (Optional) The external custom Availability Zone.
 * `target_db_snapshot_identifier` - (Required) The Identifier for the snapshot.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The option to share a snapshot when copying it with the resource  `db_snapshot_copy` is implemented (https://github.com/hashicorp/terraform-provider-aws/blob/835fdcd788b737b95c394daed625a62b73506bb2/internal/service/rds/snapshot_copy.go#L109), but it isn't documented. This PR will fix that.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
