### PR TITLE
skaff: fix framework data source annotation

### DIFF
--- a/skaff/datasource/datasourcefw.gtpl
+++ b/skaff/datasource/datasourcefw.gtpl
@@ -68,7 +68,7 @@ import (
 {{- end }}
 
 // Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
-// @SDKDataSource("{{ .ProviderResourceName }}", name="{{ .HumanDataSourceName }}")
+// @FrameworkDataSource("{{ .ProviderResourceName }}", name="{{ .HumanDataSourceName }}")
 func newDataSource{{ .DataSource }}(context.Context) (datasource.DataSourceWithConfigure, error) {
 	return &dataSource{{ .DataSource }}{}, nil
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The Terraform Plugin Framework template incorrectly sets the `@SDKDataSource` annotation.
