### PR TITLE
r/aws_lb_listener: remove `tcp_idle_timeout_seconds` default value

### DIFF
--- a/.changelog/40039.txt
+++ b/.changelog/40039.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_lb_listener: Remove the default `tcp_idle_timeout_seconds` value, preventing `ModifyListenerAttributes` API calls when a value is not explicitly configured
+```
+```release-note:bug
+resource/aws_lb_listener: Fix errors when updating the `tcp_idle_timeout_seconds` argument for gateway load balancers
+```

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -602,9 +602,7 @@ func resourceListenerUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ELBV2Client(ctx)
 
-	var attributes []awstypes.ListenerAttribute
-
-	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
+	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll, "tcp_idle_timeout_seconds") {
 		input := &elasticloadbalancingv2.ModifyListenerInput{
 			ListenerArn: aws.String(d.Id()),
 		}
@@ -642,20 +640,29 @@ func resourceListenerUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			input.SslPolicy = aws.String(v.(string))
 		}
 
-		attributes = append(attributes, listenerAttributes.expand(d, awstypes.ProtocolEnum(d.Get(names.AttrProtocol).(string)), true)...)
-
-		if len(attributes) > 0 {
-			if err := modifyListenerAttributes(ctx, conn, d.Id(), attributes); err != nil {
-				return sdkdiag.AppendFromErr(diags, err)
-			}
-		}
-
 		_, err := tfresource.RetryWhenIsA[*awstypes.CertificateNotFoundException](ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
 			return conn.ModifyListener(ctx, input)
 		})
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "modifying ELBv2 Listener (%s): %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChanges("tcp_idle_timeout_seconds") {
+		lbARN := d.Get("load_balancer_arn").(string)
+		listenerProtocolType := awstypes.ProtocolEnum(d.Get(names.AttrProtocol).(string))
+		// Protocol does not need to be explicitly set with GWLB listeners, nor is it returned by the API
+		// If protocol is not set, use the load balancer ARN to determine if listener is gateway type and set protocol appropriately
+		if listenerProtocolType == awstypes.ProtocolEnum("") && strings.Contains(lbARN, "loadbalancer/gwy/") {
+			listenerProtocolType = awstypes.ProtocolEnumGeneve
+		}
+
+		attributes := listenerAttributes.expand(d, listenerProtocolType, true)
+		if len(attributes) > 0 {
+			if err := modifyListenerAttributes(ctx, conn, d.Id(), attributes); err != nil {
+				return sdkdiag.AppendFromErr(diags, err)
+			}
 		}
 	}
 

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strconv"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -1016,7 +1017,7 @@ func TestAccELBV2Listener_attributes_gwlb_TCPIdleTimeoutSeconds(t *testing.T) {
 	lbResourceName := "aws_lb.test"
 	resourceName := "aws_lb_listener.test"
 	tcpTimeout1 := 60
-	// tcpTimeout2 := 6000
+	tcpTimeout2 := 6000
 
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -1035,8 +1036,7 @@ func TestAccELBV2Listener_attributes_gwlb_TCPIdleTimeoutSeconds(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", lbResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrProtocol, ""),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPort, "0"),
-					resource.TestCheckResourceAttr(resourceName, "tcp_idle_timeout_seconds", "60"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tcp_idle_timeout_seconds", strconv.Itoa(tcpTimeout1)),
 				),
 			},
 			{
@@ -1046,6 +1046,16 @@ func TestAccELBV2Listener_attributes_gwlb_TCPIdleTimeoutSeconds(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"default_action.0.forward",
 				},
+			},
+			{
+				Config: testAccListenerConfig_attributes_gwlbTCPIdleTimeoutSeconds(rName, tcpTimeout2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckListenerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", lbResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, names.AttrProtocol, ""),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPort, "0"),
+					resource.TestCheckResourceAttr(resourceName, "tcp_idle_timeout_seconds", strconv.Itoa(tcpTimeout2)),
+				),
 			},
 		},
 	})
@@ -1056,6 +1066,8 @@ func TestAccELBV2Listener_attributes_nlb_TCPIdleTimeoutSeconds(t *testing.T) {
 	var conf awstypes.Listener
 	resourceName := "aws_lb_listener.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	tcpTimeout1 := 60
+	tcpTimeout2 := 6000
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -1064,31 +1076,13 @@ func TestAccELBV2Listener_attributes_nlb_TCPIdleTimeoutSeconds(t *testing.T) {
 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccListenerConfig_attributes_nlbTCPIdleTimeoutSeconds(rName),
+				Config: testAccListenerConfig_attributes_nlbTCPIdleTimeoutSeconds(rName, tcpTimeout1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckListenerExists(ctx, resourceName, &conf),
-					resource.TestCheckResourceAttr("aws_lb.test", "load_balancer_type", "network"),
 					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", names.AttrARN),
-					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "elasticloadbalancing", regexache.MustCompile("listener/.+$")),
-					resource.TestCheckNoResourceAttr(resourceName, "alpn_policy"),
-					resource.TestCheckNoResourceAttr(resourceName, names.AttrCertificateARN),
-					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_action.0.order", "1"),
-					resource.TestCheckResourceAttr(resourceName, "default_action.0.type", "forward"),
-					resource.TestCheckResourceAttrPair(resourceName, "default_action.0.target_group_arn", "aws_lb_target_group.test", names.AttrARN),
-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_cognito.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_action.0.authenticate_oidc.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_action.0.fixed_response.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_action.0.forward.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "default_action.0.redirect.#", "0"),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
-					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrProtocol, "TCP"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPort, "80"),
-					resource.TestCheckResourceAttr(resourceName, "ssl_policy", ""),
-					resource.TestCheckResourceAttr(resourceName, "tcp_idle_timeout_seconds", "60"),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsAllPercent, "0"),
+					resource.TestCheckResourceAttr(resourceName, "tcp_idle_timeout_seconds", strconv.Itoa(tcpTimeout1)),
 				),
 			},
 			{
@@ -1098,6 +1092,16 @@ func TestAccELBV2Listener_attributes_nlb_TCPIdleTimeoutSeconds(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"default_action.0.forward",
 				},
+			},
+			{
+				Config: testAccListenerConfig_attributes_nlbTCPIdleTimeoutSeconds(rName, tcpTimeout2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckListenerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttrPair(resourceName, "load_balancer_arn", "aws_lb.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, names.AttrProtocol, "TCP"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPort, "80"),
+					resource.TestCheckResourceAttr(resourceName, "tcp_idle_timeout_seconds", strconv.Itoa(tcpTimeout2)),
+				),
 			},
 		},
 	})
@@ -2967,7 +2971,7 @@ resource "aws_lb_listener" "test" {
 `, rName, seconds))
 }
 
-func testAccListenerConfig_attributes_nlbTCPIdleTimeoutSeconds(rName string) string {
+func testAccListenerConfig_attributes_nlbTCPIdleTimeoutSeconds(rName string, seconds int) string {
 	return acctest.ConfigCompose(
 		testAccListenerConfig_base(rName), fmt.Sprintf(`
 resource "aws_lb_listener" "test" {
@@ -2979,7 +2983,8 @@ resource "aws_lb_listener" "test" {
     target_group_arn = aws_lb_target_group.test.id
     type             = "forward"
   }
-  tcp_idle_timeout_seconds = 60
+
+  tcp_idle_timeout_seconds = %[2]d
 }
 
 resource "aws_lb" "test" {
@@ -3015,7 +3020,7 @@ resource "aws_lb_target_group" "test" {
     Name = %[1]q
   }
 }
-`, rName))
+`, rName, seconds))
 }
 
 func testAccListenerConfig_Forward_changeWeightedToBasic(rName, rName2 string) string {

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -62,6 +62,7 @@ func TestAccELBV2Listener_Application_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ssl_policy", ""),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsAllPercent, "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "tcp_idle_timeout_seconds"),
 				),
 			},
 			{
@@ -114,6 +115,7 @@ func TestAccELBV2Listener_Network_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ssl_policy", ""),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsAllPercent, "0"),
+					resource.TestCheckResourceAttr(resourceName, "tcp_idle_timeout_seconds", "350"),
 				),
 			},
 			{
@@ -165,6 +167,7 @@ func TestAccELBV2Listener_Gateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ssl_policy", ""),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsAllPercent, "0"),
+					resource.TestCheckResourceAttr(resourceName, "tcp_idle_timeout_seconds", "350"),
 				),
 			},
 			{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change fixes two issues related to the newly added `tcp_idle_timeout_seconds` argument.

### Regression caused by a default value

Reported in #40000 

The `tcp_idle_timeout_seconds` default value of `350` has been removed in favor or marking this argument optional and computed. In practice, this means the default value of `350` is still read and stored in state for protocols which support this feature, but unless explicitly configured by the user, the `ModifyListenerAttributes` API will not be called during create or update operations.

This change fixes a regression introduced by the addition of the `tcp_idle_timeout_seconds` argument with a default value, which caused any existing configuration using the `aws_lb_listener` resource to now require the calling principal to include the `elasticloadbalancing:ModifyLoadBalancerAttributes` IAM action in an attached IAM policy. By only sending this value when explicitly configured, existing configurations can continue to operate as expected with no modifications to the IAM permissions of the calling principal.

To confirm the API is no longer being called when `tcp_idle_timeout_seconds` is not explicitly configured, I've grepped the debug logs of the same configuration applied with `v5.74.0` of the AWS provider and a locally built binary from this branch. The former includes a result with the API request body where the TCP idle timeout is set to the default of `350`. The latter includes no result indicating the `ModifyListenerAttributes` API was not called, as expected.

__`v5.74.0`__:

```console
% rg "Action=ModifyListenerAttributes" apply-old.out
2672:  | Action=ModifyListenerAttributes&Attributes.member.1.Key=tcp.idle_timeout.seconds&Attributes.member.1.Value=350&ListenerArn=arn%3Aaws%3Aelasticloadbalancing%3Aus-west-2%3A<redacted>%3Alistener%2Fnet%2Fjb-test%2Fb0f926497af0c80f%2F819828f77724007f&Version=2015-12-01
```

__This branch__:

```console
% rg "Action=ModifyListenerAttributes" apply.out
```

### Failed updates 

Reported in #40022 

Updates to the `tcp_idle_timeout_seconds` argument are now handled distinctly from changes to other non-tag related arguments. Additionally, the logic applied to appropriately infer the protocol for gateway load balancers during the create operation has been replicated during update. Together these changes prevent failures when updating the `tcp_idle_timeout_seconds` argument for gateway load balancers like the following:

```
Error: modifying ELBv2 Listener (arn:aws:elasticloadbalancing:us-west-2:<redacted>:listener/gwy/tf-acc-test-5332588832756138226/541226271e9ad4ec/2bbf23d4354df440): operation error Elastic Load Balancing v2: ModifyListener, https response error StatusCode: 400, RequestID: c6f51e60-0511-443d-a98e-6f51b48fce11, api error ValidationError: An action must be specified
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40000 
Closes #40022 


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/elasticloadbalancing/latest/network/update-idle-timeout.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elbv2 TESTS=TestAccELBV2Listener_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2Listener_'  -timeout 360m
2024/11/06 20:29:55 Initializing Terraform AWS Provider...

--- PASS: TestAccELBV2Listener_Forward_removeStickiness (241.51s)
=== CONT  TestAccELBV2Listener_DefaultAction_specifyOrder
--- PASS: TestAccELBV2Listener_attributes_gwlb_TCPIdleTimeoutSeconds (180.15s)
=== CONT  TestAccELBV2Listener_DefaultAction_defaultOrder
--- PASS: TestAccELBV2Listener_Protocol_upd (222.16s)
=== CONT  TestAccELBV2Listener_oidc
--- PASS: TestAccELBV2Listener_Forward_addStickiness (253.42s)
=== CONT  TestAccELBV2Listener_Protocol_tls
--- PASS: TestAccELBV2Listener_tags_DefaultTags_emptyProviderOnlyTag (241.46s)
=== CONT  TestAccELBV2Listener_fixedResponse
--- PASS: TestAccELBV2Listener_Forward_TGARNToForward_noChanges (275.36s)
=== CONT  TestAccELBV2Listener_redirect
--- PASS: TestAccELBV2Listener_tags_DefaultTags_emptyResourceTag (240.24s)
=== CONT  TestAccELBV2Listener_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccELBV2Listener_Forward_ignoreFields (237.42s)
=== CONT  TestAccELBV2Listener_Forward_removeAction
--- PASS: TestAccELBV2Listener_tags_EmptyTag_OnUpdate_Replace (236.03s)
=== CONT  TestAccELBV2Listener_tags_EmptyMap
--- PASS: TestAccELBV2Listener_tags_EmptyTag_OnCreate (249.34s)
=== CONT  TestAccELBV2Listener_tags_AddOnUpdate
--- PASS: TestAccELBV2Listener_tags_DefaultTags_updateToResourceOnly (277.34s)
=== CONT  TestAccELBV2Listener_tags_null
--- PASS: TestAccELBV2Listener_cognito (237.65s)
=== CONT  TestAccELBV2Listener_Forward_ToTGARN_noChanges
--- PASS: TestAccELBV2Listener_Forward_ToTGARN_weightStickiness (246.06s)
=== CONT  TestAccELBV2Listener_mutualAuthenticationPassthrough
--- PASS: TestAccELBV2Listener_tags_DefaultTags_updateToProviderOnly (279.55s)
=== CONT  TestAccELBV2Listener_Gateway_lbARN
--- PASS: TestAccELBV2Listener_tags_EmptyTag_OnUpdate_Add (274.50s)
=== CONT  TestAccELBV2Listener_mutualAuthentication
--- PASS: TestAccELBV2Listener_DefaultAction_actionDisappears (216.04s)
=== CONT  TestAccELBV2Listener_DefaultAction_empty/forward
=== CONT  TestAccELBV2Listener_DefaultAction_empty/redirect
=== CONT  TestAccELBV2Listener_DefaultAction_empty/fixed-response
=== CONT  TestAccELBV2Listener_DefaultAction_empty/authenticate-cognito
=== CONT  TestAccELBV2Listener_DefaultAction_empty/authenticate-oidc
--- PASS: TestAccELBV2Listener_DefaultAction_empty (0.00s)
    --- PASS: TestAccELBV2Listener_DefaultAction_empty/forward (1.66s)
    --- PASS: TestAccELBV2Listener_DefaultAction_empty/redirect (1.63s)
    --- PASS: TestAccELBV2Listener_DefaultAction_empty/fixed-response (1.64s)
    --- PASS: TestAccELBV2Listener_DefaultAction_empty/authenticate-cognito (1.53s)
    --- PASS: TestAccELBV2Listener_DefaultAction_empty/authenticate-oidc (1.65s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_overlapping (343.64s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_nonOverlapping (335.24s)
--- PASS: TestAccELBV2Listener_redirectWithTargetGroupARN (294.64s)
--- PASS: TestAccELBV2Listener_DefaultAction_specifyOrder (226.95s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_providerOnly (425.48s)
--- PASS: TestAccELBV2Listener_oidc (238.82s)
--- PASS: TestAccELBV2Listener_DefaultAction_defaultOrder (247.28s)
--- PASS: TestAccELBV2Listener_fixedResponse (227.85s)
--- PASS: TestAccELBV2Listener_redirect (237.89s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_nullNonOverlappingResourceTag (238.94s)
--- PASS: TestAccELBV2Listener_Gateway_lbARN (199.06s)
--- PASS: TestAccELBV2Listener_tags_EmptyMap (226.45s)
--- PASS: TestAccELBV2Listener_Forward_removeAction (245.84s)
--- PASS: TestAccELBV2Listener_tags_null (226.03s)
--- PASS: TestAccELBV2Listener_mutualAuthenticationPassthrough (248.35s)
--- PASS: TestAccELBV2Listener_Forward_ToTGARN_noChanges (255.34s)
--- PASS: TestAccELBV2Listener_tags_AddOnUpdate (263.88s)
--- PASS: TestAccELBV2Listener_Protocol_tls (334.90s)
--- PASS: TestAccELBV2Listener_mutualAuthentication (248.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      831.853s
```
