### PR TITLE
docs: add argument `validation_window_hours`

### DIFF
--- a/website/docs/r/backup_restore_testing_selection.html.markdown
+++ b/website/docs/r/backup_restore_testing_selection.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 * `protected_resource_arns` - (Optional) The ARNs for the protected resources.
 * `protected_resource_conditions` - (Optional) The conditions for the protected resource.
 * `restore_metadata_overrides` - (Optional) Override certain restore metadata keys. See the complete list of [restore testing inferred metadata](https://docs.aws.amazon.com/aws-backup/latest/devguide/restore-testing-inferred-metadata.html) .
+* `validation_window_hours` - (Optional) The amount of hours available to run a validation script on the data. Valid range is `1` to `168`.
 
 The `protected_resource_conditions` block supports the following arguments:
 


### PR DESCRIPTION
### Description
The resoure `aws_backup_restore_testing_selection` is missing documentation for the argument `validation_window_hours`.

This PR adds a brief description (compared to SDK/ CLI) and details on the value range.

### Relations

Closes #40011 

### References

- [AWS CLI Docs](https://docs.aws.amazon.com/cli/latest/reference/backup/create-restore-testing-selection.html)
- [AWS SDK Go v2 -RestoreTestingSelectionForGet ](https://github.com/aws/aws-sdk-go-v2/blob/70eb57ac775f782db6856c73f1ca22eae8e48ac2/service/backup/types/types.go#L2204) 
- [Validation in TF resource](https://github.com/hashicorp/terraform-provider-aws/blob/c220a4002aa159f68a3e6e1428368918e7c7d154/internal/service/backup/restore_testing_selection.go#L115)

### Output from Acceptance Testing

Not applicable. Only resource documentation changed.