### PR TITLE
dynamodb/table: Fix ability to disable dynamodb table ttl

### DIFF
--- a/.changelog/40046.txt
+++ b/.changelog/40046.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dynamodb_table: Allow table TTL to be disabled by allowing `ttl[0].attribute_name` to be set
+```

--- a/.changelog/40046.txt
+++ b/.changelog/40046.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_dynamodb_table: Allow table TTL to be disabled by allowing `ttl[0].attribute_name` to be set
+resource/aws_dynamodb_table: Allow table TTL to be disabled by allowing `ttl[0].attribute_name` to be set when `ttl[0].enabled` is false
 ```

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -473,6 +473,14 @@ func resourceTable() *schema.Resource {
 						"attribute_name": {
 							Type:     schema.TypeString,
 							Optional: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// AWS requires the attribute name to be set when disabling TTL but
+								// does not return it so it causes a diff.
+								if old == "" && new != "" && !d.Get("ttl.0.enabled").(bool) {
+									return true
+								}
+								return false
+							},
 						},
 						names.AttrEnabled: {
 							Type:     schema.TypeBool,
@@ -2628,13 +2636,9 @@ func ttlPlantimeValidate(ttlPath cty.Path, ttl cty.Value, diags *diag.Diagnostic
 				errs.PathString(ttlPath.GetAttr("attribute_name")),
 			))
 		}
-	} else {
-		if !(attribute.IsNull() || attribute.AsString() == "") {
-			*diags = append(*diags, errs.NewAttributeConflictsWhenError(
-				ttlPath.GetAttr("attribute_name"),
-				ttlPath.GetAttr(names.AttrEnabled),
-				"false",
-			))
-		}
 	}
+
+	// !! Not a validation error for attribute_name to be set when enabled is false !!
+	// AWS *requires* attribute_name to be set when disabling TTL but does not return it, causing a diff.
+	// The diff is handled by DiffSuppressFunc of AttrEnabled.
 }

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -2640,5 +2640,5 @@ func ttlPlantimeValidate(ttlPath cty.Path, ttl cty.Value, diags *diag.Diagnostic
 
 	// !! Not a validation error for attribute_name to be set when enabled is false !!
 	// AWS *requires* attribute_name to be set when disabling TTL but does not return it, causing a diff.
-	// The diff is handled by DiffSuppressFunc of AttrEnabled.
+	// The diff is handled by DiffSuppressFunc of attribute_name.
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Brief history:
* #10304 describes a diff bug caused by `ttl.0.attribute_name` going out to AWS but not coming back
* #37991 attempted to fix the diff by applying validation preventing `ttl.0.attribute_name` from being set if `ttl.0.enabled` is `false`. That fixed the diff but caused another problem.
* In order to disable TTL on a table, you *_must_* pass in `ttl.0.attribute_name`, even though AWS will not return it. #37991 made it impossible to disable TTL.
* This PR removes the validation preventing `ttl.0.attribute_name` from being set if `ttl.0.enabled` is `false` and addresses the diff issue with a `DiffSuppressFunc`.
* Unfortunately, testing this fix is complicated because AWS will not allow you to disable TTL in the first hour it's enabled. I've added a test that sleeps an hour so it can verify that disabling works.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39195
Relates #37991 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* #37991
* #10304

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccDynamoDBTable_TTL_updateDisable K=dynamodb
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_TTL_updateDisable'  -timeout 360m
2024/11/07 13:57:43 Initializing Terraform AWS Provider...
=== RUN   TestAccDynamoDBTable_TTL_updateDisable
=== PAUSE TestAccDynamoDBTable_TTL_updateDisable
=== CONT  TestAccDynamoDBTable_TTL_updateDisable
--- PASS: TestAccDynamoDBTable_TTL_updateDisable (3639.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	3643.912s
```
