### PR TITLE
sagemaker/domain: Fix ValidationException with AppSecurityGroupMangement

### DIFF
--- a/.changelog/40049.txt
+++ b/.changelog/40049.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_domain: Fix issue causing a `ValidationException` on updates when RStudio is disabled on the domain
+```

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -730,6 +730,42 @@ func testAccDomain_rStudioServerProDomainSettings(t *testing.T) {
 	})
 }
 
+func testAccDomain_rStudioServerProDomainSettingsUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var domain sagemaker.DescribeDomainOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_domain.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainConfig_rStudioServerProDomainSettingsUpdate(rName, "PublicInternetOnly", "https://connect.domain.com", "https://package.domain.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.0.r_studio_server_pro_domain_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.0.r_studio_server_pro_domain_settings.0.r_studio_connect_url", "https://connect.domain.com"),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.0.r_studio_server_pro_domain_settings.0.r_studio_package_manager_url", "https://package.domain.com"),
+				),
+			},
+			{
+				Config: testAccDomainConfig_rStudioServerProDomainSettingsUpdate(rName, "VpcOnly", "https://connect.domain.com", "https://package.domain.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.0.r_studio_server_pro_domain_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.0.r_studio_server_pro_domain_settings.0.r_studio_connect_url", "https://connect.domain.com"),
+					resource.TestCheckResourceAttr(resourceName, "domain_settings.0.r_studio_server_pro_domain_settings.0.r_studio_package_manager_url", "https://package.domain.com"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDomain_kernelGatewayAppSettings(t *testing.T) {
 	ctx := acctest.Context(t)
 	var domain sagemaker.DescribeDomainOutput
@@ -2485,6 +2521,47 @@ resource "aws_sagemaker_domain" "test" {
   }
 }
 `, rName, connectURL, packageURL))
+}
+
+func testAccDomainConfig_rStudioServerProDomainSettingsUpdate(rName, networkAccess, connectURL, packageURL string) string {
+	return acctest.ConfigCompose(testAccDomainConfig_baseWithLicense(rName), fmt.Sprintf(`
+resource "aws_sagemaker_domain" "test" {
+  domain_name             = %[1]q
+  auth_mode               = "IAM"
+  vpc_id                  = aws_vpc.test.id
+  subnet_ids              = aws_subnet.test[*].id
+  app_network_access_type = %[2]q
+
+  domain_settings {
+
+    r_studio_server_pro_domain_settings {
+      r_studio_connect_url         = %[3]q
+      r_studio_package_manager_url = %[4]q
+      domain_execution_role_arn    = aws_iam_role.test.arn
+      default_resource_spec {
+        instance_type = "system"
+      }
+    }
+  }
+
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
+
+  # ignoring default image
+  # it would be too hard to create the logic to find the default Rstudio image: https://docs.aws.amazon.com/sagemaker/latest/dg/rstudio-version.html
+  # it changes for every region
+  lifecycle {
+    ignore_changes = [
+      domain_settings[0].r_studio_server_pro_domain_settings[0].default_resource_spec[0]
+    ]
+  }
+}
+`, rName, networkAccess, connectURL, packageURL))
 }
 
 func testAccDomainConfig_baseWithLicense(rName string) string {

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -74,7 +74,7 @@ func TestAccSageMaker_serial(t *testing.T) {
 			"rSessionAppSettings":                                     testAccDomain_rSessionAppSettings,
 			"rStudioServerProAppSettings":                             testAccDomain_rStudioServerProAppSettings,
 			"rStudioServerProDomainSettings":                          testAccDomain_rStudioServerProDomainSettings,
-			"rStudioServerProDomainSettingsUpdate":                    testAccDomain_rStudioServerProDomainSettingsUpdate,
+			"rStudioDomainDisabledNetworkUpdate":                      testAccDomain_rStudioDomainDisabledNetworkUpdate,
 			"spaceSettingsKernelGatewayAppSettings":                   testAccDomain_spaceSettingsKernelGatewayAppSettings,
 			"spaceSettingsJupyterLabAppSettings":                      testAccDomain_spaceSettingsJupyterLabAppSettings,
 			"spaceSettingsSpaceStorageSettings":                       testAccDomain_spaceSettingsSpaceStorageSettings,

--- a/internal/service/sagemaker/sagemaker_test.go
+++ b/internal/service/sagemaker/sagemaker_test.go
@@ -74,6 +74,7 @@ func TestAccSageMaker_serial(t *testing.T) {
 			"rSessionAppSettings":                                     testAccDomain_rSessionAppSettings,
 			"rStudioServerProAppSettings":                             testAccDomain_rStudioServerProAppSettings,
 			"rStudioServerProDomainSettings":                          testAccDomain_rStudioServerProDomainSettings,
+			"rStudioServerProDomainSettingsUpdate":                    testAccDomain_rStudioServerProDomainSettingsUpdate,
 			"spaceSettingsKernelGatewayAppSettings":                   testAccDomain_spaceSettingsKernelGatewayAppSettings,
 			"spaceSettingsJupyterLabAppSettings":                      testAccDomain_spaceSettingsJupyterLabAppSettings,
 			"spaceSettingsSpaceStorageSettings":                       testAccDomain_spaceSettingsSpaceStorageSettings,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

It seems like AWS may return something in `app_security_group_management` and then on an update it tries to pass that to AWS when it's not allowed. Note that this is an AWS ValidationException.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39923

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T='TestAccSageMaker_serial/Domain/rStudioDomainDisabledNetworkUpdate' K=sagemaker
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMaker_serial/Domain/rStudioDomainDisabledNetworkUpdate'  -timeout 360m
2024/11/07 15:59:51 Initializing Terraform AWS Provider...
=== RUN   TestAccSageMaker_serial
=== PAUSE TestAccSageMaker_serial
=== CONT  TestAccSageMaker_serial
=== RUN   TestAccSageMaker_serial/Domain
=== RUN   TestAccSageMaker_serial/Domain/rStudioDomainDisabledNetworkUpdate
--- PASS: TestAccSageMaker_serial (259.63s)
    --- PASS: TestAccSageMaker_serial/Domain (259.63s)
        --- PASS: TestAccSageMaker_serial/Domain/rStudioDomainDisabledNetworkUpdate (259.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	263.606s
```
