### PR TITLE
docs: remove invalid argument from resource documentation

### DIFF
--- a/website/docs/r/sagemaker_space.html.markdown
+++ b/website/docs/r/sagemaker_space.html.markdown
@@ -62,7 +62,6 @@ The `space_sharing_settings` block supports the following argument:
 The `code_editor_app_settings` block supports the following argument:
 
 * `app_lifecycle_management` - (Optional) Settings that are used to configure and manage the lifecycle of JupyterLab applications in a space. See [`app_lifecycle_management` Block](#app_lifecycle_management-block) below.
-* `code_repository` - (Optional) A list of Git repositories that SageMaker automatically displays to users for cloning in the JupyterServer application. See [`code_repository` Block](#code_repository-block) below.
 * `default_resource_spec` - (Required) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. See [`default_resource_spec` Block](#default_resource_spec-block) below.
 
 ### `custom_file_system` Block
@@ -76,7 +75,7 @@ The `custom_file_system` block supports the following argument:
 The `jupyter_lab_app_settings` block supports the following arguments:
 
 * `app_lifecycle_management` - (Optional) Settings that are used to configure and manage the lifecycle of JupyterLab applications in a space. See [`app_lifecycle_management` Block](#app_lifecycle_management-block) below.
-* `code_repository` - (Optional) A list of Git repositories that SageMaker automatically displays to users for cloning in the JupyterServer application. See [`code_repository` Block](#code_repository-block) below.
+* `code_repository` - (Optional) A list of Git repositories that SageMaker automatically displays to users for cloning in the JupyterLab application. See [`code_repository` Block](#code_repository-block) below.
 * `default_resource_spec` - (Required) The default instance type and the Amazon Resource Name (ARN) of the SageMaker image created on the instance. See [`default_resource_spec` Block](#default_resource_spec-block) below.
 
 ### `jupyter_server_app_settings` Block


### PR DESCRIPTION
### Description

- The resource `aws_sagemaker_space` does not contain a `code repository` block inside the `code_editor_app_settings` block. The resource documentation available [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_space#code_editor_app_settings-block) is updated accordingly.
- The documentation for the `code repository` block inside the `jupyter_lab_app_settings` is updated also. It should refer to `JupyterLab` instead of `JupyterServer`.


### Relations

Closes #40038 

### References

- [AWS Go SDK v2  - SpaceCodeEditorAppSettings](https://github.com/aws/aws-sdk-go-v2/blob/2f70834c690f3fecf04ef006f0ea7022884b367f/service/sagemaker/types/types.go#L16682)
- [AWS GO SDK v2 -SpaceJupyterLabAppSettings](https://github.com/aws/aws-sdk-go-v2/blob/2f70834c690f3fecf04ef006f0ea7022884b367f/service/sagemaker/types/types.go#L16739)
- [TF AWS Provider - code_editor_app_settings](https://github.com/hashicorp/terraform-provider-aws/blob/ab85962284e452f510f128d1a8621f59b9ef416d/internal/service/sagemaker/space.go#L97)

### Output from Acceptance Testing

Not applicable. Only documentation was updated.