### PR TITLE
dynamodb/table: TTL validation test no longer valid

### DIFF
--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -1695,10 +1695,6 @@ func TestAccDynamoDBTable_TTL_validate(t *testing.T) {
 		CheckDestroy:             testAccCheckTableDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTableConfig_timeToLive(rName, "TestTTL", false),
-				ExpectError: regexache.MustCompile(regexp.QuoteMeta(`Attribute "ttl[0].attribute_name" cannot be specified when "ttl[0].enabled" is "false"`)),
-			},
-			{
 				Config:      testAccTableConfig_timeToLive(rName, "", true),
 				ExpectError: regexache.MustCompile(regexp.QuoteMeta(`Attribute "ttl[0].attribute_name" cannot have an empty value`)),
 			},

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -776,6 +776,10 @@ func TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges(t 
 
 func TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned(t *testing.T) {
 	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf awstypes.TableDescription
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -814,6 +818,10 @@ func TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned(t *testing.T
 
 func TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest(t *testing.T) {
 	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf awstypes.TableDescription
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -849,6 +857,10 @@ func TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest(t *testing.T
 
 func TestAccDynamoDBTable_BillingMode_payPerRequestBasic(t *testing.T) {
 	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	var conf awstypes.TableDescription
 	resourceName := "aws_dynamodb_table.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

#40046 broke a test that this fixes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #40046

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccDynamoDBTable_TTL_validate K=dynamodb
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTable_TTL_validate'  -timeout 360m
2024/11/08 15:02:15 Initializing Terraform AWS Provider...
=== RUN   TestAccDynamoDBTable_TTL_validate
=== PAUSE TestAccDynamoDBTable_TTL_validate
=== CONT  TestAccDynamoDBTable_TTL_validate
--- PASS: TestAccDynamoDBTable_TTL_validate (4.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	8.111s
% make testacc-short T=TestAccDynamoDBTable K=dynamodb
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
Running acceptance tests with -short flag
TF_ACC=1 go1.23.2 test ./internal/service/dynamodb/... -v -short -count 1 -parallel 20 -run='TestAccDynamoDBTable'  -timeout 360m
2024/11/08 15:07:04 Initializing Terraform AWS Provider...
=== RUN   TestAccDynamoDBTableDataSource_tags
=== PAUSE TestAccDynamoDBTableDataSource_tags
=== RUN   TestAccDynamoDBTableDataSource_tags_NullMap
=== PAUSE TestAccDynamoDBTableDataSource_tags_NullMap
=== RUN   TestAccDynamoDBTableDataSource_tags_EmptyMap
=== PAUSE TestAccDynamoDBTableDataSource_tags_EmptyMap
=== RUN   TestAccDynamoDBTableDataSource_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccDynamoDBTableDataSource_tags_DefaultTags_nonOverlapping
=== RUN   TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccDynamoDBTableDataSource_basic
=== PAUSE TestAccDynamoDBTableDataSource_basic
=== RUN   TestAccDynamoDBTableExport_basic
    table_export_test.go:26: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTableExport_basic (0.00s)
=== RUN   TestAccDynamoDBTableExport_kms
    table_export_test.go:74: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTableExport_kms (0.00s)
=== RUN   TestAccDynamoDBTableExport_s3Prefix
    table_export_test.go:127: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTableExport_s3Prefix (0.00s)
=== RUN   TestAccDynamoDBTableItemDataSource_basic
=== PAUSE TestAccDynamoDBTableItemDataSource_basic
=== RUN   TestAccDynamoDBTableItemDataSource_projectionExpression
=== PAUSE TestAccDynamoDBTableItemDataSource_projectionExpression
=== RUN   TestAccDynamoDBTableItemDataSource_expressionAttributeNames
=== PAUSE TestAccDynamoDBTableItemDataSource_expressionAttributeNames
=== RUN   TestAccDynamoDBTableItem_basic
=== PAUSE TestAccDynamoDBTableItem_basic
=== RUN   TestAccDynamoDBTableItem_rangeKey
=== PAUSE TestAccDynamoDBTableItem_rangeKey
=== RUN   TestAccDynamoDBTableItem_withMultipleItems
=== PAUSE TestAccDynamoDBTableItem_withMultipleItems
=== RUN   TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey
=== PAUSE TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey
=== RUN   TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey
=== PAUSE TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey
=== RUN   TestAccDynamoDBTableItem_wonkyItems
=== PAUSE TestAccDynamoDBTableItem_wonkyItems
=== RUN   TestAccDynamoDBTableItem_update
=== PAUSE TestAccDynamoDBTableItem_update
=== RUN   TestAccDynamoDBTableItem_updateWithRangeKey
=== PAUSE TestAccDynamoDBTableItem_updateWithRangeKey
=== RUN   TestAccDynamoDBTableItem_disappears
=== PAUSE TestAccDynamoDBTableItem_disappears
=== RUN   TestAccDynamoDBTableItem_mapOutOfBandUpdate
=== PAUSE TestAccDynamoDBTableItem_mapOutOfBandUpdate
=== RUN   TestAccDynamoDBTableReplica_tags
=== PAUSE TestAccDynamoDBTableReplica_tags
=== RUN   TestAccDynamoDBTableReplica_tags_null
=== PAUSE TestAccDynamoDBTableReplica_tags_null
=== RUN   TestAccDynamoDBTableReplica_tags_EmptyMap
=== PAUSE TestAccDynamoDBTableReplica_tags_EmptyMap
=== RUN   TestAccDynamoDBTableReplica_tags_AddOnUpdate
=== PAUSE TestAccDynamoDBTableReplica_tags_AddOnUpdate
=== RUN   TestAccDynamoDBTableReplica_tags_EmptyTag_OnCreate
=== PAUSE TestAccDynamoDBTableReplica_tags_EmptyTag_OnCreate
=== RUN   TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccDynamoDBTableReplica_tags_DefaultTags_providerOnly
=== PAUSE TestAccDynamoDBTableReplica_tags_DefaultTags_providerOnly
=== RUN   TestAccDynamoDBTableReplica_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccDynamoDBTableReplica_tags_DefaultTags_nonOverlapping
=== RUN   TestAccDynamoDBTableReplica_tags_DefaultTags_overlapping
=== PAUSE TestAccDynamoDBTableReplica_tags_DefaultTags_overlapping
=== RUN   TestAccDynamoDBTableReplica_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccDynamoDBTableReplica_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccDynamoDBTableReplica_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccDynamoDBTableReplica_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccDynamoDBTableReplica_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccDynamoDBTableReplica_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccDynamoDBTableReplica_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccDynamoDBTableReplica_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccDynamoDBTableReplica_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccDynamoDBTableReplica_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccDynamoDBTableReplica_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccDynamoDBTableReplica_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccDynamoDBTableReplica_tags_ComputedTag_OnCreate
=== PAUSE TestAccDynamoDBTableReplica_tags_ComputedTag_OnCreate
=== RUN   TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccDynamoDBTableReplica_basic
    table_replica_test.go:25: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTableReplica_basic (0.00s)
=== RUN   TestAccDynamoDBTableReplica_disappears
    table_replica_test.go:56: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTableReplica_disappears (0.00s)
=== RUN   TestAccDynamoDBTableReplica_pitr
    table_replica_test.go:83: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTableReplica_pitr (0.00s)
=== RUN   TestAccDynamoDBTableReplica_pitrKMS
    table_replica_test.go:114: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTableReplica_pitrKMS (0.00s)
=== RUN   TestAccDynamoDBTableReplica_pitrDefault
    table_replica_test.go:162: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTableReplica_pitrDefault (0.00s)
=== RUN   TestAccDynamoDBTableReplica_tableClass
    table_replica_test.go:210: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTableReplica_tableClass (0.00s)
=== RUN   TestAccDynamoDBTableReplica_keys
    table_replica_test.go:248: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTableReplica_keys (0.00s)
=== RUN   TestAccDynamoDBTable_tags
=== PAUSE TestAccDynamoDBTable_tags
=== RUN   TestAccDynamoDBTable_tags_null
=== PAUSE TestAccDynamoDBTable_tags_null
=== RUN   TestAccDynamoDBTable_tags_EmptyMap
=== PAUSE TestAccDynamoDBTable_tags_EmptyMap
=== RUN   TestAccDynamoDBTable_tags_AddOnUpdate
=== PAUSE TestAccDynamoDBTable_tags_AddOnUpdate
=== RUN   TestAccDynamoDBTable_tags_EmptyTag_OnCreate
=== PAUSE TestAccDynamoDBTable_tags_EmptyTag_OnCreate
=== RUN   TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccDynamoDBTable_tags_DefaultTags_providerOnly
=== PAUSE TestAccDynamoDBTable_tags_DefaultTags_providerOnly
=== RUN   TestAccDynamoDBTable_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccDynamoDBTable_tags_DefaultTags_nonOverlapping
=== RUN   TestAccDynamoDBTable_tags_DefaultTags_overlapping
=== PAUSE TestAccDynamoDBTable_tags_DefaultTags_overlapping
=== RUN   TestAccDynamoDBTable_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccDynamoDBTable_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccDynamoDBTable_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccDynamoDBTable_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccDynamoDBTable_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccDynamoDBTable_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccDynamoDBTable_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccDynamoDBTable_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccDynamoDBTable_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccDynamoDBTable_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccDynamoDBTable_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccDynamoDBTable_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccDynamoDBTable_tags_ComputedTag_OnCreate
=== PAUSE TestAccDynamoDBTable_tags_ComputedTag_OnCreate
=== RUN   TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccDynamoDBTable_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccDynamoDBTable_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccDynamoDBTable_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccDynamoDBTable_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccDynamoDBTable_basic
=== PAUSE TestAccDynamoDBTable_basic
=== RUN   TestAccDynamoDBTable_deletion_protection
=== PAUSE TestAccDynamoDBTable_deletion_protection
=== RUN   TestAccDynamoDBTable_disappears
=== PAUSE TestAccDynamoDBTable_disappears
=== RUN   TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== PAUSE TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== RUN   TestAccDynamoDBTable_extended
    table_test.go:501: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_extended (0.00s)
=== RUN   TestAccDynamoDBTable_enablePITR
=== PAUSE TestAccDynamoDBTable_enablePITR
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== PAUSE TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest
    table_test.go:694: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequest (0.00s)
=== RUN   TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges
    table_test.go:737: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_BillingMode_provisionedToPayPerRequestIgnoreChanges (0.00s)
=== RUN   TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned
    table_test.go:780: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_BillingModeGSI_payPerRequestToProvisioned (0.00s)
=== RUN   TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest
    table_test.go:822: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_BillingModeGSI_provisionedToPayPerRequest (0.00s)
=== RUN   TestAccDynamoDBTable_BillingMode_payPerRequestBasic
    table_test.go:861: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_BillingMode_payPerRequestBasic (0.00s)
=== RUN   TestAccDynamoDBTable_onDemandThroughput
=== PAUSE TestAccDynamoDBTable_onDemandThroughput
=== RUN   TestAccDynamoDBTable_gsiOnDemandThroughput
=== PAUSE TestAccDynamoDBTable_gsiOnDemandThroughput
=== RUN   TestAccDynamoDBTable_streamSpecification
=== PAUSE TestAccDynamoDBTable_streamSpecification
=== RUN   TestAccDynamoDBTable_streamSpecificationDiffs
=== PAUSE TestAccDynamoDBTable_streamSpecificationDiffs
=== RUN   TestAccDynamoDBTable_streamSpecificationValidation
=== PAUSE TestAccDynamoDBTable_streamSpecificationValidation
=== RUN   TestAccDynamoDBTable_gsiUpdateCapacity
=== PAUSE TestAccDynamoDBTable_gsiUpdateCapacity
=== RUN   TestAccDynamoDBTable_gsiUpdateOtherAttributes
    table_test.go:1218: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_gsiUpdateOtherAttributes (0.00s)
=== RUN   TestAccDynamoDBTable_lsiNonKeyAttributes
=== PAUSE TestAccDynamoDBTable_lsiNonKeyAttributes
=== RUN   TestAccDynamoDBTable_gsiUpdateNonKeyAttributes
    table_test.go:1349: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_gsiUpdateNonKeyAttributes (0.00s)
=== RUN   TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== PAUSE TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
=== RUN   TestAccDynamoDBTable_TTL_enabled
=== PAUSE TestAccDynamoDBTable_TTL_enabled
=== RUN   TestAccDynamoDBTable_TTL_disabled
=== PAUSE TestAccDynamoDBTable_TTL_disabled
=== RUN   TestAccDynamoDBTable_TTL_updateEnable
=== PAUSE TestAccDynamoDBTable_TTL_updateEnable
=== RUN   TestAccDynamoDBTable_TTL_updateDisable
    table_test.go:1629: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_TTL_updateDisable (0.00s)
=== RUN   TestAccDynamoDBTable_TTL_validate
=== PAUSE TestAccDynamoDBTable_TTL_validate
=== RUN   TestAccDynamoDBTable_attributeUpdate
    table_test.go:1724: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_attributeUpdate (0.00s)
=== RUN   TestAccDynamoDBTable_lsiUpdate
=== PAUSE TestAccDynamoDBTable_lsiUpdate
=== RUN   TestAccDynamoDBTable_attributeUpdateValidation
=== PAUSE TestAccDynamoDBTable_attributeUpdateValidation
=== RUN   TestAccDynamoDBTable_encryption
    table_test.go:1832: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_encryption (0.00s)
=== RUN   TestAccDynamoDBTable_restoreCrossRegion
    table_test.go:1885: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_restoreCrossRegion (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_multiple
    table_test.go:1925: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_multiple (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_single
    table_test.go:1975: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_single (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_singleStreamSpecification
    table_test.go:2033: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_singleStreamSpecification (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted
    table_test.go:2069: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_singleDefaultKeyEncrypted (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned
    table_test.go:2112: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_singleDefaultKeyEncryptedAmazonOwned (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_singleCMK
    table_test.go:2151: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_singleCMK (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_doubleAddCMK
    table_test.go:2186: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_doubleAddCMK (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_pitr
    table_test.go:2247: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_pitr (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_pitrKMS
    table_test.go:2310: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_pitrKMS (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_tagsOneOfTwo
    table_test.go:2436: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_tagsOneOfTwo (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_tagsTwoOfTwo
    table_test.go:2476: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_tagsTwoOfTwo (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_tagsNext
    table_test.go:2516: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_tagsNext (0.00s)
=== RUN   TestAccDynamoDBTable_Replica_tagsUpdate
    table_test.go:2614: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_Replica_tagsUpdate (0.00s)
=== RUN   TestAccDynamoDBTable_tableClassInfrequentAccess
=== PAUSE TestAccDynamoDBTable_tableClassInfrequentAccess
=== RUN   TestAccDynamoDBTable_tableClassExplicitDefault
=== PAUSE TestAccDynamoDBTable_tableClassExplicitDefault
=== RUN   TestAccDynamoDBTable_tableClass_ConcurrentModification
=== PAUSE TestAccDynamoDBTable_tableClass_ConcurrentModification
=== RUN   TestAccDynamoDBTable_tableClass_migrate
=== PAUSE TestAccDynamoDBTable_tableClass_migrate
=== RUN   TestAccDynamoDBTable_backupEncryption
    table_test.go:2861: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_backupEncryption (0.00s)
=== RUN   TestAccDynamoDBTable_backup_overrideEncryption
    table_test.go:2901: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_backup_overrideEncryption (0.00s)
=== RUN   TestAccDynamoDBTable_importTable
    table_test.go:2942: skipping long-running test in short mode
--- SKIP: TestAccDynamoDBTable_importTable (0.00s)
=== CONT  TestAccDynamoDBTableDataSource_tags
=== CONT  TestAccDynamoDBTable_gsiUpdateCapacity
=== CONT  TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Add
=== CONT  TestAccDynamoDBTable_streamSpecificationValidation
=== CONT  TestAccDynamoDBTable_streamSpecificationDiffs
=== CONT  TestAccDynamoDBTable_streamSpecification
=== CONT  TestAccDynamoDBTable_gsiOnDemandThroughput
=== CONT  TestAccDynamoDBTableItem_basic
=== CONT  TestAccDynamoDBTable_onDemandThroughput
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges
=== CONT  TestAccDynamoDBTableItem_disappears
=== CONT  TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned
=== CONT  TestAccDynamoDBTableItem_updateWithRangeKey
=== CONT  TestAccDynamoDBTable_enablePITR
=== CONT  TestAccDynamoDBTableItem_update
=== CONT  TestAccDynamoDBTable_Disappears_payPerRequestWithGSI
=== CONT  TestAccDynamoDBTableItem_mapOutOfBandUpdate
=== CONT  TestAccDynamoDBTableItem_wonkyItems
=== CONT  TestAccDynamoDBTable_disappears
--- PASS: TestAccDynamoDBTable_streamSpecificationValidation (3.32s)
=== CONT  TestAccDynamoDBTable_deletion_protection
--- PASS: TestAccDynamoDBTableItem_disappears (26.26s)
=== CONT  TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey
--- PASS: TestAccDynamoDBTableDataSource_tags (26.34s)
=== CONT  TestAccDynamoDBTable_basic
--- PASS: TestAccDynamoDBTableItem_basic (27.60s)
=== CONT  TestAccDynamoDBTableReplica_tags_ComputedTag_OnCreate
--- PASS: TestAccDynamoDBTableItem_wonkyItems (27.73s)
=== CONT  TestAccDynamoDBTableItem_withMultipleItems
--- PASS: TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_ResourceTag (29.13s)
=== CONT  TestAccDynamoDBTable_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccDynamoDBTable_disappears (31.41s)
=== CONT  TestAccDynamoDBTableReplica_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccDynamoDBTableItem_updateWithRangeKey (31.42s)
=== CONT  TestAccDynamoDBTable_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccDynamoDBTableItem_mapOutOfBandUpdate (33.41s)
=== CONT  TestAccDynamoDBTableItem_rangeKey
--- PASS: TestAccDynamoDBTableItem_update (35.29s)
=== CONT  TestAccDynamoDBTableReplica_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccDynamoDBTable_deletion_protection (37.16s)
=== CONT  TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccDynamoDBTableItem_withDuplicateItemsSameRangeKey (15.98s)
=== CONT  TestAccDynamoDBTableReplica_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccDynamoDBTableItem_withMultipleItems (20.90s)
=== CONT  TestAccDynamoDBTableDataSource_tags_DefaultTags_nonOverlapping
--- PASS: TestAccDynamoDBTable_gsiUpdateCapacity (50.78s)
=== CONT  TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccDynamoDBTable_basic (25.22s)
=== CONT  TestAccDynamoDBTableReplica_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccDynamoDBTableItem_rangeKey (20.21s)
=== CONT  TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccDynamoDBTable_onDemandThroughput (57.61s)
=== CONT  TestAccDynamoDBTable_tags_ComputedTag_OnCreate
--- PASS: TestAccDynamoDBTable_gsiOnDemandThroughput (61.16s)
=== CONT  TestAccDynamoDBTableReplica_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccDynamoDBTable_streamSpecification (64.04s)
=== CONT  TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccDynamoDBTable_enablePITR (64.87s)
=== CONT  TestAccDynamoDBTable_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccDynamoDBTableDataSource_tags_DefaultTags_nonOverlapping (20.69s)
=== CONT  TestAccDynamoDBTableReplica_tags_EmptyTag_OnCreate
--- PASS: TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_DefaultTag (23.26s)
=== CONT  TestAccDynamoDBTableReplica_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccDynamoDBTable_tags_IgnoreTags_Overlap_DefaultTag (48.26s)
=== CONT  TestAccDynamoDBTableReplica_tags_AddOnUpdate
--- PASS: TestAccDynamoDBTable_tags_IgnoreTags_Overlap_ResourceTag (52.67s)
=== CONT  TestAccDynamoDBTableReplica_tags_DefaultTags_overlapping
--- PASS: TestAccDynamoDBTable_Disappears_payPerRequestWithGSI (82.60s)
=== CONT  TestAccDynamoDBTableReplica_tags_EmptyMap
--- PASS: TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Replace (44.25s)
=== CONT  TestAccDynamoDBTableReplica_tags_DefaultTags_nonOverlapping
--- PASS: TestAccDynamoDBTable_tags_ComputedTag_OnCreate (28.50s)
=== CONT  TestAccDynamoDBTableReplica_tags_null
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_nullNonOverlappingResourceTag (26.11s)
=== CONT  TestAccDynamoDBTableReplica_tags_DefaultTags_providerOnly
--- PASS: TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Add (44.26s)
=== CONT  TestAccDynamoDBTableReplica_tags
--- PASS: TestAccDynamoDBTable_streamSpecificationDiffs (101.08s)
=== CONT  TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisionedIgnoreChanges (155.64s)
=== CONT  TestAccDynamoDBTableDataSource_tags_EmptyMap
--- PASS: TestAccDynamoDBTableDataSource_tags_EmptyMap (20.99s)
=== CONT  TestAccDynamoDBTableItemDataSource_projectionExpression
--- PASS: TestAccDynamoDBTable_BillingMode_payPerRequestToProvisioned (193.75s)
=== CONT  TestAccDynamoDBTableItemDataSource_expressionAttributeNames
--- PASS: TestAccDynamoDBTableItemDataSource_projectionExpression (19.87s)
=== CONT  TestAccDynamoDBTable_lsiUpdate
--- PASS: TestAccDynamoDBTableReplica_tags_DefaultTags_nullNonOverlappingResourceTag (180.91s)
=== CONT  TestAccDynamoDBTableItemDataSource_basic
--- PASS: TestAccDynamoDBTableReplica_tags_DefaultTags_nullOverlappingResourceTag (178.69s)
=== CONT  TestAccDynamoDBTable_tableClass_migrate
--- PASS: TestAccDynamoDBTableItemDataSource_expressionAttributeNames (21.32s)
=== CONT  TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccDynamoDBTableReplica_tags_DefaultTags_emptyResourceTag (164.10s)
=== CONT  TestAccDynamoDBTable_tableClassInfrequentAccess
--- PASS: TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Add (223.35s)
=== CONT  TestAccDynamoDBTable_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccDynamoDBTableItemDataSource_basic (21.58s)
=== CONT  TestAccDynamoDBTable_attributeUpdateValidation
--- PASS: TestAccDynamoDBTable_attributeUpdateValidation (3.36s)
=== CONT  TestAccDynamoDBTable_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccDynamoDBTable_tableClass_migrate (30.46s)
=== CONT  TestAccDynamoDBTable_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_emptyProviderOnlyTag (25.09s)
=== CONT  TestAccDynamoDBTable_tableClass_ConcurrentModification
--- PASS: TestAccDynamoDBTable_lsiUpdate (52.75s)
=== CONT  TestAccDynamoDBTable_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccDynamoDBTable_tableClassInfrequentAccess (38.59s)
=== CONT  TestAccDynamoDBTable_tags_DefaultTags_overlapping
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_emptyResourceTag (22.95s)
=== CONT  TestAccDynamoDBTableDataSource_basic
--- PASS: TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Add (55.40s)
=== CONT  TestAccDynamoDBTable_tags_DefaultTags_nonOverlapping
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_updateToResourceOnly (32.56s)
=== CONT  TestAccDynamoDBTable_tags_DefaultTags_providerOnly
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_updateToProviderOnly (34.11s)
=== CONT  TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccDynamoDBTable_tableClass_ConcurrentModification (39.03s)
=== CONT  TestAccDynamoDBTableDataSource_tags_NullMap
--- PASS: TestAccDynamoDBTableDataSource_basic (28.54s)
=== CONT  TestAccDynamoDBTable_tags_null
--- PASS: TestAccDynamoDBTableDataSource_tags_NullMap (21.80s)
=== CONT  TestAccDynamoDBTable_tags_EmptyTag_OnCreate
--- PASS: TestAccDynamoDBTable_tags_null (26.31s)
=== CONT  TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Replace (34.08s)
=== CONT  TestAccDynamoDBTable_tags_AddOnUpdate
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_overlapping (64.45s)
=== CONT  TestAccDynamoDBTable_tags
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_nonOverlapping (54.80s)
=== CONT  TestAccDynamoDBTable_tags_EmptyMap
--- PASS: TestAccDynamoDBTableReplica_tags_DefaultTags_updateToProviderOnly (248.81s)
=== CONT  TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccDynamoDBTableReplica_tags_EmptyMap (253.32s)
=== CONT  TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccDynamoDBTableReplica_tags_DefaultTags_overlapping (254.54s)
=== CONT  TestAccDynamoDBTable_TTL_disabled
--- PASS: TestAccDynamoDBTableReplica_tags_ComputedTag_OnCreate (309.41s)
=== CONT  TestAccDynamoDBTable_TTL_validate
--- PASS: TestAccDynamoDBTableReplica_tags_DefaultTags_providerOnly (247.84s)
=== CONT  TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan
--- PASS: TestAccDynamoDBTable_TTL_validate (2.36s)
=== CONT  TestAccDynamoDBTable_TTL_updateEnable
--- PASS: TestAccDynamoDBTableReplica_tags_DefaultTags_nonOverlapping (255.65s)
=== CONT  TestAccDynamoDBTable_TTL_enabled
--- PASS: TestAccDynamoDBTableReplica_tags_null (257.51s)
=== CONT  TestAccDynamoDBTable_lsiNonKeyAttributes
--- PASS: TestAccDynamoDBTableReplica_tags_AddOnUpdate (267.58s)
=== CONT  TestAccDynamoDBTable_tableClassExplicitDefault
--- PASS: TestAccDynamoDBTableReplica_tags (253.92s)
=== CONT  TestAccDynamoDBTable_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccDynamoDBTableReplica_tags_EmptyTag_OnCreate (280.00s)
=== CONT  TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey
--- PASS: TestAccDynamoDBTableReplica_tags_DefaultTags_updateToResourceOnly (289.68s)
--- PASS: TestAccDynamoDBTable_tags_EmptyTag_OnCreate (42.77s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_providerOnly (75.04s)
--- PASS: TestAccDynamoDBTable_tags_EmptyMap (26.99s)
--- PASS: TestAccDynamoDBTableReplica_tags_DefaultTags_emptyProviderOnlyTag (310.69s)
--- PASS: TestAccDynamoDBTable_tags_AddOnUpdate (36.40s)
--- PASS: TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Replace (254.17s)
--- PASS: TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Add (291.61s)
--- PASS: TestAccDynamoDBTable_TTL_disabled (27.85s)
--- PASS: TestAccDynamoDBTable_TTL_enabled (26.65s)
--- PASS: TestAccDynamoDBTableItem_withDuplicateItemsDifferentRangeKey (21.91s)
--- PASS: TestAccDynamoDBTable_TTL_updateEnable (32.14s)
--- PASS: TestAccDynamoDBTable_lsiNonKeyAttributes (28.88s)
--- PASS: TestAccDynamoDBTable_tableClassExplicitDefault (26.22s)
--- PASS: TestAccDynamoDBTable_tags_DefaultTags_nullOverlappingResourceTag (25.48s)
--- PASS: TestAccDynamoDBTable_GsiUpdateNonKeyAttributes_emptyPlan (44.25s)
--- PASS: TestAccDynamoDBTable_tags (74.38s)
--- PASS: TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Replace (194.61s)
--- PASS: TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_DefaultTag (220.01s)
--- PASS: TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_ResourceTag (233.87s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	553.011s
```
