### PR TITLE
resource/aws_api_gateway_deployment: Reverts validation errors

### DIFF
--- a/.changelog/40067.txt
+++ b/.changelog/40067.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_deployment: Rolls back validation of `canary_settings` and `stage_description` when `stage_name` not set.
+```

--- a/internal/service/apigateway/deployment.go
+++ b/internal/service/apigateway/deployment.go
@@ -47,11 +47,10 @@ func resourceDeployment() *schema.Resource {
 				Optional: true,
 			},
 			"canary_settings": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				ForceNew:     true,
-				MaxItems:     1,
-				RequiredWith: []string{"stage_name"},
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"percent_traffic": {
@@ -70,6 +69,7 @@ func resourceDeployment() *schema.Resource {
 						},
 					},
 				},
+				Deprecated: `The attribute "canary_settings" will be removed in a future major version. Use an explicit "aws_api_gateway_stage" instead.`,
 			},
 			"execution_arn": {
 				Type:     schema.TypeString,
@@ -85,15 +85,16 @@ func resourceDeployment() *schema.Resource {
 				ForceNew: true,
 			},
 			"stage_description": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				RequiredWith: []string{"stage_name"},
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: `The attribute "stage_description" will be removed in a future major version. Use an explicit "aws_api_gateway_stage" instead.`,
 			},
 			"stage_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: `The attribute "stage_name" will be removed in a future major version. Use an explicit "aws_api_gateway_stage" instead.`,
 			},
 			names.AttrTriggers: {
 				Type:     schema.TypeMap,

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -132,9 +132,11 @@ This resource supports the following arguments:
 
 * `canary_settings` - (Optional, **Deprecated** Use an explicit [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead) Input configuration for the canary deployment when the deployment is a canary release deployment.
   See [`canary_settings](#canary_settings-argument-reference) below.
+  Has no effect when `stage_name` is not set.
 * `description` - (Optional) Description of the deployment
 * `rest_api_id` - (Required) REST API identifier.
 * `stage_description` - (Optional, **Deprecated** Use an explicit [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead) Description to set on the stage managed by the `stage_name` argument.
+  Has no effect when `stage_name` is not set.
 * `stage_name` - (Optional, **Deprecated** Use an explicit [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead) Name of the stage to create with this deployment.
   If the specified stage already exists, it will be updated to point to the new deployment.
   We recommend using the [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead to manage stages.

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -130,11 +130,14 @@ resource "aws_api_gateway_stage" "example" {
 
 This resource supports the following arguments:
 
-* `canary_settings` - (Optional) Input configuration for the canary deployment when the deployment is a canary release deployment. See [`canary_settings](#canary_settings-argument-reference) below.
+* `canary_settings` - (Optional, **Deprecated** Use an explicit [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead) Input configuration for the canary deployment when the deployment is a canary release deployment.
+  See [`canary_settings](#canary_settings-argument-reference) below.
 * `description` - (Optional) Description of the deployment
 * `rest_api_id` - (Required) REST API identifier.
-* `stage_description` - (Optional) Description to set on the stage managed by the `stage_name` argument.
-* `stage_name` - (Optional) Name of the stage to create with this deployment. If the specified stage already exists, it will be updated to point to the new deployment. We recommend using the [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead to manage stages.
+* `stage_description` - (Optional, **Deprecated** Use an explicit [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead) Description to set on the stage managed by the `stage_name` argument.
+* `stage_name` - (Optional, **Deprecated** Use an explicit [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead) Name of the stage to create with this deployment.
+  If the specified stage already exists, it will be updated to point to the new deployment.
+  We recommend using the [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead to manage stages.
 * `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger a redeployment. To force a redeployment without changing these keys/values, use the [`-replace` option](https://developer.hashicorp.com/terraform/cli/commands/plan#replace-address) with `terraform plan` or `terraform apply`.
 * `variables` - (Optional) Map to set on the stage managed by the `stage_name` argument.
 


### PR DESCRIPTION
### Description

The PR #39929 added the following validation to `canary_settings` and `stage_description`, since the values are ignored when `stage_name` is not set:

```go
RequiredWith: []string{
	"stage_name",
},
```

This caused some users to have errors with their existing configurations.

Remove the validation error and add run-time warnings.

Also deprecates `stage_name`, `stage_description`, and `canary_settings` on the `aws_api_gateway_deployment` resource if favour of an explicit `aws_api_gateway_stage`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39957

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apigateway TESTS=TestAccAPIGatewayDeployment_

--- PASS: TestAccAPIGatewayDeployment_variables (47.22s)
--- PASS: TestAccAPIGatewayDeployment_deploymentCanarySettings (47.46s)
--- PASS: TestAccAPIGatewayDeployment_Disappears_restAPI (47.70s)
--- PASS: TestAccAPIGatewayDeployment_conflictingConnectionType (91.50s)
--- PASS: TestAccAPIGatewayDeployment_stageName (119.71s)
--- PASS: TestAccAPIGatewayDeployment_disappears (130.63s)
--- PASS: TestAccAPIGatewayDeployment_basic (205.23s)
--- PASS: TestAccAPIGatewayDeployment_stageDescription (224.13s)
--- PASS: TestAccAPIGatewayDeployment_triggers (283.42s)
--- PASS: TestAccAPIGatewayDeployment_StageName_emptyString (425.85s)
--- PASS: TestAccAPIGatewayDeployment_description (476.43s)
```
