### PR TITLE
feat: support serverSdkVersion in gamelift

### DIFF
--- a/internal/service/gamelift/build_test.go
+++ b/internal/service/gamelift/build_test.go
@@ -63,6 +63,7 @@ func TestAccGameLiftBuild_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "gamelift", regexache.MustCompile(`build/build-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "operating_system", "WINDOWS_2016"),
+					resource.TestCheckResourceAttr(resourceName, "server_sdk_version", "5.0.0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.0.bucket", bucketName),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.0.key", key),
@@ -83,6 +84,7 @@ func TestAccGameLiftBuild_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rNameUpdated),
 					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "gamelift", regexache.MustCompile(`build/build-.+`)),
 					resource.TestCheckResourceAttr(resourceName, "operating_system", "WINDOWS_2016"),
+					resource.TestCheckResourceAttr(resourceName, "server_sdk_version", "5.0.0"),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.0.bucket", bucketName),
 					resource.TestCheckResourceAttr(resourceName, "storage_location.0.key", key),
@@ -278,8 +280,9 @@ func testAccPreCheck(ctx context.Context, t *testing.T) {
 func testAccBuildConfig_basic(buildName, bucketName, key, roleArn string) string {
 	return fmt.Sprintf(`
 resource "aws_gamelift_build" "test" {
-  name             = %[1]q
-  operating_system = "WINDOWS_2016"
+  name               = %[1]q
+  operating_system   = "WINDOWS_2016"
+  server_sdk_version = "5.0.0"
 
   storage_location {
     bucket   = %[2]q
@@ -293,8 +296,10 @@ resource "aws_gamelift_build" "test" {
 func testAccBuildConfig_basicTags1(buildName, bucketName, key, roleArn, tagKey1, tagValue1 string) string {
 	return fmt.Sprintf(`
 resource "aws_gamelift_build" "test" {
-  name             = %[1]q
-  operating_system = "WINDOWS_2016"
+  name               = %[1]q
+  operating_system   = "WINDOWS_2016"
+  server_sdk_version = "5.0.0"
+
 
   storage_location {
     bucket   = %[2]q
@@ -312,8 +317,9 @@ resource "aws_gamelift_build" "test" {
 func testAccBuildConfig_basicTags2(buildName, bucketName, key, roleArn, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return fmt.Sprintf(`
 resource "aws_gamelift_build" "test" {
-  name             = %[1]q
-  operating_system = "WINDOWS_2016"
+  name               = %[1]q
+  operating_system   = "WINDOWS_2016"
+  server_sdk_version = "5.0.0"
 
   storage_location {
     bucket   = %[2]q

--- a/website/docs/cdktf/python/r/gamelift_build.html.markdown
+++ b/website/docs/cdktf/python/r/gamelift_build.html.markdown
@@ -43,6 +43,7 @@ This resource supports the following arguments:
 
 * `name` - (Required) Name of the build
 * `operating_system` - (Required) Operating system that the game server binaries are built to run on. Valid values: `WINDOWS_2012`, `AMAZON_LINUX`, `AMAZON_LINUX_2`, `WINDOWS_2016`, `AMAZON_LINUX_2023`.
+* `server_sdk_version` - (Optional) The server SDK version you used when integrating your game server build with Amazon GameLift. Format: (`X.X.X`). By default Amazon GameLift sets this value to `4.0.2`.
 * `storage_location` - (Required) Information indicating where your game build files are stored. See below.
 * `version` - (Optional) Version that is associated with this build.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.

--- a/website/docs/r/gamelift_build.html.markdown
+++ b/website/docs/r/gamelift_build.html.markdown
@@ -31,6 +31,7 @@ This resource supports the following arguments:
 
 * `name` - (Required) Name of the build
 * `operating_system` - (Required) Operating system that the game server binaries are built to run on. Valid values: `WINDOWS_2012`, `AMAZON_LINUX`, `AMAZON_LINUX_2`, `WINDOWS_2016`, `AMAZON_LINUX_2023`.
+* `server_sdk_version` - (Optional) The server SDK version you used when integrating your game server build with Amazon GameLift. Format: (`X.X.X`). By default Amazon GameLift sets this value to `4.0.2`.
 * `storage_location` - (Required) Information indicating where your game build files are stored. See below.
 * `version` - (Optional) Version that is associated with this build.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Support ServerSdkVersion for Gamelift:
* https://docs.aws.amazon.com/sdk-for-go/api/service/gamelift/


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39772

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccGameLiftBuild_basic PKG=gamelift
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/gamelift/... -v -count 1 -parallel 20 -run='TestAccGameLiftBuild_basic'  -timeout 360m
2024/11/09 20:14:21 Initializing Terraform AWS Provider...
=== RUN   TestAccGameLiftBuild_basic
=== PAUSE TestAccGameLiftBuild_basic
=== CONT  TestAccGameLiftBuild_basic
--- PASS: TestAccGameLiftBuild_basic (33.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/gamelift   49.125s

...
```
