### PR TITLE
Fix `aws_key_pair` import re-creation bug

### DIFF
--- a/internal/service/ec2/ec2_key_pair.go
+++ b/internal/service/ec2/ec2_key_pair.go
@@ -150,6 +150,7 @@ func resourceKeyPairRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("key_name_prefix", create.NamePrefixFromName(aws.ToString(keyPair.KeyName)))
 	d.Set("key_pair_id", keyPair.KeyPairId)
 	d.Set("key_type", keyPair.KeyType)
+	d.Set(names.AttrPublicKey, keyPair.PublicKey)
 
 	setTagsOut(ctx, keyPair.Tags)
 

--- a/internal/service/ec2/ec2_key_pair_data_source_test.go
+++ b/internal/service/ec2/ec2_key_pair_data_source_test.go
@@ -10,7 +10,7 @@ import (
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -82,7 +82,7 @@ func TestAccEC2KeyPairDataSource_includePublicKey(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSource1Name, "key_name", resourceName, "key_name"),
 					resource.TestCheckResourceAttrPair(dataSource1Name, "key_pair_id", resourceName, "key_pair_id"),
 					resource.TestCheckResourceAttrWith(dataSource1Name, names.AttrPublicKey, func(v string) error {
-						if !tfec2.OpenSSHPublicKeysEqual(v, publicKey) {
+						if !verify.SuppressEquivalentOpenSSHPublicKeyDiffs("", v, publicKey, nil) {
 							return fmt.Errorf("Attribute 'public_key' expected %q, not equal to %q", publicKey, v)
 						}
 

--- a/internal/service/ec2/ec2_key_pair_test.go
+++ b/internal/service/ec2/ec2_key_pair_test.go
@@ -49,10 +49,9 @@ func TestAccEC2KeyPair_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrPublicKey},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -84,10 +83,9 @@ func TestAccEC2KeyPair_tags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrPublicKey},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccKeyPairConfig_tags2(rName, publicKey, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
@@ -135,10 +133,9 @@ func TestAccEC2KeyPair_nameGenerated(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrPublicKey},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -169,10 +166,9 @@ func TestAccEC2KeyPair_namePrefix(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrPublicKey},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/service/ec2/ec2_key_pair_test.go
+++ b/internal/service/ec2/ec2_key_pair_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -45,7 +46,13 @@ func TestAccEC2KeyPair_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "fingerprint", regexache.MustCompile(`[0-9a-f]{2}(:[0-9a-f]{2}){15}`)),
 					resource.TestCheckResourceAttr(resourceName, "key_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "key_name_prefix", ""),
-					resource.TestCheckResourceAttr(resourceName, names.AttrPublicKey, publicKey),
+					resource.TestCheckResourceAttrWith(resourceName, names.AttrPublicKey, func(v string) error {
+						if !verify.SuppressEquivalentOpenSSHPublicKeyDiffs("", v, publicKey, nil) {
+							return fmt.Errorf("Attribute 'public_key' expected %q, not equal to %q", publicKey, v)
+						}
+
+						return nil
+					}),
 				),
 			},
 			{
@@ -80,6 +87,13 @@ func TestAccEC2KeyPair_tags(t *testing.T) {
 					testAccCheckKeyPairExists(ctx, resourceName, &keyPair),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+					resource.TestCheckResourceAttrWith(resourceName, names.AttrPublicKey, func(v string) error {
+						if !verify.SuppressEquivalentOpenSSHPublicKeyDiffs("", v, publicKey, nil) {
+							return fmt.Errorf("Attribute 'public_key' expected %q, not equal to %q", publicKey, v)
+						}
+
+						return nil
+					}),
 				),
 			},
 			{
@@ -130,6 +144,13 @@ func TestAccEC2KeyPair_nameGenerated(t *testing.T) {
 					testAccCheckKeyPairExists(ctx, resourceName, &keyPair),
 					acctest.CheckResourceAttrNameGenerated(resourceName, "key_name"),
 					resource.TestCheckResourceAttr(resourceName, "key_name_prefix", "terraform-"),
+					resource.TestCheckResourceAttrWith(resourceName, names.AttrPublicKey, func(v string) error {
+						if !verify.SuppressEquivalentOpenSSHPublicKeyDiffs("", v, publicKey, nil) {
+							return fmt.Errorf("Attribute 'public_key' expected %q, not equal to %q", publicKey, v)
+						}
+
+						return nil
+					}),
 				),
 			},
 			{
@@ -163,6 +184,13 @@ func TestAccEC2KeyPair_namePrefix(t *testing.T) {
 					testAccCheckKeyPairExists(ctx, resourceName, &keyPair),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, "key_name", "tf-acc-test-prefix-"),
 					resource.TestCheckResourceAttr(resourceName, "key_name_prefix", "tf-acc-test-prefix-"),
+					resource.TestCheckResourceAttrWith(resourceName, names.AttrPublicKey, func(v string) error {
+						if !verify.SuppressEquivalentOpenSSHPublicKeyDiffs("", v, publicKey, nil) {
+							return fmt.Errorf("Attribute 'public_key' expected %q, not equal to %q", publicKey, v)
+						}
+
+						return nil
+					}),
 				),
 			},
 			{

--- a/internal/service/ec2/exports_test.go
+++ b/internal/service/ec2/exports_test.go
@@ -253,7 +253,6 @@ var (
 	NewAttributeFilterList                                     = newAttributeFilterList
 	NewCustomFilterList                                        = newCustomFilterList
 	NewTagFilterList                                           = newTagFilterList
-	OpenSSHPublicKeysEqual                                     = openSSHPublicKeysEqual
 	ParseInstanceType                                          = parseInstanceType
 	ProtocolForValue                                           = protocolForValue
 	ProtocolStateFunc                                          = protocolStateFunc

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -5477,7 +5477,8 @@ func findKeyPairs(ctx context.Context, conn *ec2.Client, input *ec2.DescribeKeyP
 
 func findKeyPairByName(ctx context.Context, conn *ec2.Client, name string) (*awstypes.KeyPairInfo, error) {
 	input := &ec2.DescribeKeyPairsInput{
-		KeyNames: []string{name},
+		KeyNames:         []string{name},
+		IncludePublicKey: aws.Bool(true),
 	}
 
 	output, err := findKeyPair(ctx, conn, input)

--- a/internal/verify/open_ssh.go
+++ b/internal/verify/open_ssh.go
@@ -1,0 +1,25 @@
+package verify
+
+import (
+	"bytes"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"golang.org/x/crypto/ssh"
+)
+
+// SuppressEquivalentOpenSSHPublicKeyDiffs returns whether two OpenSSH public key format strings represent the same key.
+// Any key comment is ignored when comparing values.
+func SuppressEquivalentOpenSSHPublicKeyDiffs(k, old, new string, d *schema.ResourceData) bool {
+	oldKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(old))
+	if err != nil {
+		return false
+	}
+
+	newKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(new))
+
+	if err != nil {
+		return false
+	}
+
+	return oldKey.Type() == newKey.Type() && bytes.Equal(oldKey.Marshal(), newKey.Marshal())
+}

--- a/website/docs/r/key_pair.html.markdown
+++ b/website/docs/r/key_pair.html.markdown
@@ -64,5 +64,3 @@ Using `terraform import`, import Key Pairs using the `key_name`. For example:
 ```console
 % terraform import aws_key_pair.deployer deployer-key
 ```
-
-~> **NOTE:** The AWS API does not include the public key in the response, so `terraform apply` will attempt to replace the key pair. There is currently no supported workaround for this limitation.


### PR DESCRIPTION
### Description

**Why I Opened this PR:**
I recently imported many ec2 key pairs in our infra. And it's very toil job. One needs to **manually edit** state files, which may contains secrets. If we used many terraform modules in a single root, I probably can't edit due to permissions and security. In some organizations this may be impossible and need many tickets (internal in the company) to resolve.

**Why this happens:**
Currently if one imports a key pair, its public key material is not included. Since there's no a public key (empty) terraform find a diff, even if you write correct key, and **recreates** it.

You can _now_ get public key material of ec2 key pair via `DescribeKeyPair` api call.  For example
It's added in April 28, 2022, [relevant doc](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/DocumentHistory.html) 

>||[Describe public keys](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/describe-keys.html)|You can query the public key and creation date of an Amazon EC2 key pair.|April 28, 2022|

```
aws ec2 describe-key-pairs --key-names key-pair-name --include-public-key
```
**Some catches of this PR**

Since we ignored `aws_key_pair.public_key` in tests we didn't see the problem of aws `DescribeKeyPair` api. The API overrides the comment you give to the name of the key pair name, if you use console or the sdk. (It's known in data source of key pair, thus its tests handled that.)
<details>
  <summary>Example Code</summary>

Prints:
```
// ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINNmjoQb6LuFti6eBe/oeTN017N/A22A4ee9H3SJkLty umut-3
// **Not** ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINNmjoQb6LuFti6eBe/oeTN017N/A22A4ee9H3SJkLty umut-custom-comment
```
  ```go
func main() {
	cfg, err := config.LoadDefaultConfig(context.TODO())
	if err != nil {
		log.Fatal(err)
	}

	svc := ec2.NewFromConfig(cfg)
	pair, err := svc.ImportKeyPair(context.Background(), &ec2.ImportKeyPairInput{
		KeyName:           aws.String("umut-3"),
		PublicKeyMaterial: []byte("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINNmjoQb6LuFti6eBe/oeTN017N/A22A4ee9H3SJkLty umut-custom-comment"),
	})
	if err != nil {
		log.Fatal(err)
	}

	pairs, err := svc.DescribeKeyPairs(context.Background(), &ec2.DescribeKeyPairsInput{
		IncludePublicKey: aws.Bool(true),
		Filters: []types.Filter{
			types.Filter{
				Name:   aws.String("key-pair-id"),
				Values: []string{*pair.KeyPairId},
			},
		},
	})
	if err != nil {
		log.Fatal()
	}
	fmt.Println(*pairs.KeyPairs[0].PublicKey)
}
```
</details>

That's why I need to add `DiffSuppressFunc`. Currently we put the required argument from operator directly to the state and never compare with real value. Thus that may effect many workflows. With this diff function it won't happen. Changed tests with this in mind.


### Relations

Closes #8529
Closes #5347
Closes  #1092

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
```
> make testacc TESTS='TestAccEC2KeyPair' PKG=ec2 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2KeyPair'  -timeout 360m
2024/11/10 18:24:50 Initializing Terraform AWS Provider...
=== RUN   TestAccEC2KeyPairDataSource_basic
=== PAUSE TestAccEC2KeyPairDataSource_basic
=== RUN   TestAccEC2KeyPairDataSource_includePublicKey
=== PAUSE TestAccEC2KeyPairDataSource_includePublicKey
=== RUN   TestAccEC2KeyPair_basic
=== PAUSE TestAccEC2KeyPair_basic
=== RUN   TestAccEC2KeyPair_tags
=== PAUSE TestAccEC2KeyPair_tags
=== RUN   TestAccEC2KeyPair_nameGenerated
=== PAUSE TestAccEC2KeyPair_nameGenerated
=== RUN   TestAccEC2KeyPair_namePrefix
=== PAUSE TestAccEC2KeyPair_namePrefix
=== RUN   TestAccEC2KeyPair_disappears
=== PAUSE TestAccEC2KeyPair_disappears
=== CONT  TestAccEC2KeyPairDataSource_basic
=== CONT  TestAccEC2KeyPair_nameGenerated
=== CONT  TestAccEC2KeyPair_basic
=== CONT  TestAccEC2KeyPairDataSource_includePublicKey
=== CONT  TestAccEC2KeyPair_tags
=== CONT  TestAccEC2KeyPair_disappears
=== CONT  TestAccEC2KeyPair_namePrefix
--- PASS: TestAccEC2KeyPairDataSource_includePublicKey (28.04s)
--- PASS: TestAccEC2KeyPairDataSource_basic (28.12s)
--- PASS: TestAccEC2KeyPair_disappears (28.23s)
--- PASS: TestAccEC2KeyPair_nameGenerated (31.51s)
--- PASS: TestAccEC2KeyPair_namePrefix (31.70s)
--- PASS: TestAccEC2KeyPair_basic (31.89s)
--- PASS: TestAccEC2KeyPair_tags (59.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        66.441s
```
