### PR TITLE
r/role_policy_attachments_exclusive: Fix 'Value Conversion Error' on …

### DIFF
--- a/internal/service/iam/role_policy_attachments_exclusive.go
+++ b/internal/service/iam/role_policy_attachments_exclusive.go
@@ -67,6 +67,17 @@ func (r *resourceRolePolicyAttachmentsExclusive) Create(ctx context.Context, req
 		return
 	}
 
+	// Pre-validation for null values in policy_arns
+	for _, element := range plan.PolicyARNs.Elements() {
+		if element.IsNull() {
+			resp.Diagnostics.AddError(
+				"Null value found in list",
+				"Null values are not allowed for this attribute value.",
+			)
+			return
+		}
+	}
+
 	var policyARNs []string
 	resp.Diagnostics.Append(plan.PolicyARNs.ElementsAs(ctx, &policyARNs, false)...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Error raised here: https://github.com/hashicorp/terraform-plugin-framework/blob/c9bbe5e02cfc78b6efe82a227a55c26dc2a1daa9/internal/reflect/into.go#L130-L149. As Allowing Unhandled Nulls was set to false here.

Please find attached a screenshot for the new error message after building the development provider and running it locally.

<img width="768" alt="Screenshot 2024-11-10 at 6 59 41 PM" src="https://github.com/user-attachments/assets/20ecd586-a5ae-4600-9c2d-e469967dac23">

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->



Closes #39786

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=iam TESTS=TestAccIAMRolePolicyAttachmentsExclusive_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMRolePolicyAttachmentsExclusive_'  -timeout 360m
2024/11/10 17:28:20 Initializing Terraform AWS Provider...
=== RUN   TestAccIAMRolePolicyAttachmentsExclusive_basic
=== PAUSE TestAccIAMRolePolicyAttachmentsExclusive_basic
=== RUN   TestAccIAMRolePolicyAttachmentsExclusive_disappears_Role
=== PAUSE TestAccIAMRolePolicyAttachmentsExclusive_disappears_Role
=== RUN   TestAccIAMRolePolicyAttachmentsExclusive_disappears_Policy
=== PAUSE TestAccIAMRolePolicyAttachmentsExclusive_disappears_Policy
=== RUN   TestAccIAMRolePolicyAttachmentsExclusive_multiple
=== PAUSE TestAccIAMRolePolicyAttachmentsExclusive_multiple
=== RUN   TestAccIAMRolePolicyAttachmentsExclusive_empty
=== PAUSE TestAccIAMRolePolicyAttachmentsExclusive_empty
=== RUN   TestAccIAMRolePolicyAttachmentsExclusive_outOfBandRemoval
=== PAUSE TestAccIAMRolePolicyAttachmentsExclusive_outOfBandRemoval
=== RUN   TestAccIAMRolePolicyAttachmentsExclusive_outOfBandAddition
=== PAUSE TestAccIAMRolePolicyAttachmentsExclusive_outOfBandAddition
=== CONT  TestAccIAMRolePolicyAttachmentsExclusive_basic
=== CONT  TestAccIAMRolePolicyAttachmentsExclusive_empty
=== CONT  TestAccIAMRolePolicyAttachmentsExclusive_disappears_Policy
=== CONT  TestAccIAMRolePolicyAttachmentsExclusive_multiple
=== CONT  TestAccIAMRolePolicyAttachmentsExclusive_disappears_Role
=== CONT  TestAccIAMRolePolicyAttachmentsExclusive_outOfBandAddition
=== CONT  TestAccIAMRolePolicyAttachmentsExclusive_outOfBandRemoval
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_empty (116.08s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_disappears_Role (116.62s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_disappears_Policy (122.91s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_basic (123.43s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_outOfBandAddition (159.84s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_outOfBandRemoval (160.92s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_multiple (172.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        173.497s
...
```
