### PR TITLE
Increase operation count of stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
           days-before-close: 30
           exempt-issue-labels: 'needs-triage'
           exempt-pr-labels: 'needs-triage'
-          operations-per-run: 150
+          operations-per-run: 200
           stale-issue-label: 'stale'
           stale-issue-message: |
             Marking this issue as stale due to inactivity. This helps our maintainers find and focus on the active issues. If this issue receives no comments in the next 30 days it will automatically be closed. Maintainers can also remove the stale label.


### PR DESCRIPTION
### Description

I noticed some items with the  `stale` label that had been open for longer than the prescribed 30 additional days. Upon review, the stale workflow [is finishing](https://github.com/hashicorp/terraform-provider-aws/actions/runs/11746909216) with a warning indicating that we should increase [`operations-per-run`](https://github.com/actions/stale?tab=readme-ov-file#operations-per-run).

This PR increases the operations count by 50 to see if that's enough. Will monitor and increase further as needed.


### Output from Acceptance Testing

N/a, workflow