### PR TITLE
autoscaling/group: Handle eventual consistency

### DIFF
--- a/.changelog/40088.txt
+++ b/.changelog/40088.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_autoscaling_group: Handle eventual consistency issues that occur when using a `launch_template` that is updated causing `ValidationError: You must use a valid fully-formed launch template.`
+```
+
+```release-note:bug
+resource/aws_iam_instance_profile: Handle eventual consistency issues that occur when this resource is updated and has dependents
+```
+
+```release-note:bug
+resource/aws_launch_template: Handle eventual consistency issues that occur when this resource is update and has dependents
+```

--- a/.changelog/40088.txt
+++ b/.changelog/40088.txt
@@ -7,5 +7,5 @@ resource/aws_iam_instance_profile: Handle eventual consistency issues that occur
 ```
 
 ```release-note:bug
-resource/aws_launch_template: Handle eventual consistency issues that occur when this resource is update and has dependents
+resource/aws_launch_template: Handle eventual consistency issues that occur when this resource is updated and has dependents
 ```

--- a/internal/service/autoscaling/errors.go
+++ b/internal/service/autoscaling/errors.go
@@ -15,3 +15,8 @@ var (
 	errCodeResourceInUseFault             = (*awstypes.ResourceInUseFault)(nil).ErrorCode()
 	errCodeScalingActivityInProgressFault = (*awstypes.ScalingActivityInProgressFault)(nil).ErrorCode()
 )
+
+const (
+	errCodeOperationError         = "operation error"
+	errCodeUpdateAutoScalingGroup = "UpdateAutoScalingGroup"
+)

--- a/internal/service/autoscaling/errors.go
+++ b/internal/service/autoscaling/errors.go
@@ -17,6 +17,6 @@ var (
 )
 
 const (
-	errCodeOperationError         = "operation error"
-	errCodeUpdateAutoScalingGroup = "UpdateAutoScalingGroup"
+	errCodeOperationError = "operation error"
+	errCodeUpdateASG      = "UpdateAutoScalingGroup"
 )

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -1481,7 +1481,11 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			input.VPCZoneIdentifier = expandVPCZoneIdentifiers(d.Get("vpc_zone_identifier").(*schema.Set).List())
 		}
 
-		_, err := conn.UpdateAutoScalingGroup(ctx, input)
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate),
+			func() (interface{}, error) {
+				return conn.UpdateAutoScalingGroup(ctx, input)
+			},
+			errCodeOperationError, errCodeUpdateAutoScalingGroup, errCodeValidationError)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Auto Scaling Group (%s): %s", d.Id(), err)

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -1485,7 +1485,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			func() (interface{}, error) {
 				return conn.UpdateAutoScalingGroup(ctx, input)
 			},
-			errCodeOperationError, errCodeUpdateAutoScalingGroup, errCodeValidationError)
+			errCodeOperationError, errCodeUpdateASG, errCodeValidationError)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Auto Scaling Group (%s): %s", d.Id(), err)

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -3229,7 +3229,7 @@ func TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instance
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupConfig_mixedInstancesPolicyLaunchTemplateOverrideInstanceRequirements(rName,
-					`cpu_manufacturers = ["amazon-web-services"]
+					`cpu_manufacturers = ["amazon-web-services", "amd"]
                      memory_mib {
                        min = 500
                      }
@@ -3243,8 +3243,9 @@ func TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instance
 					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.launch_template.0.override.#", "1"),
 
 					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.launch_template.0.override.0.instance_requirements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.launch_template.0.override.0.instance_requirements.0.cpu_manufacturers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mixed_instances_policy.0.launch_template.0.override.0.instance_requirements.0.cpu_manufacturers.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "mixed_instances_policy.0.launch_template.0.override.0.instance_requirements.0.cpu_manufacturers.*", "amazon-web-services"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "mixed_instances_policy.0.launch_template.0.override.0.instance_requirements.0.cpu_manufacturers.*", "amd"),
 				),
 			},
 			testAccGroupImportStep(resourceName),

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -1914,6 +1914,36 @@ func TestAccAutoScalingGroup_launchTempPartitionNum(t *testing.T) {
 	})
 }
 
+// TestAccAutoScalingGroup_launchTemplateIAMInstanceProfile is an eventually consistent test that fails
+// without the update retry, or waiters in the IAM instance profile and launch template resources.
+func TestAccAutoScalingGroup_launchTemplateIAMInstanceProfile(t *testing.T) {
+	ctx := acctest.Context(t)
+	var group awstypes.AutoScalingGroup
+	resourceName := "aws_autoscaling_group.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AutoScalingServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGroupConfig_launchTemplateIAMInstanceProfile(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &group),
+				),
+			},
+			{
+				Config: testAccGroupConfig_launchTemplateIAMInstanceProfile(rName, sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGroupExists(ctx, resourceName, &group),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn(t *testing.T) {
 	ctx := acctest.Context(t)
 	var group awstypes.AutoScalingGroup
@@ -6471,4 +6501,83 @@ resource "aws_autoscaling_group" "test" {
   }
 }
 `, rName))
+}
+
+func testAccGroupConfig_launchTemplateIAMInstanceProfile(rName, instanceProfileName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+  name = %[1]q
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Effect = "Allow"
+        Sid    = ""
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "test" {
+  name        = %[1]q
+  description = "Policy for EC2 instances"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "test" {
+  policy_arn = aws_iam_policy.test.arn
+  role       = aws_iam_role.test.name
+}
+
+resource "aws_iam_instance_profile" "test" {
+  name = %[2]q
+  role = aws_iam_role.test.name
+}
+
+resource "aws_launch_template" "test" {
+  name          = %[1]q
+  image_id      = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = %[3]q
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.test.arn
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "test" {
+  availability_zones = [data.aws_availability_zones.available.names[0]]
+  desired_capacity   = 2
+  max_size           = 5
+  min_size           = 1
+
+  launch_template {
+    id      = aws_launch_template.test.id
+    version = aws_launch_template.test.latest_version
+  }
+}
+`, rName, instanceProfileName, "t3.micro"))
 }

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -1222,11 +1222,7 @@ func waitLaunchTemplateReady(ctx context.Context, conn *ec2.Client, id string, i
 
 	_, err := stateConf.WaitForStateContext(ctx)
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *schema.ResourceData) (*awstypes.RequestLaunchTemplateData, error) {

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -1018,6 +1019,10 @@ func resourceLaunchTemplateCreate(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "creating EC2 Launch Template (%s): %s", name, err)
 	}
 
+	if _, err := waitLaunchTemplateReady(ctx, conn, name, true, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for EC2 Launch Template (%s) to be ready: %s", name, err)
+	}
+
 	d.SetId(aws.ToString(output.LaunchTemplate.LaunchTemplateId))
 
 	return append(diags, resourceLaunchTemplateRead(ctx, d, meta)...)
@@ -1151,6 +1156,10 @@ func resourceLaunchTemplateUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
+	if _, err := waitLaunchTemplateReady(ctx, conn, d.Id(), false, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for EC2 Launch Template (%s) to be ready: %s", d.Id(), err)
+	}
+
 	return append(diags, resourceLaunchTemplateRead(ctx, d, meta)...)
 }
 
@@ -1172,6 +1181,52 @@ func resourceLaunchTemplateDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	return diags
+}
+
+const (
+	LaunchTemplateFound = "Found"
+)
+
+func statusLaunchTemplate(ctx context.Context, conn *ec2.Client, id string, idIsName bool) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var output *awstypes.LaunchTemplate
+		var err error
+		if idIsName {
+			output, err = findLaunchTemplateByName(ctx, conn, id)
+		} else {
+			output, err = findLaunchTemplateByID(ctx, conn, id)
+		}
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, LaunchTemplateFound, nil
+	}
+}
+
+func waitLaunchTemplateReady(ctx context.Context, conn *ec2.Client, id string, idIsName bool, timeout time.Duration) (*awstypes.LaunchTemplate, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{""},
+		Target:                    enum.Slice(LaunchTemplateFound),
+		Refresh:                   statusLaunchTemplate(ctx, conn, id, idIsName),
+		Timeout:                   timeout,
+		Delay:                     5 * time.Second,
+		NotFoundChecks:            5,
+		ContinuousTargetOccurence: 3,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*awstypes.LaunchTemplate); ok {
+		return output, err
+	}
+
+	return nil, err
 }
 
 func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *schema.ResourceData) (*awstypes.RequestLaunchTemplateData, error) {

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -711,6 +711,27 @@ func findLaunchTemplates(ctx context.Context, conn *ec2.Client, input *ec2.Descr
 	return output, nil
 }
 
+func findLaunchTemplateByName(ctx context.Context, conn *ec2.Client, name string) (*awstypes.LaunchTemplate, error) {
+	input := &ec2.DescribeLaunchTemplatesInput{
+		LaunchTemplateNames: []string{name},
+	}
+
+	output, err := findLaunchTemplate(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Eventual consistency check.
+	if aws.ToString(output.LaunchTemplateName) != name {
+		return nil, &retry.NotFoundError{
+			LastRequest: input,
+		}
+	}
+
+	return output, nil
+}
+
 func findLaunchTemplateByID(ctx context.Context, conn *ec2.Client, id string) (*awstypes.LaunchTemplate, error) {
 	input := &ec2.DescribeLaunchTemplatesInput{
 		LaunchTemplateIds: []string{id},

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -18,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -149,6 +151,10 @@ func resourceInstanceProfileCreate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
+	if _, err := waitInstanceProfileReady(ctx, conn, name, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for IAM Instance Profile (%s) to be ready: %s", name, err)
+	}
+
 	return append(diags, resourceInstanceProfileRead(ctx, d, meta)...)
 }
 
@@ -227,6 +233,10 @@ func resourceInstanceProfileUpdate(ctx context.Context, d *schema.ResourceData, 
 				return sdkdiag.AppendFromErr(diags, err)
 			}
 		}
+	}
+
+	if _, err := waitInstanceProfileReady(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for IAM Instance Profile (%s) to be ready: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceInstanceProfileRead(ctx, d, meta)...)
@@ -332,6 +342,51 @@ func findInstanceProfileByName(ctx context.Context, conn *iam.Client, name strin
 	}
 
 	return output.InstanceProfile, nil
+}
+
+const (
+	InstanceProfileFound      = "Found"
+	InstanceProfileInvalidARN = "InvalidARN"
+)
+
+func statusInstanceProfile(ctx context.Context, conn *iam.Client, name string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := findInstanceProfileByName(ctx, conn, name)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		_, err = arn.Parse(aws.ToString(output.Arn))
+		if err != nil {
+			return nil, InstanceProfileInvalidARN, nil
+		}
+
+		return output, InstanceProfileFound, nil
+	}
+}
+
+func waitInstanceProfileReady(ctx context.Context, conn *iam.Client, id string, timeout time.Duration) (*awstypes.InstanceProfile, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:                   []string{"", InstanceProfileInvalidARN},
+		Target:                    enum.Slice(InstanceProfileFound),
+		Refresh:                   statusInstanceProfile(ctx, conn, id),
+		Timeout:                   timeout,
+		Delay:                     5 * time.Second,
+		NotFoundChecks:            5,
+		ContinuousTargetOccurence: 3,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*awstypes.InstanceProfile); ok {
+		return output, err
+	}
+
+	return nil, err
 }
 
 func instanceProfileTags(ctx context.Context, conn *iam.Client, identifier string) ([]awstypes.Tag, error) {

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -362,7 +362,7 @@ func statusInstanceProfile(ctx context.Context, conn *iam.Client, name string) r
 
 		_, err = arn.Parse(aws.ToString(output.Arn))
 		if err != nil {
-			return nil, InstanceProfileInvalidARN, nil
+			return nil, InstanceProfileInvalidARN, nil // lint:ignore nilerr // this is usually a temporary state
 		}
 
 		return output, InstanceProfileFound, nil
@@ -382,11 +382,7 @@ func waitInstanceProfileReady(ctx context.Context, conn *iam.Client, id string, 
 
 	_, err := stateConf.WaitForStateContext(ctx)
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func instanceProfileTags(ctx context.Context, conn *iam.Client, identifier string) ([]awstypes.Tag, error) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
When using an Auto Scaling group (ASG) with a launch template that specifies an IAM instance profile, changes to the instance profile can cause errors in the ASG due to a lack of built-in waiting for resource consistency. Specifically, if the IAM instance profile is updated, the ASG immediately updates with the outdated configuration before the change has propagated fully, leading to failures.

```
Error: updating Auto Scaling Group (xyz): ValidationError: You must use a valid fully-formed launch template. Value
(arn:aws:iam::012345678901:instance-profile/node-xyz) for parameter iamInstanceProfile.arn is invalid. Invalid IAM
Instance Profile ARN
```

This pull request addresses the issue by adding wait mechanisms for eventual consistency on the launch template and instance profile resources. Additionally, it introduces a retry mechanism within the ASG to ensure it has the most recent configuration, thus preventing errors caused by timing inconsistencies in resource propagation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #24910

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccIAMInstanceProfile_ K=iam P=10
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/iam/... -v -count 1 -parallel 10 -run='TestAccIAMInstanceProfile_'  -timeout 360m
2024/11/11 16:11:00 Initializing Terraform AWS Provider...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_tags_null
=== PAUSE TestAccIAMInstanceProfile_tags_null
=== RUN   TestAccIAMInstanceProfile_tags_EmptyMap
=== PAUSE TestAccIAMInstanceProfile_tags_EmptyMap
=== RUN   TestAccIAMInstanceProfile_tags_AddOnUpdate
=== PAUSE TestAccIAMInstanceProfile_tags_AddOnUpdate
=== RUN   TestAccIAMInstanceProfile_tags_EmptyTag_OnCreate
=== PAUSE TestAccIAMInstanceProfile_tags_EmptyTag_OnCreate
=== RUN   TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_providerOnly
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_providerOnly
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_nonOverlapping
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_overlapping
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_overlapping
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccIAMInstanceProfile_tags_ComputedTag_OnCreate
=== PAUSE TestAccIAMInstanceProfile_tags_ComputedTag_OnCreate
=== RUN   TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccIAMInstanceProfile_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccIAMInstanceProfile_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccIAMInstanceProfile_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccIAMInstanceProfile_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMInstanceProfile_withoutRole
=== PAUSE TestAccIAMInstanceProfile_withoutRole
=== RUN   TestAccIAMInstanceProfile_nameGenerated
=== PAUSE TestAccIAMInstanceProfile_nameGenerated
=== RUN   TestAccIAMInstanceProfile_namePrefix
=== PAUSE TestAccIAMInstanceProfile_namePrefix
=== RUN   TestAccIAMInstanceProfile_disappears
=== PAUSE TestAccIAMInstanceProfile_disappears
=== RUN   TestAccIAMInstanceProfile_Disappears_role
=== PAUSE TestAccIAMInstanceProfile_Disappears_role
=== RUN   TestAccIAMInstanceProfile_launchConfiguration
=== PAUSE TestAccIAMInstanceProfile_launchConfiguration
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_providerOnly
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMInstanceProfile_tags_EmptyTag_OnCreate
=== CONT  TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccIAMInstanceProfile_basic (21.77s)
=== CONT  TestAccIAMInstanceProfile_launchConfiguration
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_emptyProviderOnlyTag (24.28s)
=== CONT  TestAccIAMInstanceProfile_Disappears_role
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_emptyResourceTag (24.35s)
=== CONT  TestAccIAMInstanceProfile_disappears
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_nullOverlappingResourceTag (24.64s)
=== CONT  TestAccIAMInstanceProfile_namePrefix
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_updateToResourceOnly (33.39s)
=== CONT  TestAccIAMInstanceProfile_nameGenerated
--- PASS: TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Replace (40.44s)
=== CONT  TestAccIAMInstanceProfile_withoutRole
--- PASS: TestAccIAMInstanceProfile_Disappears_role (17.58s)
=== CONT  TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccIAMInstanceProfile_tags_EmptyTag_OnCreate (41.99s)
=== CONT  TestAccIAMInstanceProfile_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccIAMInstanceProfile_disappears (18.00s)
=== CONT  TestAccIAMInstanceProfile_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccIAMInstanceProfile_namePrefix (20.02s)
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_overlapping
--- PASS: TestAccIAMInstanceProfile_nameGenerated (19.20s)
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Add (58.26s)
=== CONT  TestAccIAMInstanceProfile_tags_EmptyMap
--- PASS: TestAccIAMInstanceProfile_withoutRole (19.33s)
=== CONT  TestAccIAMInstanceProfile_tags_AddOnUpdate
--- PASS: TestAccIAMInstanceProfile_tags (76.79s)
=== CONT  TestAccIAMInstanceProfile_tags_ComputedTag_OnCreate
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_providerOnly (81.84s)
=== CONT  TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Replace (40.59s)
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_nonOverlapping
--- PASS: TestAccIAMInstanceProfile_tags_EmptyMap (25.35s)
=== CONT  TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccIAMInstanceProfile_tags_IgnoreTags_Overlap_DefaultTag (44.31s)
=== CONT  TestAccIAMInstanceProfile_tags_null
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_updateToProviderOnly (36.97s)
--- PASS: TestAccIAMInstanceProfile_launchConfiguration (68.67s)
--- PASS: TestAccIAMInstanceProfile_tags_AddOnUpdate (35.73s)
--- PASS: TestAccIAMInstanceProfile_tags_IgnoreTags_Overlap_ResourceTag (54.10s)
--- PASS: TestAccIAMInstanceProfile_tags_ComputedTag_OnCreate (23.29s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_overlapping (58.53s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag (20.28s)
--- PASS: TestAccIAMInstanceProfile_tags_null (23.24s)
--- PASS: TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Add (37.08s)
--- PASS: TestAccIAMInstanceProfile_tags_DefaultTags_nonOverlapping (53.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	140.505s
% make t T=TestAccEC2LaunchTemplate_ K=ec2 P=5     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/ec2/... -v -count 1 -parallel 5 -run='TestAccEC2LaunchTemplate_'  -timeout 360m
2024/11/11 16:10:29 Initializing Terraform AWS Provider...
=== RUN   TestAccEC2LaunchTemplate_basic
=== PAUSE TestAccEC2LaunchTemplate_basic
=== RUN   TestAccEC2LaunchTemplate_Name_generated
=== PAUSE TestAccEC2LaunchTemplate_Name_generated
=== RUN   TestAccEC2LaunchTemplate_Name_prefix
=== PAUSE TestAccEC2LaunchTemplate_Name_prefix
=== RUN   TestAccEC2LaunchTemplate_disappears
=== PAUSE TestAccEC2LaunchTemplate_disappears
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
=== PAUSE TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination
=== PAUSE TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3
=== PAUSE TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3
=== RUN   TestAccEC2LaunchTemplate_ebsOptimized
=== PAUSE TestAccEC2LaunchTemplate_ebsOptimized
=== RUN   TestAccEC2LaunchTemplate_elasticInferenceAccelerator
=== PAUSE TestAccEC2LaunchTemplate_elasticInferenceAccelerator
=== RUN   TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
=== RUN   TestAccEC2LaunchTemplate_data
=== PAUSE TestAccEC2LaunchTemplate_data
=== RUN   TestAccEC2LaunchTemplate_description
=== PAUSE TestAccEC2LaunchTemplate_description
=== RUN   TestAccEC2LaunchTemplate_update
=== PAUSE TestAccEC2LaunchTemplate_update
=== RUN   TestAccEC2LaunchTemplate_tags
=== PAUSE TestAccEC2LaunchTemplate_tags
=== RUN   TestAccEC2LaunchTemplate_CapacityReservation_preference
=== PAUSE TestAccEC2LaunchTemplate_CapacityReservation_preference
=== RUN   TestAccEC2LaunchTemplate_CapacityReservation_target
=== PAUSE TestAccEC2LaunchTemplate_CapacityReservation_target
=== RUN   TestAccEC2LaunchTemplate_cpuOptions
=== PAUSE TestAccEC2LaunchTemplate_cpuOptions
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t2
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t2
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t3
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t3
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t4g
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t4g
=== RUN   TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
=== PAUSE TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
=== RUN   TestAccEC2LaunchTemplate_networkInterface
=== PAUSE TestAccEC2LaunchTemplate_networkInterface
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceAddresses
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceAddresses
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceType
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceType
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceCardIndex
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceCardIndex
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== RUN   TestAccEC2LaunchTemplate_associatePublicIPAddress
=== PAUSE TestAccEC2LaunchTemplate_associatePublicIPAddress
=== RUN   TestAccEC2LaunchTemplate_associateCarrierIPAddress
=== PAUSE TestAccEC2LaunchTemplate_associateCarrierIPAddress
=== RUN   TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
=== PAUSE TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
=== RUN   TestAccEC2LaunchTemplate_Placement_partitionNum
=== PAUSE TestAccEC2LaunchTemplate_Placement_partitionNum
=== RUN   TestAccEC2LaunchTemplate_privateDNSNameOptions
=== PAUSE TestAccEC2LaunchTemplate_privateDNSNameOptions
=== RUN   TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
=== RUN   TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
=== RUN   TestAccEC2LaunchTemplate_instanceMarketOptions
=== PAUSE TestAccEC2LaunchTemplate_instanceMarketOptions
=== RUN   TestAccEC2LaunchTemplate_primaryIPv6
=== PAUSE TestAccEC2LaunchTemplate_primaryIPv6
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_localStorage
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_localStorage
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
=== RUN   TestAccEC2LaunchTemplate_licenseSpecification
=== PAUSE TestAccEC2LaunchTemplate_licenseSpecification
=== RUN   TestAccEC2LaunchTemplate_metadataOptions
=== PAUSE TestAccEC2LaunchTemplate_metadataOptions
=== RUN   TestAccEC2LaunchTemplate_enclaveOptions
=== PAUSE TestAccEC2LaunchTemplate_enclaveOptions
=== RUN   TestAccEC2LaunchTemplate_hibernation
=== PAUSE TestAccEC2LaunchTemplate_hibernation
=== RUN   TestAccEC2LaunchTemplate_defaultVersion
=== PAUSE TestAccEC2LaunchTemplate_defaultVersion
=== RUN   TestAccEC2LaunchTemplate_updateDefaultVersion
=== PAUSE TestAccEC2LaunchTemplate_updateDefaultVersion
=== CONT  TestAccEC2LaunchTemplate_basic
=== CONT  TestAccEC2LaunchTemplate_privateDNSNameOptions
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
=== CONT  TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
=== CONT  TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination
--- PASS: TestAccEC2LaunchTemplate_basic (19.75s)
=== CONT  TestAccEC2LaunchTemplate_elasticInferenceAccelerator
--- PASS: TestAccEC2LaunchTemplate_privateDNSNameOptions (20.08s)
=== CONT  TestAccEC2LaunchTemplate_ebsOptimized
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable (20.09s)
=== CONT  TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3
--- PASS: TestAccEC2LaunchTemplate_elasticInferenceAccelerator (34.41s)
=== CONT  TestAccEC2LaunchTemplate_disappears
--- PASS: TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination (55.63s)
=== CONT  TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination (60.43s)
=== CONT  TestAccEC2LaunchTemplate_tags
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3 (41.60s)
=== CONT  TestAccEC2LaunchTemplate_cpuOptions
--- PASS: TestAccEC2LaunchTemplate_disappears (17.46s)
=== CONT  TestAccEC2LaunchTemplate_CapacityReservation_target
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_target (22.68s)
=== CONT  TestAccEC2LaunchTemplate_CapacityReservation_preference
--- PASS: TestAccEC2LaunchTemplate_cpuOptions (34.58s)
=== CONT  TestAccEC2LaunchTemplate_Name_prefix
--- PASS: TestAccEC2LaunchTemplate_ebsOptimized (77.68s)
=== CONT  TestAccEC2LaunchTemplate_Name_generated
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs (42.33s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
--- PASS: TestAccEC2LaunchTemplate_tags (49.20s)
=== CONT  TestAccEC2LaunchTemplate_updateDefaultVersion
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_preference (20.24s)
=== CONT  TestAccEC2LaunchTemplate_defaultVersion
--- PASS: TestAccEC2LaunchTemplate_Name_prefix (20.20s)
=== CONT  TestAccEC2LaunchTemplate_hibernation
--- PASS: TestAccEC2LaunchTemplate_Name_generated (20.34s)
=== CONT  TestAccEC2LaunchTemplate_enclaveOptions
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations (41.76s)
=== CONT  TestAccEC2LaunchTemplate_metadataOptions
--- PASS: TestAccEC2LaunchTemplate_defaultVersion (46.17s)
=== CONT  TestAccEC2LaunchTemplate_licenseSpecification
--- PASS: TestAccEC2LaunchTemplate_hibernation (47.40s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
--- PASS: TestAccEC2LaunchTemplate_enclaveOptions (46.92s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
--- PASS: TestAccEC2LaunchTemplate_updateDefaultVersion (60.39s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
--- PASS: TestAccEC2LaunchTemplate_licenseSpecification (20.51s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice (20.80s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
--- PASS: TestAccEC2LaunchTemplate_metadataOptions (58.38s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (21.45s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport (39.27s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB (58.58s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice (20.64s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount (58.47s)
=== CONT  TestAccEC2LaunchTemplate_Placement_partitionNum
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount (18.42s)
=== CONT  TestAccEC2LaunchTemplate_description
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps (59.49s)
=== CONT  TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU (58.80s)
=== CONT  TestAccEC2LaunchTemplate_update
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes (40.34s)
=== CONT  TestAccEC2LaunchTemplate_associateCarrierIPAddress
--- PASS: TestAccEC2LaunchTemplate_Placement_partitionNum (34.17s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
--- PASS: TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN (21.69s)
=== CONT  TestAccEC2LaunchTemplate_associatePublicIPAddress
--- PASS: TestAccEC2LaunchTemplate_description (32.93s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
--- PASS: TestAccEC2LaunchTemplate_update (59.44s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes (40.16s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
--- PASS: TestAccEC2LaunchTemplate_associateCarrierIPAddress (61.12s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB (59.85s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes (18.67s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
--- PASS: TestAccEC2LaunchTemplate_associatePublicIPAddress (61.06s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount (18.90s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes (18.42s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers (40.54s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes (40.70s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes (41.30s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_localStorage
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance (61.05s)
=== CONT  TestAccEC2LaunchTemplate_instanceMarketOptions
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps (60.89s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_bareMetal (60.10s)
=== CONT  TestAccEC2LaunchTemplate_networkInterface
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount (40.75s)
=== CONT  TestAccEC2LaunchTemplate_primaryIPv6
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames (40.11s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
--- PASS: TestAccEC2LaunchTemplate_networkInterface (26.28s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceCardIndex
--- PASS: TestAccEC2LaunchTemplate_instanceMarketOptions (59.09s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorage (59.93s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceCardIndex (18.73s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceType
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount (18.83s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t4g
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers (39.75s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceAddresses
--- PASS: TestAccEC2LaunchTemplate_primaryIPv6 (60.48s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t3
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceType (19.00s)
=== CONT  TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t4g (19.58s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t2
--- PASS: TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock (17.70s)
=== CONT  TestAccEC2LaunchTemplate_data
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t3 (19.86s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceAddresses (26.39s)
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t2 (19.05s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount (59.97s)
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses (18.56s)
--- PASS: TestAccEC2LaunchTemplate_data (20.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	528.126s
% make t T=TestAccAutoScalingGroup_ P=10 K=autoscaling
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/autoscaling/... -v -count 1 -parallel 10 -run='TestAccAutoScalingGroup_'  -timeout 360m
2024/11/11 16:06:30 Initializing Terraform AWS Provider...
=== RUN   TestAccAutoScalingGroup_basic
=== PAUSE TestAccAutoScalingGroup_basic
=== RUN   TestAccAutoScalingGroup_disappears
=== PAUSE TestAccAutoScalingGroup_disappears
=== RUN   TestAccAutoScalingGroup_defaultInstanceWarmup
=== PAUSE TestAccAutoScalingGroup_defaultInstanceWarmup
=== RUN   TestAccAutoScalingGroup_nameGenerated
=== PAUSE TestAccAutoScalingGroup_nameGenerated
=== RUN   TestAccAutoScalingGroup_namePrefix
=== PAUSE TestAccAutoScalingGroup_namePrefix
=== RUN   TestAccAutoScalingGroup_tags
=== PAUSE TestAccAutoScalingGroup_tags
=== RUN   TestAccAutoScalingGroup_simple
=== PAUSE TestAccAutoScalingGroup_simple
=== RUN   TestAccAutoScalingGroup_terminationPolicies
=== PAUSE TestAccAutoScalingGroup_terminationPolicies
=== RUN   TestAccAutoScalingGroup_vpcUpdates
=== PAUSE TestAccAutoScalingGroup_vpcUpdates
=== RUN   TestAccAutoScalingGroup_withInstanceMaintenancePolicyAfterCreation
=== PAUSE TestAccAutoScalingGroup_withInstanceMaintenancePolicyAfterCreation
=== RUN   TestAccAutoScalingGroup_withInstanceMaintenancePolicyAtCreation
=== PAUSE TestAccAutoScalingGroup_withInstanceMaintenancePolicyAtCreation
=== RUN   TestAccAutoScalingGroup_withInstanceMaintenancePolicyNegativeValues
=== PAUSE TestAccAutoScalingGroup_withInstanceMaintenancePolicyNegativeValues
=== RUN   TestAccAutoScalingGroup_withLoadBalancer
=== PAUSE TestAccAutoScalingGroup_withLoadBalancer
=== RUN   TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup
=== PAUSE TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup
=== RUN   TestAccAutoScalingGroup_withTrafficSourceELB
=== PAUSE TestAccAutoScalingGroup_withTrafficSourceELB
=== RUN   TestAccAutoScalingGroup_withTrafficSourcesELBs
=== PAUSE TestAccAutoScalingGroup_withTrafficSourcesELBs
=== RUN   TestAccAutoScalingGroup_withTrafficSourceELB_toTargetGroup
=== PAUSE TestAccAutoScalingGroup_withTrafficSourceELB_toTargetGroup
=== RUN   TestAccAutoScalingGroup_withTrafficSourceELBV2
=== PAUSE TestAccAutoScalingGroup_withTrafficSourceELBV2
=== RUN   TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroup
=== PAUSE TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroup
=== RUN   TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroups
=== PAUSE TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroups
=== RUN   TestAccAutoScalingGroup_withPlacementGroup
=== PAUSE TestAccAutoScalingGroup_withPlacementGroup
=== RUN   TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType
=== PAUSE TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType
=== RUN   TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture
=== PAUSE TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture
=== RUN   TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_IgnoreFailedScalingActivities
=== PAUSE TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_IgnoreFailedScalingActivities
=== RUN   TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_Recovers
=== PAUSE TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_Recovers
=== RUN   TestAccAutoScalingGroup_enablingMetrics
=== PAUSE TestAccAutoScalingGroup_enablingMetrics
=== RUN   TestAccAutoScalingGroup_withMetrics
=== PAUSE TestAccAutoScalingGroup_withMetrics
=== RUN   TestAccAutoScalingGroup_suspendingProcesses
=== PAUSE TestAccAutoScalingGroup_suspendingProcesses
=== RUN   TestAccAutoScalingGroup_serviceLinkedRoleARN
=== PAUSE TestAccAutoScalingGroup_serviceLinkedRoleARN
=== RUN   TestAccAutoScalingGroup_maxInstanceLifetime
=== PAUSE TestAccAutoScalingGroup_maxInstanceLifetime
=== RUN   TestAccAutoScalingGroup_initialLifecycleHook
=== PAUSE TestAccAutoScalingGroup_initialLifecycleHook
=== RUN   TestAccAutoScalingGroup_launchTemplate
=== PAUSE TestAccAutoScalingGroup_launchTemplate
=== RUN   TestAccAutoScalingGroup_LaunchTemplate_update
=== PAUSE TestAccAutoScalingGroup_LaunchTemplate_update
=== RUN   TestAccAutoScalingGroup_largeDesiredCapacity
=== PAUSE TestAccAutoScalingGroup_largeDesiredCapacity
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_basic
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_basic
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_start
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_start
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_triggers
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_triggers
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_autoRollback
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_autoRollback
=== RUN   TestAccAutoScalingGroup_InstanceRefresh_alarmSpecification
=== PAUSE TestAccAutoScalingGroup_InstanceRefresh_alarmSpecification
=== RUN   TestAccAutoScalingGroup_loadBalancers
=== PAUSE TestAccAutoScalingGroup_loadBalancers
=== RUN   TestAccAutoScalingGroup_targetGroups
=== PAUSE TestAccAutoScalingGroup_targetGroups
=== RUN   TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity
=== PAUSE TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity
=== RUN   TestAccAutoScalingGroup_warmPool
=== PAUSE TestAccAutoScalingGroup_warmPool
=== RUN   TestAccAutoScalingGroup_launchTempPartitionNum
=== PAUSE TestAccAutoScalingGroup_launchTempPartitionNum
=== RUN   TestAccAutoScalingGroup_launchTemplateIAMInstanceProfile
=== PAUSE TestAccAutoScalingGroup_launchTemplateIAMInstanceProfile
=== RUN   TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn
=== PAUSE TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn
=== RUN   TestAccAutoScalingGroup_mixedInstancesPolicy
=== PAUSE TestAccAutoScalingGroup_mixedInstancesPolicy
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorManufacturers
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorManufacturers
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorNames
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorNames
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTypes
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTypes
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_allowedInstanceTypes
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_allowedInstanceTypes
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_bareMetal
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_bareMetal
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_burstablePerformance
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_burstablePerformance
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_cpuManufacturers
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_cpuManufacturers
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_excludedInstanceTypes
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_excludedInstanceTypes
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_instanceGenerations
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_instanceGenerations
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorage
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorage
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorageTypes
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorageTypes
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_requireHibernateSupport
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_requireHibernateSupport
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits
=== RUN   TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU
=== PAUSE TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU
=== CONT  TestAccAutoScalingGroup_basic
=== CONT  TestAccAutoScalingGroup_launchTempPartitionNum
=== CONT  TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture
=== CONT  TestAccAutoScalingGroup_warmPool
=== CONT  TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity
=== CONT  TestAccAutoScalingGroup_targetGroups
=== CONT  TestAccAutoScalingGroup_loadBalancers
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_alarmSpecification
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_autoRollback
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_triggers
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture (26.50s)
=== CONT  TestAccAutoScalingGroup_withInstanceMaintenancePolicyNegativeValues
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_start
--- PASS: TestAccAutoScalingGroup_basic (30.78s)
--- PASS: TestAccAutoScalingGroup_launchTempPartitionNum (41.66s)
=== CONT  TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorPlacementGroupNotSupportedOnInstanceType (30.96s)
=== CONT  TestAccAutoScalingGroup_InstanceRefresh_basic
--- PASS: TestAccAutoScalingGroup_withInstanceMaintenancePolicyNegativeValues (56.35s)
=== CONT  TestAccAutoScalingGroup_withPlacementGroup
--- PASS: TestAccAutoScalingGroup_targetGroups (121.91s)
=== CONT  TestAccAutoScalingGroup_largeDesiredCapacity
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_autoRollback (146.73s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroups
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_alarmSpecification (154.51s)
=== CONT  TestAccAutoScalingGroup_LaunchTemplate_update
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_triggers (180.36s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroup
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_start (187.79s)
=== CONT  TestAccAutoScalingGroup_launchTemplate
--- PASS: TestAccAutoScalingGroup_loadBalancers (236.62s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourceELBV2
--- PASS: TestAccAutoScalingGroup_InstanceRefresh_basic (174.82s)
=== CONT  TestAccAutoScalingGroup_initialLifecycleHook
--- PASS: TestAccAutoScalingGroup_LaunchTemplate_update (100.97s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourceELB_toTargetGroup
=== NAME  TestAccAutoScalingGroup_withTrafficSourceELBV2
    acctest.go:1744: skipping test for aws/us-west-2: Error running apply: exit status 1
        
        Error: attaching Auto Scaling Group (tf-acc-test-1002537129360346776) traffic sources: operation error Auto Scaling: AttachTrafficSources, https response error StatusCode: 400, RequestID: 3dd778f3-df1f-4e82-8137-0731b10d7848, api error ValidationError: Setting elasticloadbalancingv2 as traffic sources is currently not supported. Supported sources are [elb, elbv2, vpc-lattice]. Provide a supported traffic source in your request and try again.
        
          with aws_autoscaling_group.test,
          on terraform_plugin_test.tf line 80, in resource "aws_autoscaling_group" "test":
          80: resource "aws_autoscaling_group" "test" {
        
--- PASS: TestAccAutoScalingGroup_launchTemplate (43.86s)
=== CONT  TestAccAutoScalingGroup_maxInstanceLifetime
--- SKIP: TestAccAutoScalingGroup_withTrafficSourceELBV2 (36.22s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourcesELBs
--- PASS: TestAccAutoScalingGroup_maxInstanceLifetime (48.47s)
=== CONT  TestAccAutoScalingGroup_serviceLinkedRoleARN
--- PASS: TestAccAutoScalingGroup_ALBTargetGroups_elbCapacity (321.12s)
=== CONT  TestAccAutoScalingGroup_withTrafficSourceELB
--- PASS: TestAccAutoScalingGroup_largeDesiredCapacity (202.78s)
=== CONT  TestAccAutoScalingGroup_suspendingProcesses
--- PASS: TestAccAutoScalingGroup_serviceLinkedRoleARN (28.95s)
=== CONT  TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup
=== NAME  TestAccAutoScalingGroup_withTrafficSourceELB_toTargetGroup
    acctest.go:1744: skipping test for aws/us-west-2: Error running apply: exit status 1
        
        Error: attaching Auto Scaling Group (tf-acc-test-3432805018595755396) traffic sources: operation error Auto Scaling: AttachTrafficSources, https response error StatusCode: 400, RequestID: 7cf5caf6-bae2-49ba-b4ed-09ac5b859269, api error ValidationError: Setting elasticloadbalancingv2 as traffic sources is currently not supported. Supported sources are [elb, elbv2, vpc-lattice]. Provide a supported traffic source in your request and try again.
        
          with aws_autoscaling_group.test,
          on terraform_plugin_test.tf line 137, in resource "aws_autoscaling_group" "test":
         137: resource "aws_autoscaling_group" "test" {
        
--- PASS: TestAccAutoScalingGroup_withPlacementGroup (338.76s)
=== CONT  TestAccAutoScalingGroup_withMetrics
--- PASS: TestAccAutoScalingGroup_withMetrics (34.94s)
=== CONT  TestAccAutoScalingGroup_withLoadBalancer
--- PASS: TestAccAutoScalingGroup_withTrafficSourcesELBs (192.97s)
=== CONT  TestAccAutoScalingGroup_enablingMetrics
--- PASS: TestAccAutoScalingGroup_warmPool (470.22s)
=== CONT  TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_Recovers
--- SKIP: TestAccAutoScalingGroup_withTrafficSourceELB_toTargetGroup (246.77s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB
--- PASS: TestAccAutoScalingGroup_enablingMetrics (46.49s)
=== CONT  TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_IgnoreFailedScalingActivities
--- PASS: TestAccAutoScalingGroup_suspendingProcesses (188.74s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU
--- PASS: TestAccAutoScalingGroup_withTrafficSourceELB (235.28s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTotalMemoryMiB (56.28s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotMaxPrice (56.25s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorNames
--- PASS: TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroups (477.98s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB
--- PASS: TestAccAutoScalingGroup_withTrafficSourceVPCLatticeTargetGroup (457.48s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorManufacturers
--- PASS: TestAccAutoScalingGroup_initialLifecycleHook (391.58s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice
--- PASS: TestAccAutoScalingGroup_WithLoadBalancer_toTargetGroup (308.01s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorNames (43.73s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_requireHibernateSupport
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_IgnoreFailedScalingActivities (145.46s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeVCPU (147.15s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_spotMaxPricePercentageOverLowestPrice (29.04s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorManufacturers (48.19s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_totalLocalStorageGB (73.19s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (43.13s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_requireHibernateSupport (47.93s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryMiBAndVCPUCount (49.63s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU
--- PASS: TestAccAutoScalingGroup_withLoadBalancer (266.11s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorCount (75.86s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceTypeWithLaunchTemplateSpecification (29.64s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice (28.71s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorageTypes
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkInterfaceCount (80.60s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_networkBandwidthGbps (69.65s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorage
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceType (54.69s)
=== CONT  TestAccAutoScalingGroup_simple
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_version (45.04s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_instanceGenerations
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_memoryGiBPerVCPU (79.56s)
=== CONT  TestAccAutoScalingGroup_withInstanceMaintenancePolicyAtCreation
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorageTypes (55.72s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_excludedInstanceTypes
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateLaunchTemplateSpecification_launchTemplateName (45.31s)
=== CONT  TestAccAutoScalingGroup_withInstanceMaintenancePolicyAfterCreation
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_instanceGenerations (48.71s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_cpuManufacturers
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity (138.04s)
=== CONT  TestAccAutoScalingGroup_vpcUpdates
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_cpuManufacturers (47.86s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_burstablePerformance
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_localStorage (69.50s)
=== CONT  TestAccAutoScalingGroup_terminationPolicies
--- PASS: TestAccAutoScalingGroup_withScalingActivityErrorIncorrectInstanceArchitecture_Recovers (383.49s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_excludedInstanceTypes (47.09s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTypes
--- PASS: TestAccAutoScalingGroup_vpcUpdates (41.39s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_bareMetal
--- PASS: TestAccAutoScalingGroup_terminationPolicies (59.00s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_desiredCapacityTypeUnits (350.98s)
=== CONT  TestAccAutoScalingGroup_mixedInstancesPolicy
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_acceleratorTypes (54.79s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_burstablePerformance (78.10s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_baselineEBSBandwidthMbps (83.50s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_bareMetal (61.22s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance
--- PASS: TestAccAutoScalingGroup_mixedInstancesPolicy (31.57s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_weightedCapacity_withELB (275.76s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity
--- PASS: TestAccAutoScalingGroup_simple (168.14s)
=== CONT  TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandAllocationStrategy (42.80s)
=== CONT  TestAccAutoScalingGroup_nameGenerated
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotInstancePools (53.68s)
=== CONT  TestAccAutoScalingGroup_launchTemplateIAMInstanceProfile
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandBaseCapacity (63.10s)
=== CONT  TestAccAutoScalingGroup_tags
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicy_capacityRebalance (36.65s)
=== CONT  TestAccAutoScalingGroup_namePrefix
--- PASS: TestAccAutoScalingGroup_nameGenerated (28.63s)
=== CONT  TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_allowedInstanceTypes
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_updateToZeroOnDemandBaseCapacity (52.73s)
=== CONT  TestAccAutoScalingGroup_defaultInstanceWarmup
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_onDemandPercentageAboveBaseCapacity (66.44s)
=== CONT  TestAccAutoScalingGroup_disappears
--- PASS: TestAccAutoScalingGroup_namePrefix (32.60s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyInstancesDistribution_spotAllocationStrategy (78.71s)
--- PASS: TestAccAutoScalingGroup_tags (51.70s)
--- PASS: TestAccAutoScalingGroup_defaultInstanceWarmup (37.62s)
--- PASS: TestAccAutoScalingGroup_disappears (36.05s)
--- PASS: TestAccAutoScalingGroup_MixedInstancesPolicyLaunchTemplateOverride_instanceRequirements_allowedInstanceTypes (61.62s)
--- PASS: TestAccAutoScalingGroup_Destroy_whenProtectedFromScaleIn (156.77s)
--- PASS: TestAccAutoScalingGroup_launchTemplateIAMInstanceProfile (194.41s)
--- PASS: TestAccAutoScalingGroup_withInstanceMaintenancePolicyAfterCreation (370.57s)
--- PASS: TestAccAutoScalingGroup_withInstanceMaintenancePolicyAtCreation (398.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	1189.077s
```
