### PR TITLE
feat(batch): add `container_properties` to `job_definition` data source

### DIFF
--- a/internal/service/batch/job_definition_data_source.go
+++ b/internal/service/batch/job_definition_data_source.go
@@ -57,6 +57,10 @@ func (d *jobDefinitionDataSource) Schema(ctx context.Context, request datasource
 			"container_orchestration_type": schema.StringAttribute{
 				Computed: true,
 			},
+			"container_properties": schema.ListAttribute{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[containerPropertiesModel](ctx),
+				Computed:   true,
+			},
 			"eks_properties": schema.ListAttribute{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[eksPropertiesModel](ctx),
 				Computed:   true,
@@ -138,7 +142,6 @@ func (d *jobDefinitionDataSource) Read(ctx context.Context, request datasource.R
 		}
 
 		output, err := findJobDefinition(ctx, conn, input)
-
 		if err != nil {
 			response.Diagnostics.AddError(fmt.Sprintf("reading Batch Job Definition (%s)", arn), err.Error())
 
@@ -192,6 +195,44 @@ func (d *jobDefinitionDataSource) Read(ctx context.Context, request datasource.R
 		}
 	}
 
+	if cProps := jd.ContainerProperties; cProps != nil {
+		// HACK: populate .ResourceRequirements using the .Memory and .Vcpus fields.
+		// Currently, findJobDefinition() returns the deprecated fields and doesn't
+		// populate the preferred .ResourceRequirements field.
+		if cProps.Memory != nil {
+			found := false
+			for _, r := range cProps.ResourceRequirements {
+				if r.Type == awstypes.ResourceTypeMemory {
+					found = true
+					break
+				}
+			}
+			if !found {
+				val := fmt.Sprintf("%d", aws.ToInt32(cProps.Memory))
+				cProps.ResourceRequirements = append(cProps.ResourceRequirements, awstypes.ResourceRequirement{
+					Type:  awstypes.ResourceTypeMemory,
+					Value: &val,
+				})
+			}
+		}
+		if cProps.Vcpus != nil {
+			found := false
+			for _, r := range cProps.ResourceRequirements {
+				if r.Type == awstypes.ResourceTypeVcpu {
+					found = true
+					break
+				}
+			}
+			if !found {
+				val := fmt.Sprintf("%d", aws.ToInt32(cProps.Vcpus))
+				cProps.ResourceRequirements = append(cProps.ResourceRequirements, awstypes.ResourceRequirement{
+					Type:  awstypes.ResourceTypeVcpu,
+					Value: &val,
+				})
+			}
+		}
+	}
+
 	response.Diagnostics.Append(fwflex.Flatten(ctx, jd, &data)...)
 	if response.Diagnostics.HasError() {
 		return
@@ -215,20 +256,21 @@ func (d *jobDefinitionDataSource) ConfigValidators(context.Context) []resource.C
 }
 
 type jobDefinitionDataSourceModel struct {
-	ARNPrefix                  types.String                                         `tfsdk:"arn_prefix"`
-	ContainerOrchestrationType types.String                                         `tfsdk:"container_orchestration_type"`
-	EKSProperties              fwtypes.ListNestedObjectValueOf[eksPropertiesModel]  `tfsdk:"eks_properties"`
-	ID                         types.String                                         `tfsdk:"id"`
-	JobDefinitionARN           fwtypes.ARN                                          `tfsdk:"arn"`
-	JobDefinitionName          types.String                                         `tfsdk:"name"`
-	NodeProperties             fwtypes.ListNestedObjectValueOf[nodePropertiesModel] `tfsdk:"node_properties"`
-	RetryStrategy              fwtypes.ListNestedObjectValueOf[retryStrategyModel]  `tfsdk:"retry_strategy"`
-	Revision                   types.Int64                                          `tfsdk:"revision"`
-	SchedulingPriority         types.Int64                                          `tfsdk:"scheduling_priority"`
-	Status                     types.String                                         `tfsdk:"status"`
-	Tags                       tftags.Map                                           `tfsdk:"tags"`
-	Timeout                    fwtypes.ListNestedObjectValueOf[jobTimeoutModel]     `tfsdk:"timeout"`
-	Type                       types.String                                         `tfsdk:"type"`
+	ARNPrefix                  types.String                                              `tfsdk:"arn_prefix"`
+	ContainerOrchestrationType types.String                                              `tfsdk:"container_orchestration_type"`
+	ContainerProperties        fwtypes.ListNestedObjectValueOf[containerPropertiesModel] `tfsdk:"container_properties"`
+	EKSProperties              fwtypes.ListNestedObjectValueOf[eksPropertiesModel]       `tfsdk:"eks_properties"`
+	ID                         types.String                                              `tfsdk:"id"`
+	JobDefinitionARN           fwtypes.ARN                                               `tfsdk:"arn"`
+	JobDefinitionName          types.String                                              `tfsdk:"name"`
+	NodeProperties             fwtypes.ListNestedObjectValueOf[nodePropertiesModel]      `tfsdk:"node_properties"`
+	RetryStrategy              fwtypes.ListNestedObjectValueOf[retryStrategyModel]       `tfsdk:"retry_strategy"`
+	Revision                   types.Int64                                               `tfsdk:"revision"`
+	SchedulingPriority         types.Int64                                               `tfsdk:"scheduling_priority"`
+	Status                     types.String                                              `tfsdk:"status"`
+	Tags                       tftags.Map                                                `tfsdk:"tags"`
+	Timeout                    fwtypes.ListNestedObjectValueOf[jobTimeoutModel]          `tfsdk:"timeout"`
+	Type                       types.String                                              `tfsdk:"type"`
 }
 
 type eksPropertiesModel struct {

--- a/internal/service/batch/job_definition_data_source_test.go
+++ b/internal/service/batch/job_definition_data_source_test.go
@@ -5,6 +5,7 @@ package batch_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -204,4 +205,40 @@ data "aws_batch_job_definition" "test" {
   arn = aws_batch_job_definition.test.arn
 }
 `)
+}
+
+func TestAccJobDefinitionDataSourceConfig_basicARN_ContainerProperties(t *testing.T) {
+	env := os.Getenv("TF_ACC")
+	fmt.Println(env)
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_batch_job_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.BatchEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobDefinitionDataSourceConfig_basicARN(rName, "1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "container_properties.0.image", "busybox"),
+
+					resource.TestCheckResourceAttr(dataSourceName, "container_properties.0.command.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "container_properties.0.command.0", "echo"),
+					resource.TestCheckResourceAttr(dataSourceName, "container_properties.0.command.1", "test1"),
+
+					resource.TestCheckResourceAttr(dataSourceName, "container_properties.0.environment.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "container_properties.0.volumes.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "container_properties.0.mount_points.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "container_properties.0.ulimits.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "container_properties.0.resource_requirements.#", "2"),
+				),
+			},
+		},
+	})
 }

--- a/website/docs/d/batch_job_definition.html.markdown
+++ b/website/docs/d/batch_job_definition.html.markdown
@@ -43,6 +43,7 @@ The following arguments are optional:
 This data source exports the following attributes in addition to the arguments above:
 
 * `container_orchestration_type` - The orchestration type of the compute environment.
+* `container_properties` - An [object](#container) describing the container properties of AWS ECS-based jobs.
 * `scheduling_priority` - The scheduling priority for jobs that are submitted with this job definition. This only affects jobs in job queues with a fair share policy. Jobs with a higher scheduling priority are scheduled before jobs with a lower scheduling priority.
 * `id` - The ARN
 * `eks_properties` - An [object](#eks_properties) with various properties that are specific to Amazon EKS based jobs. This must not be specified for Amazon ECS based job definitions.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This PR adds a top-level `.container_properties` attribute. `.container_properties` is only defined for ECS-based batch jobs, but it shares the structure of the elements of `.eks_properties.pod_properties.containers` and `.node_properties.node_range_properties.[].container`.
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36263

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccJobDefinitionDataSourceConfig_basicARN_ContainerProperties PKG=batch

--- PASS: TestAccJobDefinitionDataSourceConfig_basicARN_ContainerProperties (13.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      17.586s
```
