### PR TITLE
feat: add topic_name_configuration to msk replicator

### DIFF
--- a/internal/service/kafka/replicator.go
+++ b/internal/service/kafka/replicator.go
@@ -175,6 +175,22 @@ func resourceReplicator() *schema.Resource {
 											},
 										},
 									},
+									"topic_name_configuration": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												names.AttrType: {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ForceNew:         true,
+													ValidateDiagFunc: enum.Validate[types.ReplicationTopicNameConfigurationType](),
+												},
+											},
+										},
+									},
 									"topics_to_exclude": {
 										Type:     schema.TypeSet,
 										Optional: true,
@@ -579,6 +595,10 @@ func flattenTopicReplication(apiObject *types.TopicReplication) map[string]inter
 		tfMap["starting_position"] = []interface{}{flattenReplicationStartingPosition(v)}
 	}
 
+	if v := apiObject.TopicNameConfiguration; v != nil {
+		tfMap["topic_name_configuration"] = []interface{}{flattenReplicationTopicNameConfiguration(v)}
+	}
+
 	if v := apiObject.TopicsToReplicate; v != nil {
 		tfMap["topics_to_replicate"] = v
 	}
@@ -591,6 +611,20 @@ func flattenTopicReplication(apiObject *types.TopicReplication) map[string]inter
 }
 
 func flattenReplicationStartingPosition(apiObject *types.ReplicationStartingPosition) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{}
+
+	if v := apiObject.Type; v != "" {
+		tfMap[names.AttrType] = v
+	}
+
+	return tfMap
+}
+
+func flattenReplicationTopicNameConfiguration(apiObject *types.ReplicationTopicNameConfiguration) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
@@ -799,6 +833,10 @@ func expandTopicReplication(tfMap map[string]interface{}) *types.TopicReplicatio
 		apiObject.StartingPosition = expandReplicationStartingPosition(v[0].(map[string]interface{}))
 	}
 
+	if v, ok := tfMap["topic_name_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		apiObject.TopicNameConfiguration = expandReplicationTopicNameConfiguration(v[0].(map[string]interface{}))
+	}
+
 	if v, ok := tfMap["topics_to_replicate"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.TopicsToReplicate = flex.ExpandStringValueSet(v)
 	}
@@ -815,6 +853,16 @@ func expandReplicationStartingPosition(tfMap map[string]interface{}) *types.Repl
 
 	if v, ok := tfMap[names.AttrType].(string); ok {
 		apiObject.Type = types.ReplicationStartingPositionType(v)
+	}
+
+	return apiObject
+}
+
+func expandReplicationTopicNameConfiguration(tfMap map[string]interface{}) *types.ReplicationTopicNameConfiguration {
+	apiObject := &types.ReplicationTopicNameConfiguration{}
+
+	if v, ok := tfMap[names.AttrType].(string); ok {
+		apiObject.Type = types.ReplicationTopicNameConfigurationType(v)
 	}
 
 	return apiObject

--- a/internal/service/kafka/replicator_test.go
+++ b/internal/service/kafka/replicator_test.go
@@ -56,6 +56,7 @@ func TestAccKafkaReplicator_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.consumer_group_replication.0.consumer_groups_to_replicate.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.target_compression_type", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.starting_position.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.topic_name_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.topics_to_replicate.#", "1"),
 				),
 			},
@@ -105,6 +106,7 @@ func TestAccKafkaReplicator_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.consumer_group_replication.0.consumer_groups_to_replicate.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.target_compression_type", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.starting_position.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.topic_name_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.topics_to_replicate.#", "1"),
 				),
 			},
@@ -132,6 +134,8 @@ func TestAccKafkaReplicator_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.target_compression_type", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.starting_position.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.starting_position.0.type", "EARLIEST"),
+					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.topic_name_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.topic_name_configuration.0.type", "IDENTICAL"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.topics_to_replicate.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.topics_to_exclude.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replication_info_list.0.topic_replication.0.copy_topic_configurations", acctest.CtFalse),
@@ -628,6 +632,10 @@ resource "aws_msk_replicator" "test" {
 
       starting_position {
         type = "EARLIEST"
+      }
+
+      topic_name_configuration {
+        type = "IDENTICAL"
       }
     }
 

--- a/website/docs/r/msk_replicator.html.markdown
+++ b/website/docs/r/msk_replicator.html.markdown
@@ -49,6 +49,9 @@ resource "aws_msk_replicator" "test" {
 
 
     topic_replication {
+      topic_configuration_name {
+        type = "PREFIXED_WITH_SOURCE_CLUSTER_ALIAS"
+      }
       topics_to_replicate = [".*"]
       starting_position {
         type = "LATEST"
@@ -96,6 +99,7 @@ The following arguments are required:
 
 ### topic_replication Argument Reference
 
+* `topic_configuration_name` - (Optional) Configuration for specifying replicated topic names should be the same as their corresponding upstream topics or prefixed with source cluster alias.
 * `topics_to_replicate` - (Required) List of regular expression patterns indicating the topics to copy.
 * `topics_to_exclude` - (Optional) List of regular expression patterns indicating the topics that should not be replica.
 * `detect_and_copy_new_topics` - (Optional) Whether to periodically check for new topics and partitions.
@@ -109,6 +113,10 @@ The following arguments are required:
 * `consumer_groups_to_exclude` - (Optional) List of regular expression patterns indicating the consumer groups that should not be replicated.
 * `detect_and_copy_new_consumer_groups` - (Optional) Whether to periodically check for new consumer groups.
 * `synchronise_consumer_group_offsets` - (Optional) Whether to periodically write the translated offsets to __consumer_offsets topic in target cluster.
+
+### topic_configuration_name
+
+* `type` - (optional) The type of topic configuration name. Supports `PREFIXED_WITH_SOURCE_CLUSTER_ALIAS` and `IDENTICAL`.
 
 ### starting_position
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add `topic_name_configuration` attribute to MSK replicator.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39309

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/kafka@v1.38.4/types#ReplicationTopicNameConfigurationTypehttps://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/kafka@v1.38.4/types#ReplicationTopicNameConfigurationType

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTARGS='-run=TestAccKafkaReplicator_basic\|TestAccKafkaReplicator_update' PKG=kafka
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/kafka/... -v -count 1 -parallel 20  -run=TestAccKafkaReplicator_basic\|TestAccKafkaReplicator_update -timeout 360m
2024/11/12 11:50:56 Initializing Terraform AWS Provider...
=== RUN   TestAccKafkaReplicator_basic
=== PAUSE TestAccKafkaReplicator_basic
=== RUN   TestAccKafkaReplicator_update
=== PAUSE TestAccKafkaReplicator_update
=== CONT  TestAccKafkaReplicator_basic
=== CONT  TestAccKafkaReplicator_update
--- PASS: TestAccKafkaReplicator_basic (9085.58s)
--- PASS: TestAccKafkaReplicator_update (9902.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/kafka      9919.192s

...
```
