### PR TITLE
Adds `aws_servicecatalogappregistry_application` sweeper

### DIFF
--- a/internal/service/resourcegroups/sweep.go
+++ b/internal/service/resourcegroups/sweep.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func RegisterSweepers() {

--- a/internal/service/resourcegroups/sweep.go
+++ b/internal/service/resourcegroups/sweep.go
@@ -16,7 +16,9 @@ import (
 )
 
 func RegisterSweepers() {
-	awsv2.Register("aws_resourcegroups_group", sweepGroups)
+	awsv2.Register("aws_resourcegroups_group", sweepGroups,
+		"aws_servicecatalogappregistry_application",
+	)
 }
 
 func sweepGroups(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {

--- a/internal/service/resourcegroups/sweep.go
+++ b/internal/service/resourcegroups/sweep.go
@@ -45,8 +45,8 @@ func sweepGroups(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepabl
 
 			if slices.Contains(tags.Keys(), "aws:servicecatalog:applicationId") {
 				tflog.Warn(ctx, "Skipping resource", map[string]any{
-					"skip_reason": "managed by AppRegistry",
-					"group_name":  aws.ToString(v.GroupName),
+					"skip_reason":       "managed by AppRegistry",
+					names.AttrGroupName: aws.ToString(v.GroupName),
 				})
 				continue
 			}

--- a/internal/service/resourcegroups/sweep.go
+++ b/internal/service/resourcegroups/sweep.go
@@ -4,48 +4,51 @@
 package resourcegroups
 
 import (
-	"fmt"
-	"log"
+	"context"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroups"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 )
 
 func RegisterSweepers() {
-	resource.AddTestSweepers("aws_resourcegroups_group", &resource.Sweeper{
-		Name: "aws_resourcegroups_group",
-		F:    sweepGroups,
-	})
+	awsv2.Register("aws_resourcegroups_group", sweepGroups)
 }
 
-func sweepGroups(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("error getting client: %s", err)
-	}
+func sweepGroups(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.ResourceGroupsClient(ctx)
-	input := &resourcegroups.ListGroupsInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
 
-	pages := resourcegroups.NewListGroupsPaginator(conn, input)
+	var sweepResources []sweep.Sweepable
+
+	r := resourceGroup()
+	pages := resourcegroups.NewListGroupsPaginator(conn, &resourcegroups.ListGroupsInput{})
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping Resource Groups Group sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing Resource Groups Groups (%s): %w", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.GroupIdentifiers {
-			r := resourceGroup()
+			tags, err := listTags(ctx, conn, aws.ToString(v.GroupArn))
+			if err != nil {
+				tflog.Warn(ctx, "Skipping resource", map[string]any{
+					"error": err.Error(),
+				})
+				continue
+			}
+
+			if slices.Contains(tags.Keys(), "aws:servicecatalog:applicationId") {
+				tflog.Warn(ctx, "Skipping resource", map[string]any{
+					"skip_reason": "managed by AppRegistry",
+					"group_name":  aws.ToString(v.GroupName),
+				})
+				continue
+			}
+
 			d := r.Data(nil)
 			d.SetId(aws.ToString(v.GroupName))
 
@@ -53,11 +56,5 @@ func sweepGroups(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping Resource Groups Groups (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }

--- a/internal/service/servicecatalogappregistry/sweep.go
+++ b/internal/service/servicecatalogappregistry/sweep.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package servicecatalogappregistry
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func RegisterSweepers() {
+	awsv2.Register("aws_servicecatalogappregistry_application", sweepScraper)
+}
+
+func sweepScraper(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	conn := client.ServiceCatalogAppRegistryClient(ctx)
+
+	var sweepResources []sweep.Sweepable
+
+	pages := servicecatalogappregistry.NewListApplicationsPaginator(conn, &servicecatalogappregistry.ListApplicationsInput{})
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, application := range page.Applications {
+			sweepResources = append(sweepResources, framework.NewSweepResource(newResourceApplication, client,
+				framework.NewAttribute(names.AttrID, aws.ToString(application.Id)),
+			))
+		}
+	}
+
+	return sweepResources, nil
+}

--- a/internal/sweep/register_gen_test.go
+++ b/internal/sweep/register_gen_test.go
@@ -139,6 +139,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/service/schemas"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalogappregistry"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/ses"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/sesv2"
@@ -305,6 +306,7 @@ func registerSweepers() {
 	schemas.RegisterSweepers()
 	secretsmanager.RegisterSweepers()
 	servicecatalog.RegisterSweepers()
+	servicecatalogappregistry.RegisterSweepers()
 	servicediscovery.RegisterSweepers()
 	ses.RegisterSweepers()
 	sesv2.RegisterSweepers()


### PR DESCRIPTION
### Description

Adds sweeper for `aws_servicecatalogappregistry_application`.

Also skips `aws_resourcegroups_group` resources with `aws:servicecatalog:applicationId` tag
