### PR TITLE
Correct typo in elasticache_replication_group regarding number of allowed Secondary replica groups

### DIFF
--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -130,7 +130,7 @@ for full details on using Replication Groups.
 
 ### Creating a secondary replication group for a global replication group
 
-A Global Replication Group can have one one two secondary Replication Groups in different regions. These are added to an existing Global Replication Group.
+A Global Replication Group can have up to two secondary Replication Groups in different regions. These are added to an existing Global Replication Group.
 
 ```terraform
 resource "aws_elasticache_replication_group" "secondary" {


### PR DESCRIPTION
Prior typo was confusing and had no semantic meaning. Updated to be accurate per AWS documentation

https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/Redis-Global-Datastores-Getting-Started.html

The above documentation from AWS states:
"You can set up replication for a primary cluster from one AWS Region to a secondary cluster in up to two other AWS Regions. Note: The exception to this are China (Beijing) Region and China (Ningxia) regions, where replication can only occur between the two regions."

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
