### PR TITLE
apigateway/integration: Fix parameters issues

### DIFF
--- a/.changelog/40124.txt
+++ b/.changelog/40124.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_integration: Fix `BadRequestException: Invalid mapping expression specified` and `NotFoundException: Invalid parameter name specified` errors when making updates to `request_parameters` and/or `cache_key_parameters`
+```

--- a/.changelog/40124.txt
+++ b/.changelog/40124.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_api_gateway_integration: Fix `BadRequestException: Invalid mapping expression specified` and `NotFoundException: Invalid parameter name specified` errors when making updates to `request_parameters` and/or `cache_key_parameters`
 ```
+
+```release-note:bug
+resource/aws_api_gateway_method: Fix `BadRequestException: Invalid mapping expression specified` and `NotFoundException: Invalid parameter name specified` errors when making updates to `request_parameters`
+```

--- a/internal/service/apigateway/integration.go
+++ b/internal/service/apigateway/integration.go
@@ -507,7 +507,7 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 	// the #29991 attempt in *method* but it can likely be removed.
 
 	// No reasonable way to determine the first stage has fully propagated, so we wait a bit.
-	time.Sleep(3 * time.Second)
+	time.Sleep(pauseBetweenUpdateStages)
 
 	integration, err := findIntegrationByThreePartKey(ctx, conn, d.Get("http_method").(string), d.Get(names.AttrResourceID).(string), d.Get("rest_api_id").(string))
 	if err != nil {
@@ -617,6 +617,8 @@ const (
 	requestParameterType  = "requestParameters"
 	cacheKeyParameterType = "cacheKeyParameters"
 	requestTemplatesType  = "requestTemplates"
+
+	pauseBetweenUpdateStages = 3 * time.Second
 )
 
 // parameterizeParameter takes a parameter path and adds a prefix and escapes. For example:

--- a/internal/service/apigateway/integration.go
+++ b/internal/service/apigateway/integration.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
@@ -224,7 +225,6 @@ func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	_, err := conn.PutIntegration(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating API Gateway Integration: %s", err)
 	}
@@ -289,7 +289,6 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 	// According to the above documentation, only a few parts are addable / removable.
 	if d.HasChange("request_templates") {
 		o, n := d.GetChange("request_templates")
-		prefix := "requestTemplates"
 
 		os := o.(map[string]interface{})
 		ns := n.(map[string]interface{})
@@ -299,7 +298,7 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 			if _, ok := ns[k]; !ok {
 				operations = append(operations, types.PatchOperation{
 					Op:   types.OpRemove,
-					Path: aws.String(fmt.Sprintf("/%s/%s", prefix, strings.Replace(k, "/", "~1", -1))),
+					Path: aws.String(parameterizeParameter(k, requestTemplatesType)),
 				})
 			}
 		}
@@ -309,7 +308,7 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 			if _, ok := os[k]; ok {
 				operations = append(operations, types.PatchOperation{
 					Op:    types.OpReplace,
-					Path:  aws.String(fmt.Sprintf("/%s/%s", prefix, strings.Replace(k, "/", "~1", -1))),
+					Path:  aws.String(parameterizeParameter(k, requestTemplatesType)),
 					Value: aws.String(v.(string)),
 				})
 			}
@@ -318,7 +317,7 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 			if _, ok := os[k]; !ok {
 				operations = append(operations, types.PatchOperation{
 					Op:    types.OpAdd,
-					Path:  aws.String(fmt.Sprintf("/%s/%s", prefix, strings.Replace(k, "/", "~1", -1))),
+					Path:  aws.String(parameterizeParameter(k, requestTemplatesType)),
 					Value: aws.String(v.(string)),
 				})
 			}
@@ -327,27 +326,28 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	if d.HasChange("request_parameters") {
 		o, n := d.GetChange("request_parameters")
-		prefix := "requestParameters"
 
 		os := o.(map[string]interface{})
 		ns := n.(map[string]interface{})
 
 		// Handle Removal
-		for k := range os {
+		for k, v := range os {
 			if _, ok := ns[k]; !ok {
 				operations = append(operations, types.PatchOperation{
-					Op:   types.OpRemove,
-					Path: aws.String(fmt.Sprintf("/%s/%s", prefix, strings.Replace(k, "/", "~1", -1))),
+					Op:    types.OpRemove,
+					Path:  aws.String(parameterizeParameter(k, requestParameterType)),
+					Value: aws.String(v.(string)),
 				})
 			}
 		}
 
 		for k, v := range ns {
 			// Handle replaces
-			if _, ok := os[k]; ok {
+			// Replaces only if values are different
+			if _, ok := os[k]; ok && os[k].(string) != v.(string) {
 				operations = append(operations, types.PatchOperation{
 					Op:    types.OpReplace,
-					Path:  aws.String(fmt.Sprintf("/%s/%s", prefix, strings.Replace(k, "/", "~1", -1))),
+					Path:  aws.String(parameterizeParameter(k, requestParameterType)),
 					Value: aws.String(v.(string)),
 				})
 			}
@@ -356,12 +356,14 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 			if _, ok := os[k]; !ok {
 				operations = append(operations, types.PatchOperation{
 					Op:    types.OpAdd,
-					Path:  aws.String(fmt.Sprintf("/%s/%s", prefix, strings.Replace(k, "/", "~1", -1))),
+					Path:  aws.String(parameterizeParameter(k, requestParameterType)),
 					Value: aws.String(v.(string)),
 				})
 			}
 		}
 	}
+
+	ckpOperations := make([]types.PatchOperation, 0) // separating from the other operations
 
 	if d.HasChange("cache_key_parameters") {
 		o, n := d.GetChange("cache_key_parameters")
@@ -371,18 +373,28 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 		removalList := os.Difference(ns)
 		for _, v := range removalList.List() {
-			operations = append(operations, types.PatchOperation{
+			ckpOperations = append(ckpOperations, types.PatchOperation{
 				Op:    types.OpRemove,
-				Path:  aws.String(fmt.Sprintf("/cacheKeyParameters/%s", v.(string))),
+				Path:  aws.String(parameterizeParameter(v.(string), cacheKeyParameterType)),
 				Value: aws.String(""),
 			})
 		}
 
-		additionList := ns.Difference(os)
-		for _, v := range additionList.List() {
-			operations = append(operations, types.PatchOperation{
+		// "Replace" for cache key parameter isn't actually a thing but provides a way to mark the
+		// parameter for further evaluation during update processing. For example, sometimes, according to
+		// Terraform, it's a replace, but the parameter doesn't exist. In that case, it should be an add.
+		for _, v := range ns.Intersection(os).List() {
+			ckpOperations = append(ckpOperations, types.PatchOperation{
+				Op:    types.OpReplace,
+				Path:  aws.String(parameterizeParameter(v.(string), cacheKeyParameterType)),
+				Value: aws.String(""),
+			})
+		}
+
+		for _, v := range ns.Difference(os).List() {
+			ckpOperations = append(ckpOperations, types.PatchOperation{
 				Op:    types.OpAdd,
-				Path:  aws.String(fmt.Sprintf("/cacheKeyParameters/%s", v.(string))),
+				Path:  aws.String(parameterizeParameter(v.(string), cacheKeyParameterType)),
 				Value: aws.String(""),
 			})
 		}
@@ -451,17 +463,129 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	input := &apigateway.UpdateIntegrationInput{
-		HttpMethod:      aws.String(d.Get("http_method").(string)),
-		PatchOperations: operations,
-		ResourceId:      aws.String(d.Get(names.AttrResourceID).(string)),
-		RestApiId:       aws.String(d.Get("rest_api_id").(string)),
+	// Updating, Stage 1: Everything except cache key parameters
+
+	// Updating is handled in two stages because of the challenges of keeping AWS and state in sync in
+	// these, and probably other, situations:
+	//  - Cache key parameters are updated by request parameter updates.
+	//  - One cache key parameter can disappear when another is added.
+	//  - Cache key parameters can be updated independently of request parameters.
+	//
+	// These challenges are not documented in the API Gateway documentation, but they are observed in
+	// practice resulting in these errors:
+	//  - BadRequestException: Invalid mapping expression specified: Validation Result: warnings : [], errors : [Invalid mapping expression parameter specified: method.request.querystring.X-Some-Header-2]
+	//  - NotFoundException: Invalid parameter name specified
+	//
+	// Using two stages is necessary because making these updates simultaneously can cause unpredictable
+	// "not found" errors: the first operation succeeds, but the second fails if it attempts to modify a
+	// non-existent parameter. To prevent this, we initially perform only the request parameter updates.
+	// In a second stage, we examine the results and adjust the cache key parameter operations as needed
+	// based on those results.
+
+	if len(operations) > 0 {
+		input := &apigateway.UpdateIntegrationInput{
+			HttpMethod:      aws.String(d.Get("http_method").(string)),
+			PatchOperations: operations,
+			ResourceId:      aws.String(d.Get(names.AttrResourceID).(string)),
+			RestApiId:       aws.String(d.Get("rest_api_id").(string)),
+		}
+
+		_, err := conn.UpdateIntegration(ctx, input)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating API Gateway Integration, initial (%s): %s", d.Id(), err)
+		}
 	}
 
-	_, err := conn.UpdateIntegration(ctx, input)
+	// Updating, Stage 2: Cache key parameters
 
+	// As described above, in the second stage, we look at the results of the first stage and adjust the
+	// cache key parameter operations as needed.
+
+	// NOTE: The changes in #29991 seem like an attempt to fix this same problem in the *method* resource.
+	// However, in debugging, the approach there always calls Update with an empty set of operations and
+	// that sometimes causes errors. To avoid the risk of breaking some remote edge case, we're leaving
+	// the #29991 attempt in *method* but it can likely be removed.
+
+	// No reasonable way to determine the first stage has fully propagated, so we wait a bit.
+	time.Sleep(3 * time.Second)
+
+	integration, err := findIntegrationByThreePartKey(ctx, conn, d.Get("http_method").(string), d.Get(names.AttrResourceID).(string), d.Get("rest_api_id").(string))
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating API Gateway Integration (%s): %s", d.Id(), err)
+	}
+
+	// Go through the cache key parameters, one by one, and include or exclude them based on the existing
+	// cache key parameters.
+	if len(ckpOperations) > 0 {
+		lackingOperations := make([]types.PatchOperation, 0)
+
+	outer:
+		for _, ckp := range ckpOperations {
+			if ckp.Op == types.OpReplace {
+				// Search for the cache key parameter in the existing cache key parameters
+				for _, p := range integration.CacheKeyParameters {
+					if aws.ToString(ckp.Path) == parameterizeParameter(p, cacheKeyParameterType) {
+						// Op is excluded--for a cache key parameter, a replace doesn't do anything if the parameter already exists.
+						// Testing against the API, this is reached.
+						continue outer
+					}
+				}
+
+				// Op is included--since it's not found, it changes "replace" to "add".
+				// Testing against the API, this is reached.
+				lackingOperations = append(lackingOperations, types.PatchOperation{
+					Op:    types.OpAdd,
+					Path:  ckp.Path,
+					Value: ckp.Value,
+				})
+				continue
+			}
+
+			if ckp.Op == types.OpRemove {
+				// Search for the cache key parameter in the existing cache key parameters
+				for _, p := range integration.CacheKeyParameters {
+					if aws.ToString(ckp.Path) == parameterizeParameter(p, cacheKeyParameterType) {
+						// Op is included--since it's found, it's removed.
+						// Testing against the API, this is NOT reached but included for completeness or just in case.
+						lackingOperations = append(lackingOperations, ckp)
+						continue outer
+					}
+				}
+				// Op is excluded--since it's not found, it's not removed.
+				// Testing against the API, this is reached.
+				continue
+			}
+
+			if ckp.Op == types.OpAdd {
+				// Search for the cache key parameter in the existing cache key parameters
+				for _, p := range integration.CacheKeyParameters {
+					if aws.ToString(ckp.Path) == parameterizeParameter(p, cacheKeyParameterType) {
+						// Op is excluded--since it's found, it doesn't need to be added.
+						// Testing against the API, this is NOT reached but included for completeness or just in case.
+						continue outer
+					}
+				}
+
+				// Op is included--since it's not found, it's added.
+				// Testing against the API, this is reached.
+				lackingOperations = append(lackingOperations, ckp)
+				continue outer
+			}
+		}
+
+		if len(lackingOperations) > 0 {
+			input := &apigateway.UpdateIntegrationInput{
+				HttpMethod:      aws.String(d.Get("http_method").(string)),
+				PatchOperations: lackingOperations,
+				ResourceId:      aws.String(d.Get(names.AttrResourceID).(string)),
+				RestApiId:       aws.String(d.Get("rest_api_id").(string)),
+			}
+
+			_, err = conn.UpdateIntegration(ctx, input)
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating API Gateway Integration, secondary (%s): %s", d.Id(), err)
+			}
+		}
 	}
 
 	return append(diags, resourceIntegrationRead(ctx, d, meta)...)
@@ -487,6 +611,19 @@ func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	return diags
+}
+
+const (
+	requestParameterType  = "requestParameters"
+	cacheKeyParameterType = "cacheKeyParameters"
+	requestTemplatesType  = "requestTemplates"
+)
+
+// parameterizeParameter takes a parameter path and adds a prefix and escapes. For example:
+// in : integration.request.querystring.X-Some-Header-2
+// out: /requestParameters/integration.request.querystring.X-Some-Header-2
+func parameterizeParameter(s string, paramType string) string {
+	return fmt.Sprintf("/%s/%s", paramType, strings.Replace(s, "/", "~1", -1))
 }
 
 func findIntegrationByThreePartKey(ctx context.Context, conn *apigateway.Client, httpMethod, resourceID, apiID string) (*apigateway.GetIntegrationOutput, error) {

--- a/internal/service/apigateway/integration_test.go
+++ b/internal/service/apigateway/integration_test.go
@@ -1081,11 +1081,11 @@ resource "aws_api_gateway_method" "test" {
     "application/json" = "Error"
   }
 
-  request_parameters = {for param in var.utm_params : "method.request.querystring.${param}" => false}
+  request_parameters = { for param in var.utm_params : "method.request.querystring.${param}" => false }
 }
 
 variable "utm_params" {
-  type = list(string)
+  type    = list(string)
   default = ["%[2]s"]
 }
 
@@ -1098,7 +1098,7 @@ resource "aws_api_gateway_integration" "test" {
   type                    = "HTTP_PROXY"
   uri                     = "https://www.google.de"
 
-  request_parameters = {for param in var.utm_params : "integration.request.querystring.${param}" => "method.request.querystring.${param}"}
+  request_parameters = { for param in var.utm_params : "integration.request.querystring.${param}" => "method.request.querystring.${param}" }
 }
 `, rName, strings.Join(params, `", "`))
 }
@@ -1116,7 +1116,7 @@ resource "aws_api_gateway_resource" "test" {
 }
 
 variable "utm_params" {
-  type = list(string)
+  type    = list(string)
   default = ["%[2]s"]
 }
 
@@ -1130,7 +1130,7 @@ resource "aws_api_gateway_method" "test" {
     {
       "method.request.path.proxy" = true
     },
-    {for param in var.utm_params : "method.request.querystring.${param}" => false}
+    { for param in var.utm_params : "method.request.querystring.${param}" => false }
   )
 }
 
@@ -1146,8 +1146,8 @@ resource "aws_api_gateway_integration" "test" {
   request_parameters = merge({
     "integration.request.path.proxy"  = "method.request.path.proxy"
     "integration.request.header.Host" = "'method.request.querystring.name'"
-  },
-  {for param in var.utm_params : "integration.request.querystring.${param}" => "method.request.querystring.${param}"}
+    },
+    { for param in var.utm_params : "integration.request.querystring.${param}" => "method.request.querystring.${param}" }
   )
 
   cache_key_parameters = concat(

--- a/internal/service/apigateway/integration_test.go
+++ b/internal/service/apigateway/integration_test.go
@@ -6,6 +6,7 @@ package apigateway_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -210,7 +211,7 @@ func TestAccAPIGatewayIntegration_contentHandling(t *testing.T) {
 	})
 }
 
-func TestAccAPIGatewayIntegration_CacheKey_parameters(t *testing.T) {
+func TestAccAPIGatewayIntegration_Parameters_cacheKey(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -223,7 +224,7 @@ func TestAccAPIGatewayIntegration_CacheKey_parameters(t *testing.T) {
 		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntegrationConfig_cacheKeyParameters(rName),
+				Config: testAccIntegrationConfig_Parameters_cacheKey(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIntegrationExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
@@ -254,7 +255,7 @@ func TestAccAPIGatewayIntegration_CacheKey_parameters(t *testing.T) {
 	})
 }
 
-func TestAccAPIGatewayIntegration_CacheKeyUpdate_parameters(t *testing.T) {
+func TestAccAPIGatewayIntegration_Parameters_cacheKeyUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetIntegrationOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -267,7 +268,7 @@ func TestAccAPIGatewayIntegration_CacheKeyUpdate_parameters(t *testing.T) {
 		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntegrationConfig_cacheKeyParameters(rName),
+				Config: testAccIntegrationConfig_Parameters_cacheKey(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIntegrationExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
@@ -289,7 +290,7 @@ func TestAccAPIGatewayIntegration_CacheKeyUpdate_parameters(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIntegrationConfig_cacheKeyUpdateParameters(rName),
+				Config: testAccIntegrationConfig_Parameters_cacheKeyUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIntegrationExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP"),
@@ -316,6 +317,188 @@ func TestAccAPIGatewayIntegration_CacheKeyUpdate_parameters(t *testing.T) {
 				ImportState:       true,
 				ImportStateIdFunc: testAccIntegrationImportStateIdFunc(resourceName),
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayIntegration_Parameters_requestUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf apigateway.GetIntegrationOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_api_gateway_integration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntegrationConfig_Parameters_requestUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-2", "X-Some-Header-3"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-1", "method.request.querystring.X-Some-Header-1"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-2", "method.request.querystring.X-Some-Header-2"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-3", "method.request.querystring.X-Some-Header-3"),
+				),
+			},
+			{
+				Config: testAccIntegrationConfig_Parameters_requestUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-3"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-1", "method.request.querystring.X-Some-Header-1"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-3", "method.request.querystring.X-Some-Header-3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf apigateway.GetIntegrationOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_api_gateway_integration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIntegrationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-2", "X-Some-Header-3"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.header.Host", "'method.request.querystring.name'"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.path.proxy", "method.request.path.proxy"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-1", "method.request.querystring.X-Some-Header-1"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-2", "method.request.querystring.X-Some-Header-2"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-3", "method.request.querystring.X-Some-Header-3"),
+					resource.TestCheckResourceAttr(resourceName, "cache_key_parameters.#", "9"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.path.proxy"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.path.proxy"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.header.Host"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-3"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-3"),
+				),
+			},
+			{
+				Config: testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-3"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
+					/*
+						          resource.TestCheckTypeSetElemNestedAttrs(resourceName, "request_parameters.*", map[string]string{
+												"access_tier": "DEEP_ARCHIVE_ACCESS",
+												"days":        "365",
+											}),
+					*/
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.header.Host", "'method.request.querystring.name'"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.path.proxy", "method.request.path.proxy"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-1", "method.request.querystring.X-Some-Header-1"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-3", "method.request.querystring.X-Some-Header-3"),
+					resource.TestCheckResourceAttr(resourceName, "cache_key_parameters.#", "7"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.path.proxy"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.path.proxy"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.header.Host"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-3"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-3"),
+				),
+			},
+			{
+				Config: testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-4"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.header.Host", "'method.request.querystring.name'"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.path.proxy", "method.request.path.proxy"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-1", "method.request.querystring.X-Some-Header-1"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-4", "method.request.querystring.X-Some-Header-4"),
+					resource.TestCheckResourceAttr(resourceName, "cache_key_parameters.#", "7"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.path.proxy"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.path.proxy"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.header.Host"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-4"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-4"),
+				),
+			},
+			{
+				Config: testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName, []string{"X-Some-Header-1", "X-Some-Header-4", "X-Some-Header-5", "X-Some-Header-6", "X-Some-Header-7"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "7"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.header.Host", "'method.request.querystring.name'"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.path.proxy", "method.request.path.proxy"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-1", "method.request.querystring.X-Some-Header-1"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-4", "method.request.querystring.X-Some-Header-4"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-5", "method.request.querystring.X-Some-Header-5"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-6", "method.request.querystring.X-Some-Header-6"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-7", "method.request.querystring.X-Some-Header-7"),
+					resource.TestCheckResourceAttr(resourceName, "cache_key_parameters.#", "13"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.path.proxy"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.path.proxy"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.header.Host"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-4"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-5"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-6"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-7"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-4"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-5"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-6"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-7"),
+				),
+			},
+			{
+				Config: testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName, []string{"X-Some-Header-2"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
+					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.header.Host", "'method.request.querystring.name'"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.path.proxy", "method.request.path.proxy"),
+					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.querystring.X-Some-Header-2", "method.request.querystring.X-Some-Header-2"),
+					resource.TestCheckResourceAttr(resourceName, "cache_key_parameters.#", "5"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.path.proxy"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.path.proxy"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.header.Host"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "method.request.querystring.X-Some-Header-2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cache_key_parameters.*", "integration.request.querystring.X-Some-Header-2"),
+				),
 			},
 		},
 	})
@@ -763,7 +946,7 @@ resource "aws_api_gateway_integration" "test" {
 `, rName)
 }
 
-func testAccIntegrationConfig_cacheKeyParameters(rName string) string {
+func testAccIntegrationConfig_Parameters_cacheKey(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name = %[1]q
@@ -819,7 +1002,7 @@ resource "aws_api_gateway_integration" "test" {
 `, rName)
 }
 
-func testAccIntegrationConfig_cacheKeyUpdateParameters(rName string) string {
+func testAccIntegrationConfig_Parameters_cacheKeyUpdate(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_rest_api" "test" {
   name = %[1]q
@@ -874,6 +1057,106 @@ resource "aws_api_gateway_integration" "test" {
   timeout_milliseconds    = 2000
 }
 `, rName)
+}
+
+func testAccIntegrationConfig_Parameters_requestUpdate(rName string, params []string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "{param}"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "GET"
+  authorization = "NONE"
+
+  request_models = {
+    "application/json" = "Error"
+  }
+
+  request_parameters = {for param in var.utm_params : "method.request.querystring.${param}" => false}
+}
+
+variable "utm_params" {
+  type = list(string)
+  default = ["%[2]s"]
+}
+
+resource "aws_api_gateway_integration" "test" {
+  http_method             = aws_api_gateway_method.test.http_method
+  integration_http_method = "ANY"
+  resource_id             = aws_api_gateway_resource.test.id
+  rest_api_id             = aws_api_gateway_rest_api.test.id
+  timeout_milliseconds    = 2000
+  type                    = "HTTP_PROXY"
+  uri                     = "https://www.google.de"
+
+  request_parameters = {for param in var.utm_params : "integration.request.querystring.${param}" => "method.request.querystring.${param}"}
+}
+`, rName, strings.Join(params, `", "`))
+}
+
+func testAccIntegrationConfig_Parameters_requestCacheKeyUpdate(rName string, headers []string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name = %[1]q
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = aws_api_gateway_rest_api.test.id
+  parent_id   = aws_api_gateway_rest_api.test.root_resource_id
+  path_part   = "{param}"
+}
+
+variable "utm_params" {
+  type = list(string)
+  default = ["%[2]s"]
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  resource_id   = aws_api_gateway_resource.test.id
+  http_method   = "ANY"
+  authorization = "NONE"
+
+  request_parameters = merge(
+    {
+      "method.request.path.proxy" = true
+    },
+    {for param in var.utm_params : "method.request.querystring.${param}" => false}
+  )
+}
+
+resource "aws_api_gateway_integration" "test" {
+  http_method             = aws_api_gateway_method.test.http_method
+  integration_http_method = "ANY"
+  resource_id             = aws_api_gateway_resource.test.id
+  rest_api_id             = aws_api_gateway_rest_api.test.id
+  timeout_milliseconds    = 2000
+  type                    = "HTTP_PROXY"
+  uri                     = "https://www.google.de"
+
+  request_parameters = merge({
+    "integration.request.path.proxy"  = "method.request.path.proxy"
+    "integration.request.header.Host" = "'method.request.querystring.name'"
+  },
+  {for param in var.utm_params : "integration.request.querystring.${param}" => "method.request.querystring.${param}"}
+  )
+
+  cache_key_parameters = concat(
+    ["method.request.path.proxy", "integration.request.path.proxy", "integration.request.header.Host"],
+    [for param in var.utm_params : "integration.request.querystring.${param}"],
+    [for param in var.utm_params : "method.request.querystring.${param}"]
+  )
+}
+`, rName, strings.Join(headers, `", "`))
 }
 
 func testAccIntegrationConfig_IntegrationTypeBase(rName string) string {

--- a/internal/service/apigateway/integration_test.go
+++ b/internal/service/apigateway/integration_test.go
@@ -407,12 +407,6 @@ func TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate(t *testing.T)
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "HTTP_PROXY"),
 					resource.TestCheckResourceAttr(resourceName, "integration_http_method", "ANY"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURI, "https://www.google.de"),
-					/*
-						          resource.TestCheckTypeSetElemNestedAttrs(resourceName, "request_parameters.*", map[string]string{
-												"access_tier": "DEEP_ARCHIVE_ACCESS",
-												"days":        "365",
-											}),
-					*/
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.%", "4"),
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.header.Host", "'method.request.querystring.name'"),
 					resource.TestCheckResourceAttr(resourceName, "request_parameters.integration.request.path.proxy", "method.request.path.proxy"),

--- a/internal/service/apigateway/method.go
+++ b/internal/service/apigateway/method.go
@@ -292,12 +292,48 @@ func resourceMethodUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	_, err := conn.UpdateMethod(ctx, input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating API Gateway Method (%s): %s", d.Id(), err)
 	}
 
-	// Get current cacheKeyParameters from integration before any request parameters are updated on method.
+	if err := updateIntegration(ctx, d, conn, operations); err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating API Gateway Integration (from Method): %s", err)
+	}
+
+	return append(diags, resourceMethodRead(ctx, d, meta)...)
+}
+
+func resourceMethodDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).APIGatewayClient(ctx)
+
+	log.Printf("[DEBUG] Deleting API Gateway Method: %s", d.Id())
+	_, err := conn.DeleteMethod(ctx, &apigateway.DeleteMethodInput{
+		HttpMethod: aws.String(d.Get("http_method").(string)),
+		ResourceId: aws.String(d.Get(names.AttrResourceID).(string)),
+		RestApiId:  aws.String(d.Get("rest_api_id").(string)),
+	})
+
+	if errs.IsA[*types.NotFoundException](err) {
+		return diags
+	}
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting API Gateway Method (%s): %s", d.Id(), err)
+	}
+
+	return diags
+}
+
+// updateIntegration updates the integration with cacheKeyParameters for replaced request parameters.
+// Get current cacheKeyParameters from integration before any request parameters are updated on method.
+//
+// NOTE 1: This is a concerning approach when one resource is updating data managed by another resource.
+// NOTE 2: This does not appear to do anything since len(integrationOperations) always seems to be 0.
+// NOTE 3: The problem this addresses has likely been fixed in the *integration* resource--see Update.
+// NOTE 4: We're leaving this in the codebase on remote chance it does handle an edge case.
+// NOTE 5: This should be removed when we're confident it's no longer needed.
+func updateIntegration(ctx context.Context, d *schema.ResourceData, conn *apigateway.Client, operations []types.PatchOperation) error {
 	replacedRequestParameters := []string{}
 	var currentCacheKeyParameters []string
 	if integration, err := findIntegrationByThreePartKey(ctx, conn, d.Get("http_method").(string), d.Get(names.AttrResourceID).(string), d.Get("rest_api_id").(string)); err == nil {
@@ -325,6 +361,10 @@ func resourceMethodUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 		}
 
+		if len(integrationOperations) == 0 {
+			return nil
+		}
+
 		input := &apigateway.UpdateIntegrationInput{
 			HttpMethod:      aws.String(d.Get("http_method").(string)),
 			PatchOperations: integrationOperations,
@@ -335,33 +375,11 @@ func resourceMethodUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		_, err = conn.UpdateIntegration(ctx, input)
 
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating API Gateway Integration: %s", err)
+			return err
 		}
 	}
 
-	return append(diags, resourceMethodRead(ctx, d, meta)...)
-}
-
-func resourceMethodDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).APIGatewayClient(ctx)
-
-	log.Printf("[DEBUG] Deleting API Gateway Method: %s", d.Id())
-	_, err := conn.DeleteMethod(ctx, &apigateway.DeleteMethodInput{
-		HttpMethod: aws.String(d.Get("http_method").(string)),
-		ResourceId: aws.String(d.Get(names.AttrResourceID).(string)),
-		RestApiId:  aws.String(d.Get("rest_api_id").(string)),
-	})
-
-	if errs.IsA[*types.NotFoundException](err) {
-		return diags
-	}
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting API Gateway Method (%s): %s", d.Id(), err)
-	}
-
-	return diags
+	return nil
 }
 
 func findMethodByThreePartKey(ctx context.Context, conn *apigateway.Client, httpMethod, resourceID, apiID string) (*apigateway.GetMethodOutput, error) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This update introduces a two-stage approach to handle AWS request and cache key parameter updates more reliably due to observed challenges in API Gateway parameter behavior:
  - Request parameter updates can alter cache key parameters (see #39801).
  - Adding one cache key parameter may unexpectedly remove another (see #29910, #25736).
  - Cache key parameters can be updated independently of request parameters.

Keeping Terraform state in sync with what is in place on AWS is problematic due to these unpredictable, from Terraform's perspective, changes. For example, trying to remove or replace a parameter that state says exists but doesn't actually exist, causes _not-found-type_ errors. Another example is simultaneously performing multiple operations that have the net effect of removing a parameter--the first succeeds but the second gives a _not-found-type_ error.

The sorts of errors seen:

```console
BadRequestException: Invalid mapping expression specified: Validation Result: warnings : [], errors : [Invalid mapping expression parameter specified: method.request.querystring.X-Some-Header-2]

NotFoundException: Invalid parameter name specified
```

Although not reported, this update also fixes a variety of issues that would have caused problems in some configurations. For example, cache key parameters were not escaped, limiting the naming options without errors.

The new approach:

**Stage 1: Request Parameter Updates Only**
In the first stage, we update everything except cache key parameters.

**Stage 2: Cache Key Parameter Adjustments**
After examining results from the first stage (reading AWS rather than relying solely on state), we update the cache key parameters accordingly. For example, replacing (adding back) a poor parameter that got waylaid on her way to visit her grandmother, deep in the forest, with a freshly baked, towering _croquembouche_. This two-stage approach ensures alignment between the state and AWS.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39801 
Relates #29991 
Closes #29910 
Closes #25736

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

The laudable attempt at a fix in #29991 seems to be aimed at the same problem. Unfortunately, that fix was put in the method resource rather than integration. The _integration update in the method resource_ confusingly looked like it was coming from the integration resource itself. In addition, debugging shows that the _integration update in the method resource_ always calls `Update` with an empty set of operations, occasionally causing errors. We’re keeping the #29991 approach in place to avoid potential edge case disruptions, but it may be safe to remove it in the future. For now, we've gated off the _integration update in the method resource_ so that it only calls `Update` when there are operations to perform.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccAPIGatewayIntegration_ K=apigateway 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayIntegration_'  -timeout 360m
2024/11/13 22:47:00 Initializing Terraform AWS Provider...
=== RUN   TestAccAPIGatewayIntegration_basic
=== PAUSE TestAccAPIGatewayIntegration_basic
=== RUN   TestAccAPIGatewayIntegration_contentHandling
=== PAUSE TestAccAPIGatewayIntegration_contentHandling
=== RUN   TestAccAPIGatewayIntegration_Parameters_cacheKey
=== PAUSE TestAccAPIGatewayIntegration_Parameters_cacheKey
=== RUN   TestAccAPIGatewayIntegration_Parameters_cacheKeyUpdate
=== PAUSE TestAccAPIGatewayIntegration_Parameters_cacheKeyUpdate
=== RUN   TestAccAPIGatewayIntegration_Parameters_requestUpdate
=== PAUSE TestAccAPIGatewayIntegration_Parameters_requestUpdate
=== RUN   TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate
=== PAUSE TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate
=== RUN   TestAccAPIGatewayIntegration_integrationType
=== PAUSE TestAccAPIGatewayIntegration_integrationType
=== RUN   TestAccAPIGatewayIntegration_TLS_insecureSkipVerification
=== PAUSE TestAccAPIGatewayIntegration_TLS_insecureSkipVerification
=== RUN   TestAccAPIGatewayIntegration_disappears
=== PAUSE TestAccAPIGatewayIntegration_disappears
=== CONT  TestAccAPIGatewayIntegration_basic
=== CONT  TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate
=== CONT  TestAccAPIGatewayIntegration_integrationType
=== CONT  TestAccAPIGatewayIntegration_TLS_insecureSkipVerification
=== CONT  TestAccAPIGatewayIntegration_disappears
=== CONT  TestAccAPIGatewayIntegration_Parameters_cacheKeyUpdate
=== CONT  TestAccAPIGatewayIntegration_Parameters_requestUpdate
=== CONT  TestAccAPIGatewayIntegration_Parameters_cacheKey
=== CONT  TestAccAPIGatewayIntegration_contentHandling
--- PASS: TestAccAPIGatewayIntegration_contentHandling (42.27s)
--- PASS: TestAccAPIGatewayIntegration_basic (75.44s)
--- PASS: TestAccAPIGatewayIntegration_Parameters_requestCacheKeyUpdate (108.11s)
--- PASS: TestAccAPIGatewayIntegration_disappears (204.04s)
--- PASS: TestAccAPIGatewayIntegration_TLS_insecureSkipVerification (206.17s)
--- PASS: TestAccAPIGatewayIntegration_Parameters_cacheKeyUpdate (268.23s)
--- PASS: TestAccAPIGatewayIntegration_Parameters_cacheKey (374.39s)
--- PASS: TestAccAPIGatewayIntegration_Parameters_requestUpdate (423.50s)
--- PASS: TestAccAPIGatewayIntegration_integrationType (672.06s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	675.985s
% make t T=TestAccAPIGatewayMethod_ K=apigateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayMethod_'  -timeout 360m
2024/11/13 22:57:27 Initializing Terraform AWS Provider...
=== RUN   TestAccAPIGatewayMethod_basic
=== PAUSE TestAccAPIGatewayMethod_basic
=== RUN   TestAccAPIGatewayMethod_customAuthorizer
=== PAUSE TestAccAPIGatewayMethod_customAuthorizer
=== RUN   TestAccAPIGatewayMethod_cognitoAuthorizer
=== PAUSE TestAccAPIGatewayMethod_cognitoAuthorizer
=== RUN   TestAccAPIGatewayMethod_customRequestValidator
=== PAUSE TestAccAPIGatewayMethod_customRequestValidator
=== RUN   TestAccAPIGatewayMethod_disappears
=== PAUSE TestAccAPIGatewayMethod_disappears
=== RUN   TestAccAPIGatewayMethod_operationName
=== PAUSE TestAccAPIGatewayMethod_operationName
=== CONT  TestAccAPIGatewayMethod_basic
=== CONT  TestAccAPIGatewayMethod_customRequestValidator
=== CONT  TestAccAPIGatewayMethod_disappears
=== CONT  TestAccAPIGatewayMethod_cognitoAuthorizer
=== CONT  TestAccAPIGatewayMethod_operationName
=== CONT  TestAccAPIGatewayMethod_customAuthorizer
--- PASS: TestAccAPIGatewayMethod_basic (23.36s)
--- PASS: TestAccAPIGatewayMethod_customRequestValidator (23.38s)
--- PASS: TestAccAPIGatewayMethod_customAuthorizer (92.07s)
--- PASS: TestAccAPIGatewayMethod_operationName (180.28s)
--- PASS: TestAccAPIGatewayMethod_cognitoAuthorizer (180.39s)
--- PASS: TestAccAPIGatewayMethod_disappears (191.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	195.316s
```
