### PR TITLE
Replace golangci `errcheck` `ignore` with `exclude-functions`

### DIFF
--- a/.ci/.golangci2.yml
+++ b/.ci/.golangci2.yml
@@ -34,20 +34,11 @@ linters-settings:
   dogsled:
     max-blank-identifiers: 3
   errcheck:
-    ignore: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set
-    # "ignore" is deprecated but "exclude-functions" doesn't seem to work or the syntax is non-obvious.
-    # https://github.com/kisielk/errcheck#excluding-functions
-    # Under exclude-functions are the various attempts at getting it to work, all of which result in d.Set being linted everywhere.
-    # exclude-functions:
-    #   - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).Set
-    #   - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceData.Set
-    #   - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set,io:Close
-    #   - (github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceData).Set
-    #   - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set
-    #   - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew
-    #   - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:Set
-    #   - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.Set
-    #   - io:Close
+    exclude-functions:
+      - (*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceData).Set
+      - (*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceDiff).SetNewComputed
+      - (*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceDiff).ForceNew
+      - io:Close
   errorlint:
     errorf: false
   goconst:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

@gdavison I believe I have the right syntax for the golangci `linters.errcheck.exclude-functions` configuration.  Change is update the yaml as follows:

```
    exclude-functions:
      - (*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceData).Set
      - (*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceDiff).SetNewComputed
      - (*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceDiff).ForceNew
      - io:Close
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

N/a

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://github.com/hashicorp/terraform-provider-aws/blob/8d4fd10c76ecc212ac3acc4d6657772c14ff24a4/.ci/.golangci2.yml#L36-L50

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

(only `errcheck` run)

```console
% golangci-lint -v run -c .ci/.golangci2.yml --enable-only errcheck
INFO golangci-lint has version v1.62.0 built with go1.23.3 from (unknown, modified: ?, mod sum: "") on (unknown) 
INFO [config_reader] Used config file .ci/.golangci2.yml 
INFO [lintersdb] Active 1 linters: [errcheck]     
INFO [loader] Go packages loading at mode 8767 (files|imports|compiled_files|deps|types_sizes|exports_file|name) took 9.22979666s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 719.354946ms 
INFO [linters_context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 65, after processing: 0 
INFO [runner] Processors filtering stat (in/out): identifier_marker: 65/65, exclude: 65/65, skip_dirs: 65/65, exclude-rules: 65/0, path_prettifier: 65/65, cgo: 65/65, invalid_issue: 65/65, autogenerated_exclude: 65/65, filename_unadjuster: 65/65, skip_files: 65/65 
INFO [runner] processing took 4.470971ms with stages: autogenerated_exclude: 2.820878ms, identifier_marker: 833.331µs, path_prettifier: 508.345µs, exclude-rules: 145.122µs, skip_dirs: 138.718µs, cgo: 10.171µs, invalid_issue: 6.949µs, filename_unadjuster: 2.911µs, max_same_issues: 1.103µs, nolint: 830ns, uniq_by_line: 349ns, skip_files: 334ns, fixer: 292ns, path_prefixer: 246ns, exclude: 235ns, sort_results: 220ns, severity-rules: 179ns, max_from_linter: 179ns, source_code: 150ns, path_shortener: 148ns, diff: 146ns, max_per_file_from_linter: 135ns 
INFO [runner] linters took 6.035571945s with stages: goanalysis_metalinter: 6.030847117s 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 162 samples, avg is 127.6MB, max is 258.7MB 
INFO Execution took 16.027529803s 
```
