### PR TITLE
d/aws_elbv2_listener_rule(test): fix flaky test configuration

### DIFF
--- a/internal/service/elbv2/listener_rule_data_source_test.go
+++ b/internal/service/elbv2/listener_rule_data_source_test.go
@@ -432,6 +432,7 @@ func TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness(t *testi
 
 	var listenerRule awstypes.Rule
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName = rName[:min(len(rName), 30)]
 	dataSourceName := "data.aws_lb_listener_rule.test"
 	resourceName := "aws_lb_listener_rule.test"
 
@@ -1106,7 +1107,7 @@ resource "aws_security_group" "test" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
-`, rName[:30]))
+`, rName))
 }
 
 func testAccListenerRuleDataSourceConfig_actionRedirect(rName string) string {


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change prevents intermittent panics caused by variable lengths of the random integer appended to the generated resource name. This approach now mirrors how the corresponding resoure acceptance test handles truncating the generated resource name.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40136 


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elbv2 TESTS=TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness'  -timeout 360m
2024/11/15 09:31:54 Initializing Terraform AWS Provider...

--- PASS: TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness (237.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      243.811s
```
