### PR TITLE
d/aws_subnet: use `Tags` field from `DescribeSubnets` response

### DIFF
--- a/.changelog/40144.txt
+++ b/.changelog/40144.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_subnet: Set `tags` from the `DescribeSubnets` response, removing the need for the `ec2:DescribeTags` IAM permission
+```

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -476,9 +476,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceSubnet,
 			TypeName: "aws_subnet",
-			Tags: &types.ServicePackageResourceTags{
-				IdentifierAttribute: names.AttrID,
-			},
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  dataSourceSubnets,

--- a/internal/service/ec2/vpc_subnet_data_source.go
+++ b/internal/service/ec2/vpc_subnet_data_source.go
@@ -20,8 +20,8 @@ import (
 )
 
 // @SDKDataSource("aws_subnet")
-// @Tags(identifierAttribute="id")
-// @Testing(generator=false)
+// @Tags
+// @Testing(tagsIdentifierAttribute="id", generator=false)
 func dataSourceSubnet() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSubnetRead,
@@ -237,6 +237,7 @@ func dataSourceSubnetRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	d.Set(names.AttrVPCID, subnet.VpcId)
+	setTagsOut(ctx, subnet.Tags)
 
 	return diags
 }

--- a/internal/service/ec2/vpc_subnet_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_subnet_data_source_tags_gen_test.go
@@ -3,6 +3,7 @@
 package ec2_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -11,6 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
+	tfec2 "github.com/hashicorp/terraform-provider-aws/internal/service/ec2"
+	"github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -140,7 +144,7 @@ func TestAccVPCSubnetDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
 						acctest.CtResourceKey1: knownvalue.StringExact(acctest.CtResourceValue1),
 					})),
-					expectFullDataSourceTags(dataSourceName, knownvalue.MapExact(map[string]knownvalue.Check{
+					expectFullSubnetDataSourceTags(dataSourceName, knownvalue.MapExact(map[string]knownvalue.Check{
 						acctest.CtProviderKey1: knownvalue.StringExact(acctest.CtProviderValue1),
 						acctest.CtResourceKey1: knownvalue.StringExact(acctest.CtResourceValue1),
 					})),
@@ -171,7 +175,7 @@ func TestAccVPCSubnetDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 				},
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
-					expectFullDataSourceTags(dataSourceName, knownvalue.MapExact(map[string]knownvalue.Check{
+					expectFullSubnetDataSourceTags(dataSourceName, knownvalue.MapExact(map[string]knownvalue.Check{
 						acctest.CtResourceKey1: knownvalue.StringExact(acctest.CtResourceValue1),
 					})),
 				},
@@ -179,4 +183,10 @@ func TestAccVPCSubnetDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 			},
 		},
 	})
+}
+
+func expectFullSubnetDataSourceTags(resourceAddress string, knownValue knownvalue.Check) statecheck.StateCheck {
+	return tfstatecheck.ExpectFullDataSourceTagsSpecTags(tfec2.ServicePackage(context.Background()), resourceAddress, &types.ServicePackageResourceTags{
+		IdentifierAttribute: names.AttrID,
+	}, knownValue)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change modifies the transparent tagging configuration for this data source to use the `Tags` field from the `DescribeSubnets` response, rather than making an additional call to the `DescribeTags` API. As a side effect, this data source will no longer require the calling principal to have the `ec2:DescribeTags` IAM permission, fixing a regression introduced in `v5.73.0`.

---

As additional confirmation that this change no longer results in calls to the `DescribeTags` API I created a simple configuration with the following subnet data source. 

```
data "aws_subnet" "by_id" {
  id = aws_subnet.test.id
}
```

After the initial infrastructure is provisioned, this data source is read on every plan operation. By searching the debug logs for a plan operation with `v5.76.0` (latest release) and a build from this release branch, it can be confirmed that the data source is no longer making the additional API call.

**`v5.76.0`:**
```console
% TF_LOG=debug terraform plan &> plan-old.out
% rg "Action\=DescribeTags" plan-old.out
514:  | Action=DescribeTags&Filter.1.Name=resource-id&Filter.1.Value.1=subnet-0ae0a93e8c9560290&Version=2016-11-15
```

**This branch:**
```console
% TF_LOG=debug TF_CLI_CONFIG_FILE=dev.tfrc terraform plan &> plan.out
% rg "Action\=DescribeTags" plan.out
(no results)
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40104


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS=TestAccVPCSubnetDataSource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCSubnetDataSource_'  -timeout 360m
2024/11/15 10:06:55 Initializing Terraform AWS Provider...

=== NAME  TestAccVPCSubnetDataSource_enableLniAtDeviceIndex
    vpc_subnet_data_source_test.go:197: skipping since no Outposts found
--- SKIP: TestAccVPCSubnetDataSource_enableLniAtDeviceIndex (0.79s)
--- PASS: TestAccVPCSubnetDataSource_tags_EmptyMap (19.23s)
--- PASS: TestAccVPCSubnetDataSource_tags (19.64s)
--- PASS: TestAccVPCSubnetDataSource_tags_NullMap (19.64s)
--- PASS: TestAccVPCSubnetDataSource_tags_IgnoreTags_Overlap_DefaultTag (19.73s)
--- PASS: TestAccVPCSubnetDataSource_tags_DefaultTags_nonOverlapping (19.74s)
--- PASS: TestAccVPCSubnetDataSource_basic (20.45s)
--- PASS: TestAccVPCSubnetDataSource_tags_IgnoreTags_Overlap_ResourceTag (20.92s)
--- PASS: TestAccVPCSubnetDataSource_ipv6ByIPv6CIDRBlock (36.98s)
--- PASS: TestAccVPCSubnetDataSource_ipv6ByIPv6Filter (37.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        42.238s
```
