### PR TITLE
[Help Wanted] Migrate Batch Job Definition to Framework + AutoFlex

### DIFF
--- a/internal/service/batch/exports_test.go
+++ b/internal/service/batch/exports_test.go
@@ -6,7 +6,7 @@ package batch
 // Exports for use in tests only.
 var (
 	ResourceComputeEnvironment = resourceComputeEnvironment
-	ResourceJobDefinition      = resourceJobDefinition
+	ResourceJobDefinition      = newResourceJobDefinition
 	ResourceJobQueue           = newJobQueueResource
 	ResourceSchedulingPolicy   = resourceSchedulingPolicy
 

--- a/internal/service/batch/job_definition_data_source.go
+++ b/internal/service/batch/job_definition_data_source.go
@@ -235,9 +235,26 @@ type eksPropertiesModel struct {
 	PodProperties fwtypes.ListNestedObjectValueOf[eksPodPropertiesModel] `tfsdk:"pod_properties"`
 }
 
+type DNSPolicy struct {
+	types.String
+}
+
+func (d DNSPolicy) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	for _, v := range dnsPolicy_Values() {
+		if strings.EqualFold(v, req.ConfigValue.ValueString()) {
+			return
+		}
+	}
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid DNS Policy",
+		fmt.Sprintf("must be one of %s", strings.Join(dnsPolicy_Values(), ", ")),
+	)
+}
+
 type eksPodPropertiesModel struct {
 	Containers            fwtypes.ListNestedObjectValueOf[eksContainerModel]   `tfsdk:"containers"`
-	DNSPolicy             types.String                                         `tfsdk:"dns_policy"`
+	DNSPolicy             DNSPolicy                                            `tfsdk:"dns_policy"`
 	HostNetwork           types.Bool                                           `tfsdk:"host_network"`
 	ImagePullSecrets      fwtypes.ListNestedObjectValueOf[eksImagePullSecrets] `tfsdk:"image_pull_secrets"`
 	InitContainers        fwtypes.ListNestedObjectValueOf[eksContainerModel]   `tfsdk:"init_containers"`
@@ -251,12 +268,29 @@ type eksImagePullSecrets struct {
 	Name types.String `tfsdk:"name"`
 }
 
+type ImagePullPolicy struct {
+	types.String
+}
+
+func (d ImagePullPolicy) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	for _, v := range imagePullPolicy_Values() {
+		if strings.EqualFold(v, req.ConfigValue.ValueString()) {
+			return
+		}
+	}
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid Image Pull Secret",
+		fmt.Sprintf("must be one of %s", strings.Join(imagePullPolicy_Values(), ", ")),
+	)
+}
+
 type eksContainerModel struct {
 	Args            fwtypes.ListValueOf[types.String]                                      `tfsdk:"args"`
 	Command         fwtypes.ListValueOf[types.String]                                      `tfsdk:"command"`
 	Env             fwtypes.ListNestedObjectValueOf[eksContainerEnvironmentVariableModel]  `tfsdk:"env"`
 	Image           types.String                                                           `tfsdk:"image"`
-	ImagePullPolicy types.String                                                           `tfsdk:"image_pull_policy"`
+	ImagePullPolicy ImagePullPolicy                                                        `tfsdk:"image_pull_policy"`
 	Name            types.String                                                           `tfsdk:"name"`
 	Resources       fwtypes.ListNestedObjectValueOf[eksContainerResourceRequirementsModel] `tfsdk:"resources"`
 	SecurityContext fwtypes.ListNestedObjectValueOf[eksContainerSecurityContextModel]      `tfsdk:"security_context"`

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -192,7 +192,7 @@ func TestAccBatchJobDefinition_disappears(t *testing.T) {
 				Config: testAccJobDefinitionConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
-					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfbatch.ResourceJobDefinition(), resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfbatch.ResourceJobDefinition, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/internal/service/batch/job_definition_types.go
+++ b/internal/service/batch/job_definition_types.go
@@ -30,11 +30,11 @@ func (m *ecsStringPlanModifier) PlanModifyString(ctx context.Context, req planmo
 }
 
 func (m *ecsStringPlanModifier) Description(ctx context.Context) string {
-	return "Compares JSON strings by parsing and comparing their content"
+	return "compares ecs properties by parsing and comparing their content"
 }
 
 func (m *ecsStringPlanModifier) MarkdownDescription(ctx context.Context) string {
-	return "Compares JSON strings by parsing and comparing their content"
+	return m.Description(ctx)
 }
 
 func ECSStringPlanModifier() planmodifier.String {
@@ -57,11 +57,11 @@ func (m *containerPropertiesStringPlanModifier) PlanModifyString(ctx context.Con
 }
 
 func (m *containerPropertiesStringPlanModifier) Description(ctx context.Context) string {
-	return "Compares JSON strings by parsing and comparing their content"
+	return "compares container properties by parsing and comparing their content"
 }
 
 func (m *containerPropertiesStringPlanModifier) MarkdownDescription(ctx context.Context) string {
-	return "Compares JSON strings by parsing and comparing their content"
+	return m.Description(ctx)
 }
 
 func ContainerPropertiesStringPlanModifier() planmodifier.String {
@@ -84,11 +84,11 @@ func (m *nodePropertiesStringPlanModifier) PlanModifyString(ctx context.Context,
 }
 
 func (m *nodePropertiesStringPlanModifier) Description(ctx context.Context) string {
-	return "Compares JSON strings by parsing and comparing their content"
+	return "compares node properties by parsing and comparing their content"
 }
 
 func (m *nodePropertiesStringPlanModifier) MarkdownDescription(ctx context.Context) string {
-	return "Compares JSON strings by parsing and comparing their content"
+	return m.Description(ctx)
 }
 
 func NodePropertiesStringPlanModifier() planmodifier.String {

--- a/internal/service/batch/job_definition_types.go
+++ b/internal/service/batch/job_definition_types.go
@@ -1,0 +1,96 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package batch
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// This file is meant to be used as a plan modifier from the
+// It provides plan modifiers for comparing JSON strings representing the properties
+// Eventually this can be removed with #29817
+// DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool
+// DiffSuppressOnRefresh: true,
+// ValidateFunc:          validJobContainerProperties,
+
+type ecsStringPlanModifier struct{}
+
+func (m *ecsStringPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.PlanValue.IsNull() || req.StateValue.IsNull() {
+		return
+	}
+
+	ok, err := equivalentECSPropertiesJSON(req.PlanValue.ValueString(), req.StateValue.ValueString())
+	if err == nil && ok {
+		resp.PlanValue = req.StateValue
+	}
+}
+
+func (m *ecsStringPlanModifier) Description(ctx context.Context) string {
+	return "Compares JSON strings by parsing and comparing their content"
+}
+
+func (m *ecsStringPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return "Compares JSON strings by parsing and comparing their content"
+}
+
+func ECSStringPlanModifier() planmodifier.String {
+	return &ecsStringPlanModifier{}
+}
+
+type containerPropertiesStringPlanModifier struct{}
+
+func (m *containerPropertiesStringPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.PlanValue.IsNull() || req.StateValue.IsNull() {
+		return
+	}
+
+	ok, err := equivalentContainerPropertiesJSON(req.PlanValue.ValueString(), req.StateValue.ValueString())
+	if err == nil && ok {
+		// If the query specifications are equivalent, suppress the diff
+		// by setting the plan value to value already in state.
+		resp.PlanValue = req.StateValue
+	}
+}
+
+func (m *containerPropertiesStringPlanModifier) Description(ctx context.Context) string {
+	return "Compares JSON strings by parsing and comparing their content"
+}
+
+func (m *containerPropertiesStringPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return "Compares JSON strings by parsing and comparing their content"
+}
+
+func ContainerPropertiesStringPlanModifier() planmodifier.String {
+	return &containerPropertiesStringPlanModifier{}
+}
+
+type nodePropertiesStringPlanModifier struct{}
+
+func (m *nodePropertiesStringPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.PlanValue.IsNull() || req.StateValue.IsNull() {
+		return
+	}
+
+	ok, err := equivalentNodePropertiesJSON(req.PlanValue.ValueString(), req.StateValue.ValueString())
+	if err == nil && ok {
+		// If the query specifications are equivalent, suppress the diff
+		// by setting the plan value to value already in state.
+		resp.PlanValue = req.StateValue
+	}
+}
+
+func (m *nodePropertiesStringPlanModifier) Description(ctx context.Context) string {
+	return "Compares JSON strings by parsing and comparing their content"
+}
+
+func (m *nodePropertiesStringPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return "Compares JSON strings by parsing and comparing their content"
+}
+
+func NodePropertiesStringPlanModifier() planmodifier.String {
+	return &nodePropertiesStringPlanModifier{}
+}

--- a/internal/service/batch/service_package_gen.go
+++ b/internal/service/batch/service_package_gen.go
@@ -33,6 +33,10 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 				IdentifierAttribute: names.AttrARN,
 			},
 		},
+		{
+			Factory: newResourceJobDefinition,
+			Name:    "Job Definition",
+		},
 	}
 }
 
@@ -65,14 +69,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			Factory:  resourceComputeEnvironment,
 			TypeName: "aws_batch_compute_environment",
 			Name:     "Compute Environment",
-			Tags: &types.ServicePackageResourceTags{
-				IdentifierAttribute: names.AttrARN,
-			},
-		},
-		{
-			Factory:  resourceJobDefinition,
-			TypeName: "aws_batch_job_definition",
-			Name:     "Job Definition",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Looking to migrate this resource to framework. A lot of the code can be removed with auto flex, and will make migration on #29817 a little easier down the line. I'm currently running into a couple bugs that I am struggling to fix, and would love some assistance on.

- [ ] SDK uses `DiffSuppressFunc` to do comparison of the `container_properties` `node_properties` and `ecs_properties`. Currently when writing back to state, the sdk will add the empty arrays, so the strings are different. 
```
 new value: .container_properties: was
        cty.StringVal("{\"command\":[\"echo\",\"test\"],\"image\":\"busybox\",\"memory\":128,\"vcpus\":1}"),
        but now
        cty.StringVal("{\"command\":[\"echo\",\"test\"],\"environment\":[],\"image\":\"busybox\",\"memory\":128,\"mountPoints\":[],\"resourceRequirements\":[],\"secrets\":[],\"ulimits\":[],\"vcpus\":1,\"volumes\":[]}").
```

Maybe [relevant code](https://github.com/hashicorp/terraform-provider-aws/blob/37786fefbe3d4855608345568a00f7f629e466da/internal/service/batch/ecs_properties.go#L28-L69)

- [ ] Null to empty. I think this is something to do with a missing upgrade function, but adding the `legacy` tag on auto flex doesn't seem to resolve it.
```
.parameters: was null, but now cty.MapValEmpty(cty.String).
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
