### PR TITLE
feat: add new linking_mode NO_REGIONS to security hub aggregator

### DIFF
--- a/.changelog/40156.txt
+++ b/.changelog/40156.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_securityhub_finding_aggregator: Add new linking_mode NO_REGIONS
+```

--- a/internal/service/securityhub/finding_aggregator.go
+++ b/internal/service/securityhub/finding_aggregator.go
@@ -23,6 +23,7 @@ import (
 const (
 	linkingModeAllRegions                = "ALL_REGIONS"
 	linkingModeAllRegionsExceptSpecified = "ALL_REGIONS_EXCEPT_SPECIFIED"
+	linkingModeNoRegions                 = "NO_REGIONS"
 	linkingModeSpecifiedRegions          = "SPECIFIED_REGIONS"
 )
 
@@ -30,6 +31,7 @@ func linkingMode_Values() []string {
 	return []string{
 		linkingModeAllRegions,
 		linkingModeAllRegionsExceptSpecified,
+		linkingModeNoRegions,
 		linkingModeSpecifiedRegions,
 	}
 }

--- a/internal/service/securityhub/finding_aggregator_test.go
+++ b/internal/service/securityhub/finding_aggregator_test.go
@@ -153,7 +153,7 @@ resource "aws_securityhub_finding_aggregator" "test_aggregator" {
 
   depends_on = [aws_securityhub_account.example]
 }
-`, names.EUWest3RegionID, names.EUWest2RegionID, names.USEast1RegionID)
+`, names.EUWest1RegionID, names.EUWest2RegionID, names.USEast1RegionID)
 }
 
 func testAccFindingAggregatorConfig_allRegionsExceptSpecified() string {
@@ -166,7 +166,7 @@ resource "aws_securityhub_finding_aggregator" "test_aggregator" {
 
   depends_on = [aws_securityhub_account.example]
 }
-`, names.EUWest3RegionID, names.EUWest2RegionID)
+`, names.EUWest1RegionID, names.EUWest2RegionID)
 }
 
 func testAccFindingAggregatorConfig_noRegions() string {

--- a/internal/service/securityhub/finding_aggregator_test.go
+++ b/internal/service/securityhub/finding_aggregator_test.go
@@ -56,6 +56,14 @@ func testAccFindingAggregator_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "specified_regions.#", "2"),
 				),
 			},
+			{
+				Config: testAccFindingAggregatorConfig_noRegions(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFindingAggregatorExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "linking_mode", "NO_REGIONS"),
+					resource.TestCheckResourceAttr(resourceName, "specified_regions.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -145,7 +153,7 @@ resource "aws_securityhub_finding_aggregator" "test_aggregator" {
 
   depends_on = [aws_securityhub_account.example]
 }
-`, names.EUWest1RegionID, names.EUWest2RegionID, names.USEast1RegionID)
+`, names.EUWest3RegionID, names.EUWest2RegionID, names.USEast1RegionID)
 }
 
 func testAccFindingAggregatorConfig_allRegionsExceptSpecified() string {
@@ -158,5 +166,17 @@ resource "aws_securityhub_finding_aggregator" "test_aggregator" {
 
   depends_on = [aws_securityhub_account.example]
 }
-`, names.EUWest1RegionID, names.EUWest2RegionID)
+`, names.EUWest3RegionID, names.EUWest2RegionID)
+}
+
+func testAccFindingAggregatorConfig_noRegions() string {
+	return `
+resource "aws_securityhub_account" "example" {}
+
+resource "aws_securityhub_finding_aggregator" "test_aggregator" {
+  linking_mode = "NO_REGIONS"
+
+  depends_on = [aws_securityhub_account.example]
+}
+`
 }

--- a/website/docs/r/securityhub_finding_aggregator.html.markdown
+++ b/website/docs/r/securityhub_finding_aggregator.html.markdown
@@ -60,7 +60,7 @@ resource "aws_securityhub_finding_aggregator" "example" {
 
 This resource supports the following arguments:
 
-- `linking_mode` - (Required) Indicates whether to aggregate findings from all of the available Regions or from a specified list. The options are `ALL_REGIONS`, `NO_REGIONS`, `ALL_REGIONS_EXCEPT_SPECIFIED` or `SPECIFIED_REGIONS`. When `ALL_REGIONS` or `ALL_REGIONS_EXCEPT_SPECIFIED` are used, Security Hub will automatically aggregate findings from new Regions as Security Hub supports them and you opt into them.
+- `linking_mode` - (Required) Indicates whether to aggregate findings from all of the available Regions or from a specified list. The options are `ALL_REGIONS`, `ALL_REGIONS_EXCEPT_SPECIFIED`, `SPECIFIED_REGIONS` or `NO_REGIONS`. When `ALL_REGIONS` or `ALL_REGIONS_EXCEPT_SPECIFIED` are used, Security Hub will automatically aggregate findings from new Regions as Security Hub supports them and you opt into them.
 - `specified_regions` - (Optional) List of regions to include or exclude (required if `linking_mode` is set to `ALL_REGIONS_EXCEPT_SPECIFIED` or `SPECIFIED_REGIONS`)
 
 ## Attribute Reference

--- a/website/docs/r/securityhub_finding_aggregator.html.markdown
+++ b/website/docs/r/securityhub_finding_aggregator.html.markdown
@@ -60,7 +60,7 @@ resource "aws_securityhub_finding_aggregator" "example" {
 
 This resource supports the following arguments:
 
-- `linking_mode` - (Required) Indicates whether to aggregate findings from all of the available Regions or from a specified list. The options are `ALL_REGIONS`, `ALL_REGIONS_EXCEPT_SPECIFIED` or `SPECIFIED_REGIONS`. When `ALL_REGIONS` or `ALL_REGIONS_EXCEPT_SPECIFIED` are used, Security Hub will automatically aggregate findings from new Regions as Security Hub supports them and you opt into them.
+- `linking_mode` - (Required) Indicates whether to aggregate findings from all of the available Regions or from a specified list. The options are `ALL_REGIONS`, `NO_REGIONS`, `ALL_REGIONS_EXCEPT_SPECIFIED` or `SPECIFIED_REGIONS`. When `ALL_REGIONS` or `ALL_REGIONS_EXCEPT_SPECIFIED` are used, Security Hub will automatically aggregate findings from new Regions as Security Hub supports them and you opt into them.
 - `specified_regions` - (Optional) List of regions to include or exclude (required if `linking_mode` is set to `ALL_REGIONS_EXCEPT_SPECIFIED` or `SPECIFIED_REGIONS`)
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The Security Hub finding aggregator resource should allow a linking_mode of 'NO_REGIONS'.

 - https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_CreateFindingAggregator.html

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39390

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccSecurityHub_serial/FindingAggregator PKG=securityhub
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/securityhub/... -v -count 1 -parallel 20 -run='TestAccSecurityHub_serial/FindingAggregator'  -timeout 360m
2024/11/17 09:46:18 Initializing Terraform AWS Provider...
=== RUN   TestAccSecurityHub_serial
=== PAUSE TestAccSecurityHub_serial
=== CONT  TestAccSecurityHub_serial
=== RUN   TestAccSecurityHub_serial/FindingAggregator
=== RUN   TestAccSecurityHub_serial/FindingAggregator/basic
=== RUN   TestAccSecurityHub_serial/FindingAggregator/disappears
--- PASS: TestAccSecurityHub_serial (76.10s)
    --- PASS: TestAccSecurityHub_serial/FindingAggregator (76.10s)
        --- PASS: TestAccSecurityHub_serial/FindingAggregator/basic (57.64s)
        --- PASS: TestAccSecurityHub_serial/FindingAggregator/disappears (18.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/securityhub        91.404s

...
```
