### PR TITLE
feat: update default value for CloudFront distribution  argument

### DIFF
--- a/.changelog/40157.txt
+++ b/.changelog/40157.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_aws_cloudfront_distribution: Change the default value of `is_ipv6_enabled` from `false` to `true`
+```

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -304,7 +304,7 @@ func resourceDistribution() *schema.Resource {
 			"is_ipv6_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 			"last_modified_time": {
 				Type:     schema.TypeString,

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -702,7 +702,7 @@ func TestAccCloudFrontDistribution_noOptionalItems(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "etag", regexache.MustCompile(`^[0-9A-Z]+$`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrHostedZoneID, "Z2FDTNDATAQYW2"),
 					resource.TestCheckResourceAttrSet(resourceName, "http_version"),
-					resource.TestCheckResourceAttr(resourceName, "is_ipv6_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "is_ipv6_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "logging_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "origin.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "origin.*", map[string]string{

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -249,7 +249,7 @@ The CloudFront distribution argument layout is a complex structure composed of s
 * `default_cache_behavior` (Required) - [Default cache behavior](#default-cache-behavior-arguments) for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
 * `default_root_object` (Optional) - Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.
 * `enabled` (Required) - Whether the distribution is enabled to accept end user requests for content.
-* `is_ipv6_enabled` (Optional) - Whether the IPv6 is enabled for the distribution.
+* `is_ipv6_enabled` (Optional) - Whether the IPv6 is enabled for the distribution. Default: `true`.
 * `http_version` (Optional) - Maximum HTTP version to support on the distribution. Allowed values are `http1.1`, `http2`, `http2and3` and `http3`. The default is `http2`.
 * `logging_config` (Optional) - The [logging configuration](#logging-config-arguments) that controls how logs are written to your distribution (maximum one).
 * `ordered_cache_behavior` (Optional) - Ordered list of [cache behaviors](#cache-behavior-arguments) resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0.


### PR DESCRIPTION
### Description

As explained in #39911 on Oct 6, 2016  AWS announced [here](https://aws.amazon.com/about-aws/whats-new/2016/10/ipv6-support-for-cloudfront-waf-and-s3-transfer-acceleration/)

> IPv6 will be enabled by default for all newly created Amazon CloudFront web distributions starting today.

In the current AWS provider version the default value for `is_ipv6_enabled` is set to [`false`](https://github.com/hashicorp/terraform-provider-aws/blob/0574c999b92b638e45784db97ddf4352d0342be0/internal/service/cloudfront/distribution.go#L307).

This PR updates the default value and adds the details also to the resource documentation.

### Relations

Closes #39911 

### References

- [AWS Blog Post](https://aws.amazon.com/about-aws/whats-new/2016/10/ipv6-support-for-cloudfront-waf-and-s3-transfer-acceleration/)
- AWS Management Console screenhot showing "IPv6 Enabled" when creating a new distribution.
![image](https://github.com/user-attachments/assets/03a3ddec-a46f-4ef3-955b-ffbbe57ef8c6)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
❯ make testacc TESTS=TestAccCloudFrontDistribution PKG=cloudfront
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontDistribution'  -timeout 360m
2024/11/17 17:38:28 Initializing Terraform AWS Provider...
=== RUN   TestAccCloudFrontDistributionDataSource_basic
=== PAUSE TestAccCloudFrontDistributionDataSource_basic
=== RUN   TestAccCloudFrontDistribution_basic
=== PAUSE TestAccCloudFrontDistribution_basic
=== RUN   TestAccCloudFrontDistribution_disappears
=== PAUSE TestAccCloudFrontDistribution_disappears
=== RUN   TestAccCloudFrontDistribution_tags
=== PAUSE TestAccCloudFrontDistribution_tags
=== RUN   TestAccCloudFrontDistribution_s3Origin
=== PAUSE TestAccCloudFrontDistribution_s3Origin
=== RUN   TestAccCloudFrontDistribution_customOrigin
=== PAUSE TestAccCloudFrontDistribution_customOrigin
=== RUN   TestAccCloudFrontDistribution_originPolicyDefault
=== PAUSE TestAccCloudFrontDistribution_originPolicyDefault
=== RUN   TestAccCloudFrontDistribution_originPolicyOrdered
=== PAUSE TestAccCloudFrontDistribution_originPolicyOrdered
=== RUN   TestAccCloudFrontDistribution_multiOrigin
=== PAUSE TestAccCloudFrontDistribution_multiOrigin
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehavior
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehavior
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
=== RUN   TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== PAUSE TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
=== RUN   TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== PAUSE TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
=== RUN   TestAccCloudFrontDistribution_Origin_emptyDomainName
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyDomainName
=== RUN   TestAccCloudFrontDistribution_Origin_emptyOriginID
=== PAUSE TestAccCloudFrontDistribution_Origin_emptyOriginID
=== RUN   TestAccCloudFrontDistribution_Origin_connectionAttempts
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionAttempts
=== RUN   TestAccCloudFrontDistribution_Origin_connectionTimeout
=== PAUSE TestAccCloudFrontDistribution_Origin_connectionTimeout
=== RUN   TestAccCloudFrontDistribution_Origin_originShield
=== PAUSE TestAccCloudFrontDistribution_Origin_originShield
=== RUN   TestAccCloudFrontDistribution_Origin_originAccessControl
=== PAUSE TestAccCloudFrontDistribution_Origin_originAccessControl
=== RUN   TestAccCloudFrontDistribution_noOptionalItems
=== PAUSE TestAccCloudFrontDistribution_noOptionalItems
=== RUN   TestAccCloudFrontDistribution_http11
=== PAUSE TestAccCloudFrontDistribution_http11
=== RUN   TestAccCloudFrontDistribution_isIPV6Enabled
=== PAUSE TestAccCloudFrontDistribution_isIPV6Enabled
=== RUN   TestAccCloudFrontDistribution_noCustomErrorResponse
=== PAUSE TestAccCloudFrontDistribution_noCustomErrorResponse
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== RUN   TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== RUN   TestAccCloudFrontDistribution_enabled
=== PAUSE TestAccCloudFrontDistribution_enabled
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== RUN   TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== PAUSE TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== RUN   TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== RUN   TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== PAUSE TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== RUN   TestAccCloudFrontDistribution_waitForDeployment
=== PAUSE TestAccCloudFrontDistribution_waitForDeployment
=== RUN   TestAccCloudFrontDistribution_preconditionFailed
=== PAUSE TestAccCloudFrontDistribution_preconditionFailed
=== RUN   TestAccCloudFrontDistribution_originGroups
=== PAUSE TestAccCloudFrontDistribution_originGroups
=== CONT  TestAccCloudFrontDistributionDataSource_basic
=== CONT  TestAccCloudFrontDistribution_noOptionalItems
=== CONT  TestAccCloudFrontDistribution_originGroups
=== CONT  TestAccCloudFrontDistribution_preconditionFailed
=== CONT  TestAccCloudFrontDistribution_waitForDeployment
=== CONT  TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate
=== CONT  TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames
=== CONT  TestAccCloudFrontDistribution_enabled
=== CONT  TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers
=== CONT  TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames
=== CONT  TestAccCloudFrontDistribution_noCustomErrorResponse
=== CONT  TestAccCloudFrontDistribution_isIPV6Enabled
=== CONT  TestAccCloudFrontDistribution_http11
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedSigners (386.83s)
=== CONT  TestAccCloudFrontDistribution_Origin_originAccessControl
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValuesCookies_whitelistedNames (388.04s)
=== CONT  TestAccCloudFrontDistribution_Origin_originShield
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehaviorForwardedValues_headers (388.09s)
=== CONT  TestAccCloudFrontDistribution_Origin_connectionTimeout
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValues_headers (391.59s)
=== CONT  TestAccCloudFrontDistribution_Origin_connectionAttempts
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehaviorForwardedValuesCookies_whitelistedNames (393.35s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyOriginID
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_trustedKeyGroups (398.98s)
=== CONT  TestAccCloudFrontDistribution_Origin_emptyDomainName
--- PASS: TestAccCloudFrontDistribution_Origin_emptyOriginID (8.33s)
=== CONT  TestAccCloudFrontDistribution_forwardedValuesToCachePolicy
--- PASS: TestAccCloudFrontDistribution_OrderedCacheBehavior_realtimeLogARN (402.82s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy
--- PASS: TestAccCloudFrontDistribution_Origin_emptyDomainName (9.60s)
=== CONT  TestAccCloudFrontDistribution_customOrigin
--- PASS: TestAccCloudFrontDistribution_DefaultCacheBehavior_realtimeLogARN (412.39s)
=== CONT  TestAccCloudFrontDistribution_orderedCacheBehavior
--- PASS: TestAccCloudFrontDistributionDataSource_basic (442.09s)
=== CONT  TestAccCloudFrontDistribution_multiOrigin
--- PASS: TestAccCloudFrontDistribution_ViewerCertificateACMCertificateARN_conflictsWithCloudFrontDefaultCertificate (457.34s)
=== CONT  TestAccCloudFrontDistribution_originPolicyOrdered
--- PASS: TestAccCloudFrontDistribution_ViewerCertificate_acmCertificateARN (457.24s)
=== CONT  TestAccCloudFrontDistribution_originPolicyDefault
--- PASS: TestAccCloudFrontDistribution_http11 (808.38s)
=== CONT  TestAccCloudFrontDistribution_tags
--- PASS: TestAccCloudFrontDistribution_isIPV6Enabled (812.41s)
=== CONT  TestAccCloudFrontDistribution_s3Origin
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorCachePolicy (813.50s)
=== CONT  TestAccCloudFrontDistribution_disappears
--- PASS: TestAccCloudFrontDistribution_noOptionalItems (814.50s)
=== CONT  TestAccCloudFrontDistribution_basic
--- PASS: TestAccCloudFrontDistribution_noCustomErrorResponse (814.65s)
--- PASS: TestAccCloudFrontDistribution_originGroups (824.69s)
--- PASS: TestAccCloudFrontDistribution_waitForDeployment (845.57s)
--- PASS: TestAccCloudFrontDistribution_preconditionFailed (854.65s)
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehavior (655.11s)
--- PASS: TestAccCloudFrontDistribution_orderedCacheBehaviorResponseHeadersPolicy (673.79s)
--- PASS: TestAccCloudFrontDistribution_Origin_connectionTimeout (747.29s)
--- PASS: TestAccCloudFrontDistribution_multiOrigin (693.56s)
--- PASS: TestAccCloudFrontDistribution_enabled (1136.99s)
--- PASS: TestAccCloudFrontDistribution_Origin_connectionAttempts (747.54s)
--- PASS: TestAccCloudFrontDistribution_originPolicyOrdered (683.55s)
--- PASS: TestAccCloudFrontDistribution_originPolicyDefault (683.77s)
--- PASS: TestAccCloudFrontDistribution_forwardedValuesToCachePolicy (742.42s)
--- PASS: TestAccCloudFrontDistribution_customOrigin (736.55s)
--- PASS: TestAccCloudFrontDistribution_Origin_originShield (757.14s)
--- PASS: TestAccCloudFrontDistribution_disappears (343.45s)
--- PASS: TestAccCloudFrontDistribution_basic (349.63s)
--- PASS: TestAccCloudFrontDistribution_Origin_originAccessControl (780.62s)
--- PASS: TestAccCloudFrontDistribution_tags (391.89s)
--- PASS: TestAccCloudFrontDistribution_s3Origin (668.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 1481.541s
...
```
