### PR TITLE
r/aws_eks_addon: fix crash when updating `pod_identity_association`

### DIFF
--- a/.changelog/40168.txt
+++ b/.changelog/40168.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_addon: Fix crash when `pod_identity_association` is modified
+```

--- a/.changelog/40168.txt
+++ b/.changelog/40168.txt
@@ -1,3 +1,6 @@
 ```release-note:bug
 resource/aws_eks_addon: Fix crash when `pod_identity_association` is modified
 ```
+```release-note:bug
+resource/aws_eks_addon: Fix to prevent persistent differences when `pod_identity_association` is changed
+```

--- a/internal/service/eks/addon.go
+++ b/internal/service/eks/addon.go
@@ -270,7 +270,7 @@ func resourceAddonUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if d.HasChanges("addon_version", "service_account_role_arn", "configuration_values") {
+	if d.HasChanges("addon_version", "service_account_role_arn", "configuration_values", "pod_identity_association") {
 		input := &eks.UpdateAddonInput{
 			AddonName:          aws.String(addonName),
 			ClientRequestToken: aws.String(sdkid.UniqueId()),
@@ -288,6 +288,8 @@ func resourceAddonUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		if d.HasChange("pod_identity_association") {
 			if v, ok := d.GetOk("pod_identity_association"); ok && v.(*schema.Set).Len() > 0 {
 				input.PodIdentityAssociations = expandAddonPodIdentityAssociations(v.(*schema.Set).List())
+			} else {
+				input.PodIdentityAssociations = []types.AddonPodIdentityAssociations{}
 			}
 		}
 

--- a/internal/service/eks/addon.go
+++ b/internal/service/eks/addon.go
@@ -286,8 +286,8 @@ func resourceAddonUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if d.HasChange("pod_identity_association") {
-			if v, ok := d.GetOk("pod_identity_association"); ok && len(v.([]interface{})) > 0 {
-				input.PodIdentityAssociations = expandAddonPodIdentityAssociations(v.([]interface{}))
+			if v, ok := d.GetOk("pod_identity_association"); ok && v.(*schema.Set).Len() > 0 {
+				input.PodIdentityAssociations = expandAddonPodIdentityAssociations(v.(*schema.Set).List())
 			}
 		}
 

--- a/internal/service/eks/addon_test.go
+++ b/internal/service/eks/addon_test.go
@@ -381,6 +381,22 @@ func TestAccEKSAddon_podIdentityAssociation(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAddonConfig_basic(rName, addonName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAddonExists(ctx, resourceName, &addon),
+					resource.TestCheckResourceAttr(resourceName, "pod_identity_association.#", "0"),
+				),
+			},
+			{
+				Config: testAccAddonConfig_podIdentityAssociation(rName, addonName, serviceAccount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAddonExists(ctx, resourceName, &addon),
+					resource.TestCheckResourceAttr(resourceName, "pod_identity_association.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "pod_identity_association.0.role_arn", podIdentityRoleResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "pod_identity_association.0.service_account", serviceAccount),
+				),
+			},
 		},
 	})
 }
@@ -610,32 +626,36 @@ resource "aws_eks_addon" "test" {
 }
 
 func testAccAddonConfig_podIdentityAssociation(rName, addonName, serviceAccount string) string {
-	return acctest.ConfigCompose(testAccAddonConfig_base(rName), fmt.Sprintf(`
-resource "aws_iam_role" "test_pod_identity" {
-  name               = "test-pod-identity"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "sts:AssumeRole",
-        "sts:TagSession"
-	  ],
-      "Principal": {
-        "Service": "pods.eks.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
+	return acctest.ConfigCompose(
+		testAccAddonConfig_base(rName),
+		fmt.Sprintf(`
+data "aws_iam_policy_document" "test_assume_role" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
     }
-  ]
+  }
 }
-EOF
 
-  managed_policy_arns = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKS_CNI_Policy"]
+resource "aws_iam_role" "test_pod_identity" {
+  name               = "%1s-pod-identity"
+  assume_role_policy = data.aws_iam_policy_document.test_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "test-AmazonEKS_CNI_Policy" {
+  role       = aws_iam_role.test_pod_identity.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
 }
 
 resource "aws_eks_addon" "test" {
+  depends_on = [aws_iam_role_policy_attachment.test-AmazonEKS_CNI_Policy]
+
   cluster_name = aws_eks_cluster.test.name
   addon_name   = %[2]q
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously attempting to update this argument would result in a crash similar to the following:

```
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵
Releasing state lock. This may take a few moments...

Stack trace from the terraform-provider-aws_v5.76.0_x5 plugin:

panic: interface conversion: interface {} is *schema.Set, not []interface {}

goroutine 353 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/eks.resourceAddonUpdate({0x1196189a8, 0x14001bbedb0}, 0x14006991c00, {0x1192eeb60, 0x140003aaa00})
        github.com/hashicorp/terraform-provider-aws/internal/service/eks/addon.go:289 +0xdac
github.com/hashicorp/terraform-provider-aws/internal/provider.New.(*wrappedResource).Update.interceptedHandler[...].func11(0x14006991c00?, {0x1192eeb60?, 0x140003aaa00})
        github.com/hashicorp/terraform-provider-aws/internal/provider/intercept.go:113 +0x1d8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update(0x1196189a8?, {0x1196189a8?, 0x140019e8ea0?}, 0xd?, {0x1192eeb60?, 0x140003aaa00?})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/resource.go:835 +0x64
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x14001899c00, {0x1196189a8, 0x140019e8ea0}, 0x140069c25b0, 0x14006991a80, {0x1192eeb60, 0x140003aaa00})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/resource.go:947 +0x660
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x14002d944b0, {0x1196189a8?, 0x140019e8ae0?}, 0x14004cf2050)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/grpc_provider.go:1155 +0xaa4
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.(*muxServer).ApplyResourceChange(0x14001323a00, {0x1196189a8?, 0x140019e3f20?}, 0x14004cf2050)
        github.com/hashicorp/terraform-plugin-mux@v0.17.0/tf5muxserver/mux_server_ApplyResourceChange.go:36 +0x184
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0x140021172c0, {0x1196189a8?, 0x140019dd440?}, 0x140069cf7a0)
        github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov5/tf5server/server.go:865 +0x2a8
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x119186d80, 0x140021172c0}, {0x1196189a8, 0x140019dd440}, 0x14006991700, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:611 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x1400159d000, {0x1196189a8, 0x140019dd170}, {0x1196985c0, 0x14002fba000}, 0x14003f85440, 0x14002dd7d40, 0x1241083f8, 0x0)
        google.golang.org/grpc@v1.67.1/server.go:1394 +0xb64
google.golang.org/grpc.(*Server).handleStream(0x1400159d000, {0x1196985c0, 0x14002fba000}, 0x14003f85440)
        google.golang.org/grpc@v1.67.1/server.go:1805 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.67.1/server.go:1029 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 52
        google.golang.org/grpc@v1.67.1/server.go:1040 +0x13c

Error: The terraform-provider-aws_v5.76.0_x5 plugin crashed!
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40165
Relates #39973

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=eks TESTS="TestAccEKSAddon_"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSAddon_'  -timeout 360m
2024/11/18 11:11:28 Initializing Terraform AWS Provider...

--- PASS: TestAccEKSAddon_serviceAccountRoleARN (477.59s)
--- PASS: TestAccEKSAddon_preserve (527.40s)
--- PASS: TestAccEKSAddon_basic (541.70s)
--- PASS: TestAccEKSAddon_Disappears_cluster (565.12s)
--- PASS: TestAccEKSAddon_tags (589.28s)
--- PASS: TestAccEKSAddon_podIdentityAssociation (590.06s)
--- PASS: TestAccEKSAddon_addonVersion (623.80s)
--- PASS: TestAccEKSAddon_deprecated (628.77s)
--- PASS: TestAccEKSAddon_resolveConflicts (643.48s)
--- PASS: TestAccEKSAddon_disappears (654.73s)
--- PASS: TestAccEKSAddon_configurationValues (659.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/eks        664.703s
```