### PR TITLE
 r/batch_job_definition :bug: fix crash when EKS and ECS Properties defined on node_properties

### DIFF
--- a/.changelog/40172.txt
+++ b/.changelog/40172.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_batch_job_definition: Fix crash when specifying `eksProperties` or `ecsProperties` block
+```

--- a/internal/service/batch/eks_properties.go
+++ b/internal/service/batch/eks_properties.go
@@ -1,0 +1,166 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package batch
+
+import (
+	"cmp"
+	"slices"
+	_ "unsafe" // Required for go:linkname
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	_ "github.com/aws/aws-sdk-go-v2/service/batch" // Required for go:linkname
+	awstypes "github.com/aws/aws-sdk-go-v2/service/batch/types"
+	smithyjson "github.com/aws/smithy-go/encoding/json"
+	tfjson "github.com/hashicorp/terraform-provider-aws/internal/json"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+)
+
+type eksProperties awstypes.EksProperties
+
+func (ep *eksProperties) reduce() {
+	if ep.PodProperties == nil {
+		return
+	}
+	ep.orderContainers()
+	ep.orderEnvironmentVariables()
+
+	// Set all empty slices to nil.
+	if len(ep.PodProperties.Containers) == 0 {
+		ep.PodProperties.Containers = nil
+	} else {
+		for j, container := range ep.PodProperties.Containers {
+			if len(container.Args) == 0 {
+				container.Args = nil
+			}
+			if len(container.Command) == 0 {
+				container.Command = nil
+			}
+			if len(container.Env) == 0 {
+				container.Env = nil
+			}
+			if len(container.VolumeMounts) == 0 {
+				container.VolumeMounts = nil
+			}
+			ep.PodProperties.Containers[j] = container
+		}
+	}
+	if len(ep.PodProperties.InitContainers) == 0 {
+		ep.PodProperties.InitContainers = nil
+	} else {
+		for j, container := range ep.PodProperties.InitContainers {
+			if len(container.Args) == 0 {
+				container.Args = nil
+			}
+			if len(container.Command) == 0 {
+				container.Command = nil
+			}
+			if len(container.Env) == 0 {
+				container.Env = nil
+			}
+			if len(container.VolumeMounts) == 0 {
+				container.VolumeMounts = nil
+			}
+			ep.PodProperties.InitContainers[j] = container
+		}
+	}
+	if ep.PodProperties.DnsPolicy == nil {
+		ep.PodProperties.DnsPolicy = aws.String("ClusterFirst")
+	}
+	if ep.PodProperties.HostNetwork == nil {
+		ep.PodProperties.HostNetwork = aws.Bool(true)
+	}
+	if len(ep.PodProperties.Volumes) == 0 {
+		ep.PodProperties.Volumes = nil
+	}
+	if len(ep.PodProperties.ImagePullSecrets) == 0 {
+		ep.PodProperties.ImagePullSecrets = nil
+	}
+}
+
+func (ep *eksProperties) orderContainers() {
+	slices.SortFunc(ep.PodProperties.Containers, func(a, b awstypes.EksContainer) int {
+		return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
+	})
+}
+
+func (ep *eksProperties) orderEnvironmentVariables() {
+	for j, container := range ep.PodProperties.Containers {
+		// Remove environment variables with empty values.
+		container.Env = tfslices.Filter(container.Env, func(kvp awstypes.EksContainerEnvironmentVariable) bool {
+			return aws.ToString(kvp.Value) != ""
+		})
+
+		slices.SortFunc(container.Env, func(a, b awstypes.EksContainerEnvironmentVariable) int {
+			return cmp.Compare(aws.ToString(a.Name), aws.ToString(b.Name))
+		})
+
+		ep.PodProperties.Containers[j].Env = container.Env
+	}
+
+}
+
+func equivalentEKSPropertiesJSON(str1, str2 string) (bool, error) {
+	if str1 == "" {
+		str1 = "{}"
+	}
+
+	if str2 == "" {
+		str2 = "{}"
+	}
+
+	var ep1 eksProperties
+	err := tfjson.DecodeFromString(str1, &ep1)
+	if err != nil {
+		return false, err
+	}
+	ep1.reduce()
+	b1, err := tfjson.EncodeToBytes(ep1)
+	if err != nil {
+		return false, err
+	}
+
+	var ep2 eksProperties
+	err = tfjson.DecodeFromString(str2, &ep2)
+	if err != nil {
+		return false, err
+	}
+	ep2.reduce()
+	b2, err := tfjson.EncodeToBytes(ep2)
+	if err != nil {
+		return false, err
+	}
+
+	return tfjson.EqualBytes(b1, b2), nil
+}
+
+func expandEKSProperties(tfString string) (*awstypes.EksProperties, error) {
+	apiObject := &awstypes.EksProperties{}
+
+	if err := tfjson.DecodeFromString(tfString, apiObject); err != nil {
+		return nil, err
+	}
+
+	return apiObject, nil
+}
+
+// Dirty hack to avoid any backwards compatibility issues with the AWS SDK for Go v2 migration.
+// Reach down into the SDK and use the same serialization function that the SDK uses.
+//
+//go:linkname serializeEKSPProperties github.com/aws/aws-sdk-go-v2/service/batch.awsRestjson1_serializeDocumentEksProperties
+func serializeEKSPProperties(v *awstypes.EksProperties, value smithyjson.Value) error
+
+func flattenEKSroperties(apiObject *awstypes.EksProperties) (string, error) {
+	if apiObject == nil {
+		return "", nil
+	}
+
+	jsonEncoder := smithyjson.NewEncoder()
+	err := serializeEKSPProperties(apiObject, jsonEncoder.Value)
+
+	if err != nil {
+		return "", err
+	}
+
+	return jsonEncoder.String(), nil
+}

--- a/internal/service/batch/eks_properties.go
+++ b/internal/service/batch/eks_properties.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	_ "github.com/aws/aws-sdk-go-v2/service/batch" // Required for go:linkname
 	awstypes "github.com/aws/aws-sdk-go-v2/service/batch/types"
-	smithyjson "github.com/aws/smithy-go/encoding/json"
 	tfjson "github.com/hashicorp/terraform-provider-aws/internal/json"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 )
@@ -132,35 +131,4 @@ func equivalentEKSPropertiesJSON(str1, str2 string) (bool, error) {
 	}
 
 	return tfjson.EqualBytes(b1, b2), nil
-}
-
-func expandEKSProperties(tfString string) (*awstypes.EksProperties, error) {
-	apiObject := &awstypes.EksProperties{}
-
-	if err := tfjson.DecodeFromString(tfString, apiObject); err != nil {
-		return nil, err
-	}
-
-	return apiObject, nil
-}
-
-// Dirty hack to avoid any backwards compatibility issues with the AWS SDK for Go v2 migration.
-// Reach down into the SDK and use the same serialization function that the SDK uses.
-//
-//go:linkname serializeEKSPProperties github.com/aws/aws-sdk-go-v2/service/batch.awsRestjson1_serializeDocumentEksProperties
-func serializeEKSPProperties(v *awstypes.EksProperties, value smithyjson.Value) error
-
-func flattenEKSroperties(apiObject *awstypes.EksProperties) (string, error) {
-	if apiObject == nil {
-		return "", nil
-	}
-
-	jsonEncoder := smithyjson.NewEncoder()
-	err := serializeEKSPProperties(apiObject, jsonEncoder.Value)
-
-	if err != nil {
-		return "", err
-	}
-
-	return jsonEncoder.String(), nil
 }

--- a/internal/service/batch/eks_properties.go
+++ b/internal/service/batch/eks_properties.go
@@ -96,7 +96,6 @@ func (ep *eksProperties) orderEnvironmentVariables() {
 
 		ep.PodProperties.Containers[j].Env = container.Env
 	}
-
 }
 
 func equivalentEKSPropertiesJSON(str1, str2 string) (bool, error) {

--- a/internal/service/batch/eks_properties_test.go
+++ b/internal/service/batch/eks_properties_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package batch_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest/jsoncmp"
+	tfbatch "github.com/hashicorp/terraform-provider-aws/internal/service/batch"
+)
+
+func TestEquivalentEKSPropertiesJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		apiJSON           string
+		configurationJSON string
+		wantEquivalent    bool
+		wantErr           bool
+	}{
+		"empty": {
+			apiJSON:           ``,
+			configurationJSON: ``,
+			wantEquivalent:    true,
+		},
+		"reordered containers": {
+			apiJSON: `
+		{
+		    "podProperties": {
+		        "containers": [
+		          {
+		            "name": "container1",
+		            "image": "my_ecr_image1"
+		          },
+		          {
+		            "name": "container2",
+		            "image": "my_ecr_image2"
+		          }
+		        ]
+		    }
+		  }
+					`,
+			configurationJSON: `
+		{
+		    "podProperties": {
+		        "containers": [
+		          {
+		            "name": "container2",
+		            "image": "my_ecr_image2"
+		          },
+		          {
+		            "name": "container1",
+		            "image": "my_ecr_image1"
+		          }
+		        ]
+		    }
+		  }
+					`,
+			wantEquivalent: true,
+		},
+		"reordered environment": {
+			apiJSON: `
+		{
+		  "podProperties": {
+		      "containers": [
+		        {
+		          "name": "container1",
+		          "image": "my_ecr_image1",
+		          "env": [
+		            {
+		              "name": "VARNAME1",
+		              "value": "VARVAL1"
+		            },
+		            {
+		              "name": "VARNAME2",
+		              "value": "VARVAL2"
+		            }
+		          ]
+		        },
+		        {
+		          "name": "container2",
+		          "image": "my_ecr_image2",
+		          "env": []
+		        }
+		      ]
+		  }
+		}
+					`,
+			configurationJSON: `
+		{
+		  "podProperties": {
+		      "containers": [
+		        {
+		          "name": "container1",
+		          "image": "my_ecr_image1",
+		          "env": [
+		            {
+		              "name": "VARNAME2",
+		              "value": "VARVAL2"
+		            },
+		            {
+		              "name": "VARNAME1",
+		              "value": "VARVAL1"
+		            }
+		          ]
+		        },
+		        {
+		          "name": "container2",
+		          "image": "my_ecr_image2"
+		        }
+		      ]
+		    }
+		}
+					`,
+			wantEquivalent: true,
+		},
+		"full": {
+			apiJSON: `
+    {
+      "podProperties": {
+        "containers": [
+          {
+            "command": ["sleep", "60"],
+            "env": [
+              {
+                "name": "test",
+                "value": "Environment Variable"
+              }
+            ],
+            "image": "public.ecr.aws/amazonlinux/amazonlinux:1",
+            "volumeMounts": [],
+            "name": "container_a",
+            "resources": {
+              "requests": {
+                "cpu": "1.0",
+                "memory": "2048"
+              }
+            }
+          },
+          {
+            "command": ["sleep", "360"],
+            "env": [],
+            "image": "public.ecr.aws/amazonlinux/amazonlinux:1",
+            "volumeMounts": [],
+            "name": "container_b",
+            "resources": {
+              "requests": {
+                "cpu": "1.0",
+                "memory": "2048"
+              }
+            }
+          }
+        ],
+        "volumes": []
+      }
+    }
+		      `,
+			configurationJSON: `
+		{
+      "podProperties": {
+        "containers": [
+          {
+            "command": ["sleep", "60"],
+            "env": [
+              {
+                "name": "test",
+                "value": "Environment Variable"
+              }
+            ],
+            "image": "public.ecr.aws/amazonlinux/amazonlinux:1",
+            "name": "container_a",
+            "resources": {
+              "requests": {
+                "cpu": "1.0",
+                "memory": "2048"
+              }
+            }
+          },
+          {
+            "command": ["sleep", "360"],
+            "image": "public.ecr.aws/amazonlinux/amazonlinux:1",
+            "name": "container_b",
+            "resources": {
+              "requests": {
+                "cpu": "1.0",
+                "memory": "2048"
+              }
+            }
+          }
+        ]
+      }
+    }
+		      `,
+			wantEquivalent: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			output, err := tfbatch.EquivalentEKSPropertiesJSON(testCase.configurationJSON, testCase.apiJSON)
+			if got, want := err != nil, testCase.wantErr; !cmp.Equal(got, want) {
+				t.Errorf("EquivalentEKSPropertiesJSON err %t, want %t", got, want)
+			}
+
+			if err == nil {
+				if got, want := output, testCase.wantEquivalent; !cmp.Equal(got, want) {
+					t.Errorf("EquivalentEKSPropertiesJSON equivalent %t, want %t", got, want)
+					if want {
+						if diff := jsoncmp.Diff(testCase.configurationJSON, testCase.apiJSON); diff != "" {
+							t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/service/batch/exports_test.go
+++ b/internal/service/batch/exports_test.go
@@ -12,6 +12,7 @@ var (
 
 	EquivalentContainerPropertiesJSON       = equivalentContainerPropertiesJSON
 	EquivalentECSPropertiesJSON             = equivalentECSPropertiesJSON
+	EquivalentEKSPropertiesJSON             = equivalentEKSPropertiesJSON
 	EquivalentNodePropertiesJSON            = equivalentNodePropertiesJSON
 	ExpandEC2ConfigurationsUpdate           = expandEC2ConfigurationsUpdate
 	ExpandLaunchTemplateSpecificationUpdate = expandLaunchTemplateSpecificationUpdate

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -790,7 +790,9 @@ func resourceJobDefinitionCreate(ctx context.Context, d *schema.ResourceData, me
 			}
 
 			for _, node := range props.NodeRangeProperties {
-				diags = append(diags, removeEmptyEnvironmentVariables(node.Container.Environment, cty.GetAttrPath("node_properties"))...)
+				if node.Container != nil {
+					diags = append(diags, removeEmptyEnvironmentVariables(node.Container.Environment, cty.GetAttrPath("node_properties"))...)
+				}
 			}
 			input.NodeProperties = props
 		}

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -775,6 +775,102 @@ func TestAccBatchJobDefinition_NodeProperties_advanced(t *testing.T) {
 	})
 }
 
+func TestAccBatchJobDefinition_NodeProperties_withEKS(t *testing.T) {
+	ctx := acctest.Context(t)
+	var jd awstypes.JobDefinition
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_batch_job_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobDefinitionConfig_nodePropertiesEKS(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
+					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+					acctest.CheckResourceAttrEquivalentJSON(resourceName, "node_properties", `{
+						"mainNode": 0,
+						"nodeRangeProperties": [
+							{
+							"eksProperties": {
+								"podProperties": {
+								"containers": [
+									{
+									"args": [],
+									"command": ["sleep", "60"],
+									"env": [],
+									"image": "public.ecr.aws/amazonlinux/amazonlinux = 2",
+									"name": "test-eks-container-1",
+									"resources": { "requests": { "memory": "1024Mi", "cpu": "1" } },
+									"securityContext": {
+										"privileged": true,
+										"readOnlyRootFilesystem": true,
+										"runAsGroup": 3000,
+										"runAsNonRoot": true,
+										"runAsUser": 1000
+									},
+									"volumeMounts": []
+									}
+								],
+								"imagePullSecrets": [],
+								"initContainers": [],
+								"volumes": []
+								}
+							},
+							"instanceTypes": [],
+							"targetNodes": "0:"
+							}
+						],
+						"numNodes": 1
+						}`),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
+			},
+		},
+	})
+}
+
+func TestAccBatchJobDefinition_NodeProperties_withECS(t *testing.T) {
+	ctx := acctest.Context(t)
+	var jd awstypes.JobDefinition
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_batch_job_definition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJobDefinitionConfig_nodePropertiesECS(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckJobDefinitionExists(ctx, resourceName, &jd),
+					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "batch", regexache.MustCompile(fmt.Sprintf(`job-definition/%s:\d+`, rName))),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"deregister_on_new_revision",
+				},
+			},
+		},
+	})
+}
 func TestAccBatchJobDefinition_EKSProperties_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var jd awstypes.JobDefinition
@@ -1364,6 +1460,104 @@ resource "aws_batch_job_definition" "test" {
     ]
 }
 CONTAINER_PROPERTIES
+}
+`, rName)
+}
+
+func testAccJobDefinitionConfig_nodePropertiesEKS(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_batch_job_definition" "test" {
+  name = %[1]q
+  type = "multinode"
+  retry_strategy {
+    attempts = 1
+  }
+
+  node_properties = jsonencode({
+    mainNode = 0
+    numNodes = 1
+    nodeRangeProperties = [{
+      targetNodes = "0:"
+      eksProperties = {
+        podProperties = {
+          containers = [
+            {
+              name  = "test-eks-container-1"
+              image = "public.ecr.aws/amazonlinux/amazonlinux = 2"
+              command = [
+                "sleep",
+                "60"
+              ]
+              resources = {
+                requests = {
+                  memory = "1024Mi"
+                  cpu    = "1"
+                }
+              }
+              securityContext = {
+                "runAsUser"              = 1000
+                "runAsGroup"             = 3000
+                "privileged"             = true
+                "readOnlyRootFilesystem" = true
+                "runAsNonRoot"           = true
+              }
+            }
+          ]
+        }
+      }
+    }]
+  })
+}
+  `, rName)
+}
+
+func testAccJobDefinitionConfig_nodePropertiesECS(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_batch_job_definition" "test" {
+  name = %[1]q
+  type = "multinode"
+  retry_strategy {
+    attempts = 1
+  }
+
+  node_properties = jsonencode({
+    mainNode = 0
+    numNodes = 1
+    nodeRangeProperties = [{
+      targetNodes = "0:"
+      ecsProperties = {
+        taskProperties = [{
+          containers = [{
+            image      = "public.ecr.aws/amazonlinux/amazonlinux:1"
+            command    = ["sleep", "60"]
+            name       = "container_a"
+            privileged = false
+            resourceRequirements = [{
+              value = "1"
+              type  = "VCPU"
+            },
+            {
+                value = "2048"
+                type  = "MEMORY"
+            }]
+            },
+            {
+              image   = "public.ecr.aws/amazonlinux/amazonlinux:1"
+              command = ["sleep", "360"]
+              name    = "container_b"
+              resourceRequirements = [{
+                value = "1"
+                type  = "VCPU"
+                },
+                {
+                  value = "2048"
+                  type  = "MEMORY"
+              }]
+          }]
+        }]
+      }
+    }]
+  })
 }
 `, rName)
 }

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -1535,8 +1535,8 @@ resource "aws_batch_job_definition" "test" {
             resourceRequirements = [{
               value = "1"
               type  = "VCPU"
-            },
-            {
+              },
+              {
                 value = "2048"
                 type  = "MEMORY"
             }]

--- a/internal/service/batch/job_definition_test.go
+++ b/internal/service/batch/job_definition_test.go
@@ -835,6 +835,7 @@ func TestAccBatchJobDefinition_NodeProperties_withEKS(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"deregister_on_new_revision",
+					"node_properties",
 				},
 			},
 		},

--- a/internal/service/batch/node_properties.go
+++ b/internal/service/batch/node_properties.go
@@ -15,18 +15,29 @@ import (
 type nodeProperties struct {
 	MainNode            *int64
 	NodeRangeProperties []*nodeRangeProperty
-	NumNodes            *int64
+
+	NumNodes *int64
 }
 
 type nodeRangeProperty struct {
-	Container   *containerProperties
-	TargetNodes *string
+	Container     *containerProperties
+	EcsProperties *ecsProperties
+	EKSProperties *eksProperties
+	TargetNodes   *string
 }
 
 func (np *nodeProperties) reduce() {
 	// Deal with Environment objects which may be re-ordered in the API.
 	for _, node := range np.NodeRangeProperties {
-		node.Container.reduce()
+		if node.Container != nil {
+			node.Container.reduce()
+		}
+		if node.EcsProperties != nil {
+			node.EcsProperties.reduce()
+		}
+		if node.EKSProperties != nil {
+			node.EKSProperties.reduce()
+		}
 	}
 }
 

--- a/internal/service/batch/node_properties_test.go
+++ b/internal/service/batch/node_properties_test.go
@@ -134,6 +134,68 @@ func TestEquivalentNodePropertiesJSON(t *testing.T) {
 `,
 			wantEquivalent: true,
 		},
+		"Single node ECS Properties with multiple containers": {
+			apiJSON: `
+{
+	"mainNode": 1,
+	"nodeRangeProperties": [
+		{
+			"ecsProperties": {
+				"taskProperties": [
+				{
+					"containers": [
+					{
+						"name": "container1",
+						"image": "my_ecr_image1"
+					},
+					{
+						"name": "container2",
+						"image": "my_ecr_image2"
+					}
+					]
+				}
+				]
+			},
+			"targetNodes": "0:",
+			"environment": [],
+			"mountPoints": []
+		}
+	],
+	"numNodes": 1
+}
+`,
+			configurationJSON: `
+{
+  "mainNode": 1,
+  "nodeRangeProperties": [
+    {
+      "ecsProperties": {
+        "taskProperties": [
+          {
+            "containers": [
+              {
+                "name": "container2",
+                "image": "my_ecr_image2"
+              },
+              {
+                "name": "container1",
+                "image": "my_ecr_image1"
+              }
+            ]
+          }
+        ]
+      },
+      "targetNodes": "0:",
+      "environment": [],
+      "mountPoints": []
+    }
+  ],
+  "numNodes": 1
+}
+
+`,
+			wantEquivalent: true,
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
When specifying EKS or ECS Properties within node range properties, a nil pointer crash occurred.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38605

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccBatchJobDefinition_NodeProperties PKG=batch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/batch/... -v -count 1 -parallel 20 -run='TestAccBatchJobDefinition_NodeProperties'  -timeout 360m
2024/11/18 13:33:38 Initializing Terraform AWS Provider...
=== RUN   TestAccBatchJobDefinition_NodeProperties_basic
=== PAUSE TestAccBatchJobDefinition_NodeProperties_basic
=== RUN   TestAccBatchJobDefinition_NodeProperties_advanced
=== PAUSE TestAccBatchJobDefinition_NodeProperties_advanced
=== RUN   TestAccBatchJobDefinition_NodeProperties_withEKS
=== PAUSE TestAccBatchJobDefinition_NodeProperties_withEKS
=== RUN   TestAccBatchJobDefinition_NodeProperties_withECS
=== PAUSE TestAccBatchJobDefinition_NodeProperties_withECS
=== CONT  TestAccBatchJobDefinition_NodeProperties_basic
=== CONT  TestAccBatchJobDefinition_NodeProperties_withEKS
=== CONT  TestAccBatchJobDefinition_NodeProperties_advanced
=== CONT  TestAccBatchJobDefinition_NodeProperties_withECS
--- PASS: TestAccBatchJobDefinition_NodeProperties_withEKS (15.64s)
--- PASS: TestAccBatchJobDefinition_NodeProperties_basic (15.76s)
--- PASS: TestAccBatchJobDefinition_NodeProperties_withECS (16.47s)
--- PASS: TestAccBatchJobDefinition_NodeProperties_advanced (24.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      28.411s                                       

% make test PKG=batch
make: Running unit tests...
go1.23.2 test -count 1 ./internal/service/batch/...  -timeout=15m
ok      github.com/hashicorp/terraform-provider-aws/internal/service/batch      4.421s
```
