### PR TITLE
chore(aws_s3_bucket_acl): add valid values for canned acl to the documentation.

### DIFF
--- a/website/docs/r/s3_bucket_acl.html.markdown
+++ b/website/docs/r/s3_bucket_acl.html.markdown
@@ -123,8 +123,8 @@ resource "aws_s3_bucket_acl" "example" {
 
 This resource supports the following arguments:
 
-* `acl` - (Optional, One of `acl` or `access_control_policy` is required) Canned ACL to apply to the bucket.
-* `access_control_policy` - (Optional, One of `access_control_policy` or `acl` is required) Configuration block that sets the ACL permissions for an object per grantee. [See below](#access_control_policy).
+* `acl` - (Optional, either `access_control_policy` or `acl` is required) Specifies the Canned ACL to apply to the bucket. Valid values: `private`, `public-read`, `public-read-write`, `aws-exec-read`, `authenticated-read`, `bucket-owner-read`, `bucket-owner-full-control`, `log-delivery-write`. Full details are available on the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl.
+* `access_control_policy` - (Optional, either `access_control_policy` or `acl` is required) Configuration block that sets the ACL permissions for an object per grantee. [See below](#access_control_policy).
 * `bucket` - (Required, Forces new resource) Bucket to which to apply the ACL.
 * `expected_bucket_owner` - (Optional, Forces new resource) Account ID of the expected bucket owner.
 


### PR DESCRIPTION
### Description
This PR aims to add more details about valid values to be set for an AWS S3 bucket canned ACL.

### Relations
Closes #39582
