### PR TITLE
chore(aws_imagebuilder_image_pipeline): add replace_triggered_by

### DIFF
--- a/website/docs/r/imagebuilder_image_pipeline.html.markdown
+++ b/website/docs/r/imagebuilder_image_pipeline.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages an Image Builder Image Pipeline.
 
+~> **NOTE:** Starting version `5.74.0`, lifecycle meta-argument `replace_triggered_by` needs to be used to prevent a dependency error on destroy. 
+
 ## Example Usage
 
 ```terraform
@@ -21,6 +23,42 @@ resource "aws_imagebuilder_image_pipeline" "example" {
   schedule {
     schedule_expression = "cron(0 0 * * ? *)"
   }
+
+  lifecycle {
+    replace_triggered_by = [
+      aws_imagebuilder_image_recipe.example
+    ]
+  }
+}
+
+resource "aws_imagebuilder_image_recipe" "example" {
+  block_device_mapping {
+    device_name = "/dev/xvdb"
+
+    ebs {
+      delete_on_termination = true
+      volume_size           = 100
+      volume_type           = "gp2"
+    }
+  }
+
+  component {
+    component_arn = aws_imagebuilder_component.example.arn
+
+    parameter {
+      name  = "Parameter1"
+      value = "Value1"
+    }
+
+    parameter {
+      name  = "Parameter2"
+      value = "Value2"
+    }
+  }
+
+  name         = "example"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  version      = "1.0.0"
 }
 ```
 


### PR DESCRIPTION
### Description
This PR aims to clarify usage of Terraform lifecycle meta-argument `replace_triggered_by` in `aws_imagebuilder_image_pipeline` resource.

### Relations
Closes #39985
Closes #40037
Closes #40057