### PR TITLE
Add new sesv2 attributes

### DIFF
--- a/internal/service/sesv2/configuration_set_data_source.go
+++ b/internal/service/sesv2/configuration_set_data_source.go
@@ -37,6 +37,10 @@ func dataSourceConfigurationSet() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"max_delivery_seconds": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						"sending_pool_name": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -98,6 +102,10 @@ func dataSourceConfigurationSet() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"custom_redirect_domain": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"https_policy": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/internal/service/sesv2/configuration_set_data_source_test.go
+++ b/internal/service/sesv2/configuration_set_data_source_test.go
@@ -32,6 +32,7 @@ func TestAccSESV2ConfigurationSetDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, dataSourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_set_name", dataSourceName, "configuration_set_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "delivery_options.#", dataSourceName, "delivery_options.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "delivery_options.0.max_delivery_seconds", dataSourceName, "delivery_options.0.max_delivery_seconds"),
 					resource.TestCheckResourceAttrPair(resourceName, "delivery_options.0.sending_pool_name", dataSourceName, "delivery_options.0.sending_pool_name"),
 					resource.TestCheckResourceAttrPair(resourceName, "delivery_options.0.tls_policy", dataSourceName, "delivery_options.0.tls_policy"),
 					resource.TestCheckResourceAttrPair(resourceName, "reputation_options.#", dataSourceName, "reputation_options.#"),
@@ -40,7 +41,7 @@ func TestAccSESV2ConfigurationSetDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "sending_options.#", dataSourceName, "sending_options.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "sending_options.0.sending_enabled", dataSourceName, "sending_options.0.sending_enabled"),
 					resource.TestCheckResourceAttrPair(resourceName, "suppression_options.#", dataSourceName, "suppression_options.#"),
-					resource.TestCheckResourceAttrPair(resourceName, "suppression_options.#", dataSourceName, "suppression_options.#"),
+					resource.TestCheckResourceAttrPair(resourceName, "suppression_options.0.suppressed_reasons", dataSourceName, "suppression_options.0.suppressed_reasons"),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsPercent, dataSourceName, acctest.CtTagsPercent),
 					resource.TestCheckResourceAttrPair(resourceName, "vdm_options.#", dataSourceName, "vdm_options.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "vdm_options.0.dashboard_options.#", dataSourceName, "vdm_options.0.dashboard_options.#"),
@@ -59,7 +60,8 @@ resource "aws_sesv2_configuration_set" "test" {
   configuration_set_name = %[1]q
 
   delivery_options {
-    tls_policy = "REQUIRE"
+    max_delivery_seconds = 300
+    tls_policy           = "REQUIRE"
   }
 
   reputation_options {

--- a/internal/service/sesv2/configuration_set_test.go
+++ b/internal/service/sesv2/configuration_set_test.go
@@ -71,7 +71,7 @@ func TestAccSESV2ConfigurationSet_disappears(t *testing.T) {
 	})
 }
 
-func TestAccSESV2ConfigurationSet_tlsPolicy(t *testing.T) {
+func TestAccSESV2ConfigurationSet_deliveryOptions(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sesv2_configuration_set.test"
@@ -83,10 +83,11 @@ func TestAccSESV2ConfigurationSet_tlsPolicy(t *testing.T) {
 		CheckDestroy:             testAccCheckConfigurationSetDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetConfig_tlsPolicy(rName, string(types.TlsPolicyRequire)),
+				Config: testAccConfigurationSetConfig_deliveryOptions(rName, 300, string(types.TlsPolicyRequire)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_options.0.max_delivery_seconds", "300"),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.0.tls_policy", string(types.TlsPolicyRequire)),
 				),
 			},
@@ -96,10 +97,11 @@ func TestAccSESV2ConfigurationSet_tlsPolicy(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigurationSetConfig_tlsPolicy(rName, string(types.TlsPolicyOptional)),
+				Config: testAccConfigurationSetConfig_deliveryOptions(rName, 800, string(types.TlsPolicyOptional)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_options.0.max_delivery_seconds", "800"),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.0.tls_policy", string(types.TlsPolicyOptional)),
 				),
 			},
@@ -381,16 +383,17 @@ resource "aws_sesv2_configuration_set" "test" {
 `, rName)
 }
 
-func testAccConfigurationSetConfig_tlsPolicy(rName, tlsPolicy string) string {
+func testAccConfigurationSetConfig_deliveryOptions(rName string, MaxDeliverySeconds int, tlsPolicy string) string {
 	return fmt.Sprintf(`
 resource "aws_sesv2_configuration_set" "test" {
   configuration_set_name = %[1]q
 
   delivery_options {
-    tls_policy = %[2]q
+    max_delivery_seconds = %[2]d
+    tls_policy           = %[3]q
   }
 }
-`, rName, tlsPolicy)
+`, rName, MaxDeliverySeconds, tlsPolicy)
 }
 
 func testAccConfigurationSetConfig_reputationMetricsEnabled(rName string, reputationMetricsEnabled bool) string {

--- a/website/docs/d/sesv2_configuration_set.html.markdown
+++ b/website/docs/d/sesv2_configuration_set.html.markdown
@@ -31,6 +31,7 @@ The following arguments are required:
 This data source exports the following attributes in addition to the arguments above:
 
 * `delivery_options` - An object that defines the dedicated IP pool that is used to send emails that you send using the configuration set.
+    * `max_delivery_seconds` - The maximum amount of time, in seconds, that Amazon SES API v2 will attempt delivery of email. If specified, the value must greater than or equal to 300 seconds (5 minutes) and less than or equal to 50400 seconds (840 minutes).
     * `sending_pool_name` - The name of the dedicated IP pool to associate with the configuration set.
     * `tls_policy` - Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS).
 * `reputation_options` - An object that defines whether or not Amazon SES collects reputation metrics for the emails that you send that use the configuration set.
@@ -43,6 +44,7 @@ This data source exports the following attributes in addition to the arguments a
 * `tags` - Key-value map of resource tags for the container recipe.
 * `tracking_options` - An object that defines the open and click tracking options for emails that you send using the configuration set.
     * `custom_redirect_domain` - The domain to use for tracking open and click events.
+    * `https_policy`: The https policy to use for tracking open and click events. Valid values are `REQUIRE`, `REQUIRE_OPEN_ONLY` or `OPTIONAL`.
 * `vdm_options` - An object that contains information about the VDM preferences for your configuration set.
     * `dashboard_options` - Specifies additional settings for your VDM configuration as applicable to the Dashboard.
         * `engagement_metrics` - Specifies the status of your VDM engagement metrics collection.

--- a/website/docs/r/sesv2_configuration_set.html.markdown
+++ b/website/docs/r/sesv2_configuration_set.html.markdown
@@ -19,7 +19,8 @@ resource "aws_sesv2_configuration_set" "example" {
   configuration_set_name = "example"
 
   delivery_options {
-    tls_policy = "REQUIRE"
+    max_delivery_seconds = 300
+    tls_policy           = "REQUIRE"
   }
 
   reputation_options {
@@ -36,6 +37,7 @@ resource "aws_sesv2_configuration_set" "example" {
 
   tracking_options {
     custom_redirect_domain = "example.com"
+    https_policy           = "REQUIRE"
   }
 }
 ```
@@ -57,6 +59,7 @@ This resource supports the following arguments:
 
 The `delivery_options` configuration block supports the following arguments:
 
+* `max_delivery_seconds` - The maximum amount of time, in seconds, that Amazon SES API v2 will attempt delivery of email. If specified, the value must greater than or equal to 300 seconds (5 minutes) and less than or equal to 50400 seconds (840 minutes).
 * `sending_pool_name` - (Optional) The name of the dedicated IP pool to associate with the configuration set.
 * `tls_policy` - (Optional) Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). Valid values: `REQUIRE`, `OPTIONAL`.
 
@@ -83,6 +86,7 @@ The `suppression_options` configuration block supports the following arguments:
 The `tracking_options` configuration block supports the following arguments:
 
 * `custom_redirect_domain` - (Required) The domain to use for tracking open and click events.
+* `https_policy`: The https policy to use for tracking open and click events. Valid values are `REQUIRE`, `REQUIRE_OPEN_ONLY` or `OPTIONAL`.
 
 ### `vdm_options` Block
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add 2 new attributes

* aws_sesv2_configuration_set.delivery_options.max_delivery_seconds
* aws_sesv2_configuration_set.tracking_options.https_policy

* https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_DeliveryOptions.html#SES-Type-DeliveryOptions-MaxDeliverySeconds
* https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_TrackingOptions.html#SES-Type-TrackingOptions-HttpsPolicy

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #40170
--->

Closes #40170

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccSESV2ConfigurationSet_deliveryOptions PKG=sesv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/sesv2/... -v -count 1 -parallel 20 -run='TestAccSESV2ConfigurationSet_deliveryOptions'  -timeout 360m
2024/11/19 20:40:05 Initializing Terraform AWS Provider...
=== RUN   TestAccSESV2ConfigurationSet_deliveryOptions
=== PAUSE TestAccSESV2ConfigurationSet_deliveryOptions
=== CONT  TestAccSESV2ConfigurationSet_deliveryOptions
--- PASS: TestAccSESV2ConfigurationSet_deliveryOptions (31.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      47.642s


$ make testacc TESTS=TestAccSESV2ConfigurationSetDataSource_basic PKG=sesv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/sesv2/... -v -count 1 -parallel 20 -run='TestAccSESV2ConfigurationSetDataSource_basic'  -timeout 360m
2024/11/19 20:38:35 Initializing Terraform AWS Provider...
=== RUN   TestAccSESV2ConfigurationSetDataSource_basic
=== PAUSE TestAccSESV2ConfigurationSetDataSource_basic
=== CONT  TestAccSESV2ConfigurationSetDataSource_basic
--- PASS: TestAccSESV2ConfigurationSetDataSource_basic (17.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      31.649s
...
```

Remark: No test added for the new `https_policy`. This requires a `custom_redirect_domain` which requires a verified domain.
