### PR TITLE
Add support for UEFI data

### DIFF
--- a/.changelog/40210.txt
+++ b/.changelog/40210.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+data-source/aws_ami: Add support for UEFI data
+```
+
+```release-note:enhancement
+resource/aws_ami: Add support for UEFI data
+```

--- a/internal/service/ec2/ec2_ami_copy.go
+++ b/internal/service/ec2/ec2_ami_copy.go
@@ -256,6 +256,10 @@ func resourceAMICopy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"uefi_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"usage_operation": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -217,6 +217,10 @@ func dataSourceAMI() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"uefi_data": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"usage_operation": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -337,6 +341,13 @@ func dataSourceAMIRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("tpm_support", image.TpmSupport)
 	d.Set("usage_operation", image.UsageOperation)
 	d.Set("virtualization_type", image.VirtualizationType)
+
+	instanceData, err := conn.GetInstanceUefiData(ctx, &ec2.GetInstanceUefiDataInput{
+		InstanceId: aws.String(d.Id()),
+	})
+	if err == nil {
+		d.Set("uefi_data", instanceData.UefiData)
+	}
 
 	setTagsOut(ctx, image.Tags)
 

--- a/internal/service/ec2/ec2_ami_from_instance.go
+++ b/internal/service/ec2/ec2_ami_from_instance.go
@@ -238,6 +238,10 @@ func resourceAMIFromInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"uefi_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"usage_operation": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -125,6 +125,7 @@ interpolation.
 * `tpm_support` - If the image is configured for NitroTPM support, the value is `v2.0`.
 * `virtualization_type` - Type of virtualization of the AMI (ie: `hvm` or
   `paravirtual`).
+* `uefi_data` - (Optional) Base64 representation of the non-volatile UEFI variable store.
 * `usage_operation` - Operation of the Amazon EC2 instance and the billing code that is associated with the AMI.
 * `platform_details` - Platform details associated with the billing code of the AMI.
 * `ena_support` - Whether enhanced networking with ENA is enabled.

--- a/website/docs/r/ami.html.markdown
+++ b/website/docs/r/ami.html.markdown
@@ -57,6 +57,7 @@ This resource supports the following arguments:
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `tpm_support` - (Optional) If the image is configured for NitroTPM support, the value is `v2.0`. For more information, see [NitroTPM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nitrotpm.html) in the Amazon Elastic Compute Cloud User Guide.
 * `imds_support` - (Optional) If EC2 instances started from this image should require the use of the Instance Metadata Service V2 (IMDSv2), set this argument to `v2.0`. For more information, see [Configure instance metadata options for new instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#configure-IMDS-new-instances-ami-configuration).
+* `uefi_data` - (Optional) Base64 representation of the non-volatile UEFI variable store.
 
 When `virtualization_type` is "paravirtual" the following additional arguments apply:
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR provides support to use UEFI secure boot with `terraform-provider-aws`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40094

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The requirement originates from enabling UEFI secure boot with custom config and keys. See https://github.com/gardenlinux/gardenlinux/issues/2472