### PR TITLE
.github/workflows: address breaking changes to `slack-github-action`

### DIFF
--- a/.github/workflows/comments-feed.yml
+++ b/.github/workflows/comments-feed.yml
@@ -34,9 +34,9 @@ jobs:
           COMMENT_URL: ${{ github.event.comment.html_url }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
-          SLACK_WEBHOOK_URL: ${{ secrets.FEED_SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [

--- a/.github/workflows/label-notifications.yml
+++ b/.github/workflows/label-notifications.yml
@@ -27,6 +27,8 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [

--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -111,6 +111,8 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [

--- a/.github/workflows/pull_request_feed.yml
+++ b/.github/workflows/pull_request_feed.yml
@@ -8,8 +8,6 @@ permissions:
   contents: read
 
 env:
-  SLACK_WEBHOOK_URL: ${{ secrets.FEED_SLACK_WEBHOOK_URL }}
-  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   PR_HTML_URL: ${{ github.event.pull_request.html_url }}
   PR_TITLE: ${{ github.event.pull_request.title }}
 
@@ -38,6 +36,8 @@ jobs:
           MERGED_BY_URL: ${{ github.event.pull_request.merged_by.html_url }}
           MERGED_BY_LOGIN: ${{ github.event.pull_request.merged_by.login }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [
@@ -61,6 +61,8 @@ jobs:
           PR_AUTHOR_URL: ${{ github.event.pull_request.user.html_url }}
           PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [
@@ -83,6 +85,8 @@ jobs:
           PR_AUTHOR_URL: ${{ github.event.pull_request.user.html_url }}
           PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [

--- a/.github/workflows/pull_request_review.yml
+++ b/.github/workflows/pull_request_review.yml
@@ -34,9 +34,9 @@ jobs:
           REVIEW_AUTHOR_LOGIN: ${{ github.event.review.user.login }}
           PR_HTML_URL: ${{ github.event.pull_request.html_url }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-          SLACK_WEBHOOK_URL: ${{ secrets.FEED_SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,6 +11,8 @@ jobs:
         id: slack
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "blocks": [
@@ -23,6 +25,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FEED_SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The `webhook-type` argument is now required. The `webhook` argument is optional and can also be configured by setting the `SLACK_WEBHOOK_URL` environment variable, but I've migrated to the explicit argument to align with the documentation for the release. See the [release notes](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0) for complete details on the breaking changes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #40160 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0


