### PR TITLE
docs: add missing transformation block

### DIFF
--- a/website/docs/r/bedrockagent_data_source.html.markdown
+++ b/website/docs/r/bedrockagent_data_source.html.markdown
@@ -113,7 +113,7 @@ The `semantic_chunking_configuration` block supports the following arguments:
 The `custom_transformation_configuration` block supports the following arguments:
 
 * `intermediate_storage` - (Required, Forces new resource) The intermediate storage for custom transformation.
-* `transformation_function` - (Required) The configuration of transformation function.
+* `transformation` - (Required) A custom processing step for documents moving through the data source ingestion pipeline.
 
 ### `intermediate_storage` block
 
@@ -127,12 +127,18 @@ The `s3_location` block supports the following arguments:
 
 * `uri` - (Required, Forces new resource) S3 URI for intermediate storage.
 
-### `transformation_function` block
+### `transformation` block
+
+The `transformation` block supports the following arguments:
+
+* `step_to_apply` - (Required, Forces new resource) When the service applies the transformation. Currently only `POST_CHUNKING` is supported.
+* `transformation_function` - (Required) The lambda function that processes documents.
+
+### `transformation_function` block 
 
 The `transformation_function` block supports the following arguments:
 
-* `step_to_apply` - (Required, Forces new resource) Currently only `POST_CHUNKING` is supported.
-* `transformation_lambda_configuration` - (Required, Forces new resource) The lambda configuration for custom transformation.
+* `transformation_lambda_configuration` - (Required, Forces new resource) The configuration of the lambda function.
 
 ### `transformation_lambda_configuration` block
 

--- a/website/docs/r/bedrockagent_data_source.html.markdown
+++ b/website/docs/r/bedrockagent_data_source.html.markdown
@@ -134,7 +134,7 @@ The `transformation` block supports the following arguments:
 * `step_to_apply` - (Required, Forces new resource) When the service applies the transformation. Currently only `POST_CHUNKING` is supported.
 * `transformation_function` - (Required) The lambda function that processes documents.
 
-### `transformation_function` block 
+### `transformation_function` block
 
 The `transformation_function` block supports the following arguments:
 


### PR DESCRIPTION
### Description

As mentioned in #39773 the documentation for the resource[ `aws_bedrockagent_data_source`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagent_data_source) is missing the block `transformation` inside of the `custom_transformation_configuration` block. 
Actually, the block `transformation_function` (that exists inside of `transformation`) is mentioned instead.

### Relations

Closes #39773 

### References
- [AWS CloudFormation Docs - CustomTransformationConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-bedrock-datasource-customtransformationconfiguration.html)  
  shows nesting of elements in CloudFormation: `CustomTransformationConfiguration` -> `Transformations` -> `TransformationFunction`
- [Terraform AWS Provider - Terraform code in tests](https://github.com/hashicorp/terraform-provider-aws/blob/08f131ce76df717ef55484128c08cdfe3e92882f/internal/service/bedrockagent/data_source_test.go#L760)  
shows the `transformation` block as part of tests already in place
- [AWS SDK Go V2 - Transformation](https://github.com/aws/aws-sdk-go-v2/blob/c527ee8b854b0a2813c0332b1de89357e2a5621f/service/bedrockagent/types/types.go#L958)  
 showing `Transformation` inside `CustomTransformationConfiguration`

### Output from Acceptance Testing

Not applicable. Only documentation is updated.