### PR TITLE
.github/workflows: fix formatting in `post_publish` shell script

### DIFF
--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -69,7 +69,7 @@ jobs:
               sleep 1h
             else
               echo "Registry and Github Version matches"
-                echo "current=$LATEST_VERSION >> "$GITHUB_OUTPUT"
+              echo "current=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
             fi
           done
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
A missed quote caused the script to fail during the `v5.77.0` release.

```
/home/runner/work/_temp/b9a14e53-10ad-497f-a91b-d57575e541f4.sh: line 12: unexpected EOF while looking for matching `"'
Error: Process completed with exit code 2.
```

Ref: https://github.com/hashicorp/terraform-provider-aws/actions/runs/11959899920/job/33342735174

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #39964
