### PR TITLE
[WIP] New Resource: aws_cloudfront_vpc_origin_endpoint_configuration

### DIFF
--- a/.ci/.semgrep-constants.yml
+++ b/.ci/.semgrep-constants.yml
@@ -1513,6 +1513,42 @@ rules:
     options:
       constant_propagation: false
 
+  - id: literal-http_port-string-constant
+    languages: [go]
+    message: Use the constant `names.AttrHTTPPort` for the string literal "http_port"
+    paths:
+      include:
+        - "internal/service/**/*.go"
+    patterns:
+      - pattern: '"http_port"'
+      - pattern-not-regex: '"http_port":\s+test\w+,'
+      - pattern-not-inside: 'config.Variables{ ... }'
+      - pattern-not-inside: 'packageName = ...'
+      - pattern-not-inside: 'provider.ConflictingEndpointsWarningDiag(...)'
+      - pattern-not-inside: 'const $X = ...'
+    severity: ERROR
+    fix: "names.AttrHTTPPort"
+    options:
+      constant_propagation: false
+
+  - id: literal-https_port-string-constant
+    languages: [go]
+    message: Use the constant `names.AttrHTTPSPort` for the string literal "https_port"
+    paths:
+      include:
+        - "internal/service/**/*.go"
+    patterns:
+      - pattern: '"https_port"'
+      - pattern-not-regex: '"https_port":\s+test\w+,'
+      - pattern-not-inside: 'config.Variables{ ... }'
+      - pattern-not-inside: 'packageName = ...'
+      - pattern-not-inside: 'provider.ConflictingEndpointsWarningDiag(...)'
+      - pattern-not-inside: 'const $X = ...'
+    severity: ERROR
+    fix: "names.AttrHTTPSPort"
+    options:
+      constant_propagation: false
+
   - id: literal-header-string-constant
     languages: [go]
     message: Use the constant `names.AttrHeader` for the string literal "header"

--- a/internal/service/cloudfront/service_package_gen.go
+++ b/internal/service/cloudfront/service_package_gen.go
@@ -26,6 +26,10 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
 	return []*types.ServicePackageFrameworkResource{
 		{
+			Factory: newCloudfrontVPCOriginEndpointConfigResource,
+			Name:    "VPC Origin Endpoint Config",
+		},
+		{
 			Factory: newContinuousDeploymentPolicyResource,
 			Name:    "Continuous Deployment Policy",
 		},

--- a/internal/service/cloudfront/vpc_origin_endpoint_config.go
+++ b/internal/service/cloudfront/vpc_origin_endpoint_config.go
@@ -1,0 +1,52 @@
+package cloudfront
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"time"
+)
+
+// @FrameworkResource("aws_cloudfront_vpc_origin_endpoint_config", name="VPC Origin Endpoint Config")
+func newCloudfrontVPCOriginEndpointConfigResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &cloudfrontVPCOriginEndpointConfigResource{}
+
+	r.SetDefaultCreateTimeout(5 * time.Minute)
+	r.SetDefaultDeleteTimeout(5 * time.Minute)
+
+	return r, nil
+}
+
+type cloudfrontVPCOriginEndpointConfigResource struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+func (r *cloudfrontVPCOriginEndpointConfigResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r *cloudfrontVPCOriginEndpointConfigResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r *cloudfrontVPCOriginEndpointConfigResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r *cloudfrontVPCOriginEndpointConfigResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r *cloudfrontVPCOriginEndpointConfigResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r *cloudfrontVPCOriginEndpointConfigResource) Metadata(_ context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "aws_cloudfront_vpc_origin_endpoint_config"
+}

--- a/internal/service/cloudfront/vpc_origin_endpoint_config.go
+++ b/internal/service/cloudfront/vpc_origin_endpoint_config.go
@@ -2,8 +2,13 @@ package cloudfront
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
 	"time"
 )
 
@@ -23,8 +28,30 @@ type cloudfrontVPCOriginEndpointConfigResource struct {
 }
 
 func (r *cloudfrontVPCOriginEndpointConfigResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
-	//TODO implement me
-	panic("implement me")
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			names.AttrHTTPPort: schema.NumberAttribute{
+				Required: true,
+			},
+			names.AttrHTTPSPort: schema.NumberAttribute{
+				Required: true,
+			},
+			// TODO: OriginProtocolPolicy
+			// TODO: OriginSslProtocols
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Delete: true,
+			}),
+		},
+	}
 }
 
 func (r *cloudfrontVPCOriginEndpointConfigResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {

--- a/names/attr_constants.csv
+++ b/names/attr_constants.csv
@@ -85,6 +85,8 @@ group_name,GroupName
 header,Header
 health_check,HealthCheck
 hosted_zone_id,HostedZoneID
+http_port,HTTPPort
+https_port,HTTPSPort
 iam_role_arn,IAMRoleARN
 id,ID
 identifier,Identifier

--- a/names/attr_consts_gen.go
+++ b/names/attr_consts_gen.go
@@ -89,6 +89,8 @@ const (
 	AttrFormat                     = "format"
 	AttrFunctionARN                = "function_arn"
 	AttrGroupName                  = "group_name"
+	AttrHTTPPort                   = "http_port"
+	AttrHTTPSPort                  = "https_port"
 	AttrHeader                     = "header"
 	AttrHealthCheck                = "health_check"
 	AttrHostedZoneID               = "hosted_zone_id"

--- a/names/generate/const_or_quote_gen.go
+++ b/names/generate/const_or_quote_gen.go
@@ -97,6 +97,8 @@ func ConstOrQuote(constant string) string {
 		"format":                        "AttrFormat",
 		"function_arn":                  "AttrFunctionARN",
 		"group_name":                    "AttrGroupName",
+		"http_port":                     "AttrHTTPPort",
+		"https_port":                    "AttrHTTPSPort",
 		"header":                        "AttrHeader",
 		"health_check":                  "AttrHealthCheck",
 		"hosted_zone_id":                "AttrHostedZoneID",


### PR DESCRIPTION
### Description
This change adds the new "Cloudfront VPC Origin Endpoint Config" resource.


### Relations
Relates #40234
Relates #40239

### References
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/cloudfront@v1.43.0/types#VpcOriginEndpointConfig


### Output from Acceptance Testing
TODO