### PR TITLE
fix(aws_bedrockagent_agent): argument instruction is mandatory

### DIFF
--- a/.changelog/40255.txt
+++ b/.changelog/40255.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagent_agent: Set instruction argument as mandatory and improve documentation.
+```

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -125,8 +125,7 @@ func (r *agentResource) Schema(ctx context.Context, request resource.SchemaReque
 				},
 			},
 			"instruction": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
+				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/website/docs/r/bedrockagent_agent.html.markdown
+++ b/website/docs/r/bedrockagent_agent.html.markdown
@@ -64,6 +64,7 @@ resource "aws_bedrockagent_agent" "example" {
   agent_resource_role_arn     = aws_iam_role.example.arn
   idle_session_ttl_in_seconds = 500
   foundation_model            = "anthropic.claude-v2"
+  instruction                 = "You are a chatbot programmed to provide answers with clear and detailed steps."
 }
 ```
 
@@ -74,6 +75,7 @@ The following arguments are required:
 * `agent_name` - (Required) Name of the agent.
 * `agent_resource_role_arn` - (Required) ARN of the IAM role with permissions to invoke API operations on the agent.
 * `foundation_model` - (Required) Foundation model used for orchestration by the agent.
+* `instruction` - (Required) Instructions that tell the agent what it should do and how it should interact with users. The size of the instructions must range between 40 and 4000 characters.
 
 The following arguments are optional:
 
@@ -81,7 +83,6 @@ The following arguments are optional:
 * `description` - (Optional) Description of the agent.
 * `guardrail_config` - (Optional) Details about the guardrail associated with the agent. See [`guardrail_config` Block](#guardrail_config-block) for details.
 * `idle_session_ttl_in_seconds` - (Optional) Number of seconds for which Amazon Bedrock keeps information about a user's conversation with the agent. A user interaction remains active for the amount of time specified. If no conversation occurs during this time, the session expires and Amazon Bedrock deletes any data provided before the timeout.
-* `instruction` - (Optional) Instructions that tell the agent what it should do and how it should interact with users.
 * `prepare_agent` (Optional) Whether to prepare the agent after creation or modification. Defaults to `true`.
 * `prompt_override_configuration` (Optional) Configurations to override prompt templates in different parts of an agent sequence. For more information, see [Advanced prompts](https://docs.aws.amazon.com/bedrock/latest/userguide/advanced-prompts.html). See [`prompt_override_configuration` Block](#prompt_override_configuration-block) for details.
 * `skip_resource_in_use_check` - (Optional) Whether the in-use check is skipped when deleting the agent.


### PR DESCRIPTION
### Description
This PR aims to set the argument `instruction` to be mandatory. While reviewing the AWS API reference, it appears this argument is marked as optional. However, in real-world usage, omitting it leads to the following issue:

```
│ Error: creating Agent
│
│   with aws_bedrockagent_agent.demo,
│   on agent.tf line 46, in resource "aws_bedrockagent_agent" "demo":
│   46: resource "aws_bedrockagent_agent" "demo" {
│
│ waiting for Bedrock Agent (3TTM4DCSXX) prepare: unexpected state 'FAILED', wanted target 'PREPARED'. last error: Exception: Agent Instruction cannot be null
```

Here's the source code related to this error message:

```hcl
resource "aws_bedrockagent_agent" "demo" {
  agent_name              = "my-agent-name"
  agent_resource_role_arn = aws_iam_role.example.arn
  foundation_model        = "anthropic.claude-v2"
}
```

### Relations
Closes #40255

### References
(https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_CreateAgent.html#API_agent_CreateAgent_RequestSyntax)


### Output from Acceptance Testing
```bash
make testacc TESTS=TestAccBedrockAgentAgent_basic PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentAgent_basic'  -timeout 360m
2024/11/22 10:11:54 Initializing Terraform AWS Provider...
=== RUN   TestAccBedrockAgentAgent_basic
=== PAUSE TestAccBedrockAgentAgent_basic
=== CONT  TestAccBedrockAgentAgent_basic
--- PASS: TestAccBedrockAgentAgent_basic (28.75s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       28.844s
```
