### PR TITLE
dependabot: Remove `/tools/awssdkpatch`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,7 +47,6 @@ updates:
       - "/.ci/providerlint"
       - "/.ci/tools"
       - "/skaff"
-      - "/tools/awssdkpatch"
       - "/tools/tfsdk2fw"
     schedule:
       interval: "daily"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Removes `/tools/awssdkpatch` from the `.ci/tools/go.mod` `dependabot` group.
Errors were being [reported](https://github.com/hashicorp/terraform-provider-aws/actions/runs/11973703877/job/33383175737):

```
updater | 2024/11/22 13:40:44 ERROR <job_921179691> Error during file fetching; aborting: No files found in /tools/awssdkpatch
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/39926.