### PR TITLE
r/aws_s3_bucket_lifecycle_configuration: S3 directory buckets are now supported

### DIFF
--- a/.changelog/40268.txt
+++ b/.changelog/40268.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_s3_bucket_lifecycle_configuration: Lifecycle configurations can now be applied to directory buckets
+```

--- a/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
+++ b/website/docs/r/s3_bucket_lifecycle_configuration.html.markdown
@@ -18,13 +18,11 @@ An S3 Lifecycle configuration consists of one or more Lifecycle rules. Each rule
 
 For more information see the Amazon S3 User Guide on [`Lifecycle Configuration Elements`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html).
 
-~> **NOTE:** S3 Buckets only support a single lifecycle configuration. Declaring multiple `aws_s3_bucket_lifecycle_configuration` resources to the same S3 Bucket will cause a perpetual difference in configuration.
+~> S3 Buckets only support a single lifecycle configuration. Declaring multiple `aws_s3_bucket_lifecycle_configuration` resources to the same S3 Bucket will cause a perpetual difference in configuration.
 
-~> **NOTE:** Lifecycle configurations may take some time to fully propagate to all AWS S3 systems.
+~> Lifecycle configurations may take some time to fully propagate to all AWS S3 systems.
 Running Terraform operations shortly after creating a lifecycle configuration may result in changes that affect configuration idempotence.
 See the Amazon S3 User Guide on [setting lifecycle configuration on a bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html).
-
--> This resource cannot be used with S3 directory buckets.
 
 ## Example Usage
 
@@ -374,12 +372,12 @@ This resource supports the following arguments:
 
 ### rule
 
-~> **NOTE:** The `filter` argument, while Optional, is required if the `rule` configuration block does not contain a `prefix` **and** you intend to override the default behavior of setting the rule to filter objects with the empty string prefix (`""`).
+~> The `filter` argument, while Optional, is required if the `rule` configuration block does not contain a `prefix` **and** you intend to override the default behavior of setting the rule to filter objects with the empty string prefix (`""`).
 Since `prefix` is deprecated by Amazon S3 and will be removed in the next major version of the Terraform AWS Provider, we recommend users either specify `filter` or leave both `filter` and `prefix` unspecified.
 
-~> **NOTE:** A rule cannot be updated from having a filter (via either the `rule.filter` parameter or when neither `rule.filter` and `rule.prefix` are specified) to only having a prefix via the `rule.prefix` parameter.
+~> A rule cannot be updated from having a filter (via either the `rule.filter` parameter or when neither `rule.filter` and `rule.prefix` are specified) to only having a prefix via the `rule.prefix` parameter.
 
-~> **NOTE** Terraform cannot distinguish a difference between configurations that use `rule.filter {}` and configurations that neither use `rule.filter` nor `rule.prefix`, so a rule cannot be updated from applying to all objects in the bucket via `rule.filter {}` to applying to a subset of objects based on the key prefix `""` and vice versa.
+~> Terraform cannot distinguish a difference between configurations that use `rule.filter {}` and configurations that neither use `rule.filter` nor `rule.prefix`, so a rule cannot be updated from applying to all objects in the bucket via `rule.filter {}` to applying to a subset of objects based on the key prefix `""` and vice versa.
 
 The `rule` configuration block supports the following arguments:
 
@@ -409,7 +407,7 @@ The `expiration` configuration block supports the following arguments:
 
 ### filter
 
-~> **NOTE:** The `filter` configuration block must either be specified as the empty configuration block (`filter {}`) or with exactly one of `prefix`, `tag`, `and`, `object_size_greater_than` or `object_size_less_than` specified.
+~> The `filter` configuration block must either be specified as the empty configuration block (`filter {}`) or with exactly one of `prefix`, `tag`, `and`, `object_size_greater_than` or `object_size_less_than` specified.
 
 The `filter` configuration block supports the following arguments:
 
@@ -438,7 +436,7 @@ The `noncurrent_version_transition` configuration block supports the following a
 
 The `transition` configuration block supports the following arguments:
 
-~> **Note:** Only one of `date` or `days` should be specified. If neither are specified, the `transition` will default to 0 `days`.
+~> Only one of `date` or `days` should be specified. If neither are specified, the `transition` will default to 0 `days`.
 
 * `date` - (Optional, Conflicts with `days`) Date objects are transitioned to the specified storage class. The date value must be in [RFC3339 full-date format](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) e.g. `2023-08-22`.
 * `days` - (Optional, Conflicts with `date`) Number of days after creation when objects are transitioned to the specified storage class. The value must be a positive integer. If both `days` and `date` are not specified, defaults to `0`. Valid values depend on `storage_class`, see [Transition objects using Amazon S3 Lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-transition-general-considerations.html) for more details.
@@ -468,7 +466,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import S3 bucket lifecycle configuration using the `bucket` or using the `bucket` and `expected_bucket_owner` separated by a comma (`,`). For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import an S3 bucket lifecycle configuration using the `bucket` or the `bucket` and `expected_bucket_owner` separated by a comma (`,`). For example:
 
 If the owner (account ID) of the source bucket is the same account used to configure the Terraform AWS Provider, import using the `bucket`:
 
@@ -488,7 +486,7 @@ import {
 }
 ```
 
-**Using `terraform import` to import** S3 bucket lifecycle configuration using the `bucket` or using the `bucket` and `expected_bucket_owner` separated by a comma (`,`). For example:
+Using `terraform import`, import an S3 bucket lifecycle configuration using the `bucket` or the `bucket` and `expected_bucket_owner` separated by a comma (`,`). For example:
 
 If the owner (account ID) of the source bucket is the same account used to configure the Terraform AWS Provider, import using the `bucket`:
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Removes a note from the `aws_s3_bucket_lifecycle_configuration` documentation indicating directory buckets are not supported and adjusts the expected result from an acceptance test applying a lifecycle configuration to an S3 directory bucket.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40261

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-s3-express-one-zone-s3-lifecycle-expirations/

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3BucketLifecycleConfiguration_directoryBucket
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketLifecycleConfiguration_directoryBucket'  -timeout 360m
2024/11/13 10:55:38 Initializing Terraform AWS Provider...

--- PASS: TestAccS3BucketLifecycleConfiguration_directoryBucket (71.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 77.827s
```

```console
% make testacc PKG=s3 TESTS=TestAccS3BucketLifecycleConfiguration_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.2 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketLifecycleConfiguration_'  -timeout 360m
2024/11/13 10:59:44 Initializing Terraform AWS Provider...

--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_noChange (78.59s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (84.27s)
=== CONT  TestAccS3BucketLifecycleConfiguration_filterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (84.74s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (98.02s)
=== CONT  TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (98.13s)
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_withChange
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (98.17s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disappears
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (98.19s)
=== CONT  TestAccS3BucketLifecycleConfiguration_directoryBucket
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (98.25s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_prefix (98.25s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (98.29s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (98.31s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (98.33s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (98.36s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (98.59s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (147.79s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (70.62s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (53.85s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basicTransitionDefaultMinimumObjectSize (161.15s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (81.24s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_withChange (69.07s)
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (72.11s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (71.88s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (71.88s)
--- PASS: TestAccS3BucketLifecycleConfiguration_directoryBucket (72.67s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (175.15s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (175.49s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (226.45s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (234.25s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (157.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 247.725s
```
