### PR TITLE
Document support for AWS Lambda Node.js 22 and Python 3.13 runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ FEATURES:
 
 ENHANCEMENTS:
 
+* resource/aws_lambda_function: Add support for `python3.13` `runtime` value ([#xxxxx](https://github.com/hashicorp/terraform-provider-aws/issues/xxxxx))
+* resource/aws_lambda_layer_version: Add support for `python3.13` `compatible_runtimes` value ([#xxxxx](https://github.com/hashicorp/terraform-provider-aws/issues/xxxxx))
 * resource/aws_medialive_channel: Add missing h265 codec settings ([#40071](https://github.com/hashicorp/terraform-provider-aws/issues/40071))
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ ENHANCEMENTS:
 * resource/aws_ecs_service: Add `availability_zone_rebalancing` attribute ([#40225](https://github.com/hashicorp/terraform-provider-aws/issues/40225))
 * resource/aws_ecs_service: Add vpc_lattice_configurations argument ([#40177](https://github.com/hashicorp/terraform-provider-aws/issues/40177))
 * resource/aws_ecs_task_definition: Add `versionConsistency` argument to `container_definitions` ([#40216](https://github.com/hashicorp/terraform-provider-aws/issues/40216))
-* resource/aws_lambda_function: Add support for `nodejs22.x` `runtime` value ([#xxxxx](https://github.com/hashicorp/terraform-provider-aws/issues/xxxxx))
-* resource/aws_lambda_layer_version: Add support for `nodejs22.x` `compatible_runtimes` value ([#xxxxx](https://github.com/hashicorp/terraform-provider-aws/issues/xxxxx))
+* resource/aws_lambda_function: Add support for `nodejs22.x` `runtime` value ([#40277](https://github.com/hashicorp/terraform-provider-aws/issues/40277))
+* resource/aws_lambda_layer_version: Add support for `nodejs22.x` `compatible_runtimes` value ([#40277](https://github.com/hashicorp/terraform-provider-aws/issues/40277))
 * resource/aws_rds_global_cluster: Add `endpoint` argument to point to the writer DB instance in the current primary cluster ([#39960](https://github.com/hashicorp/terraform-provider-aws/issues/39960))
 
 BUG FIXES:
@@ -47,8 +47,8 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* resource/aws_lambda_function: Add support for `python3.13` `runtime` value ([#xxxxx](https://github.com/hashicorp/terraform-provider-aws/issues/xxxxx))
-* resource/aws_lambda_layer_version: Add support for `python3.13` `compatible_runtimes` value ([#xxxxx](https://github.com/hashicorp/terraform-provider-aws/issues/xxxxx))
+* resource/aws_lambda_function: Add support for `python3.13` `runtime` value ([#40277](https://github.com/hashicorp/terraform-provider-aws/issues/40277))
+* resource/aws_lambda_layer_version: Add support for `python3.13` `compatible_runtimes` value ([#40277](https://github.com/hashicorp/terraform-provider-aws/issues/40277))
 * resource/aws_medialive_channel: Add missing h265 codec settings ([#40071](https://github.com/hashicorp/terraform-provider-aws/issues/40071))
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ ENHANCEMENTS:
 * resource/aws_ecs_service: Add `availability_zone_rebalancing` attribute ([#40225](https://github.com/hashicorp/terraform-provider-aws/issues/40225))
 * resource/aws_ecs_service: Add vpc_lattice_configurations argument ([#40177](https://github.com/hashicorp/terraform-provider-aws/issues/40177))
 * resource/aws_ecs_task_definition: Add `versionConsistency` argument to `container_definitions` ([#40216](https://github.com/hashicorp/terraform-provider-aws/issues/40216))
+* resource/aws_lambda_function: Add support for `nodejs22.x` `runtime` value ([#xxxxx](https://github.com/hashicorp/terraform-provider-aws/issues/xxxxx))
+* resource/aws_lambda_layer_version: Add support for `nodejs22.x` `compatible_runtimes` value ([#xxxxx](https://github.com/hashicorp/terraform-provider-aws/issues/xxxxx))
 * resource/aws_rds_global_cluster: Add `endpoint` argument to point to the writer DB instance in the current primary cluster ([#39960](https://github.com/hashicorp/terraform-provider-aws/issues/39960))
 
 BUG FIXES:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Documents support for AWS Lambda Node.js 22 and Python 3.13 runtimes in the relevant CHANGELOG sections.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/40137.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* [Python 3.13 announcement](https://aws.amazon.com/about-aws/whats-new/2024/11/aws-lambda-support-python-313/)
* [Node.js 22 announcement](https://aws.amazon.com/about-aws/whats-new/2024/11/aws-lambda-support-nodejs-22/)