### PR TITLE
rds/instance: Test correct updating of cert

### DIFF
--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -10238,6 +10238,10 @@ data "aws_rds_orderable_db_instance" "test" {
   preferred_instance_classes = [%[2]s]
 }
 
+data "aws_rds_certificate" "latest" {
+  latest_valid_till = true
+}
+
 resource "aws_db_instance" "source" {
   identifier              = "%[3]s-source"
   allocated_storage       = 20
@@ -10257,7 +10261,7 @@ resource "aws_db_instance" "source" {
   timeouts {
     update = "120m"
   }
-  ca_cert_identifier = "rds-ca-rsa2048-g1"
+  ca_cert_identifier = data.aws_rds_certificate.latest.id
 }
 `, tfrds.InstanceEngineOracleEnterprise, strings.Replace(mainInstanceClasses, "db.t3.small", "frodo", 1), rName)
 }
@@ -10275,7 +10279,7 @@ resource "aws_db_instance" "test" {
   apply_immediately   = true
 
   parameter_group_name = aws_db_parameter_group.test.name
-  ca_cert_identifier   = "rds-ca-rsa2048-g1"
+  ca_cert_identifier   = data.aws_rds_certificate.latest.id
 
   timeouts {
     update = "120m"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

I was not able to find a bug with updating certificates. We're planning to close #33546 with this PR, that makes no changes but adds a test, for these reasons:

1. I'm adding a test that shows the correct updating behavior, when `apply_immediate = "true"`, changing `ca_cert_identifier` from `rds-ca-ecc384-g1` to `rds-ca-rsa2048-g1`.
2. #33546 is stale because the cert discussed, `rds-ca-2019`, is no longer available, and there is no longer urgency to change that cert since people have already done that--the time has passed.
3. Some of the problem seemed to be related to an [AWS issue](https://repost.aws/questions/QU7Qr4sLjXTrqsMRH35WyJ0Q/applying-new-ca-cert-during-maintenance-but-shows-no-changes-pending) that may have been resolved.
4. Additional [complex behavior](https://github.com/hashicorp/terraform-provider-aws/issues/33546#issuecomment-1995399319), such as applying a cert change immediately when `apply_immediate` is `false` is beyond the scope of a bug issue. We welcome a feature request to this effect, however, if it continues to be an issue.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33546

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccRDSInstance_CACertificate_update K=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_CACertificate_update'  -timeout 360m
2024/11/22 15:13:35 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSInstance_CACertificate_update
=== PAUSE TestAccRDSInstance_CACertificate_update
=== CONT  TestAccRDSInstance_CACertificate_update
--- PASS: TestAccRDSInstance_CACertificate_update (681.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	685.221s
```
