### PR TITLE
Fix aws_rds_reserved_instance_offering data source

### DIFF
--- a/.changelog/40281.txt
+++ b/.changelog/40281.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data-source/aws_rds_reserved_instance_offering: When `product_description` (e.g., "postgresql") is a substring of multiple products, fix `Error: multiple RDS Reserved Instance Offerings matched; use additional constraints to reduce matches to a single RDS Reserved Instance Offering` 
+data-source/aws_rds_reserved_instance_offering: When `product_description` (e.g., "postgresql") is a substring of multiple products, fix `Error: multiple RDS Reserved Instance Offerings matched; use additional constraints to reduce matches to a single RDS Reserved Instance Offering`
 ```

--- a/.changelog/40281.txt
+++ b/.changelog/40281.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_rds_reserved_instance_offering: When `product_description` (e.g., "postgresql") is a substring of multiple products, fix `Error: multiple RDS Reserved Instance Offerings matched; use additional constraints to reduce matches to a single RDS Reserved Instance Offering` 
+```

--- a/internal/service/rds/reserved_instance_offering_data_source.go
+++ b/internal/service/rds/reserved_instance_offering_data_source.go
@@ -81,8 +81,9 @@ func dataSourceReservedOfferingRead(ctx context.Context, d *schema.ResourceData,
 		ProductDescription: aws.String(d.Get("product_description").(string)),
 	}
 
-	offering, err := findReservedDBInstancesOffering(ctx, conn, input, tfslices.PredicateTrue[*types.ReservedDBInstancesOffering]())
-
+	offering, err := findReservedDBInstancesOffering(ctx, conn, input, func(v *types.ReservedDBInstancesOffering) bool {
+		return aws.ToString(v.ProductDescription) == d.Get("product_description").(string) && aws.ToString(v.DBInstanceClass) == d.Get("db_instance_class").(string)
+	})
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("RDS Reserved Instance Offering", err))
 	}
@@ -103,7 +104,6 @@ func dataSourceReservedOfferingRead(ctx context.Context, d *schema.ResourceData,
 
 func findReservedDBInstancesOffering(ctx context.Context, conn *rds.Client, input *rds.DescribeReservedDBInstancesOfferingsInput, filter tfslices.Predicate[*types.ReservedDBInstancesOffering]) (*types.ReservedDBInstancesOffering, error) {
 	output, err := findReservedDBInstancesOfferings(ctx, conn, input, filter)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/rds/reserved_instance_offering_data_source.go
+++ b/internal/service/rds/reserved_instance_offering_data_source.go
@@ -81,6 +81,9 @@ func dataSourceReservedOfferingRead(ctx context.Context, d *schema.ResourceData,
 		ProductDescription: aws.String(d.Get("product_description").(string)),
 	}
 
+	// A filter is necessary because the API returns all products where the product description contains
+	// the input product description. Sending "mysql" will return "mysql" *and* "aurora-mysql" offerings,
+	// causing an error: multiple RDS Reserved Instance Offerings matched
 	offering, err := findReservedDBInstancesOffering(ctx, conn, input, func(v *types.ReservedDBInstancesOffering) bool {
 		return aws.ToString(v.ProductDescription) == d.Get("product_description").(string) && aws.ToString(v.DBInstanceClass) == d.Get("db_instance_class").(string)
 	})

--- a/internal/service/rds/reserved_instance_offering_data_source_test.go
+++ b/internal/service/rds/reserved_instance_offering_data_source_test.go
@@ -4,6 +4,7 @@
 package rds_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -11,7 +12,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccRDSInstanceOffering_basic(t *testing.T) {
+const (
+	testInstanceClass = "db.r5.large"
+)
+
+func TestAccRDSReservedInstanceOffering_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_rds_reserved_instance_offering.test"
 
@@ -21,10 +26,49 @@ func TestAccRDSInstanceOffering_basic(t *testing.T) {
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceOfferingConfig_basic(),
+				Config: testAccReservedInstanceOfferingConfig_basic(testInstanceClass, "postgresql"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "currency_code"),
-					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", "db.t2.micro"),
+					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", testInstanceClass),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrDuration, "31536000"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fixed_price"),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_az", acctest.CtFalse),
+					resource.TestCheckResourceAttrSet(dataSourceName, "offering_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "offering_type", "All Upfront"),
+					resource.TestCheckResourceAttr(dataSourceName, "product_description", "postgresql"),
+				),
+			},
+			{
+				Config: testAccReservedInstanceOfferingConfig_basic(testInstanceClass, "aurora-postgresql"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "currency_code"),
+					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", testInstanceClass),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrDuration, "31536000"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fixed_price"),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_az", acctest.CtFalse),
+					resource.TestCheckResourceAttrSet(dataSourceName, "offering_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "offering_type", "All Upfront"),
+					resource.TestCheckResourceAttr(dataSourceName, "product_description", "aurora-postgresql"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSReservedInstanceOffering_mysql(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_rds_reserved_instance_offering.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReservedInstanceOfferingConfig_basic(testInstanceClass, "mysql"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "currency_code"),
+					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", testInstanceClass),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrDuration, "31536000"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "fixed_price"),
 					resource.TestCheckResourceAttr(dataSourceName, "multi_az", acctest.CtFalse),
@@ -33,18 +77,31 @@ func TestAccRDSInstanceOffering_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "product_description", "mysql"),
 				),
 			},
+			{
+				Config: testAccReservedInstanceOfferingConfig_basic(testInstanceClass, "aurora-mysql"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "currency_code"),
+					resource.TestCheckResourceAttr(dataSourceName, "db_instance_class", testInstanceClass),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrDuration, "31536000"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fixed_price"),
+					resource.TestCheckResourceAttr(dataSourceName, "multi_az", acctest.CtFalse),
+					resource.TestCheckResourceAttrSet(dataSourceName, "offering_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "offering_type", "All Upfront"),
+					resource.TestCheckResourceAttr(dataSourceName, "product_description", "aurora-mysql"),
+				),
+			},
 		},
 	})
 }
 
-func testAccInstanceOfferingConfig_basic() string {
-	return `
+func testAccReservedInstanceOfferingConfig_basic(class, desc string) string {
+	return fmt.Sprintf(`
 data "aws_rds_reserved_instance_offering" "test" {
-  db_instance_class   = "db.t2.micro"
+  db_instance_class   = %[1]q
   duration            = 31536000
   multi_az            = false
   offering_type       = "All Upfront"
-  product_description = "mysql"
+  product_description = %[2]q
 }
-`
+`, class, desc)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When `product_description` (e.g., "postgresql") was a substring of multiple products (e.g., "postgresql" and "aurora-postgresql"), you would get an error:

```
Error: multiple RDS Reserved Instance Offerings matched; use additional constraints to reduce matches to a single RDS Reserved Instance Offering
``` 

This fixes the issue so that you only get matches that exactly match the result such as `"postgresql" = "postgresql"` not `"postgresql" = "aurora-postgresql"`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28358

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccRDSReservedInstanceOffering_ K=rds                    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSReservedInstanceOffering_'  -timeout 360m
2024/11/22 18:20:33 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSReservedInstanceOffering_basic
=== PAUSE TestAccRDSReservedInstanceOffering_basic
=== RUN   TestAccRDSReservedInstanceOffering_mysql
=== PAUSE TestAccRDSReservedInstanceOffering_mysql
=== CONT  TestAccRDSReservedInstanceOffering_basic
=== CONT  TestAccRDSReservedInstanceOffering_mysql
--- PASS: TestAccRDSReservedInstanceOffering_basic (15.36s)
--- PASS: TestAccRDSReservedInstanceOffering_mysql (15.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	19.310s
```
