### PR TITLE
fix(route53profiles): improve documentation about tags usage.

### DIFF
--- a/.changelog/40241.txt
+++ b/.changelog/40241.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_route53profiles_profile: improve documentation and code example with usage of tags.
+```
+
+```release-note:enhancement
+resource/aws_route53profiles_association: improve documentation and code example with usage of tags.
+```

--- a/.changelog/40241.txt
+++ b/.changelog/40241.txt
@@ -1,7 +1,0 @@
-```release-note:enhancement
-resource/aws_route53profiles_profile: improve documentation and code example with usage of tags.
-```
-
-```release-note:enhancement
-resource/aws_route53profiles_association: improve documentation and code example with usage of tags.
-```

--- a/website/docs/r/route53profiles_association.html.markdown
+++ b/website/docs/r/route53profiles_association.html.markdown
@@ -27,16 +27,22 @@ resource "aws_route53profiles_association" "example" {
   name        = "example"
   profile_id  = aws_route53profiles_profile.example.id
   resource_id = aws_vpc.example.id
+
+  tags = {
+    Environment = "dev"
+  }
 }
 ```
 
 ## Argument Reference
 
-The following arguments are required:
+This resource supports the following arguments:
 
 * `name` - (Required) Name of the Profile Association. Must match a regex of `(?!^[0-9]+$)([a-zA-Z0-9\\-_' ']+)`.
 * `profile_id` - (Required) ID of the profile associated with the VPC.
 * `resource_id` - (Required) Resource ID of the VPC the profile to be associated with.
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tags_all` - (Optional) Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Attribute Reference
 

--- a/website/docs/r/route53profiles_association.html.markdown
+++ b/website/docs/r/route53profiles_association.html.markdown
@@ -42,15 +42,15 @@ This resource supports the following arguments:
 * `profile_id` - (Required) ID of the profile associated with the VPC.
 * `resource_id` - (Required) Resource ID of the VPC the profile to be associated with.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `tags_all` - (Optional) Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
 * `id` - ID of the Profile Association.
-* `status` - Status of the Profile Association. See the [AWS docs](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53profiles_Profile.html) for valid values.
+* `status` - Status of the Profile Association.
 * `status_message` - Status message of the Profile Association.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 

--- a/website/docs/r/route53profiles_profile.html.markdown
+++ b/website/docs/r/route53profiles_profile.html.markdown
@@ -25,9 +25,10 @@ resource "aws_route53profiles_profile" "example" {
 
 ## Argument Reference
 
-The following arguments are required:
+This resource supports the following arguments:
 
 * `name` - (Required) Name of the Profile.
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 
@@ -36,11 +37,10 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - ARN of the Profile.
 * `id` - ID of the Profile.
 * `name` - Name of the Profile.
-* `status` - Status of the Profile. Valid values [AWS docs](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53profiles_Profile.html)
+* `share_status` - Share status of the Profile.
+* `status` - Status of the Profile.
 * `status_message` - Status message of the Profile.
-* `share_status` - Share status of the Profile. Valid values [AWS docs](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53profiles_Profile.html)
-* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `tags_all` - (Optional) Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 

--- a/website/docs/r/route53profiles_profile.html.markdown
+++ b/website/docs/r/route53profiles_profile.html.markdown
@@ -17,6 +17,10 @@ Terraform resource for managing an AWS Route 53 Profile.
 ```terraform
 resource "aws_route53profiles_profile" "example" {
   name = "example"
+  
+  tags = {
+    Environment = "dev"
+  }
 }
 ```
 
@@ -36,7 +40,8 @@ This resource exports the following attributes in addition to the arguments abov
 * `status` - Status of the Profile. Valid values [AWS docs](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53profiles_Profile.html)
 * `status_message` - Status message of the Profile.
 * `share_status` - Share status of the Profile. Valid values [AWS docs](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53profiles_Profile.html)
-* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tags_all` - (Optional) Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 

--- a/website/docs/r/route53profiles_profile.html.markdown
+++ b/website/docs/r/route53profiles_profile.html.markdown
@@ -17,7 +17,6 @@ Terraform resource for managing an AWS Route 53 Profile.
 ```terraform
 resource "aws_route53profiles_profile" "example" {
   name = "example"
-  
   tags = {
     Environment = "dev"
   }


### PR DESCRIPTION
### Description
This PR aims to clarify usage of `tags` arguments on the following resources:

- `aws_route53profiles_profile`
- `aws_route53profiles_association`

➡️ Code is already present, but documentation is missing.

### Relations
Closes #40241.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/39661.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/38172.

### References
I have checked provider behaviour using the following code, based on version `5.77.0`:

```hcl
resource "aws_route53profiles_profile" "dev" {
  name = "example"

  tags = {
    IssueNumber = "40241"
    IssueLink = "https://github.com/hashicorp/terraform-provider-aws/issues/40241"
  }
}
```
Running a `terraform plan` command on this code output the following:

```bash
Terraform will perform the following actions:

  # aws_route53profiles_profile.dev will be updated in-place
  ~ resource "aws_route53profiles_profile" "dev" {
        id             = "rp-dfc217049689400e"
        name           = "example"
      + tags           = {
          + "IssueLink"   = "https://github.com/hashicorp/terraform-provider-aws/issues/40241"
          + "IssueNumber" = "40241"
        }
      ~ tags_all       = {
          + "IssueLink"   = "https://github.com/hashicorp/terraform-provider-aws/issues/40241"
          + "IssueNumber" = "40241"
        }
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

```

And `terraform apply`: 
<img width="1916" alt="image" src="https://github.com/user-attachments/assets/5093c4c6-513a-43aa-a3b8-fcffd604a19a">

