### PR TITLE
Support for rule level ChallgneConfig in wafv2_web_acl

### DIFF
--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -1087,6 +1087,7 @@ func expandWebACLRule(m map[string]interface{}) awstypes.Rule {
 	rule := awstypes.Rule{
 		Action:           expandRuleAction(m[names.AttrAction].([]interface{})),
 		CaptchaConfig:    expandCaptchaConfig(m["captcha_config"].([]interface{})),
+		ChallengeConfig:  expandChallengeConfig(m["challenge_config"].([]interface{})),
 		Name:             aws.String(m[names.AttrName].(string)),
 		OverrideAction:   expandOverrideAction(m["override_action"].([]interface{})),
 		Priority:         int32(m[names.AttrPriority].(int)),
@@ -2578,6 +2579,7 @@ func flattenWebACLRules(r []awstypes.Rule) interface{} {
 		m := make(map[string]interface{})
 		m[names.AttrAction] = flattenRuleAction(rule.Action)
 		m["captcha_config"] = flattenCaptchaConfig(rule.CaptchaConfig)
+		m["challenge_config"] = flattenChallengeConfig(rule.ChallengeConfig)
 		m["override_action"] = flattenOverrideAction(rule.OverrideAction)
 		m[names.AttrName] = aws.ToString(rule.Name)
 		m[names.AttrPriority] = rule.Priority

--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -133,7 +133,8 @@ func resourceWebACL() *schema.Resource {
 									},
 								},
 							},
-							"captcha_config": outerCaptchaConfigSchema(),
+							"captcha_config":   outerCaptchaConfigSchema(),
+							"challenge_config": outerChallengeConfigSchema(),
 							names.AttrName: {
 								Type:         schema.TypeString,
 								Required:     true,

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -2575,6 +2575,7 @@ func TestAccWAFV2WebACL_Custom_requestHandling(t *testing.T) {
 						"action.0.challenge.#": "1",
 						"action.0.count.#":     "0",
 						names.AttrPriority:     "1",
+						"challenge_config.0.immunity_time_property.0.immunity_time": "650",
 					}),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.cloudwatch_metrics_enabled", acctest.CtFalse),
@@ -3914,6 +3915,12 @@ resource "aws_wafv2_web_acl" "test" {
 
     action {
       challenge {}
+    }
+
+    challenge_config {
+	  immunity_time_property {
+        immunity_time = 650
+      }
     }
 
     statement {

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -3918,7 +3918,7 @@ resource "aws_wafv2_web_acl" "test" {
     }
 
     challenge_config {
-	  immunity_time_property {
+      immunity_time_property {
         immunity_time = 650
       }
     }


### PR DESCRIPTION
### Description

AWS WAFv2 ACL [Rule](https://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html ) supports [ChallengeConfig](https://docs.aws.amazon.com/waf/latest/APIReference/API_ChallengeConfig.html) however the AWS Terraform provider does not. This MR extends the provider with support for this attribute.

### Relations

Relates https://github.com/hashicorp/terraform-provider-aws/issues/29071#issuecomment-1588037828
Relates https://github.com/hashicorp/terraform-provider-aws/pull/35367

### References

 - https://docs.aws.amazon.com/waf/latest/APIReference/API_Rule.html
 - https://docs.aws.amazon.com/waf/latest/APIReference/API_ChallengeConfig.html
 - https://docs.aws.amazon.com/waf/latest/developerguide/waf-tokens-immunity-times.html


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccWAFV2WebACL_Custom_requestHandling PKG=wafv2

...make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_Custom_requestHandling'  -timeout 360m
2024/11/23 21:36:13 Initializing Terraform AWS Provider...
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (85.83s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafv2	92.543s
```
