### PR TITLE
resource/aws_bedrock_guardrail: Convert `content_policy_config.filters_config` to Set

### DIFF
--- a/.changelog/40304.txt
+++ b/.changelog/40304.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrock_guardrail: Fix perpetual diff if multiple `content_policy_config.filters_config`s are specified.
+```

--- a/internal/service/bedrock/guardrail.go
+++ b/internal/service/bedrock/guardrail.go
@@ -135,8 +135,8 @@ func (r *resourceGuardrail) Schema(ctx context.Context, req resource.SchemaReque
 				},
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
-						"filters_config": schema.ListNestedBlock{
-							CustomType: fwtypes.NewListNestedObjectTypeOf[filtersConfig](ctx),
+						"filters_config": schema.SetNestedBlock{
+							CustomType: fwtypes.NewSetNestedObjectTypeOf[filtersConfig](ctx),
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
 									"input_strength": schema.StringAttribute{
@@ -667,7 +667,7 @@ type resourceGuardrailData struct {
 }
 
 type contentPolicyConfig struct {
-	Filters fwtypes.ListNestedObjectValueOf[filtersConfig] `tfsdk:"filters_config"`
+	Filters fwtypes.SetNestedObjectValueOf[filtersConfig] `tfsdk:"filters_config"`
 }
 
 type filtersConfig struct {

--- a/internal/service/bedrock/guardrail_test.go
+++ b/internal/service/bedrock/guardrail_test.go
@@ -47,6 +47,8 @@ func TestAccBedrockGuardrail_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "blocked_outputs_messaging", "test"),
 					resource.TestCheckResourceAttr(resourceName, "content_policy_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "content_policy_config.0.filters_config.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "contextual_grounding_policy_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "contextual_grounding_policy_config.0.filters_config.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedAt),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test"),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrKMSKeyARN),

--- a/website/docs/r/bedrock_guardrail.html.markdown
+++ b/website/docs/r/bedrock_guardrail.html.markdown
@@ -86,7 +86,8 @@ The following arguments are optional:
 
 The `content_policy_config` configuration block supports the following arguments:
 
-* `filters_config` - (Optional) List of content filter configs in content policy. See [Filters Config](#content-filters-config) for more information.
+* `filters_config` - (Optional) Set of content filter configs in content policy.
+  See [Filters Config](#content-filters-config) for more information.
 
 #### Content Filters Config
 


### PR DESCRIPTION
### Description

The AWS API does not preserve the order of content_policy_config.filters_config`, which is causing a number of acceptance tests to fail.

Converts the parameter to a Set.

Closes https://github.com/hashicorp/terraform-provider-aws/issues/40041.

### Previously

```console
% make testacc PKG=bedrock TESTS=TestAccBedrockGuardrail_basic

    guardrail_test.go:32: Step 1/2 error: After applying this test step, the refresh plan was not empty.
        stdout
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # aws_bedrock_guardrail.test will be updated in-place
          ~ resource "aws_bedrock_guardrail" "test" {
                name                      = "tf-acc-test-2877867950171300694"
                # (9 unchanged attributes hidden)
        
              ~ content_policy_config {
                  ~ filters_config {
                      ~ input_strength  = "HIGH" -> "MEDIUM"
                      ~ output_strength = "HIGH" -> "MEDIUM"
                      ~ type            = "VIOLENCE" -> "HATE"
                    }
                  ~ filters_config {
                      ~ input_strength  = "MEDIUM" -> "HIGH"
                      ~ output_strength = "MEDIUM" -> "HIGH"
                      ~ type            = "HATE" -> "VIOLENCE"
                    }
                }
        
                # (4 unchanged blocks hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccBedrockGuardrail_basic (12.90s)
```

### Now
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bedrock TESTS=TestAccBedrockGuardrail_

--- PASS: TestAccBedrockGuardrail_disappears (14.13s)
--- PASS: TestAccBedrockGuardrail_basic (16.25s)
--- PASS: TestAccBedrockGuardrail_kmsKey (22.40s)
--- PASS: TestAccBedrockGuardrail_tags (27.57s)
--- PASS: TestAccBedrockGuardrail_update (33.76s)
```
