### PR TITLE
Adds `metrics_config` to aws_lambda_event_source_mapping

### DIFF
--- a/.changelog/40322.txt
+++ b/.changelog/40322.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_lambda_event_source_mapping: Add `metrics_config` argument to support producing metrics from the event source.
+resource/aws_lambda_event_source_mapping: Add `metrics_config` argument
 ```

--- a/.changelog/40322.txt
+++ b/.changelog/40322.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_lambda_event_source_mapping: Add `metrics_config` argument to support producing metrics from the event source.
+```

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -466,7 +466,7 @@ func resourceEventSourceMappingCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if v, ok := d.GetOk("metrics_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.MetricsConfig = expandMetricsConfig(v.([]interface{})[0].(map[string]interface{}))
+		input.MetricsConfig = expandEventSourceMappingMetricsConfig(v.([]interface{})[0].(map[string]interface{}))
 	}
 
 	if v, ok := d.GetOk("parallelization_factor"); ok {
@@ -607,7 +607,7 @@ func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("maximum_record_age_in_seconds", output.MaximumRecordAgeInSeconds)
 	d.Set("maximum_retry_attempts", output.MaximumRetryAttempts)
 	if v := output.MetricsConfig; v != nil {
-		if err := d.Set("metrics_config", []interface{}{flattenMetricsConfig(v)}); err != nil {
+		if err := d.Set("metrics_config", []interface{}{flattenEventSourceMappingMetricsConfig(v)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting metrics_config: %s", err)
 		}
 	} else {
@@ -732,7 +732,7 @@ func resourceEventSourceMappingUpdate(ctx context.Context, d *schema.ResourceDat
 
 		if d.HasChange("metrics_config") {
 			if v, ok := d.GetOk("metrics_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.MetricsConfig = expandMetricsConfig((v.([]interface{})[0].(map[string]interface{})))
+				input.MetricsConfig = expandEventSourceMappingMetricsConfig((v.([]interface{})[0].(map[string]interface{})))
 			} else {
 				input.MetricsConfig = &awstypes.EventSourceMappingMetricsConfig{}
 			}
@@ -1343,7 +1343,7 @@ func flattenScalingConfig(apiObject *awstypes.ScalingConfig) map[string]interfac
 	return tfMap
 }
 
-func expandMetricsConfig(tfMap map[string]interface{}) *awstypes.EventSourceMappingMetricsConfig {
+func expandEventSourceMappingMetricsConfig(tfMap map[string]interface{}) *awstypes.EventSourceMappingMetricsConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -1357,14 +1357,12 @@ func expandMetricsConfig(tfMap map[string]interface{}) *awstypes.EventSourceMapp
 	return apiObject
 }
 
-func flattenMetricsConfig(apiObject *awstypes.EventSourceMappingMetricsConfig) map[string]interface{} {
+func flattenEventSourceMappingMetricsConfig(apiObject *awstypes.EventSourceMappingMetricsConfig) map[string]interface{} {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
-		"metrics": apiObject.Metrics,
-	}
+	tfMap := map[string]interface{}{}
 
 	if v := apiObject.Metrics; v != nil {
 		tfMap["metrics"] = flex.FlattenStringyValueSet(v)

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -238,6 +238,24 @@ func resourceEventSourceMapping() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.IntBetween(-1, 10_000),
 			},
+			"metrics_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metrics": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: enum.Validate[awstypes.EventSourceMappingMetric](),
+							},
+						},
+					},
+				},
+			},
 			"parallelization_factor": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -447,6 +465,10 @@ func resourceEventSourceMappingCreate(ctx context.Context, d *schema.ResourceDat
 		input.MaximumRetryAttempts = aws.Int32(int32(v.(int)))
 	}
 
+	if v, ok := d.GetOk("metrics_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.MetricsConfig = expandMetricsConfig(v.([]interface{})[0].(map[string]interface{}))
+	}
+
 	if v, ok := d.GetOk("parallelization_factor"); ok {
 		input.ParallelizationFactor = aws.Int32(int32(v.(int)))
 	}
@@ -584,6 +606,13 @@ func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("maximum_batching_window_in_seconds", output.MaximumBatchingWindowInSeconds)
 	d.Set("maximum_record_age_in_seconds", output.MaximumRecordAgeInSeconds)
 	d.Set("maximum_retry_attempts", output.MaximumRetryAttempts)
+	if v := output.MetricsConfig; v != nil {
+		if err := d.Set("metrics_config", []interface{}{flattenMetricsConfig(v)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting metrics_config: %s", err)
+		}
+	} else {
+		d.Set("metrics_config", nil)
+	}
 	d.Set("parallelization_factor", output.ParallelizationFactor)
 	d.Set("queues", output.Queues)
 	if v := output.ScalingConfig; v != nil {
@@ -699,6 +728,14 @@ func resourceEventSourceMappingUpdate(ctx context.Context, d *schema.ResourceDat
 
 		if d.HasChange("maximum_retry_attempts") {
 			input.MaximumRetryAttempts = aws.Int32(int32(d.Get("maximum_retry_attempts").(int)))
+		}
+
+		if d.HasChange("metrics_config") {
+			if v, ok := d.GetOk("metrics_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+				input.MetricsConfig = expandMetricsConfig((v.([]interface{})[0].(map[string]interface{})))
+			} else {
+				input.MetricsConfig = &awstypes.EventSourceMappingMetricsConfig{}
+			}
 		}
 
 		if d.HasChange("parallelization_factor") {
@@ -1301,6 +1338,36 @@ func flattenScalingConfig(apiObject *awstypes.ScalingConfig) map[string]interfac
 
 	if v := apiObject.MaximumConcurrency; v != nil {
 		tfMap["maximum_concurrency"] = aws.ToInt32(v)
+	}
+
+	return tfMap
+}
+
+func expandMetricsConfig(tfMap map[string]interface{}) *awstypes.EventSourceMappingMetricsConfig {
+	if tfMap == nil {
+		return nil
+	}
+
+	apiObject := &awstypes.EventSourceMappingMetricsConfig{}
+
+	if v, ok := tfMap["metrics"].(*schema.Set); ok && v.Len() > 0 {
+		apiObject.Metrics = flex.ExpandStringyValueSet[awstypes.EventSourceMappingMetric](v)
+	}
+
+	return apiObject
+}
+
+func flattenMetricsConfig(apiObject *awstypes.EventSourceMappingMetricsConfig) map[string]interface{} {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]interface{}{
+		"metrics": apiObject.Metrics,
+	}
+
+	if v := apiObject.Metrics; v != nil {
+		tfMap["metrics"] = flex.FlattenStringyValueSet(v)
 	}
 
 	return tfMap

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -1309,7 +1309,7 @@ func TestAccLambdaEventSourceMapping_SQS_metricsConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckEventSourceMappingDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEventSourceMappingConfig_sqsMetricsConfig(rName),
+				Config: testAccEventSourceMappingConfig_sqsMetricsConfig1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSourceMappingExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "metrics_config.0.metrics.0", "EventCount"),
@@ -1322,7 +1322,7 @@ func TestAccLambdaEventSourceMapping_SQS_metricsConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"last_modified"},
 			},
 			{
-				Config: testAccEventSourceMappingConfig_sqsBase(rName),
+				Config: testAccEventSourceMappingConfig_sqsMetricsConfig2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEventSourceMappingExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "metrics_config.#", "0"),
@@ -2720,15 +2720,24 @@ resource "aws_lambda_event_source_mapping" "test" {
 `)
 }
 
-func testAccEventSourceMappingConfig_sqsMetricsConfig(rName string) string {
+func testAccEventSourceMappingConfig_sqsMetricsConfig1(rName string) string {
 	return acctest.ConfigCompose(testAccEventSourceMappingConfig_sqsBase(rName), `
 resource "aws_lambda_event_source_mapping" "test" {
-	event_source_arn = aws_sqs_queue.test.arn
-	function_name    = aws_lambda_function.test.arn
+  event_source_arn = aws_sqs_queue.test.arn
+  function_name    = aws_lambda_function.test.arn
 
-	metrics_config {
-		metrics = ["EventCount"]
-	}
+  metrics_config {
+    metrics = ["EventCount"]
+  }
+}
+`)
+}
+
+func testAccEventSourceMappingConfig_sqsMetricsConfig2(rName string) string {
+	return acctest.ConfigCompose(testAccEventSourceMappingConfig_sqsBase(rName), `
+resource "aws_lambda_event_source_mapping" "test" {
+  event_source_arn = aws_sqs_queue.test.arn
+  function_name    = aws_lambda_function.test.arn
 }
 `)
 }

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -58,6 +58,7 @@ func TestAccLambdaEventSourceMapping_Kinesis_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "function_response_types.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrKMSKeyARN, ""),
 					acctest.CheckResourceAttrRFC3339(resourceName, "last_modified"),
+					resource.TestCheckResourceAttr(resourceName, "metrics_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tumbling_window_in_seconds", "0"),
 				),
 			},
@@ -1294,11 +1295,7 @@ func TestAccLambdaEventSourceMapping_documentDB(t *testing.T) {
 
 func TestAccLambdaEventSourceMapping_SQS_metricsConfig(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var conf lambda.GetEventSourceMappingOutput
+	var v lambda.GetEventSourceMappingOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_lambda_event_source_mapping.test"
 
@@ -1311,7 +1308,7 @@ func TestAccLambdaEventSourceMapping_SQS_metricsConfig(t *testing.T) {
 			{
 				Config: testAccEventSourceMappingConfig_sqsMetricsConfig1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEventSourceMappingExists(ctx, resourceName, &conf),
+					testAccCheckEventSourceMappingExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "metrics_config.0.metrics.0", "EventCount"),
 				),
 			},
@@ -1324,7 +1321,7 @@ func TestAccLambdaEventSourceMapping_SQS_metricsConfig(t *testing.T) {
 			{
 				Config: testAccEventSourceMappingConfig_sqsMetricsConfig2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEventSourceMappingExists(ctx, resourceName, &conf),
+					testAccCheckEventSourceMappingExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "metrics_config.#", "0"),
 				),
 			},

--- a/website/docs/cdktf/python/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/cdktf/python/r/lambda_event_source_mapping.html.markdown
@@ -251,6 +251,7 @@ class MyConvertedCode(TerraformStack):
 * `maximum_batching_window_in_seconds` - (Optional) The maximum amount of time to gather records before invoking the function, in seconds (between 0 and 300). Records will continue to buffer (or accumulate in the case of an SQS queue event source) until either `maximum_batching_window_in_seconds` expires or `batch_size` has been met. For streaming event sources, defaults to as soon as records are available in the stream. If the batch it reads from the stream/queue only has one record in it, Lambda only sends one record to the function. Only available for stream sources (DynamoDB and Kinesis) and SQS standard queues.
 * `maximum_record_age_in_seconds`: - (Optional) The maximum age of a record that Lambda sends to a function for processing. Only available for stream sources (DynamoDB and Kinesis). Must be either -1 (forever, and the default value) or between 60 and 604800 (inclusive).
 * `maximum_retry_attempts`: - (Optional) The maximum number of times to retry when the function returns an error. Only available for stream sources (DynamoDB and Kinesis). Minimum and default of -1 (forever), maximum of 10000.
+* `metrics_config`: - (Optional) CloudWatch metrics configuration of the event source. Only available for stream sources (DynamoDB and Kinesis) and SQS queues. Detailed below.
 * `parallelization_factor`: - (Optional) The number of batches to process from each shard concurrently. Only available for stream sources (DynamoDB and Kinesis). Minimum and default of 1, maximum of 10.
 * `queues` - (Optional) The name of the Amazon MQ broker destination queue to consume. Only available for MQ sources. The list must contain exactly one queue name.
 * `scaling_config` - (Optional) Scaling configuration of the event source. Only available for SQS queues. Detailed below.
@@ -288,6 +289,10 @@ class MyConvertedCode(TerraformStack):
 #### filter_criteria filter Configuration Block
 
 * `pattern` - (Optional) A filter pattern up to 4096 characters. See [Filter Rule Syntax](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html#filtering-syntax).
+
+### metrics_config Configuration Block
+
+* `metrics` - (Required) A list containing the metrics to be produced by the event source mapping. Valid values: `EventCount`.
 
 ### scaling_config Configuration Block
 

--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -165,6 +165,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 * `maximum_batching_window_in_seconds` - (Optional) The maximum amount of time to gather records before invoking the function, in seconds (between 0 and 300). Records will continue to buffer (or accumulate in the case of an SQS queue event source) until either `maximum_batching_window_in_seconds` expires or `batch_size` has been met. For streaming event sources, defaults to as soon as records are available in the stream. If the batch it reads from the stream/queue only has one record in it, Lambda only sends one record to the function. Only available for stream sources (DynamoDB and Kinesis) and SQS standard queues.
 * `maximum_record_age_in_seconds`: - (Optional) The maximum age of a record that Lambda sends to a function for processing. Only available for stream sources (DynamoDB and Kinesis). Must be either -1 (forever, and the default value) or between 60 and 604800 (inclusive).
 * `maximum_retry_attempts`: - (Optional) The maximum number of times to retry when the function returns an error. Only available for stream sources (DynamoDB and Kinesis). Minimum and default of -1 (forever), maximum of 10000.
+* `metrics_config`: - (Optional) CloudWatch metrics configuration of the event source. Only available for stream sources (DynamoDB and Kinesis) and SQS queues. Detailed below.
 * `parallelization_factor`: - (Optional) The number of batches to process from each shard concurrently. Only available for stream sources (DynamoDB and Kinesis). Minimum and default of 1, maximum of 10.
 * `queues` - (Optional) The name of the Amazon MQ broker destination queue to consume. Only available for MQ sources. The list must contain exactly one queue name.
 * `scaling_config` - (Optional) Scaling configuration of the event source. Only available for SQS queues. Detailed below.
@@ -202,6 +203,10 @@ resource "aws_lambda_event_source_mapping" "example" {
 #### filter_criteria filter Configuration Block
 
 * `pattern` - (Optional) A filter pattern up to 4096 characters. See [Filter Rule Syntax](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html#filtering-syntax).
+
+### metrics_config Configuration Block
+
+* `metrics` - (Required) A list containing the metrics to be produced by the event source mapping. Valid values: `EventCount`.
 
 ### scaling_config Configuration Block
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR adds support for `metrics_config` in the `aws_lambda_event_source_mapping` resource. Copied from the related issue:

-----

> AWS Lambda announces new Amazon CloudWatch metrics for Lambda Event Source Mappings (ESMs), which provide customers visibility into the processing state of events read by ESMs that subscribe to Amazon SQS, Amazon Kinesis, and Amazon DynamoDB event sources.

* [Announcement](https://aws.amazon.com/about-aws/whats-new/2024/11/amazon-cloudwatch-metrics-aws-lambda-esms/)

* [Blog post](https://aws.amazon.com/blogs/compute/introducing-new-event-source-mapping-esm-metrics-for-aws-lambda/)


### Affected Resource(s) and/or Data Source(s)

* `aws_lambda_event_source_mapping`


### Potential Terraform Configuration

```hcl
resource "aws_lambda_event_source_mapping" "example" {
  metrics_config {
    metrics = ["EventCount"]
  }
}
```

-----

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40275 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

[Docs](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics-types.html#event-source-mapping-metrics) for Event Source Mapping Metrics

[API Reference](https://docs.aws.amazon.com/lambda/latest/api/API_EventSourceMappingMetricsConfig.html) for the EventSourceMappingMetricsConfig

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccLambdaEventSourceMapping_SQS_metricsConfig PKG=lambda
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/lambda/... -v -count 1 -parallel 20 -run='TestAccLambdaEventSourceMapping_SQS_metricsConfig'  -timeout 360m
2024/11/26 23:53:31 Initializing Terraform AWS Provider...
=== RUN   TestAccLambdaEventSourceMapping_SQS_metricsConfig
=== PAUSE TestAccLambdaEventSourceMapping_SQS_metricsConfig
=== CONT  TestAccLambdaEventSourceMapping_SQS_metricsConfig
--- PASS: TestAccLambdaEventSourceMapping_SQS_metricsConfig (96.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lambda     101.640s
```
