### PR TITLE
docs(r-lb-listener-rule): Notes the relationship between a tag key `Name` to the AWS Console

### DIFF
--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -267,6 +267,8 @@ The following arguments are optional:
 * `tcp_idle_timeout_seconds` - (Optional) TCP idle timeout value in seconds. Can only be set if protocol is `TCP` on Network Load Balancer, or with a Gateway Load Balancer. Not supported for Application Load Balancers. Valid values are between `60` and `6000` inclusive. Default: `350`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
+~> **Note::** When a `Name` key is specified in the map, the AWS Console maps the value to the `Name Tag` column value inside the `Listener Rules` table within a specific load balancer listener page. Otherwise, the value resolves to `Default`.
+
 ### default_action
 
 The following arguments are required:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
It has been pointed out by a community member that when a key `Name` is defined in the lb_listener_rule resource, it gets picked up by the AWS Console and displays the value within the `Name Tag` column. In order to save time for other users so that they don't perform the same investigation as the reporter did, this PR documents that quirk.

<img width="1346" alt="Screenshot 2024-11-28 at 4 13 43 PM" src="https://github.com/user-attachments/assets/8763ac5a-58bf-43a0-bd0a-b8e9c9f764e1">


### Closes
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36386

