### PR TITLE
[Enhancement]  Add profile_owner attribute to signing job resource

### DIFF
--- a/internal/service/signer/signing_job.go
+++ b/internal/service/signer/signing_job.go
@@ -37,6 +37,11 @@ func ResourceSigningJob() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"profile_owner": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			names.AttrSource: {
 				Type:     schema.TypeList,
 				Required: true,
@@ -208,6 +213,7 @@ func resourceSigningJobCreate(ctx context.Context, d *schema.ResourceData, meta 
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SignerClient(ctx)
 	profileName := d.Get("profile_name")
+	profileOwner := d.Get("profile_owner")
 	source := d.Get(names.AttrSource).([]interface{})
 	destination := d.Get(names.AttrDestination).([]interface{})
 
@@ -215,6 +221,10 @@ func resourceSigningJobCreate(ctx context.Context, d *schema.ResourceData, meta 
 		ProfileName: aws.String(profileName.(string)),
 		Source:      expandSigningJobSource(source),
 		Destination: expandSigningJobDestination(destination),
+	}
+
+	if profileOwner != nil {
+		startSigningJobInput.ProfileOwner = aws.String(profileOwner.(string))
 	}
 
 	log.Printf("[DEBUG] Starting Signer Signing Job using profile name %q.", profileName)

--- a/internal/service/signer/signing_job.go
+++ b/internal/service/signer/signing_job.go
@@ -39,7 +39,7 @@ func ResourceSigningJob() *schema.Resource {
 			},
 			"profile_owner": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			names.AttrSource: {

--- a/internal/service/signer/signing_job_test.go
+++ b/internal/service/signer/signing_job_test.go
@@ -105,40 +105,40 @@ resource "aws_signer_signing_job" "test" {
 }
 
 func TestAccSignerSigningJob_profileOwner(t *testing.T) {
-    ctx := acctest.Context(t)
-    rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-    resourceName := "aws_signer_signing_job.test"
-    profileResourceName := "aws_signer_signing_profile.test"
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_signer_signing_job.test"
+	profileResourceName := "aws_signer_signing_profile.test"
 
-    var job signer.DescribeSigningJobOutput
-    var conf signer.GetSigningProfileOutput
+	var job signer.DescribeSigningJobOutput
+	var conf signer.GetSigningProfileOutput
 
-    resource.ParallelTest(t, resource.TestCase{
-        PreCheck: func() {
-            acctest.PreCheck(ctx, t)
-            testAccPreCheckSingerSigningProfile(ctx, t, "AWSLambda-SHA384-ECDSA")
-        },
-        ErrorCheck:               acctest.ErrorCheck(t, signer.ServiceID),
-        ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-        CheckDestroy:             nil,
-        Steps: []resource.TestStep{
-            {
-                Config: testAccSigningJobConfig_profileOwner(rName),
-                Check: resource.ComposeTestCheckFunc(
-                    testAccCheckSigningProfileExists(ctx, profileResourceName, &conf),
-                    testAccCheckSigningJobExists(ctx, resourceName, &job),
-                    resource.TestCheckResourceAttr(resourceName, "platform_id", "AWSLambda-SHA384-ECDSA"),
-                    resource.TestCheckResourceAttr(resourceName, "platform_display_name", "AWS Lambda"),
-                    resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Succeeded"),
-                    resource.TestCheckResourceAttrPair(resourceName, "profile_owner", "data.aws_caller_identity.current", "account_id"),
-                ),
-            },
-        },
-    })
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckSingerSigningProfile(ctx, t, "AWSLambda-SHA384-ECDSA")
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, signer.ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSigningJobConfig_profileOwner(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSigningProfileExists(ctx, profileResourceName, &conf),
+					testAccCheckSigningJobExists(ctx, resourceName, &job),
+					resource.TestCheckResourceAttr(resourceName, "platform_id", "AWSLambda-SHA384-ECDSA"),
+					resource.TestCheckResourceAttr(resourceName, "platform_display_name", "AWS Lambda"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Succeeded"),
+					resource.TestCheckResourceAttrPair(resourceName, "profile_owner", "data.aws_caller_identity.current", "account_id"),
+				),
+			},
+		},
+	})
 }
 
 func testAccSigningJobConfig_profileOwner(rName string) string {
-    return fmt.Sprintf(`
+	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 
 resource "aws_signer_signing_profile" "test" {

--- a/internal/service/signer/signing_job_test.go
+++ b/internal/service/signer/signing_job_test.go
@@ -104,6 +104,94 @@ resource "aws_signer_signing_job" "test" {
 `, rName)
 }
 
+func TestAccSignerSigningJob_profileOwner(t *testing.T) {
+    ctx := acctest.Context(t)
+    rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+    resourceName := "aws_signer_signing_job.test"
+    profileResourceName := "aws_signer_signing_profile.test"
+
+    var job signer.DescribeSigningJobOutput
+    var conf signer.GetSigningProfileOutput
+
+    resource.ParallelTest(t, resource.TestCase{
+        PreCheck: func() {
+            acctest.PreCheck(ctx, t)
+            testAccPreCheckSingerSigningProfile(ctx, t, "AWSLambda-SHA384-ECDSA")
+        },
+        ErrorCheck:               acctest.ErrorCheck(t, signer.ServiceID),
+        ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+        CheckDestroy:             nil,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccSigningJobConfig_profileOwner(rName),
+                Check: resource.ComposeTestCheckFunc(
+                    testAccCheckSigningProfileExists(ctx, profileResourceName, &conf),
+                    testAccCheckSigningJobExists(ctx, resourceName, &job),
+                    resource.TestCheckResourceAttr(resourceName, "platform_id", "AWSLambda-SHA384-ECDSA"),
+                    resource.TestCheckResourceAttr(resourceName, "platform_display_name", "AWS Lambda"),
+                    resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "Succeeded"),
+                    resource.TestCheckResourceAttrPair(resourceName, "profile_owner", "data.aws_caller_identity.current", "account_id"),
+                ),
+            },
+        },
+    })
+}
+
+func testAccSigningJobConfig_profileOwner(rName string) string {
+    return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_signer_signing_profile" "test" {
+  platform_id = "AWSLambda-SHA384-ECDSA"
+}
+
+resource "aws_s3_bucket" "source" {
+  bucket        = "%[1]s-source"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_versioning" "source" {
+  bucket = aws_s3_bucket.source.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket" "destination" {
+  bucket        = "%[1]s"
+  force_destroy = true
+}
+
+resource "aws_s3_object" "source" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.source]
+
+  bucket = aws_s3_bucket.source.bucket
+  key    = "lambdatest.zip"
+  source = "test-fixtures/lambdatest.zip"
+}
+
+resource "aws_signer_signing_job" "test" {
+  profile_name  = aws_signer_signing_profile.test.name
+  profile_owner = data.aws_caller_identity.current.account_id
+
+  source {
+    s3 {
+      bucket  = aws_s3_object.source.bucket
+      key     = aws_s3_object.source.key
+      version = aws_s3_object.source.version_id
+    }
+  }
+
+  destination {
+    s3 {
+      bucket = aws_s3_bucket.destination.bucket
+    }
+  }
+}
+`, rName)
+}
+
 func testAccCheckSigningJobExists(ctx context.Context, res string, job *signer.DescribeSigningJobOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[res]

--- a/website/docs/r/signer_signing_job.html.markdown
+++ b/website/docs/r/signer_signing_job.html.markdown
@@ -45,6 +45,7 @@ resource "aws_signer_signing_job" "build_signing_job" {
 * `source` - (Required) The S3 bucket that contains the object to sign. See [Source](#source) below for details.
 * `destination` - (Required) The S3 bucket in which to save your signed object. See [Destination](#destination) below for details.
 * `ignore_signing_job_failure` - (Optional) Set this argument to `true` to ignore signing job failures and retrieve failed status and reason. Default `false`.
+* `profile_owner` - (Optional) The AWS account ID of the signing profile owner.
 
 ### Source
 


### PR DESCRIPTION
### Description

AWS Signer natively supports using signing profiles across accounts. This change adds support for this functionality in the provider by allowing signing jobs to use signing profiles from other AWS accounts (aka Profile Owner)

### Relations
Closes #40344

### References
https://docs.aws.amazon.com/signer/latest/api/API_StartSigningJob.html#signer-StartSigningJob-request-profileOwner


### Output from Acceptance Testing

```console
make testacc TESTS=TestAccSignerSigningJob PKG=signer
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/signer/... -v -count 1 -parallel 20 -run='TestAccSignerSigningJob'  -timeout 360m
2024/11/28 13:33:47 Initializing Terraform AWS Provider...
=== RUN   TestAccSignerSigningJobDataSource_basic
=== PAUSE TestAccSignerSigningJobDataSource_basic
=== RUN   TestAccSignerSigningJob_basic
=== PAUSE TestAccSignerSigningJob_basic
=== RUN   TestAccSignerSigningJob_profileOwner
=== PAUSE TestAccSignerSigningJob_profileOwner
=== CONT  TestAccSignerSigningJobDataSource_basic
=== CONT  TestAccSignerSigningJob_profileOwner
=== CONT  TestAccSignerSigningJob_basic
--- PASS: TestAccSignerSigningJobDataSource_basic (59.18s)
--- PASS: TestAccSignerSigningJob_profileOwner (61.03s)
--- PASS: TestAccSignerSigningJob_basic (61.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/signer     61.289s
```
