### PR TITLE
[Amplify] fix panic when updating `certificate_settings`

### DIFF
--- a/internal/service/amplify/domain_association.go
+++ b/internal/service/amplify/domain_association.go
@@ -213,7 +213,9 @@ func resourceDomainAssociationUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if d.HasChange("certificate_settings") {
-			input.CertificateSettings = expandCertificateSettings(d.Get("certificate_settings").([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("certificate_settings"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+				input.CertificateSettings = expandCertificateSettings(v.([]interface{})[0].(map[string]interface{}))
+			}
 		}
 
 		if d.HasChange("enable_auto_sub_domain") {
@@ -429,7 +431,7 @@ func expandCertificateSettings(tfMap map[string]interface{}) *types.CertificateS
 		Type: types.CertificateType(tfMap[names.AttrType].(string)),
 	}
 
-	if v, ok := tfMap["custom_certificate_arn"].(string); ok {
+	if v, ok := tfMap["custom_certificate_arn"].(string); ok && v != "" {
 		apiObject.CustomCertificateArn = aws.String(v)
 	}
 

--- a/internal/service/amplify/domain_association_test.go
+++ b/internal/service/amplify/domain_association_test.go
@@ -183,6 +183,7 @@ func testAccDomainAssociation_certificateSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.type", "AMPLIFY_MANAGED"),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_settings.0.certificate_verification_dns_record"),
+					resource.TestCheckNoResourceAttr(resourceName, "certificate_settings.0.custom_certificate_arn"),
 				),
 			},
 			{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This PR fixes two issues mentioned in #39890:
- Panic when updating Domain 
- When `certificate_settings` is provided, but `custom_certificate_arn` is not provided, then it's treated as `nil` rather than empty string 


### Relations
Closes #39890

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
