### PR TITLE
sweeper/aws_fsx_ontap_volume: Fix error

### DIFF
--- a/internal/service/fsx/lustre_file_system.go
+++ b/internal/service/fsx/lustre_file_system.go
@@ -844,11 +844,12 @@ func waitFileSystemUpdated(ctx context.Context, conn *fsx.Client, id string, sta
 
 func waitFileSystemDeleted(ctx context.Context, conn *fsx.Client, id string, timeout time.Duration) (*awstypes.FileSystem, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.FileSystemLifecycleAvailable, awstypes.FileSystemLifecycleDeleting),
-		Target:  []string{},
-		Refresh: statusFileSystem(ctx, conn, id),
-		Timeout: timeout,
-		Delay:   30 * time.Second,
+		Pending:      enum.Slice(awstypes.FileSystemLifecycleAvailable, awstypes.FileSystemLifecycleDeleting),
+		Target:       []string{},
+		Refresh:      statusFileSystem(ctx, conn, id),
+		Timeout:      timeout,
+		Delay:        10 * time.Minute,
+		PollInterval: 10 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -478,11 +478,12 @@ func waitStorageVirtualMachineUpdated(ctx context.Context, conn *fsx.Client, id 
 
 func waitStorageVirtualMachineDeleted(ctx context.Context, conn *fsx.Client, id string, timeout time.Duration) (*awstypes.StorageVirtualMachine, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.StorageVirtualMachineLifecycleCreated, awstypes.StorageVirtualMachineLifecycleDeleting),
-		Target:  []string{},
-		Refresh: statusStorageVirtualMachine(ctx, conn, id),
-		Timeout: timeout,
-		Delay:   30 * time.Second,
+		Pending:      enum.Slice(awstypes.StorageVirtualMachineLifecycleCreated, awstypes.StorageVirtualMachineLifecycleDeleting),
+		Target:       []string{},
+		Refresh:      statusStorageVirtualMachine(ctx, conn, id),
+		Timeout:      timeout,
+		Delay:        1 * time.Minute,
+		PollInterval: 10 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/fsx/ontap_volume.go
+++ b/internal/service/fsx/ontap_volume.go
@@ -749,11 +749,12 @@ func waitVolumeUpdated(ctx context.Context, conn *fsx.Client, id string, startTi
 
 func waitVolumeDeleted(ctx context.Context, conn *fsx.Client, id string, timeout time.Duration) (*awstypes.Volume, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(awstypes.VolumeLifecycleCreated, awstypes.VolumeLifecycleMisconfigured, awstypes.VolumeLifecycleAvailable, awstypes.VolumeLifecycleDeleting),
-		Target:  []string{},
-		Refresh: statusVolume(ctx, conn, id),
-		Timeout: timeout,
-		Delay:   30 * time.Second,
+		Pending:      enum.Slice(awstypes.VolumeLifecycleCreated, awstypes.VolumeLifecycleMisconfigured, awstypes.VolumeLifecycleAvailable, awstypes.VolumeLifecycleDeleting),
+		Target:       []string{},
+		Refresh:      statusVolume(ctx, conn, id),
+		Timeout:      timeout,
+		Delay:        30 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)


### PR DESCRIPTION
### Description

If an `aws_fsx_ontap_volume` does not have SnapLock configured, setting `bypass_snaplock_enterprise_retention` when deleting causes the error

> operation error FSx: DeleteVolume, https response error StatusCode: 400, BadRequest: BypassSnaplockEnterpriseRetention is not supported on this volume.

### Output

Previously:

```console
% make sweep SWEEPARGS=-sweep-run=aws_fsx_ontap_volume

2024/11/28 11:10:22 [DEBUG] Deleting FSx for NetApp ONTAP Volume: fsvol-abc123
2024/11/28 11:10:22 [DEBUG] Completed Sweeper (aws_fsx_ontap_volume) in region (us-west-2) in 2.031017959s
2024/11/28 11:10:22 [ERROR] Error running Sweeper (aws_fsx_ontap_volume) in region (us-west-2): error sweeping FSx ONTAP Volumes (us-west-2): 1 error occurred:
	* deleting FSx for NetApp ONTAP Volume (fsvol-abc123): operation error FSx: DeleteVolume, https response error StatusCode: 400, BadRequest: BypassSnaplockEnterpriseRetention is not supported on this volume.
```

Afterwards:

```console
% make sweep SWEEPARGS=-sweep-run=aws_fsx_ontap_volume

2024/11/28 11:10:22 [DEBUG] Deleting FSx for NetApp ONTAP Volume: fsvol-abc123
2024/11/28 11:16:35 [DEBUG] Waiting for state to become: []
2024/11/28 11:17:05 [TRACE] Waiting 200ms before next try
2024/11/28 11:17:05 [TRACE] Waiting 400ms before next try
2024/11/28 11:17:06 [TRACE] Waiting 800ms before next try
2024/11/28 11:17:07 [TRACE] Waiting 1.6s before next try
2024/11/28 11:17:09 [TRACE] Waiting 3.2s before next try
2024/11/28 11:17:12 [TRACE] Waiting 6.4s before next try
2024/11/28 11:17:19 [TRACE] Waiting 10s before next try
2024/11/28 11:17:29 [DEBUG] Completed Sweeper (aws_fsx_ontap_volume) in region (us-west-2) in 55.146967208s
```
