### PR TITLE
sweeper/aws_docdb_cluster: Fix error when sweeping members of global cluster

### DIFF
--- a/internal/service/docdb/sweep.go
+++ b/internal/service/docdb/sweep.go
@@ -4,6 +4,7 @@
 package docdb
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -11,19 +12,17 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/docdb"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func RegisterSweepers() {
-	resource.AddTestSweepers("aws_docdb_cluster", &resource.Sweeper{
-		Name: "aws_docdb_cluster",
-		F:    sweepClusters,
-		Dependencies: []string{
-			"aws_docdb_cluster_instance",
-		},
-	})
+	awsv2.Register("aws_docdb_cluster", sweepClusters,
+		"aws_docdb_cluster_instance",
+	)
 
 	resource.AddTestSweepers("aws_docdb_cluster_instance", &resource.Sweeper{
 		Name: "aws_docdb_cluster_instance",
@@ -68,36 +67,27 @@ func RegisterSweepers() {
 	})
 }
 
-func sweepClusters(region string) error {
-	ctx := sweep.Context(region)
-	client, err := sweep.SharedRegionalSweepClient(ctx, region)
-	if err != nil {
-		return fmt.Errorf("error getting client: %d", err)
-	}
+func sweepClusters(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
 	conn := client.DocDBClient(ctx)
-	input := &docdb.DescribeDBClustersInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
 
-	pages := docdb.NewDescribeDBClustersPaginator(conn, input)
+	var sweepResources []sweep.Sweepable
+	r := resourceCluster()
+
+	input := docdb.DescribeDBClustersInput{}
+	pages := docdb.NewDescribeDBClustersPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
-		if awsv2.SkipSweepError(err) {
-			log.Printf("[WARN] Skipping DocumentDB Cluster sweep for %s: %s", region, err)
-			return nil
-		}
-
 		if err != nil {
-			return fmt.Errorf("error listing DocumentDB Clusters for %s: %s", region, err)
+			return nil, err
 		}
 
 		for _, v := range page.DBClusters {
 			arn := aws.ToString(v.DBClusterArn)
 			id := aws.ToString(v.DBClusterIdentifier)
 
-			r := resourceCluster()
 			d := r.Data(nil)
 			d.SetId(id)
+			d.Set(names.AttrARN, arn)
 			d.Set("skip_final_snapshot", true)
 
 			globalCluster, err := findGlobalClusterByClusterARN(ctx, conn, arn)
@@ -115,13 +105,7 @@ func sweepClusters(region string) error {
 		}
 	}
 
-	err = sweep.SweepOrchestrator(ctx, sweepResources)
-
-	if err != nil {
-		return fmt.Errorf("error sweeping DocumentDB Clusters (%s): %w", region, err)
-	}
-
-	return nil
+	return sweepResources, nil
 }
 
 func sweepClusterSnapshots(region string) error {


### PR DESCRIPTION
### Description

When sweeping an `aws_docdb_cluster` which is a member of a global cluster, the cluster `arn` value is needed. Otherwise it returns an error

> removing DocumentDB Cluster () from DocumentDB Global Cluster (tf-acc-test-7157141747640475231-0): operation error DocDB: RemoveFromGlobalCluster, https response error StatusCode: 400, api error InvalidParameterValue: Db cluster identifier  is not a valid arn

Note that the "()" should contain the ARN of the cluster.
