### PR TITLE
r/aws_fsx_openzfs_file_system increase SINGLE_AZ_2 max IOPS to 400000

### DIFF
--- a/.changelog/40359.txt
+++ b/.changelog/40359.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_fsx_openzfs_file_system: Increase max IOPS to 400000 for SINGLE_AZ_2
+resource/aws_fsx_openzfs_file_system: Increase maximum value of `disk_iops_configuration.iops` from `350000` to `400000` for `deployment_type = "SINGLE_AZ_2"`
 ```

--- a/.changelog/40359.txt
+++ b/.changelog/40359.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fsx_openzfs_file_system: Increase max IOPS to 400000 for SINGLE_AZ_2
+```

--- a/internal/service/fsx/openzfs_file_system.go
+++ b/internal/service/fsx/openzfs_file_system.go
@@ -355,8 +355,8 @@ func validateDiskConfigurationIOPS(_ context.Context, d *schema.ResourceDiff, me
 						return fmt.Errorf("expected disk_iops_configuration.0.iops to be in the range (0 - 160000) when deployment_type (%s), got %d", awstypes.OpenZFSDeploymentTypeSingleAz1, v)
 					}
 				} else if deploymentType == string(awstypes.OpenZFSDeploymentTypeSingleAz2) {
-					if v < 0 || v > 350000 {
-						return fmt.Errorf("expected disk_iops_configuration.0.iops to be in the range (0 - 350000) when deployment_type (%s), got %d", awstypes.OpenZFSDeploymentTypeSingleAz2, v)
+					if v < 0 || v > 400000 {
+						return fmt.Errorf("expected disk_iops_configuration.0.iops to be in the range (0 - 400000) when deployment_type (%s), got %d", awstypes.OpenZFSDeploymentTypeSingleAz2, v)
 					}
 				}
 			}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Increases the aws_fsx_openzfs_file_system SINGLE_AZ_2 max valid IOPS to 400000 to match what's supported by AWS and allow the terraform provider to work with larger filesystems which force IOPS to be above the current 350000 limit of the provider.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40358

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Reference for max IOPS https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/performance.html#zfs-fs-performance


### Output from Acceptance Testing

Let me know if I need to run the tests myself and I can try to arrange a sandbox account.