### PR TITLE
CI: Add regional failure message for Sweeper step in "Set Up"

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -326,6 +326,17 @@ object SetUp : BuildType({
         }
     }
 
+    // For sweeper step
+    failureConditions {
+        failOnText {
+            conditionType = BuildFailureOnText.ConditionType.REGEXP
+            pattern = """Sweeper Tests for region \(([-a-z0-9]+)\) ran unsuccessfully"""
+            failureMessage = """Sweeper failure for region "${'$'}1""""
+            reverse = false
+            reportOnlyFirstMatch = false
+        }
+    }
+
     features {
         golang {
             testFormat = "json"


### PR DESCRIPTION
### Description

Adds regional failure message for Sweeper step in "Set Up" to match messaging in standalone "Sweeper"
