### PR TITLE
doc(aws_elasticache_cluster): add valkey option as engine

### DIFF
--- a/website/docs/r/elasticache_cluster.html.markdown
+++ b/website/docs/r/elasticache_cluster.html.markdown
@@ -140,7 +140,7 @@ resource "aws_elasticache_cluster" "example" {
 The following arguments are required:
 
 * `cluster_id` – (Required) Group identifier. ElastiCache converts this name to lowercase. Changing this value will re-create the resource.
-* `engine` – (Optional, Required if `replication_group_id` is not specified) Name of the cache engine to be used for this cache cluster. Valid values are `memcached` and `redis`.
+* `engine` – (Optional, Required if `replication_group_id` is not specified) Name of the cache engine to be used for this cache cluster. Valid values are `memcached`, `redis` and `valkey`.
 * `node_type` – (Required unless `replication_group_id` is provided) The instance class used.
   See AWS documentation for information on [supported node types for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html) and [guidance on selecting node types for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/nodes-select-size.html).
   See AWS documentation for information on [supported node types for Memcached](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheNodes.SupportedTypes.html) and [guidance on selecting node types for Memcached](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/nodes-select-size.html).


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-aws/pull/39745
 
Add missing `valkey` option for `aws_elasticache_cluster` engine in the documentation
