### PR TITLE
aws_rds_cluster: Verify sg destroy okay with cluster

### DIFF
--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -246,13 +246,14 @@ func TestAccRDSCluster_securityGroupUpdate(t *testing.T) {
 			{
 				Config: testAccClusterConfig_securityGroup(rName, sgName2, 2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &dbCluster1),
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster2),
+					testAccCheckClusterNotRecreated(&dbCluster1, &dbCluster2),
 				),
 			},
 			{
 				Config: testAccClusterConfig_securityGroup(rName, sgName2, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &dbCluster2),
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster1),
 					testAccCheckClusterNotRecreated(&dbCluster1, &dbCluster2),
 				),
 			},

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -3136,7 +3136,7 @@ func testAccClusterConfig_securityGroup(rName, sgName string, sgCt int) string {
 resource "aws_security_group" "test" {
   count       = %[4]d
   name_prefix = %[2]q
-  vpc_id = aws_vpc.test.id
+  vpc_id      = aws_vpc.test.id
 
   tags = {
     Name = %[2]q
@@ -5504,7 +5504,7 @@ resource "aws_iam_role" "role" {
 		"Action": "sts:AssumeRole",
 		"Principal": {
 			"Service": [
-				"directoryservice.rds.${data.aws_partition.current.dns_suffix}",				
+				"directoryservice.rds.${data.aws_partition.current.dns_suffix}",
 				"rds.${data.aws_partition.current.dns_suffix}"
 			]
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The original complaint was that performing an action that would destroy the security group (SG) associated with an RDS cluster caused the process to hang indefinitely. This issue raised concerns about Terraform's ability to handle such operations.  

This test case addresses the scenario by verifying that Terraform successfully manages the destruction and recreation of the security group associated with the RDS cluster. Specifically, the test validates the following:  

1. **Recreating the Security Group**: The test changes the name of the security group to trigger its destruction and subsequent recreation. Terraform should execute this process without hanging.  
   
2. **Handling Number Changes**: The test ensures that Terraform correctly manages changes to the number of security groups associated with the cluster, including their destruction and recreation.

By verifying these scenarios, this test confirms that Terraform can handle operations involving the destruction, recreation, and modification of security groups for an RDS cluster without encountering issues like hanging or mismanagement of resources.

This may be related to changes made in Terraform and the AWS Provider since #9692 was created, such as hashicorp/terraform#23252.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #9692

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
* hashicorp/terraform#23252

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccRDSCluster_securityGroup K=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_securityGroup'  -timeout 360m
2024/12/02 18:52:47 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSCluster_securityGroupUpdate
=== PAUSE TestAccRDSCluster_securityGroupUpdate
=== CONT  TestAccRDSCluster_securityGroupUpdate
--- PASS: TestAccRDSCluster_securityGroupUpdate (169.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	173.417s
```
