### PR TITLE
d/aws_standards_control_association: Fix resource name in docs

### DIFF
--- a/website/docs/r/securityhub_standards_control_association.html.markdown
+++ b/website/docs/r/securityhub_standards_control_association.html.markdown
@@ -28,7 +28,7 @@ resource "aws_securityhub_standards_subscription" "cis_aws_foundations_benchmark
   depends_on    = [aws_securityhub_account.example]
 }
 
-resource "aws_standards_control_association" "cis_aws_foundations_benchmark_disable_iam_1" {
+resource "aws_securityhub_standards_control_association" "cis_aws_foundations_benchmark_disable_iam_1" {
   standards_arn       = aws_securityhub_standards_subscription.cis_aws_foundations_benchmark.standards_arn
   security_control_id = "IAM.1"
   association_status  = "DISABLED"


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`aws_standards_control_association` resource does not exist in the provider. Instead, the resource in question is `aws_securityhub_standards_control_association`
