### PR TITLE
[WIP] Don't recreate Firehose stream for secret manager.

### DIFF
--- a/.changelog/40404.txt
+++ b/.changelog/40404.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kinesis_firehose_delivery_stream:: Avoid recreating stream for secretmanager changes.
+```

--- a/internal/service/firehose/delivery_stream.go
+++ b/internal/service/firehose/delivery_stream.go
@@ -321,7 +321,7 @@ func resourceDeliveryStream() *schema.Resource {
 					Elem:     s3ConfigurationElem(),
 				}
 			}
-			secretsManagerConfigurationSchema := func() *schema.Schema {
+			secretsManagerConfigurationSchema := func(forceNew bool) *schema.Schema {
 				return &schema.Schema{
 					Type:     schema.TypeList,
 					MaxItems: 1,
@@ -333,7 +333,7 @@ func resourceDeliveryStream() *schema.Resource {
 								Type:     schema.TypeBool,
 								Optional: true,
 								Computed: true,
-								ForceNew: true,
+								ForceNew: forceNew,
 							},
 							"secret_arn": {
 								Type:         schema.TypeString,
@@ -840,7 +840,7 @@ func resourceDeliveryStream() *schema.Resource {
 								ValidateDiagFunc: enum.Validate[types.HttpEndpointS3BackupMode](),
 							},
 							"s3_configuration":              s3ConfigurationSchema(),
-							"secrets_manager_configuration": secretsManagerConfigurationSchema(),
+							"secrets_manager_configuration": secretsManagerConfigurationSchema(true),
 							names.AttrURL: {
 								Type:     schema.TypeString,
 								Required: true,
@@ -1215,7 +1215,7 @@ func resourceDeliveryStream() *schema.Resource {
 								ValidateDiagFunc: enum.Validate[types.RedshiftS3BackupMode](),
 							},
 							"s3_configuration":              s3ConfigurationSchema(),
-							"secrets_manager_configuration": secretsManagerConfigurationSchema(),
+							"secrets_manager_configuration": secretsManagerConfigurationSchema(true),
 							names.AttrUsername: {
 								Type:     schema.TypeString,
 								Optional: true,
@@ -1331,7 +1331,7 @@ func resourceDeliveryStream() *schema.Resource {
 								Required:     true,
 								ValidateFunc: validation.StringLenBetween(1, 255),
 							},
-							"secrets_manager_configuration": secretsManagerConfigurationSchema(),
+							"secrets_manager_configuration": secretsManagerConfigurationSchema(true),
 							"snowflake_role_configuration": {
 								Type:     schema.TypeList,
 								Optional: true,
@@ -1431,7 +1431,7 @@ func resourceDeliveryStream() *schema.Resource {
 								ValidateDiagFunc: enum.Validate[types.SplunkS3BackupMode](),
 							},
 							"s3_configuration":              s3ConfigurationSchema(),
-							"secrets_manager_configuration": secretsManagerConfigurationSchema(),
+							"secrets_manager_configuration": secretsManagerConfigurationSchema(false),
 						},
 					},
 				},


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Changing the secret manager config can be done without recreating the stream (tested with the AWS CLI). Since I've only tested that this is the case for Splunk I'm only changing it for SecretManager configs used by Splunk.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates [PR38151](https://github.com/hashicorp/terraform-provider-aws/pull/38151)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc AWS_REGION=us-west-2  TESTARGS='-run=TestAccFirehoseDeliveryStream_Splunk\|TestAccFirehoseDeliveryStream_splunk\|TestAccFirehoseDeliveryStream_Redshift\|TestAccFirehoseDeliveryStream_redshift\|TestAccFirehoseDeliveryStream_HTTPEndpoint\|TestAccFirehoseDeliveryStream_httpEndpoint\|TestAccFirehoseDeliveryStream_snowflake' PKG=firehose ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/firehose/... -v -count 1 -parallel 3  -run=TestAccFirehoseDeliveryStream_Splunk\|TestAccFirehoseDeliveryStream_splunk\|TestAccFirehoseDeliveryStream_Redshift\|TestAccFirehoseDeliveryStream_redshift\|TestAccFirehoseDeliveryStream_HTTPEndpoint\|TestAccFirehoseDeliveryStream_httpEndpoint\|TestAccFirehoseDeliveryStream_snowflake -timeout 360m
2024/12/03 14:04:40 Initializing Terraform AWS Provider...
=== RUN   TestAccFirehoseDeliveryStream_redshiftUpdates
=== PAUSE TestAccFirehoseDeliveryStream_redshiftUpdates
=== RUN   TestAccFirehoseDeliveryStream_Redshift_SecretsManagerConfiguration
=== PAUSE TestAccFirehoseDeliveryStream_Redshift_SecretsManagerConfiguration
=== RUN   TestAccFirehoseDeliveryStream_snowflakeUpdates
=== PAUSE TestAccFirehoseDeliveryStream_snowflakeUpdates
=== RUN   TestAccFirehoseDeliveryStream_splunkUpdates
=== PAUSE TestAccFirehoseDeliveryStream_splunkUpdates
=== RUN   TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix
=== PAUSE TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix
=== RUN   TestAccFirehoseDeliveryStream_Splunk_SecretsManagerConfiguration
=== PAUSE TestAccFirehoseDeliveryStream_Splunk_SecretsManagerConfiguration
=== RUN   TestAccFirehoseDeliveryStream_httpEndpoint
=== PAUSE TestAccFirehoseDeliveryStream_httpEndpoint
=== RUN   TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix
=== PAUSE TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix
=== RUN   TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration
=== PAUSE TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration
=== RUN   TestAccFirehoseDeliveryStream_HTTPEndpoint_SecretsManagerConfiguration
=== PAUSE TestAccFirehoseDeliveryStream_HTTPEndpoint_SecretsManagerConfiguration
=== CONT  TestAccFirehoseDeliveryStream_redshiftUpdates
=== CONT  TestAccFirehoseDeliveryStream_Splunk_SecretsManagerConfiguration
=== CONT  TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration

--- PASS: TestAccFirehoseDeliveryStream_Splunk_SecretsManagerConfiguration (96.88s)
=== CONT  TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_retryDuration (112.31s)
=== CONT  TestAccFirehoseDeliveryStream_httpEndpoint
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_ErrorOutputPrefix (143.99s)
=== CONT  TestAccFirehoseDeliveryStream_HTTPEndpoint_SecretsManagerConfiguration
--- PASS: TestAccFirehoseDeliveryStream_httpEndpoint (161.26s)
=== CONT  TestAccFirehoseDeliveryStream_splunkUpdates
--- PASS: TestAccFirehoseDeliveryStream_redshiftUpdates (292.66s)
=== CONT  TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix
--- PASS: TestAccFirehoseDeliveryStream_HTTPEndpoint_SecretsManagerConfiguration (108.70s)
=== CONT  TestAccFirehoseDeliveryStream_snowflakeUpdates
--- PASS: TestAccFirehoseDeliveryStream_Splunk_ErrorOutputPrefix (137.16s)
=== CONT  TestAccFirehoseDeliveryStream_Redshift_SecretsManagerConfiguration
--- PASS: TestAccFirehoseDeliveryStream_splunkUpdates (166.46s)
--- PASS: TestAccFirehoseDeliveryStream_snowflakeUpdates (216.53s)
--- PASS: TestAccFirehoseDeliveryStream_Redshift_SecretsManagerConfiguration (208.99s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/firehose	644.879s
⏎
...
```
