### PR TITLE
.github/workflows: fix registry version check comparison

### DIFF
--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -65,7 +65,7 @@ jobs:
           for i in 1 2
           do
             LATEST_VERSION=$(curl -s "https://registry.terraform.io/v2/providers/323/provider-versions/latest" | jq -r '.data.attributes.version')
-            if [[ "${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}" != ${LATEST_VERSION} ]]; then
+            if [[ "${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}" != "v${LATEST_VERSION}" ]]; then
               sleep 1h
             else
               echo "Registry and Github Version matches"


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The version returned from the `curl` request to the registry will contain only the version number, while the release tag is prefixed with `v`.

For example, here is what is stored in the `LATEST_VERSION` environment variable:

```console
% curl -s "https://registry.terraform.io/v2/providers/323/provider-versions/latest" | jq -r '.data.attributes.version'
5.79.0
```

This changes the conditional to apply a prefix to the version number fetched from the registry to allow an accurate comparison of the two values.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #40245 
Relates #39964 

https://github.com/hashicorp/terraform-provider-aws/actions/runs/12038203742/job/33563358216