### PR TITLE
r/aws_rds_cluster_instance: fix destroy error when cluster instance is in a read replica

### DIFF
--- a/.changelog/40409.txt
+++ b/.changelog/40409.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster_instance: Fix error when destroying from a read replica cluster
+```

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -129,6 +129,11 @@ func resourceClusterInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrForceDestroy: {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			names.AttrIdentifier: {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -543,7 +548,7 @@ func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 		},
 		"Delete the replica cluster before deleting")
 
-	if errs.IsAErrorMessageContains[*types.InvalidDBClusterStateFault](err, "Cannot delete the last instance of the read replica DB cluster") {
+	if errs.IsAErrorMessageContains[*types.InvalidDBClusterStateFault](err, "Cannot delete the last instance of the read replica DB cluster") && d.Get(names.AttrForceDestroy).(bool) {
 		_, err = conn.PromoteReadReplicaDBCluster(ctx, &rds.PromoteReadReplicaDBClusterInput{
 			DBClusterIdentifier: aws.String(d.Get(names.AttrClusterIdentifier).(string)),
 		})

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -545,7 +545,7 @@ func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 
 	if errs.IsAErrorMessageContains[*types.InvalidDBClusterStateFault](err, "Cannot delete the last instance of the read replica DB cluster") {
 		_, err = conn.PromoteReadReplicaDBCluster(ctx, &rds.PromoteReadReplicaDBClusterInput{
-			DBClusterIdentifier: aws.String(d.Get("cluster_identifier").(string)),
+			DBClusterIdentifier: aws.String(d.Get(names.AttrClusterIdentifier).(string)),
 		})
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "promoting read replica to primary for RDS Cluster (%s): %s", d.Id(), err)

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -66,6 +66,7 @@ func TestAccRDSClusterInstance_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -137,6 +138,7 @@ func TestAccRDSClusterInstance_identifierGenerated(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 		},
@@ -173,6 +175,7 @@ func TestAccRDSClusterInstance_identifierPrefix(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 		},
@@ -209,6 +212,7 @@ func TestAccRDSClusterInstance_tags(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -304,6 +308,7 @@ func TestAccRDSClusterInstance_az(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 		},
@@ -340,6 +345,7 @@ func TestAccRDSClusterInstance_kmsKey(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 		},
@@ -375,6 +381,7 @@ func TestAccRDSClusterInstance_publiclyAccessible(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -390,6 +397,7 @@ func TestAccRDSClusterInstance_publiclyAccessible(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -432,6 +440,7 @@ func TestAccRDSClusterInstance_copyTagsToSnapshot(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -475,6 +484,7 @@ func TestAccRDSClusterInstance_caCertificateIdentifier(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 		},
@@ -510,6 +520,7 @@ func TestAccRDSClusterInstance_monitoringInterval(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -567,6 +578,7 @@ func TestAccRDSClusterInstance_MonitoringRoleARN_enabledToDisabled(t *testing.T)
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -610,6 +622,7 @@ func TestAccRDSClusterInstance_MonitoringRoleARN_enabledToRemoved(t *testing.T) 
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -651,6 +664,7 @@ func TestAccRDSClusterInstance_MonitoringRoleARN_removedToEnabled(t *testing.T) 
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -694,6 +708,7 @@ func TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL1(t *testin
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 		},
@@ -730,6 +745,7 @@ func TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraPostgresql(t *te
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 		},
@@ -768,6 +784,7 @@ func TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL1(t *testi
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 		},
@@ -804,6 +821,7 @@ func TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL1_defaultKe
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -847,6 +865,7 @@ func TestAccRDSClusterInstance_performanceInsightsRetentionPeriod(t *testing.T) 
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -901,6 +920,7 @@ func TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraPostgresql(t *t
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 		},
@@ -937,6 +957,7 @@ func TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defau
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					names.AttrApplyImmediately,
+					names.AttrForceDestroy,
 				},
 			},
 			{
@@ -1657,6 +1678,8 @@ resource "aws_rds_cluster_instance" "alternate" {
   instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
   engine             = aws_rds_cluster.alternate.engine
   engine_version     = aws_rds_cluster.alternate.engine_version
+
+  force_destroy = true
 }
 `, rName, tfrds.ClusterEngineAuroraMySQL))
 }

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -947,7 +947,7 @@ func TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defau
 	})
 }
 
-func TestAccRDSClusterInstance_ReplicationSourceIdentifier_basic(t *testing.T) {
+func TestAccRDSClusterInstance_Replica_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -946,6 +947,88 @@ func TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defau
 	})
 }
 
+func TestAccRDSClusterInstance_ReplicationSourceIdentifier_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var primaryInstance types.DBInstance
+	var replicaInstance types.DBInstance
+	resourceName := "aws_rds_cluster_instance.test"
+	resourceName2 := "aws_rds_cluster_instance.alternate"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	// record the initialized providers so that we can use them to
+	// check for the cluster in each region
+	var providers []*schema.Provider
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesPlusProvidersAlternate(ctx, t, &providers),
+		CheckDestroy:             acctest.CheckWithProviders(testAccCheckClusterInstanceDestroyWithProvider(ctx), &providers),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterInstanceConfig_replicationSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterInstanceExistsWithProvider(ctx, resourceName, &primaryInstance, acctest.RegionProviderFunc(ctx, acctest.Region(), &providers)),
+					testAccCheckClusterInstanceExistsWithProvider(ctx, resourceName2, &replicaInstance, acctest.RegionProviderFunc(ctx, acctest.AlternateRegion(), &providers)),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckClusterInstanceExistsWithProvider(ctx context.Context, n string, v *types.DBInstance, providerF func() *schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := providerF().Meta().(*conns.AWSClient).RDSClient(ctx)
+
+		output, err := tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccCheckClusterInstanceDestroyWithProvider(ctx context.Context) acctest.TestCheckWithProviderFunc {
+	return func(s *terraform.State, provider *schema.Provider) error {
+		conn := provider.Meta().(*conns.AWSClient).RDSClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_rds_cluster_instance" {
+				continue
+			}
+
+			_, err := tfrds.FindDBInstanceByID(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("RDS Cluster Instance %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
 func testAccPerformanceInsightsDefaultVersionPreCheck(ctx context.Context, t *testing.T, engine string) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).RDSClient(ctx)
 
@@ -1543,6 +1626,39 @@ resource "aws_rds_cluster_instance" "test" {
   performance_insights_enabled = true
 }
 `, rName))
+}
+
+func testAccClusterInstanceConfig_replicationSource_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccClusterConfig_replicationSource_base(rName),
+		fmt.Sprintf(`
+resource "aws_rds_cluster" "alternate" {
+  provider = "awsalternate"
+
+  cluster_identifier            = "%[1]s-replica"
+  db_subnet_group_name          = aws_db_subnet_group.test.name
+  engine                        = %[2]q
+  kms_key_id                    = aws_kms_key.test.arn
+  storage_encrypted             = true
+  skip_final_snapshot           = true
+  replication_source_identifier = aws_rds_cluster.test.arn
+  source_region                 = data.aws_region.current.name
+
+  depends_on = [
+    aws_rds_cluster_instance.test,
+  ]
+}
+
+resource "aws_rds_cluster_instance" "alternate" {
+  provider = "awsalternate"
+
+  identifier         = "%[1]s-replica"
+  cluster_identifier = aws_rds_cluster.alternate.id
+  instance_class     = data.aws_rds_orderable_db_instance.test.instance_class
+  engine             = aws_rds_cluster.alternate.engine
+  engine_version     = aws_rds_cluster.alternate.engine_version
+}
+`, rName, tfrds.ClusterEngineAuroraMySQL))
 }
 
 func testAccClusterInstanceConfig_performanceInsightsEnabledAuroraPostgresql(rName, engine string) string {

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -65,6 +65,7 @@ This resource supports the following arguments:
 * `engine_version` - (Optional) Database engine version. Please note that to upgrade the `engine_version` of the instance, it must be done on the `aws_rds_cluster` `engine_version`. Trying to upgrade in `aws_cluster_instance` will not update the `engine_version`.
 * `engine` - (Required, Forces new resource) Name of the database engine to be used for the RDS cluster instance.
   Valid Values: `aurora-mysql`, `aurora-postgresql`, `mysql`, `postgres`.(Note that `mysql` and `postgres` are Multi-AZ RDS clusters).
+* `force_destroy` - (Optional) Forces an instance to be destroyed when a part of a read replica cluster. **Note:** will promote the read replica to a standalone cluster before instance deletion.
 * `identifier_prefix` - (Optional, Forces new resource) Creates a unique identifier beginning with the specified prefix. Conflicts with `identifier`.
 * `identifier` - (Optional, Forces new resource) Identifier for the RDS instance, if omitted, Terraform will assign a random, unique identifier.
 * `instance_class` - (Required) Instance class to use. For details on CPU and memory, see [Scaling Aurora DB Instances][4]. Aurora uses `db.*` instance classes/types. Please see [AWS Documentation][7] for currently available instance classes and complete details. For Aurora Serverless v2 use `db.serverless`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When a `aws_rds_cluster_instance` is a part of `aws_rds_cluster` destroying failing with the following error:

```
Error: deleting RDS Cluster Instance (tf-acc-test-5080916373612377726-replica): operation error RDS: DeleteDBInstance, https response error StatusCode: 400, RequestID: d1fbb4b7-0822-40a1-b591-bf858b2a5ba5, InvalidDBClusterStateFault: Cannot delete the last instance of the read replica DB cluster. Promote the DB cluster to a standalone DB cluster in order to delete it.
```

This adds a `force_destroy` virtual attribute that will allow practitioners to destroy instances that are a part of a replica cluster. This process promotes the cluster to a standalone cluster so that the instance can be deleted.

#### reproduction in test

```console
% make testacc TESTARGS='-run=TestAccRDSClusterInstance_Replica_basic' PKG=rds

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSClusterInstance_ReplicationSourceIdentifier_basic -timeout 360m
2024/12/03 10:06:30 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSClusterInstance_Replica_basic
=== PAUSE TestAccRDSClusterInstance_Replica_basic
=== CONT  TestAccRDSClusterInstance_Replica_basic
    cluster_instance_test.go:966: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting RDS Cluster Instance (tf-acc-test-5080916373612377726-replica): operation error RDS: DeleteDBInstance, https response error StatusCode: 400, RequestID: d1fbb4b7-0822-40a1-b591-bf858b2a5ba5, InvalidDBClusterStateFault: Cannot delete the last instance of the read replica DB cluster. Promote the DB cluster to a standalone DB cluster in order to delete it.

--- FAIL: TestAccRDSClusterInstance_Replica_basic (1642.68s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/rds	1649.528s
FAIL
make: *** [testacc] Error 1
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #6749

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccRDSClusterInstance_Replica_basic' PKG=rds

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSClusterInstance_Replica_basic -timeout 360m
2024/12/03 11:21:32 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSClusterInstance_Replica_basic
=== PAUSE TestAccRDSClusterInstance_Replica_basic
=== CONT  TestAccRDSClusterInstance_Replica_basic
--- PASS: TestAccRDSClusterInstance_Replica_basic (3360.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	3367.228s
```

```console
% make testacc TESTARGS='-run=TestAccRDSClusterInstance_' PKG=rds

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSClusterInstance_ -timeout 360m
2024/12/03 12:31:44 Initializing Terraform AWS Provider...
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraPostgresql (825.47s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraPostgresql (860.38s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraPostgresql_defaultKeyToCustomKey (912.25s)
--- PASS: TestAccRDSClusterInstance_identifierPrefix (943.94s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_enabledToDisabled (1215.05s)
--- PASS: TestAccRDSClusterInstance_identifierGenerated (1221.73s)
--- PASS: TestAccRDSClusterInstance_isAlreadyBeingDeleted (1236.36s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyID_auroraMySQL1 (1237.45s)
--- PASS: TestAccRDSClusterInstance_tags (1265.27s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsEnabled_auroraMySQL1 (1287.38s)
--- PASS: TestAccRDSClusterInstance_az (1294.98s)
--- PASS: TestAccRDSClusterInstance_basic (1295.43s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_removedToEnabled (1302.95s)
--- PASS: TestAccRDSClusterInstance_copyTagsToSnapshot (1316.12s)
--- PASS: TestAccRDSClusterInstance_PerformanceInsightsKMSKeyIDAuroraMySQL1_defaultKeyToCustomKey (1321.27s)
--- PASS: TestAccRDSClusterInstance_MonitoringRoleARN_enabledToRemoved (1366.72s)
--- PASS: TestAccRDSClusterInstance_publiclyAccessible (1452.71s)
--- PASS: TestAccRDSClusterInstance_performanceInsightsRetentionPeriod (1541.29s)
--- PASS: TestAccRDSClusterInstance_monitoringInterval (1812.50s)
--- PASS: TestAccRDSClusterInstance_caCertificateIdentifier (1254.09s)
--- PASS: TestAccRDSClusterInstance_kmsKey (1392.53s)
--- PASS: TestAccRDSClusterInstance_disappears (1427.06s)
--- PASS: TestAccRDSClusterInstance_Replica_basic (3121.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	3128.253s
```
