### PR TITLE
docs: update argument name in aws_bedrock_agent resource

### DIFF
--- a/website/docs/r/bedrockagent_agent.html.markdown
+++ b/website/docs/r/bedrockagent_agent.html.markdown
@@ -79,7 +79,7 @@ The following arguments are optional:
 
 * `customer_encryption_key_arn` - (Optional) ARN of the AWS KMS key that encrypts the agent.
 * `description` - (Optional) Description of the agent.
-* `guardrail_config` - (Optional) Details about the guardrail associated with the agent. See [`guardrail_config` Block](#guardrail_config-block) for details.
+* `guardrail_configuration` - (Optional) Details about the guardrail associated with the agent. See [`guardrail_configuration` Block](#guardrail_configuration-block) for details.
 * `idle_session_ttl_in_seconds` - (Optional) Number of seconds for which Amazon Bedrock keeps information about a user's conversation with the agent. A user interaction remains active for the amount of time specified. If no conversation occurs during this time, the session expires and Amazon Bedrock deletes any data provided before the timeout.
 * `instruction` - (Optional) Instructions that tell the agent what it should do and how it should interact with users.
 * `prepare_agent` (Optional) Whether to prepare the agent after creation or modification. Defaults to `true`.
@@ -87,9 +87,9 @@ The following arguments are optional:
 * `skip_resource_in_use_check` - (Optional) Whether the in-use check is skipped when deleting the agent.
 * `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
-### `guardrail_config` Block
+### `guardrail_configuration` Block
 
-The `guardrail_config` configuration block supports the following arguments:
+The `guardrail_configuration` configuration block supports the following arguments:
 
 * `guardrail_identifier` - (Optional) Unique identifier of the guardrail.
 * `guardrail_version` - (Optional) Version of the guardrail.


### PR DESCRIPTION
### Description

- Change `guardrail_config` to `guardrail_configuration` in the documentation . The provided reference to the source code shows `guardrail_configuration` as valid.
- Update references to ensure consistency throughout the text.

### Relations

Closes #40401 

### References

- [Resource documentation in registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/bedrockagent_agent#guardrail_config-block)
-  [Source code reference](https://github.com/hashicorp/terraform-provider-aws/blob/8dad2d3a602c8fc103a7eacb1fc9f4d3a9ac3994/internal/service/bedrockagent/agent.go#L103C5-L103C28)

### Output from Acceptance Testing

Not applicable. Only documentation is update.