### PR TITLE
resource/aws_db_instance: Allow creating read replica in same region with different subnet group

### DIFF
--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -80,7 +80,7 @@ func resourceInstance() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(40 * time.Minute),
+			Create: schema.DefaultTimeout(50 * time.Minute),
 			Update: schema.DefaultTimeout(80 * time.Minute),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},

--- a/internal/service/rds/instance_diff_test.go
+++ b/internal/service/rds/instance_diff_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds
+
+import "testing"
+
+func TestInstanceReplicateSourceDBSuppressDiff(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		old, new string
+		expected bool
+	}
+	testCases := map[string]testCase{
+		"no values": {
+			old:      "",
+			new:      "",
+			expected: false,
+		},
+
+		"old ARN same identifier": {
+			old:      "arn:aws:rds:us-west-2:123456789012:db:test",
+			new:      "test",
+			expected: true,
+		},
+
+		"old ARN different identifier": {
+			old:      "arn:aws:rds:us-west-2:123456789012:db:test1",
+			new:      "test2",
+			expected: false,
+		},
+
+		"new ARN same identifier": {
+			old:      "test",
+			new:      "arn:aws:rds:us-west-2:123456789012:db:test",
+			expected: true,
+		},
+
+		"new ARN different identifier": {
+			old:      "test2",
+			new:      "arn:aws:rds:us-west-2:123456789012:db:test1",
+			expected: false,
+		},
+
+		"both ARN": {
+			old:      "arn:aws:rds:us-west-2:123456789012:db:test1",
+			new:      "arn:aws:rds:us-west-2:123456789012:db:test2",
+			expected: false,
+		},
+
+		"neither ARN": {
+			old:      "test1",
+			new:      "test2",
+			expected: false,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			v := instanceReplicateSourceDBSuppressDiff("", test.old, test.new, nil)
+			if e, a := test.expected, v; e != a {
+				t.Errorf("unexpected result: expected %t, got %t", e, a)
+			}
+		})
+	}
+}

--- a/internal/service/rds/instance_diff_test.go
+++ b/internal/service/rds/instance_diff_test.go
@@ -20,32 +20,32 @@ func TestInstanceReplicateSourceDBSuppressDiff(t *testing.T) {
 		},
 
 		"old ARN same identifier": {
-			old:      "arn:aws:rds:us-west-2:123456789012:db:test",
+			old:      "arn:aws:rds:us-west-2:123456789012:db:test", //lintignore:AWSAT003,AWSAT005
 			new:      "test",
 			expected: true,
 		},
 
 		"old ARN different identifier": {
-			old:      "arn:aws:rds:us-west-2:123456789012:db:test1",
+			old:      "arn:aws:rds:us-west-2:123456789012:db:test1", //lintignore:AWSAT003,AWSAT005
 			new:      "test2",
 			expected: false,
 		},
 
 		"new ARN same identifier": {
 			old:      "test",
-			new:      "arn:aws:rds:us-west-2:123456789012:db:test",
+			new:      "arn:aws:rds:us-west-2:123456789012:db:test", //lintignore:AWSAT003,AWSAT005
 			expected: true,
 		},
 
 		"new ARN different identifier": {
 			old:      "test2",
-			new:      "arn:aws:rds:us-west-2:123456789012:db:test1",
+			new:      "arn:aws:rds:us-west-2:123456789012:db:test1", //lintignore:AWSAT003,AWSAT005
 			expected: false,
 		},
 
 		"both ARN": {
-			old:      "arn:aws:rds:us-west-2:123456789012:db:test1",
-			new:      "arn:aws:rds:us-west-2:123456789012:db:test2",
+			old:      "arn:aws:rds:us-west-2:123456789012:db:test1", //lintignore:AWSAT003,AWSAT005
+			new:      "arn:aws:rds:us-west-2:123456789012:db:test2", //lintignore:AWSAT003,AWSAT005
 			expected: false,
 		},
 

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -10637,10 +10637,6 @@ data "aws_rds_orderable_db_instance" "test" {
   preferred_instance_classes = [%[2]s]
 }
 
-data "aws_rds_certificate" "latest" {
-  latest_valid_till = true
-}
-
 resource "aws_db_instance" "source" {
   identifier              = "%[3]s-source"
   allocated_storage       = 20
@@ -10660,7 +10656,7 @@ resource "aws_db_instance" "source" {
   timeouts {
     update = "120m"
   }
-  ca_cert_identifier = data.aws_rds_certificate.latest.id
+  ca_cert_identifier = "rds-ca-rsa2048-g1"
 }
 `, tfrds.InstanceEngineOracleEnterprise, strings.Replace(mainInstanceClasses, "db.t3.small", "frodo", 1), rName)
 }
@@ -10678,7 +10674,7 @@ resource "aws_db_instance" "test" {
   apply_immediately   = true
 
   parameter_group_name = aws_db_parameter_group.test.name
-  ca_cert_identifier   = data.aws_rds_certificate.latest.id
+  ca_cert_identifier   = "rds-ca-rsa2048-g1"
 
   timeouts {
     update = "120m"

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -1468,7 +1468,7 @@ func TestAccRDSInstance_ReplicateSourceDB_backupWindow(t *testing.T) {
 	})
 }
 
-func TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName(t *testing.T) {
+func TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_crossRegion(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -1489,7 +1489,7 @@ func TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName(t *testing.T) {
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfig_ReplicateSourceDB_dbSubnetGroupName(rName),
+				Config: testAccInstanceConfig_ReplicateSourceDB_dbSubnetGroupName_crossRegion(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDBInstanceExists(ctx, resourceName, &dbInstance),
 					resource.TestCheckResourceAttrPair(resourceName, "db_subnet_group_name", dbSubnetGroupResourceName, names.AttrName),
@@ -9203,7 +9203,7 @@ resource "aws_db_instance" "test" {
 `, rName, backupWindow, maintenanceWindow))
 }
 
-func testAccInstanceConfig_ReplicateSourceDB_dbSubnetGroupName(rName string) string {
+func testAccInstanceConfig_ReplicateSourceDB_dbSubnetGroupName_crossRegion(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAlternateRegionProvider(),
 		acctest.ConfigAvailableAZsNoOptIn(),

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -1012,8 +1012,8 @@ func TestAccRDSInstance_ReplicateSourceDB_basic(t *testing.T) {
 	var dbInstance, sourceDbInstance types.DBInstance
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	sourceResourceName := "aws_db_instance.source"
 	resourceName := "aws_db_instance.test"
+	sourceResourceName := "aws_db_instance.source"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -1507,8 +1507,9 @@ func TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_crossRegion(t *testi
 
 	var dbInstance types.DBInstance
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	dbSubnetGroupResourceName := "aws_db_subnet_group.test"
 	resourceName := "aws_db_instance.test"
+	sourceResourceName := "aws_db_instance.source"
+	dbSubnetGroupResourceName := "aws_db_subnet_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -1523,6 +1524,7 @@ func TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_crossRegion(t *testi
 				Config: testAccInstanceConfig_ReplicateSourceDB_dbSubnetGroupName_crossRegion(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDBInstanceExists(ctx, resourceName, &dbInstance),
+					resource.TestCheckResourceAttrPair(resourceName, "replicate_source_db", sourceResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(resourceName, "db_subnet_group_name", dbSubnetGroupResourceName, names.AttrName),
 				),
 			},
@@ -9254,7 +9256,7 @@ resource "aws_db_instance" "source" {
   instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
   password                = "avoid-plaintext-passwords"
   username                = "tfacctest"
-  db_subnet_group_name = aws_db_subnet_group.source.name
+  db_subnet_group_name    = aws_db_subnet_group.source.name
   skip_final_snapshot     = true
 }
 

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -1053,6 +1053,10 @@ func TestAccRDSInstance_ReplicateSourceDB_basic(t *testing.T) {
 					names.AttrPassword,
 				},
 			},
+			{
+				Config:   testAccInstanceConfig_ReplicateSourceDB_sourceARN(rName),
+				PlanOnly: true,
+			},
 		},
 	})
 }
@@ -1204,6 +1208,10 @@ func TestAccRDSInstance_ReplicateSourceDB_sourceARN(t *testing.T) {
 					names.AttrPassword,
 					"replicate_source_db",
 				},
+			},
+			{
+				Config:   testAccInstanceConfig_ReplicateSourceDB_basic(rName),
+				PlanOnly: true,
 			},
 		},
 	})

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -1031,6 +1031,7 @@ func TestAccRDSInstance_ReplicateSourceDB_basic(t *testing.T) {
 					testAccCheckInstanceReplicaAttributes(&sourceDbInstance, &dbInstance),
 					resource.TestCheckResourceAttrPair(resourceName, "replicate_source_db", sourceResourceName, names.AttrIdentifier),
 					resource.TestCheckResourceAttrPair(resourceName, "db_name", sourceResourceName, "db_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "db_subnet_group_name", sourceResourceName, "db_subnet_group_name"),
 					resource.TestCheckResourceAttr(resourceName, "dedicated_log_volume", acctest.CtFalse),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrUsername, sourceResourceName, names.AttrUsername),
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -313,8 +313,9 @@ Defaults to true.
 * `db_name` - (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
 * `db_subnet_group_name` - (Optional) Name of [DB subnet group](/docs/providers/aws/r/db_subnet_group.html).
   DB instance will be created in the VPC associated with the DB subnet group.
-  If unspecified, will be created in the `default` VPC., or in EC2 Classic, if available.
-  When working with read replicas, it should be specified only if the source database specifies an instance in another AWS Region.
+  If unspecified, will be created in the `default` Subnet Group.
+  When working with read replicas created in the same region, defaults to the Subnet Group Name of the source DB.
+  When working with read replicas created in a different region, defaults to the `default` Subnet Group.
   See [DBSubnetGroupName in API action CreateDBInstanceReadReplica](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstanceReadReplica.html) for additional read replica constraints.
 * `dedicated_log_volume` - (Optional, boolean) Use a dedicated log volume (DLV) for the DB instance. Requires Provisioned IOPS. See the [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html#USER_PIOPS.dlv) for more details.
 * `delete_automated_backups` - (Optional) Specifies whether to remove automated backups immediately after the DB instance is deleted. Default is `true`.
@@ -384,7 +385,9 @@ accessible. Default is `false`.
 * `replica_mode` - (Optional) Specifies whether the replica is in either `mounted` or `open-read-only` mode. This attribute
 is only supported by Oracle instances. Oracle replicas operate in `open-read-only` mode unless otherwise specified. See [Working with Oracle Read Replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/oracle-read-replicas.html) for more information.
 * `replicate_source_db` - (Optional) Specifies that this resource is a Replica database, and to use this value as the source database.
-  This correlates to the `identifier` of another Amazon RDS Database to replicate (if replicating within a single region) or ARN of the Amazon RDS Database to replicate (if replicating cross-region).
+  If replicating an Amazon RDS Database Instance in the same region, use the `identifier` of the source DB, unless also specifying the `db_subnet_group_name`.
+  If specifying the `db_subnet_group_name` in the same region, use the `arn` of the source DB.
+  If replicating an Instance in a different region, use the `arn` of the source DB.
   Note that if you are creating a cross-region replica of an encrypted database you will also need to specify a `kms_key_id`.
   See [DB Instance Replication][instance-replication] and [Working with PostgreSQL and MySQL Read Replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html) for more information on using Replication.
 * `upgrade_storage_config` - (Optional) Whether to upgrade the storage file system configuration on the read replica.
@@ -398,9 +401,8 @@ created before the DB instance is deleted. If true is specified, no DBSnapshot
 is created. If false is specified, a DB snapshot is created before the DB
 instance is deleted, using the value from `final_snapshot_identifier`. Default
 is `false`.
-* `snapshot_identifier` - (Optional) Specifies whether or not to create this
-database from a snapshot. This correlates to the snapshot ID you'd find in the
-RDS console, e.g: rds:production-2015-06-26-06-05.
+* `snapshot_identifier` - (Optional) Specifies whether or not to create this database from a snapshot.
+  This corresponds to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05.
 * `storage_encrypted` - (Optional) Specifies whether the DB instance is
 encrypted. Note that if you are creating a cross-region read replica this field
 is ignored and you should instead declare `kms_key_id` with a valid ARN. The

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -311,13 +311,11 @@ Defaults to true.
 * `copy_tags_to_snapshot` – (Optional, boolean) Copy all Instance `tags` to snapshots. Default is `false`.
 * `custom_iam_instance_profile` - (Optional) The instance profile associated with the underlying Amazon EC2 instance of an RDS Custom DB instance.
 * `db_name` - (Optional) The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance. Note that this does not apply for Oracle or SQL Server engines. See the [AWS documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-instance.html) for more details on what applies for those engines. If you are providing an Oracle db name, it needs to be in all upper case. Cannot be specified for a replica.
-* `db_subnet_group_name` - (Optional) Name of [DB subnet group](/docs/providers/aws/r/db_subnet_group.html). DB instance will
-be created in the VPC associated with the DB subnet group. If unspecified, will
-be created in the `default` VPC, or in EC2 Classic, if available. When working
-with read replicas, it should be specified only if the source database
-specifies an instance in another AWS Region. See [DBSubnetGroupName in API
-action CreateDBInstanceReadReplica](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstanceReadReplica.html)
-for additional read replica constraints.
+* `db_subnet_group_name` - (Optional) Name of [DB subnet group](/docs/providers/aws/r/db_subnet_group.html).
+  DB instance will be created in the VPC associated with the DB subnet group.
+  If unspecified, will be created in the `default` VPC., or in EC2 Classic, if available.
+  When working with read replicas, it should be specified only if the source database specifies an instance in another AWS Region.
+  See [DBSubnetGroupName in API action CreateDBInstanceReadReplica](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstanceReadReplica.html) for additional read replica constraints.
 * `dedicated_log_volume` - (Optional, boolean) Use a dedicated log volume (DLV) for the DB instance. Requires Provisioned IOPS. See the [AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html#USER_PIOPS.dlv) for more details.
 * `delete_automated_backups` - (Optional) Specifies whether to remove automated backups immediately after the DB instance is deleted. Default is `true`.
 * `deletion_protection` - (Optional) If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to `true`. The default is `false`.
@@ -385,17 +383,15 @@ logs, and it will be stored in the state file. Cannot be set if `manage_master_u
 accessible. Default is `false`.
 * `replica_mode` - (Optional) Specifies whether the replica is in either `mounted` or `open-read-only` mode. This attribute
 is only supported by Oracle instances. Oracle replicas operate in `open-read-only` mode unless otherwise specified. See [Working with Oracle Read Replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/oracle-read-replicas.html) for more information.
-* `replicate_source_db` - (Optional) Specifies that this resource is a Replicate
-database, and to use this value as the source database. This correlates to the
-`identifier` of another Amazon RDS Database to replicate (if replicating within
-a single region) or ARN of the Amazon RDS Database to replicate (if replicating
-cross-region). Note that if you are
-creating a cross-region replica of an encrypted database you will also need to
-specify a `kms_key_id`. See [DB Instance Replication][instance-replication] and [Working with
-PostgreSQL and MySQL Read Replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html)
-for more information on using Replication.
-* `upgrade_storage_config` - (Optional) Whether to upgrade the storage file system configuration on the read replica. Can only be set with `replicate_source_db`.
-* `restore_to_point_in_time` - (Optional, Forces new resource) A configuration block for restoring a DB instance to an arbitrary point in time. Requires the `identifier` argument to be set with the name of the new DB instance to be created. See [Restore To Point In Time](#restore-to-point-in-time) below for details.
+* `replicate_source_db` - (Optional) Specifies that this resource is a Replica database, and to use this value as the source database.
+  This correlates to the `identifier` of another Amazon RDS Database to replicate (if replicating within a single region) or ARN of the Amazon RDS Database to replicate (if replicating cross-region).
+  Note that if you are creating a cross-region replica of an encrypted database you will also need to specify a `kms_key_id`.
+  See [DB Instance Replication][instance-replication] and [Working with PostgreSQL and MySQL Read Replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html) for more information on using Replication.
+* `upgrade_storage_config` - (Optional) Whether to upgrade the storage file system configuration on the read replica.
+  Can only be set with `replicate_source_db`.
+* `restore_to_point_in_time` - (Optional, Forces new resource) A configuration block for restoring a DB instance to an arbitrary point in time.
+  Requires the `identifier` argument to be set with the name of the new DB instance to be created.
+  See [Restore To Point In Time](#restore-to-point-in-time) below for details.
 * `s3_import` - (Optional) Restore from a Percona Xtrabackup in S3.  See [Importing Data into an Amazon RDS MySQL DB Instance](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Procedural.Importing.html)
 * `skip_final_snapshot` - (Optional) Determines whether a final DB snapshot is
 created before the DB instance is deleted. If true is specified, no DBSnapshot


### PR DESCRIPTION
### Description

Allow creating read replica in same region with different subnet group. This requires using the ARN, even though they are in the same region.

### Relations

Closes #528

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTS=TestAccRDSInstance_

--- PASS: TestAccRDSInstance_basic (479.86s)
--- PASS: TestAccRDSInstance_newIdentifier_Immediately (575.60s)
--- PASS: TestAccRDSInstance_Storage_changeThroughput (577.90s)
--- PASS: TestAccRDSInstance_newIdentifier_Pending (616.16s)
--- PASS: TestAccRDSInstance_Storage_changeIOPS (743.28s)
--- PASS: TestAccRDSInstance_Storage_typePostgres (745.61s)
--- PASS: TestAccRDSInstance_Storage_changeIOPSThroughput (776.82s)
--- PASS: TestAccRDSInstance_Storage_gp3MySQL (782.13s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen (858.42s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen (875.91s)
--- SKIP: TestAccRDSInstance_Outposts_backupTarget (0.26s)
--- PASS: TestAccRDSInstance_Storage_gp3Postgres (877.65s)
--- SKIP: TestAccRDSInstance_Outposts_coIPSnapshotIdentifier (0.13s)
--- PASS: TestAccRDSInstance_Storage_throughputSSE (1203.71s)
--- SKIP: TestAccRDSInstance_Outposts_coIPRestoreToPointInTime (0.22s)
--- PASS: TestAccRDSInstance_Storage_gp3SQLServer (1222.87s)
--- SKIP: TestAccRDSInstance_Outposts_coIPEnabledToDisabled (0.14s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_tags (656.53s)
--- SKIP: TestAccRDSInstance_Outposts_coIPDisabledToEnabled (0.12s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_basic (1263.13s)
--- SKIP: TestAccRDSInstance_Outposts_coIPEnabled (0.09s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupWindow (1310.07s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset (1450.62s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_availabilityZone (973.38s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade (992.44s)
--- PASS: TestAccRDSInstance_license (1102.50s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride (1374.32s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_outOfBand (2164.86s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_nameGenerated (930.01s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups (2307.10s)
--- PASS: TestAccRDSInstance_Oracle_noNationalCharacterSet (1027.78s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved (1119.06s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection (2385.51s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_io2Storage (1557.15s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_namePrefix (1082.66s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade (1682.72s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allocatedStorage (1361.84s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup (2052.15s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_io1Storage (1549.47s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_characterSet_Source (2802.67s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass (2239.05s)
--- PASS: TestAccRDSInstance_Oracle_nationalCharacterSet (1067.28s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion (2250.13s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_manageMasterPassword (1254.61s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_ManageMasterPasswordKMSKey (1345.43s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_basic (1099.23s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (1403.09s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (1303.71s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica (3275.84s)
--- PASS: TestAccRDSInstance_password (579.90s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs (1301.07s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_port (1311.19s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists (1554.30s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue (1364.39s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica (1395.08s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier (1664.12s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth (1585.19s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth (1474.72s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_networkType (1367.04s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNamePostgres (2173.42s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupWindow (1393.12s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade (1210.12s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_characterSet_Replica (2547.87s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_multiAZ (1908.65s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_availabilityZone (1360.51s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (2733.85s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod (1594.73s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade (1442.70s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_nameGenerated (1209.27s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iops (1357.72s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorage (1379.67s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_addLater (1323.42s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops (1571.01s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_namePrefix (1311.54s)
--- PASS: TestAccRDSInstance_ManageMasterPassword_kmsKey (514.59s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_upgradeStorageConfig (1247.66s)
--- PASS: TestAccRDSInstance_ManageMasterPassword_convertToManaged (610.47s)
--- SKIP: TestAccRDSInstance_DBSubnetGroupName_ramShared (0.00s)
--- PASS: TestAccRDSInstance_ManageMasterPassword_basic (612.12s)
--- PASS: TestAccRDSInstance_isAlreadyBeingDeleted (402.04s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_sourceARN (1542.94s)
--- PASS: TestAccRDSInstance_optionGroup (602.63s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_promoteEmptyString (1650.10s)
--- PASS: TestAccRDSInstance_iamAuth (445.88s)
--- PASS: TestAccRDSInstance_Versions_allowMajor (493.99s)
--- PASS: TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs (534.45s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_promoteNull (1702.25s)
--- PASS: TestAccRDSInstance_deletionProtection (653.91s)
--- PASS: TestAccRDSInstance_Storage_maxAllocated (834.57s)
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot (861.38s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_basic (1446.21s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNameEquivalent (4143.44s)
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_basic (966.09s)
--- PASS: TestAccRDSInstance_caCertificateIdentifier (636.99s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring (1483.20s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage (1524.53s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1333.99s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow (1625.42s)
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (644.87s)
--- PASS: TestAccRDSInstance_PerformanceInsights_disabledToEnabled (694.89s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_mssqlDomain (4770.84s)
--- PASS: TestAccRDSInstance_PerformanceInsights_enabledToDisabled (839.58s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_postgresql (637.25s)
--- PASS: TestAccRDSInstance_PerformanceInsights_kmsKeyID (912.61s)
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameRAMShared (0.01s)
--- PASS: TestAccRDSInstance_dedicatedLogVolume_enableOnCreate (723.08s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameVPCSecurityGroupIDs (2011.52s)
--- PASS: TestAccRDSInstance_PerformanceInsights_retentionPeriod (1025.80s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (1174.64s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_basic (572.96s)
--- PASS: TestAccRDSInstance_Versions_minor (505.66s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_msSQL (903.50s)
--- PASS: TestAccRDSInstance_dedicatedLogVolume_enableOnUpdate (1230.86s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_oracle (1083.84s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_mySQL (939.42s)
--- PASS: TestAccRDSInstance_Versions_onlyMajor (532.87s)
--- PASS: TestAccRDSInstance_disappears (479.01s)
--- PASS: TestAccRDSInstance_kmsKey (494.05s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1680.40s)
--- PASS: TestAccRDSInstance_MSSQL_tz (1940.39s)
--- PASS: TestAccRDSInstance_engineLifecycleSupport_disabled (498.94s)
--- PASS: TestAccRDSInstance_networkType (804.60s)
--- PASS: TestAccRDSInstance_DBSubnetGroupName_basic (831.67s)
--- PASS: TestAccRDSInstance_portUpdate (513.31s)
--- PASS: TestAccRDSInstance_MSSQL_selfManagedDomainSingleDomainDNSIP (1271.26s)
--- PASS: TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion (1503.95s)
--- PASS: TestAccRDSInstance_Storage_separateIOPSUpdate_Io2 (723.13s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_removedToEnabled (627.44s)
--- PASS: TestAccRDSInstance_Storage_separateIOPSUpdate_Io1 (707.53s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved (769.63s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_sameVPC (1422.70s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_port (1075.88s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled (847.45s)
--- PASS: TestAccRDSInstance_identifierGenerated (521.77s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_crossRegion (1901.17s)
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared (0.03s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs (1051.18s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags (1118.61s)
--- PASS: TestAccRDSInstance_monitoringInterval (1232.82s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_tags (1093.93s)
--- PASS: TestAccRDSInstance_MSSQL_selfManagedDomain (2426.12s)
--- PASS: TestAccRDSInstance_identifierPrefix (492.98s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow (1249.38s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_sameAsSource (1410.01s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_parameterGroupName (1225.28s)
--- PASS: TestAccRDSInstance_MSSQL_selfManagedDomainSnapshotRestore (2698.99s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs (989.36s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage (1223.62s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_monitoring (1251.79s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled (1111.52s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_deletionProtection (1243.22s)
--- PASS: TestAccRDSInstance_MSSQL_domainSnapshotRestore (3056.18s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZ (1714.04s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName (1173.67s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (1196.51s)
--- PASS: TestAccRDSInstance_customIAMInstanceProfile (3224.75s)
--- PASS: TestAccRDSInstance_MSSQL_domain (3622.85s)
```
