### PR TITLE
fix Updated aurora serverless v2 min capacity to allow zero ACU

### DIFF
--- a/.changelog/40427.txt
+++ b/.changelog/40427.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix `expected serverlessv2_scaling_configuration.0.min_capacity to be in the range (0.500000 - 256.000000), got 0.000000` errors when min_capacity is set to zero. With the release of aurora serverless v2, you can now pause the cluster after a time period of X so long as ACU is set to 0 where previously only 0.5 was the absolute minimum.
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -547,12 +547,12 @@ func resourceCluster() *schema.Resource {
 						names.AttrMaxCapacity: {
 							Type:         schema.TypeFloat,
 							Required:     true,
-							ValidateFunc: validation.FloatBetween(0.5, 256),
+							ValidateFunc: validation.FloatBetween(0, 256),
 						},
 						"min_capacity": {
 							Type:         schema.TypeFloat,
 							Required:     true,
-							ValidateFunc: validation.FloatBetween(0.5, 256),
+							ValidateFunc: validation.FloatBetween(0, 256),
 						},
 					},
 				},

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -5672,7 +5672,7 @@ resource "aws_rds_cluster" "test" {
 
   serverlessv2_scaling_configuration {
     max_capacity = 1.0
-    min_capacity = 0.5
+    min_capacity = 0.0
   }
 }
 `, rName, tfrds.ClusterEngineAuroraPostgreSQL, enableHttpEndpoint)

--- a/website/docs/cdktf/python/r/rds_cluster.html.markdown
+++ b/website/docs/cdktf/python/r/rds_cluster.html.markdown
@@ -171,7 +171,7 @@ class MyConvertedCode(TerraformStack):
             master_username="test",
             serverlessv2_scaling_configuration=RdsClusterServerlessv2ScalingConfiguration(
                 max_capacity=1,
-                min_capacity=0.5
+                min_capacity=0
             ),
             storage_encrypted=True
         )
@@ -493,14 +493,14 @@ class MyConvertedCode(TerraformStack):
         RdsCluster(self, "example",
             serverlessv2_scaling_configuration=RdsClusterServerlessv2ScalingConfiguration(
                 max_capacity=256,
-                min_capacity=0.5
+                min_capacity=0
             ),
             engine=engine
         )
 ```
 
-* `max_capacity` - (Required) Maximum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are in a range of `0.5` up to `256` in steps of `0.5`.
-* `min_capacity` - (Required) Minimum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are in a range of `0.5` up to `256` in steps of `0.5`.
+* `max_capacity` - (Required) Maximum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`.
+* `min_capacity` - (Required) Minimum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`.
 
 ## Attribute Reference
 

--- a/website/docs/cdktf/typescript/r/rds_cluster.html.markdown
+++ b/website/docs/cdktf/typescript/r/rds_cluster.html.markdown
@@ -186,7 +186,7 @@ class MyConvertedCode extends TerraformStack {
       masterUsername: "test",
       serverlessv2ScalingConfiguration: {
         maxCapacity: 1,
-        minCapacity: 0.5,
+        minCapacity: 0,
       },
       storageEncrypted: true,
     });
@@ -548,7 +548,7 @@ class MyConvertedCode extends TerraformStack {
     new RdsCluster(this, "example", {
       serverlessv2ScalingConfiguration: {
         maxCapacity: 256,
-        minCapacity: 0.5,
+        minCapacity: 0,
       },
       engine: config.engine,
     });
@@ -557,8 +557,8 @@ class MyConvertedCode extends TerraformStack {
 
 ```
 
-* `maxCapacity` - (Required) Maximum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are in a range of `0.5` up to `256` in steps of `0.5`.
-* `minCapacity` - (Required) Minimum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are in a range of `0.5` up to `256` in steps of `0.5`.
+* `maxCapacity` - (Required) Maximum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`.
+* `minCapacity` - (Required) Minimum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`.
 
 ## Attribute Reference
 

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -114,7 +114,7 @@ resource "aws_rds_cluster" "example" {
 
   serverlessv2_scaling_configuration {
     max_capacity = 1.0
-    min_capacity = 0.5
+    min_capacity = 0
   }
 }
 
@@ -361,13 +361,13 @@ resource "aws_rds_cluster" "example" {
 
   serverlessv2_scaling_configuration {
     max_capacity = 256.0
-    min_capacity = 0.5
+    min_capacity = 0
   }
 }
 ```
 
-* `max_capacity` - (Required) Maximum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are in a range of `0.5` up to `256` in steps of `0.5`.
-* `min_capacity` - (Required) Minimum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are in a range of `0.5` up to `256` in steps of `0.5`.
+* `max_capacity` - (Required) Maximum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`.
+* `min_capacity` - (Required) Minimum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
AWS released a new feature of Aurora V2 Serverless scaling where the Aurora cluster can pause by setting the ACU to a minium of ZERO (0). Originally the min was 0.5 but now it can be set to zero.

Updated code to allow serverless scailing to be set as 0
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40421

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

This configuration is valid with the new release of Serverless v2
https://aws.amazon.com/blogs/database/introducing-scaling-to-0-capacity-with-amazon-aurora-serverless-v2/

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

