### PR TITLE
r/aws_s3tables_namespace: Fix sweeper

### DIFF
--- a/internal/service/s3tables/sweep.go
+++ b/internal/service/s3tables/sweep.go
@@ -52,7 +52,7 @@ func sweepNamespaces(ctx context.Context, client *conns.AWSClient) ([]sweep.Swee
 				for _, namespace := range page.Namespaces {
 					sweepResources = append(sweepResources, framework.NewSweepResource(newResourceNamespace, client,
 						framework.NewAttribute("table_bucket_arn", aws.ToString(bucket.Arn)),
-						framework.NewAttribute(names.AttrNamespace, namespace.Namespace),
+						framework.NewAttribute(names.AttrNamespace, namespace.Namespace[0]),
 					))
 				}
 			}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes sweeper error.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/40439.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SWEEP=us-west-2 SWEEPERS=aws_s3tables_table_bucket make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.23.3 test ./internal/sweep -v -sweep=us-west-2 -sweep-run='aws_s3tables_table_bucket' -timeout 360m
2024/12/04 11:05:44 [DEBUG] Running Sweepers for region (us-west-2):
2024/12/04 11:05:44 [DEBUG] Sweeper (aws_s3tables_table_bucket) has dependency (aws_s3tables_namespace), running..
2024/12/04 11:05:44 [DEBUG] Sweeper (aws_s3tables_namespace) has dependency (aws_s3tables_table), running..
2024/12/04 11:05:44 [DEBUG] Running Sweeper (aws_s3tables_table) in region (us-west-2)
2024/12/04 11:05:44 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024-12-04T11:05:44.464-0500 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024-12-04T11:05:44.464-0500 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024-12-04T11:05:44.464-0500 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024-12-04T11:05:44.464-0500 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table tf_aws.credentials_source=EnvConfigCredentials
2024-12-04T11:05:44.464-0500 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024/12/04 11:05:44 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024/12/04 11:05:44 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024-12-04T11:05:44.464-0500 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024-12-04T11:05:44.862-0500 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024/12/04 11:05:44 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024/12/04 11:05:45 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_table
2024/12/04 11:05:45 [DEBUG] Completed Sweeper (aws_s3tables_table) in region (us-west-2) in 1.19462425s
2024/12/04 11:05:45 [DEBUG] Running Sweeper (aws_s3tables_namespace) in region (us-west-2)
2024/12/04 11:05:45 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_s3tables_namespace
2024/12/04 11:05:45 [INFO]  sweeper: Sweeping resource: tf_resource_type=aws_s3tables_namespace namespace=testns table_bucket_arn=arn:aws:s3tables:us-west-2:123456789012:bucket/ewbankkit-test-001 resource_type=aws_s3tables_namespace sweeper_region=us-west-2
2024/12/04 11:05:45 [DEBUG] Waiting for state to become: [success]
2024/12/04 11:05:46 [DEBUG] Completed Sweeper (aws_s3tables_namespace) in region (us-west-2) in 530.622292ms
2024/12/04 11:05:46 [DEBUG] Running Sweeper (aws_s3tables_table_bucket) in region (us-west-2)
2024/12/04 11:05:46 [INFO]  sweeper: listing resources: tf_resource_type=aws_s3tables_table_bucket sweeper_region=us-west-2
2024/12/04 11:05:46 [INFO]  sweeper: Sweeping resource: tf_resource_type=aws_s3tables_table_bucket resource_type=aws_s3tables_table_bucket sweeper_region=us-west-2 arn=arn:aws:s3tables:us-west-2:187416307283:bucket/ewbankkit-test-001
2024/12/04 11:05:46 [DEBUG] Waiting for state to become: [success]
2024/12/04 11:05:46 [DEBUG] Completed Sweeper (aws_s3tables_table_bucket) in region (us-west-2) in 734.586708ms
2024/12/04 11:05:46 [DEBUG] Sweeper (aws_s3tables_namespace) has dependency (aws_s3tables_table), running..
2024/12/04 11:05:46 [DEBUG] Sweeper (aws_s3tables_table) already ran in region (us-west-2)
2024/12/04 11:05:46 [DEBUG] Sweeper (aws_s3tables_namespace) already ran in region (us-west-2)
2024/12/04 11:05:46 [DEBUG] Sweeper (aws_s3tables_table) already ran in region (us-west-2)
2024/12/04 11:05:46 Completed Sweepers for region (us-west-2) in 2.460370792s
2024/12/04 11:05:46 Sweeper Tests for region (us-west-2) ran successfully:
2024/12/04 11:05:46 	- aws_s3tables_table
2024/12/04 11:05:46 	- aws_s3tables_namespace
2024/12/04 11:05:46 	- aws_s3tables_table_bucket
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	7.591s
```
