### PR TITLE
feat(rds): add seconds_until_auto_pause parameter to RDS serverless v2 configuration

### DIFF
--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -554,6 +554,12 @@ func resourceCluster() *schema.Resource {
 							Required:     true,
 							ValidateFunc: validation.FloatBetween(0, 256),
 						},
+						"seconds_until_auto_pause": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      300,
+							ValidateFunc: validation.IntBetween(300, 86400),
+						},
 					},
 				},
 			},
@@ -2144,6 +2150,10 @@ func expandServerlessV2ScalingConfiguration(tfMap map[string]interface{}) *types
 		apiObject.MinCapacity = aws.Float64(v)
 	}
 
+	if v, ok := tfMap["seconds_until_auto_pause"].(int); ok {
+		apiObject.SecondsUntilAutoPause = aws.Int32(int32(v))
+	}
+
 	return apiObject
 }
 
@@ -2160,6 +2170,10 @@ func flattenServerlessV2ScalingConfigurationInfo(apiObject *types.ServerlessV2Sc
 
 	if v := apiObject.MinCapacity; v != nil {
 		tfMap["min_capacity"] = aws.ToFloat64(v)
+	}
+
+	if v := apiObject.SecondsUntilAutoPause; v != nil {
+		tfMap["seconds_until_auto_pause"] = aws.ToInt32(v)
 	}
 
 	return tfMap

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -113,8 +113,9 @@ resource "aws_rds_cluster" "example" {
   storage_encrypted  = true
 
   serverlessv2_scaling_configuration {
-    max_capacity = 1.0
-    min_capacity = 0.5
+    max_capacity             = 1.0
+    min_capacity             = 0.0
+    seconds_until_auto_pause = 3600
   }
 }
 
@@ -360,14 +361,16 @@ resource "aws_rds_cluster" "example" {
   # ... other configuration ...
 
   serverlessv2_scaling_configuration {
-    max_capacity = 256.0
-    min_capacity = 0.5
+    max_capacity             = 256.0
+    min_capacity             = 0.0
+    seconds_until_auto_pause = 3600
   }
 }
 ```
 
 * `max_capacity` - (Required) Maximum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`.
 * `min_capacity` - (Required) Minimum capacity for an Aurora DB cluster in `provisioned` DB engine mode. The minimum capacity must be lesser than or equal to the maximum capacity. Valid capacity values are in a range of `0` up to `256` in steps of `0.5`.
+* `seconds_until_auto_pause` - (Optional) Time, in seconds, before an Aurora DB cluster in `provisioned` DB engine mode is paused. Valid values are `300` through `86400`. Defaults to `300`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
Add seconds_until_auto_pause parameter to RDS serverless v2 cluster

### Relations
Closes #40258

### References
[ServerlessV2ScalingConfiguration](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ServerlessV2ScalingConfiguration.html)
