### PR TITLE
Docs - ECS `containerInsights` add enhanced observability as an option

### DIFF
--- a/website/docs/r/ecs_cluster.html.markdown
+++ b/website/docs/r/ecs_cluster.html.markdown
@@ -198,7 +198,7 @@ The `service_connect_defaults` configuration block supports the following argume
 The `setting` configuration block supports the following arguments:
 
 * `name` - (Required) Name of the setting to manage. Valid values: `containerInsights`.
-* `value` -  (Required) Value to assign to the setting. Valid values: `enabled`, `disabled`.
+* `value` -  (Required) Value to assign to the setting. Valid values: `enhanced`, `enabled`, `disabled`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

Minor documentation change to add `enhanced` has a potential option to `containerInsights` on ECS clusters. See #40445 for more details

I placed the new `enhanced` option at the start of the potential options in line with the order they are stated in ClusterSetting API Reference [here](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ClusterSetting.html#API_ClusterSetting_Contents)

### Relations

Closes #40445
