### PR TITLE
Bug Make instruction required

### DIFF
--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -125,8 +125,7 @@ func (r *agentResource) Schema(ctx context.Context, request resource.SchemaReque
 				},
 			},
 			"instruction": schema.StringAttribute{
-				Optional: true,
-				Computed: true,
+				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/website/docs/r/bedrockagent_agent.html.markdown
+++ b/website/docs/r/bedrockagent_agent.html.markdown
@@ -74,6 +74,7 @@ The following arguments are required:
 * `agent_name` - (Required) Name of the agent.
 * `agent_resource_role_arn` - (Required) ARN of the IAM role with permissions to invoke API operations on the agent.
 * `foundation_model` - (Required) Foundation model used for orchestration by the agent.
+* `instruction` - (Required) Instructions that tell the agent what it should do and how it should interact with users. The valid range is 40 - 8000 characters.
 
 The following arguments are optional:
 
@@ -81,7 +82,6 @@ The following arguments are optional:
 * `description` - (Optional) Description of the agent.
 * `guardrail_configuration` - (Optional) Details about the guardrail associated with the agent. See [`guardrail_configuration` Block](#guardrail_configuration-block) for details.
 * `idle_session_ttl_in_seconds` - (Optional) Number of seconds for which Amazon Bedrock keeps information about a user's conversation with the agent. A user interaction remains active for the amount of time specified. If no conversation occurs during this time, the session expires and Amazon Bedrock deletes any data provided before the timeout.
-* `instruction` - (Optional) Instructions that tell the agent what it should do and how it should interact with users. The valid range is 40 - 8000 characters.
 * `prepare_agent` (Optional) Whether to prepare the agent after creation or modification. Defaults to `true`.
 * `prompt_override_configuration` (Optional) Configurations to override prompt templates in different parts of an agent sequence. For more information, see [Advanced prompts](https://docs.aws.amazon.com/bedrock/latest/userguide/advanced-prompts.html). See [`prompt_override_configuration` Block](#prompt_override_configuration-block) for details.
 * `skip_resource_in_use_check` - (Optional) Whether the in-use check is skipped when deleting the agent.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Make instruction required as while the agent can be created without it cannot be prepared, nor is it testable without an instruction.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #ç

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc TESTS=TestAccBedrockAgentAgent_ PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgentAgent_'  -timeout 360m
2024/12/05 10:52:29 Initializing Terraform AWS Provider...
=== RUN   TestAccBedrockAgentAgent_basic
=== PAUSE TestAccBedrockAgentAgent_basic
=== RUN   TestAccBedrockAgentAgent_full
=== PAUSE TestAccBedrockAgentAgent_full
=== RUN   TestAccBedrockAgentAgent_singlePrompt
=== PAUSE TestAccBedrockAgentAgent_singlePrompt
=== RUN   TestAccBedrockAgentAgent_singlePromptUpdate
=== PAUSE TestAccBedrockAgentAgent_singlePromptUpdate
=== RUN   TestAccBedrockAgentAgent_addPrompt
=== PAUSE TestAccBedrockAgentAgent_addPrompt
=== RUN   TestAccBedrockAgentAgent_guardrail
=== PAUSE TestAccBedrockAgentAgent_guardrail
=== RUN   TestAccBedrockAgentAgent_update
=== PAUSE TestAccBedrockAgentAgent_update
=== RUN   TestAccBedrockAgentAgent_tags
=== PAUSE TestAccBedrockAgentAgent_tags
=== RUN   TestAccBedrockAgentAgent_kms
=== PAUSE TestAccBedrockAgentAgent_kms
=== CONT  TestAccBedrockAgentAgent_basic
=== CONT  TestAccBedrockAgentAgent_guardrail
=== CONT  TestAccBedrockAgentAgent_tags
=== CONT  TestAccBedrockAgentAgent_update
=== CONT  TestAccBedrockAgentAgent_singlePromptUpdate
=== CONT  TestAccBedrockAgentAgent_singlePrompt
=== CONT  TestAccBedrockAgentAgent_kms
=== CONT  TestAccBedrockAgentAgent_full
=== CONT  TestAccBedrockAgentAgent_addPrompt
--- PASS: TestAccBedrockAgentAgent_singlePrompt (30.86s)
--- PASS: TestAccBedrockAgentAgent_basic (31.49s)
--- PASS: TestAccBedrockAgentAgent_full (31.68s)
--- PASS: TestAccBedrockAgentAgent_singlePromptUpdate (46.43s)
--- PASS: TestAccBedrockAgentAgent_kms (50.07s)
--- PASS: TestAccBedrockAgentAgent_update (60.66s)
--- PASS: TestAccBedrockAgentAgent_tags (67.00s)
--- PASS: TestAccBedrockAgentAgent_guardrail (75.42s)
--- PASS: TestAccBedrockAgentAgent_addPrompt (78.63s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       83.373s

```
