### PR TITLE
feat: add aws_vpc_ipam & aws_vpc_ipams data sources

### DIFF
--- a/internal/service/ec2/ipam_data_source.go
+++ b/internal/service/ec2/ipam_data_source.go
@@ -1,0 +1,141 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_vpc_ipam", name="IPAM")
+// @Tags
+// @Testing(tagsTest=false)
+func dataSourceIPAM() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceIPAMRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"default_resource_discovery_association_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"default_resource_discovery_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_private_gua": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ipam_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ipam_region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrDescription: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrID: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrFilter: customFiltersSchema(),
+			"owner_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_default_scope_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_default_scope_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_discovery_association_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"scope_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"tier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrState: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrTags: tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceIPAMRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+
+	input := &ec2.DescribeIpamsInput{}
+
+	if v, ok := d.GetOk("ipam_id"); ok {
+		input.IpamIds = []string{v.(string)}
+	}
+
+	input.Filters = append(input.Filters, newCustomFilterList(
+		d.Get(names.AttrFilter).(*schema.Set),
+	)...)
+
+	if len(input.Filters) == 0 {
+		input.Filters = nil
+	}
+
+	ipam, err := findIPAM(ctx, conn, input)
+
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("IPAM", err))
+	}
+
+	d.SetId(aws.ToString(ipam.IpamId))
+	d.Set("default_resource_discovery_association_id", ipam.DefaultResourceDiscoveryAssociationId)
+	d.Set("default_resource_discovery_id", ipam.DefaultResourceDiscoveryId)
+	d.Set("enable_private_gua", ipam.EnablePrivateGua)
+	d.Set("ipam_region", ipam.IpamRegion)
+	d.Set(names.AttrARN, ipam.IpamArn)
+	d.Set("owner_id", ipam.OwnerId)
+	d.Set(names.AttrDescription, ipam.Description)
+	d.Set("public_default_scope_id", ipam.PublicDefaultScopeId)
+	d.Set("private_default_scope_id", ipam.PrivateDefaultScopeId)
+	d.Set("resource_discovery_association_count", ipam.ResourceDiscoveryAssociationCount)
+	d.Set("scope_count", ipam.ScopeCount)
+	d.Set("tier", ipam.Tier)
+	d.Set(names.AttrState, ipam.State)
+
+	setTagsOut(ctx, ipam.Tags)
+
+	return diags
+}

--- a/internal/service/ec2/ipam_data_source_test.go
+++ b/internal/service/ec2/ipam_data_source_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccIPAMDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_vpc_ipam.test"
+	dataSourceName := "data.aws_vpc_ipam.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPAMDataSourceConfig_optionsBasic,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "enable_private_gua", resourceName, "enable_private_gua"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tier", resourceName, "tier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDescription, resourceName, names.AttrDescription),
+					resource.TestCheckResourceAttrPair(dataSourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIPAMDataSource_withTier(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_vpc_ipam.test"
+	dataSourceName := "data.aws_vpc_ipam.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPAMDataSourceConfig_optionsBasic,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "enable_private_gua", resourceName, "enable_private_gua"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tier", resourceName, "tier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDescription, resourceName, names.AttrDescription),
+					resource.TestCheckResourceAttrPair(dataSourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
+				),
+			},
+		},
+	})
+}
+
+var testAccIPAMDataSourceConfig_optionsBasic = acctest.ConfigCompose(testAccIPAMConfig_tier("free"), `
+data "aws_vpc_ipam" "test" {
+  ipam_id = aws_vpc_ipam.test.id
+}
+`)

--- a/internal/service/ec2/ipams_data_source.go
+++ b/internal/service/ec2/ipams_data_source.go
@@ -1,0 +1,157 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_vpc_ipams", name="IPAMs")
+func dataSourceIPAMs() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceIPAMsRead,
+
+		Schema: map[string]*schema.Schema{
+			names.AttrFilter: customFiltersSchema(),
+			"ipams": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"default_resource_discovery_association_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"default_resource_discovery_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enable_private_gua": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"ipam_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ipam_region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrARN: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrDescription: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrID: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_default_scope_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_default_scope_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_discovery_association_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"scope_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"tier": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrState: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrTags: tftags.TagsSchemaComputed(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIPAMsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).EC2Client(ctx)
+	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
+
+	input := &ec2.DescribeIpamsInput{}
+
+	input.Filters = append(input.Filters, newCustomFilterList(
+		d.Get(names.AttrFilter).(*schema.Set),
+	)...)
+
+	if len(input.Filters) == 0 {
+		input.Filters = nil
+	}
+
+	ipams, err := findIPAMs(ctx, conn, input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading IPAMs: %s", err)
+	}
+
+	d.SetId(meta.(*conns.AWSClient).Region(ctx))
+	d.Set("ipams", flattenIPAMs(ctx, ipams, ignoreTagsConfig))
+
+	return diags
+}
+
+func flattenIPAMs(ctx context.Context, c []awstypes.Ipam, ignoreTagsConfig *tftags.IgnoreConfig) []interface{} {
+	ipams := []interface{}{}
+	for _, ipam := range c {
+		ipams = append(ipams, flattenIPAM(ctx, ipam, ignoreTagsConfig))
+	}
+	return ipams
+}
+
+func flattenIPAM(ctx context.Context, ip awstypes.Ipam, ignoreTagsConfig *tftags.IgnoreConfig) map[string]interface{} {
+	ipam := make(map[string]interface{})
+	ipam[names.AttrARN] = aws.ToString(ip.IpamArn)
+	ipam[names.AttrDescription] = aws.ToString(ip.Description)
+	ipam[names.AttrID] = aws.ToString(ip.IpamId)
+	ipam["default_resource_discovery_association_id"] = aws.ToString(ip.DefaultResourceDiscoveryAssociationId)
+	ipam["default_resource_discovery_id"] = aws.ToString(ip.DefaultResourceDiscoveryId)
+	ipam["enable_private_gua"] = aws.ToBool(ip.EnablePrivateGua)
+	ipam["ipam_region"] = aws.ToString(ip.IpamRegion)
+	ipam["owner_id"] = aws.ToString(ip.OwnerId)
+	ipam["public_default_scope_id"] = aws.ToString(ip.PublicDefaultScopeId)
+	ipam["private_default_scope_id"] = aws.ToString(ip.PrivateDefaultScopeId)
+	ipam["resource_discovery_association_count"] = aws.ToInt32(ip.ResourceDiscoveryAssociationCount)
+	ipam["scope_count"] = aws.ToInt32(ip.ScopeCount)
+	ipam["tier"] = aws.ToString((*string)(&ip.Tier))
+
+	ipam[names.AttrState] = ip.State
+	if v := ip.Tags; v != nil {
+		ipam[names.AttrTags] = keyValueTags(ctx, v).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()
+	}
+
+	return ipam
+}

--- a/internal/service/ec2/ipams_data_source_test.go
+++ b/internal/service/ec2/ipams_data_source_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccIPAMsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_vpc_ipams.test"
+	dataSourceNameTwo := "data.aws_vpc_ipams.testtwo"
+	resourceName := "aws_vpc_ipam.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPAMsDataSourceConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "ipams.#", 0),
+				),
+			},
+			{
+				Config: testAccIPAMsDataSourceConfig_basicWithFilter,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// DS 1 finds all 2 IPAMs
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "ipams.#", 1),
+
+					// DS 2 filters on 1 specific IPAM to validate attributes
+					resource.TestCheckResourceAttr(dataSourceNameTwo, "ipams.#", "1"),
+					// resource.TestCheckResourceAttr(dataSourceNameTwo, "ipams.0.tags.test", "two"),
+					resource.TestCheckResourceAttrPair(dataSourceNameTwo, "ipams.0.enable_private_gua", resourceName, "enable_private_gua"),
+					resource.TestCheckResourceAttrPair(dataSourceNameTwo, "ipams.0.tier", resourceName, "tier"),
+					resource.TestCheckResourceAttrPair(dataSourceNameTwo, "ipams.0.arn", resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceNameTwo, "ipams.0.description", resourceName, names.AttrDescription),
+					resource.TestCheckResourceAttrPair(dataSourceNameTwo, "ipams.0.id", resourceName, names.AttrID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIPAMsDataSource_empty(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_vpc_ipams.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIPAMsDataSourceConfig_empty,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ipams.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+var testAccIPAMsDataSourceConfig_basic = acctest.ConfigCompose(testAccIPAMConfig_basic, `
+data "aws_vpc_ipams" "test" {
+  depends_on = [
+    aws_vpc_ipam.test,
+  ]
+}
+`)
+
+var testAccIPAMsDataSourceConfig_basicWithFilter = acctest.ConfigCompose(testAccIPAMConfig_description("Some desc"), `
+data "aws_vpc_ipams" "test" {
+  depends_on = [
+    aws_vpc_ipam.test,
+  ]
+}
+  
+data "aws_vpc_ipams" "testtwo" {
+  filter {
+    name   = "description"
+    values = ["*Some*"]
+  }
+  depends_on = [
+	aws_vpc_ipam.test,
+  ]
+}
+`)
+
+const testAccIPAMsDataSourceConfig_empty = `
+data "aws_vpc_ipams" "test" {
+  filter {
+    name   = "description"
+    values = ["*none*"]
+  }
+}
+`

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -514,6 +514,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Name:     "Endpoint Service",
 		},
 		{
+			Factory:  dataSourceIPAM,
+			TypeName: "aws_vpc_ipam",
+			Name:     "IPAM",
+			Tags:     &types.ServicePackageResourceTags{},
+		},
+		{
 			Factory:  dataSourceIPAMPool,
 			TypeName: "aws_vpc_ipam_pool",
 			Name:     "IPAM Pool",
@@ -533,6 +539,11 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Factory:  dataSourceIPAMPreviewNextCIDR,
 			TypeName: "aws_vpc_ipam_preview_next_cidr",
 			Name:     "IPAM Preview Next CIDR",
+		},
+		{
+			Factory:  dataSourceIPAMs,
+			TypeName: "aws_vpc_ipams",
+			Name:     "IPAMs",
 		},
 		{
 			Factory:  dataSourceVPCPeeringConnection,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR introduces 2 new data sources: `aws_vpc_ipam` and `aws_vpc_ipams`, following the convention of the `aws_vpc_ipam_pool` and `aws_vpc_ipam_pools` data sources.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
❯ make testacc TESTS=TestAccIPAMDataSource PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccIPAMDataSource'  -timeout 360m
2024/12/05 13:18:39 Initializing Terraform AWS Provider...
=== RUN   TestAccIPAMDataSource_basic
=== PAUSE TestAccIPAMDataSource_basic
=== RUN   TestAccIPAMDataSource_withTier
=== PAUSE TestAccIPAMDataSource_withTier
=== CONT  TestAccIPAMDataSource_basic
=== CONT  TestAccIPAMDataSource_withTier
--- PASS: TestAccIPAMDataSource_withTier (23.97s)
--- PASS: TestAccIPAMDataSource_basic (24.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	28.462s

❯ make testacc TESTS=TestAccIPAMsDataSource PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccIPAMsDataSource'  -timeout 360m
2024/12/05 13:19:30 Initializing Terraform AWS Provider...
=== RUN   TestAccIPAMsDataSource_basic
=== PAUSE TestAccIPAMsDataSource_basic
=== RUN   TestAccIPAMsDataSource_empty
=== PAUSE TestAccIPAMsDataSource_empty
=== CONT  TestAccIPAMsDataSource_basic
=== CONT  TestAccIPAMsDataSource_empty
--- PASS: TestAccIPAMsDataSource_empty (9.39s)
--- PASS: TestAccIPAMsDataSource_basic (36.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	40.835s

...
```


Signed-off-by: Ismayil Mirzali <ismayil.mirzali@sap.com>
