### PR TITLE
Fix: at_rest_encryption_enabled incorrectly processed

### DIFF
--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -70,7 +70,7 @@ func resourceReplicationGroup() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
-				Default: true,
+				Default:  true,
 			},
 			"auth_token": {
 				Type:          schema.TypeString,

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -70,7 +70,7 @@ func resourceReplicationGroup() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
-				Computed: true,
+				Default: true,
 			},
 			"auth_token": {
 				Type:          schema.TypeString,


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
at_rest_encryption_enabled incorrectly processed leading to unexpected replication group state and endless replacement when set to false

Current situation:
- AWS docs specify that the default is false, but this has changed on the API for valkey, new ReplicationGroups are all being created with at_rest_encryption_enabled set to true
- By default, this provider assumes at_rest_encryption_enabled=false, and doesn't include the parameter in the CreateReplicationGroup API call
- When creating a Valkey ReplicationGroup with the provider, unless explicitly specifying  `at_rest_encryption_enabled=true`, every terraform plan/apply will try to recreate the ReplicationGroup, which is a destructive operation
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR changes `at_rest_encryption_enabled` from Computed to a normal parameter, so it is included with the CreateReplicationGroup API call
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #39955

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
-->


```
