### PR TITLE
.github/workflows: exit successfully once registry and github versions match

### DIFF
--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -70,6 +70,7 @@ jobs:
             else
               echo "Registry and Github Version matches"
               echo "current=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
           done
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Previously a version match would print the correct success message, but did not exit after doing so. This caused the loop to continue and eventually fall through to a failure message with a non-zero exit code.

Ref: https://github.com/hashicorp/terraform-provider-aws/actions/runs/12164517617/job/33926378837

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #40406 
Relates #40245 
Relates #39964


