### PR TITLE
fix: update validation for throughput capacity

### DIFF
--- a/.changelog/40468.txt
+++ b/.changelog/40468.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_fsx_windows_file_system: Fix `throughput_capacity` validation to allow values up to 12228.
+```

--- a/.changelog/40468.txt
+++ b/.changelog/40468.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_fsx_windows_file_system: Fix `throughput_capacity` validation to allow values up to 12228.
+resource/aws_fsx_windows_file_system: Fix plan-time validation of `throughput_capacity` validation to allow values up to `12228`
 ```

--- a/internal/service/fsx/windows_file_system.go
+++ b/internal/service/fsx/windows_file_system.go
@@ -281,7 +281,7 @@ func resourceWindowsFileSystem() *schema.Resource {
 			"throughput_capacity": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(8, 2048),
+				ValidateFunc: validation.IntInSlice([]int{8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4608, 6144, 9216, 12228}),
 			},
 			names.AttrVPCID: {
 				Type:     schema.TypeString,

--- a/website/docs/r/fsx_windows_file_system.html.markdown
+++ b/website/docs/r/fsx_windows_file_system.html.markdown
@@ -53,7 +53,7 @@ resource "aws_fsx_windows_file_system" "example" {
 The following arguments are required:
 
 * `subnet_ids` - (Required) A list of IDs for the subnets that the file system will be accessible from. To specify more than a single subnet set `deployment_type` to `MULTI_AZ_1`.
-* `throughput_capacity` - (Required) Throughput (megabytes per second) of the file system in power of 2 increments. Minimum of `8` and maximum of `2048`.
+* `throughput_capacity` - (Required) Throughput (megabytes per second) of the file system. For valid values, refer to the [AWS documentation](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/performance.html).
 
 The following arguments are optional:
 


### PR DESCRIPTION
### Description

Update the validation for the argument `throughput_capacity` when creating an `aws_fsx_windows_file_system` resource.

The [current validation](https://github.com/hashicorp/terraform-provider-aws/blob/74707c768f1f93b2190a0b26abd1e40aa4bc93af/internal/service/fsx/windows_file_system.go#L284) allows values between 8 and 2048. Actually, 

- only a small subset of values inside this range is allowed 
- larger values are also fine in some regions.

Here an example output when a value of 2040 is specified:

```shell
 Error: creating FSx for Windows File Server File System: operation error FSx: CreateFileSystem, https response error StatusCode: 400, RequestID: 39b44ab9-daca-46f1-a6c0-ec8a64c639d1, BadRequest: Invalid desired throughput capacity value provided: 2040 MB/s. Please refer to the performance guide (https://docs.aws.amazon.com/fsx/latest/WindowsGuide/performance.html) when selecting a value.
```

The documentation is updated and no longer mentions `in power of 2 increments` as this in no longer true for values > 2048.

### Relations

Closes #40289

### References

- [Announcement](https://aws.amazon.com/about-aws/whats-new/2023/08/amazon-fsx-windows-file-server-increases-throughput-12-gbs/)
- [FSx Windows - Performance overview](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/performance.html#perf-overview)  
 mentioning region specific maximum value for the throughput capacity.
  > Amazon FSx file systems provide up to 2 GB/s and 80,000 IOPS in all AWS Regions where Amazon FSx is available, and 12 GB/s of throughput and 400,000 IOPS in US East (N. Virginia), US West (Oregon), US East (Ohio), Europe (Ireland), Asia Pacific (Tokyo), and Asia Pacific (Singapore).


### Output from Acceptance Testing

TBD