### PR TITLE
r/aws_rds_cluster: respect `storage_type` when restored from snapshot

### DIFF
--- a/.changelog/40471.txt
+++ b/.changelog/40471.txt
@@ -1,0 +1,9 @@
+```release-note:bug
+resource/aws_rds_cluster: Respect `storage_type` when restored from snapshot
+```
+```release-note:bug
+resource/aws_rds_cluster: Respect `storage_type` when restored from s3
+```
+```release-note:bug
+resource/aws_rds_cluster: Respect `storage_type` when restored from point in time
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -1029,6 +1029,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			input.SourceDbClusterResourceId = aws.String(v)
 		}
 
+		if v, ok := d.GetOkExists(names.AttrStorageType); ok {
+			input.StorageType = aws.String(v.(string))
+		}
+
 		if v, ok := tfMap["use_latest_restorable_time"].(bool); ok && v {
 			input.UseLatestRestorableTime = aws.Bool(v)
 		}

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -761,6 +761,9 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			requiresModifyDbCluster = true
 		}
 
+		if v, ok := d.GetOkExists(names.AttrStorageType); ok {
+			input.StorageType = aws.String(v.(string))
+		}
 		if v, ok := d.GetOk(names.AttrVPCSecurityGroupIDs); ok && v.(*schema.Set).Len() > 0 {
 			input.VpcSecurityGroupIds = flex.ExpandStringValueSet(v.(*schema.Set))
 		}

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -764,6 +764,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		if v, ok := d.GetOkExists(names.AttrStorageType); ok {
 			input.StorageType = aws.String(v.(string))
 		}
+
 		if v, ok := d.GetOk(names.AttrVPCSecurityGroupIDs); ok && v.(*schema.Set).Len() > 0 {
 			input.VpcSecurityGroupIds = flex.ExpandStringValueSet(v.(*schema.Set))
 		}
@@ -882,6 +883,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if v, ok := d.GetOkExists(names.AttrStorageEncrypted); ok {
 			input.StorageEncrypted = aws.Bool(v.(bool))
+		}
+
+		if v, ok := d.GetOkExists(names.AttrStorageType); ok {
+			input.StorageType = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk(names.AttrVPCSecurityGroupIDs); ok && v.(*schema.Set).Len() > 0 {

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -761,7 +761,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			requiresModifyDbCluster = true
 		}
 
-		if v, ok := d.GetOkExists(names.AttrStorageType); ok {
+		if v, ok := d.GetOk(names.AttrStorageType); ok {
 			input.StorageType = aws.String(v.(string))
 		}
 
@@ -885,7 +885,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			input.StorageEncrypted = aws.Bool(v.(bool))
 		}
 
-		if v, ok := d.GetOkExists(names.AttrStorageType); ok {
+		if v, ok := d.GetOk(names.AttrStorageType); ok {
 			input.StorageType = aws.String(v.(string))
 		}
 
@@ -1029,7 +1029,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			input.SourceDbClusterResourceId = aws.String(v)
 		}
 
-		if v, ok := d.GetOkExists(names.AttrStorageType); ok {
+		if v, ok := d.GetOk(names.AttrStorageType); ok {
 			input.StorageType = aws.String(v.(string))
 		}
 
@@ -1213,7 +1213,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			input.StorageEncrypted = aws.Bool(v.(bool))
 		}
 
-		if v, ok := d.GetOkExists(names.AttrStorageType); ok {
+		if v, ok := d.GetOk(names.AttrStorageType); ok {
 			input.StorageType = aws.String(v.(string))
 		}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously if `storage_type` was configured on an RDS cluster restored from snapshot, the resulting cluster would always have the default value of `aurora` regardless of what was configured. This change properly sets the `storage_type` value, if configured.

Running a test to replicate this scenario against `main`:

```console
% make testacc PKG=rds TESTS=TestAccRDSCluster_SnapshotIdentifier_storageType
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_SnapshotIdentifier_storageType'  -timeout 360m
2024/12/05 14:30:09 Initializing Terraform AWS Provider...

    cluster_test.go:2520: Step 1/1 error: Check failed: Check 4/4 error: aws_rds_cluster.test: Attribute 'storage_type' expected "aurora-iopt1", got ""
--- FAIL: TestAccRDSCluster_SnapshotIdentifier_storageType (268.82s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/rds        274.075s
FAIL
make: *** [testacc] Error 1
```

And against this branch:

```console
% make testacc PKG=rds TESTS=TestAccRDSCluster_SnapshotIdentifier_storageType
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_SnapshotIdentifier_storageType'  -timeout 360m
2024/12/05 11:32:27 Initializing Terraform AWS Provider...

--- PASS: TestAccRDSCluster_SnapshotIdentifier_storageType (283.84s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        289.116s
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39935


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTS=TestAccRDSCluster_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_'  -timeout 360m
2024/12/05 14:46:44 Initializing Terraform AWS Provider...

--- PASS: TestAccRDSCluster_iamAuth (125.49s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
--- PASS: TestAccRDSCluster_localWriteForwarding (128.52s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
--- PASS: TestAccRDSCluster_basic (128.52s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
--- PASS: TestAccRDSCluster_engineLifecycleSupport_disabled (144.48s)
=== CONT  TestAccRDSCluster_scaling
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add (147.72s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_deletionProtection
--- PASS: TestAccRDSCluster_password (165.59s)
=== CONT  TestAccRDSCluster_snapshotIdentifier
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL (194.05s)
=== CONT  TestAccRDSCluster_Scaling_defaultMinCapacity
--- PASS: TestAccRDSCluster_enableHTTPEndpointProvisioned (195.43s)
=== CONT  TestAccRDSCluster_serverlessV2ScalingConfiguration
--- PASS: TestAccRDSCluster_copyTagsToSnapshot (204.78s)
=== CONT  TestAccRDSCluster_kmsKey
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned (291.40s)
=== CONT  TestAccRDSCluster_encrypted
--- PASS: TestAccRDSCluster_SnapshotIdentifier_encryptedRestore (291.79s)
=== CONT  TestAccRDSCluster_networkType
--- PASS: TestAccRDSCluster_kmsKey (109.48s)
=== CONT  TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove (207.10s)
=== CONT  TestAccRDSCluster_port
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned (214.07s)
=== CONT  TestAccRDSCluster_ManagedMasterPassword_convertToManaged
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update (213.26s)
=== CONT  TestAccRDSCluster_ReplicationSourceIdentifier_promote
--- PASS: TestAccRDSCluster_enableHTTPEndpoint (373.23s)
=== CONT  TestAccRDSCluster_copyTagsToSnapshot_restorePointInTime
--- PASS: TestAccRDSCluster_encrypted (112.92s)
=== CONT  TestAccRDSCluster_minorVersion
--- PASS: TestAccRDSCluster_serverlessV2ScalingConfiguration (218.04s)
=== CONT  TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
--- PASS: TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey (113.34s)
=== CONT  TestAccRDSCluster_allocatedStorage
--- PASS: TestAccRDSCluster_snapshotIdentifier (263.15s)
=== CONT  TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
--- PASS: TestAccRDSCluster_NoDeleteAutomatedBackups (433.28s)
=== CONT  TestAccRDSCluster_storageTypeAuroraIopt1
--- PASS: TestAccRDSCluster_Scaling_defaultMinCapacity (266.52s)
=== CONT  TestAccRDSCluster_storageTypeAuroraReturnsBlank
--- PASS: TestAccRDSCluster_SnapshotIdentifier_deletionProtection (313.04s)
=== CONT  TestAccRDSCluster_storageTypeGeneralPurposeToProvisionedIOPS
--- PASS: TestAccRDSCluster_scaling (326.24s)
=== CONT  TestAccRDSCluster_storageTypeIo2
--- PASS: TestAccRDSCluster_port (141.55s)
=== CONT  TestAccRDSCluster_storageTypeIo1
--- PASS: TestAccRDSCluster_ManagedMasterPassword_convertToManaged (145.07s)
=== CONT  TestAccRDSCluster_availabilityZones_caCertificateIdentifier
--- PASS: TestAccRDSCluster_networkType (200.23s)
=== CONT  TestAccRDSCluster_availabilityZones
--- PASS: TestAccRDSCluster_storageTypeAuroraIopt1 (103.88s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgrade
--- PASS: TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora (152.83s)
=== CONT  TestAccRDSCluster_onlyMajorVersion
--- PASS: TestAccRDSCluster_storageTypeAuroraReturnsBlank (113.50s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
--- PASS: TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1 (154.19s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
--- PASS: TestAccRDSCluster_availabilityZones (104.08s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
--- PASS: TestAccRDSCluster_copyTagsToSnapshot_restorePointInTime (336.72s)
=== CONT  TestAccRDSCluster_identifierPrefix
--- PASS: TestAccRDSCluster_identifierPrefix (116.70s)
=== CONT  TestAccRDSCluster_securityGroupUpdate
--- PASS: TestAccRDSCluster_securityGroupUpdate (202.58s)
=== CONT  TestAccRDSCluster_tags
--- PASS: TestAccRDSCluster_tags (132.66s)
=== CONT  TestAccRDSCluster_identifierGenerated
--- PASS: TestAccRDSCluster_minorVersion (765.39s)
=== CONT  TestAccRDSCluster_updateIAMRoles
--- PASS: TestAccRDSCluster_identifierGenerated (115.61s)
=== CONT  TestAccRDSCluster_ManagedMasterPassword_managed
--- PASS: TestAccRDSCluster_updateIAMRoles (121.63s)
=== CONT  TestAccRDSCluster_backupsUpdate
--- PASS: TestAccRDSCluster_ManagedMasterPassword_managed (116.13s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
--- PASS: TestAccRDSCluster_storageTypeGeneralPurposeToProvisionedIOPS (960.96s)
=== CONT  TestAccRDSCluster_engineVersion
--- PASS: TestAccRDSCluster_backupsUpdate (141.59s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
--- PASS: TestAccRDSCluster_onlyMajorVersion (868.23s)
=== CONT  TestAccRDSCluster_engineVersionWithPrimaryInstance
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately (912.21s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
--- PASS: TestAccRDSCluster_iops (1550.30s)
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
--- PASS: TestAccRDSCluster_performanceInsightsEnabled (1565.50s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global (197.59s)
=== CONT  TestAccRDSCluster_disappears
--- PASS: TestAccRDSCluster_performanceInsightsKMSKeyID (1631.24s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_tags
--- PASS: TestAccRDSCluster_performanceInsightsRetentionPeriod (1639.68s)
=== CONT  TestAccRDSCluster_engineMode
--- PASS: TestAccRDSCluster_disappears (113.38s)
=== CONT  TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
--- PASS: TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags (255.94s)
=== CONT  TestAccRDSCluster_domain
--- PASS: TestAccRDSCluster_engineVersion (412.32s)
=== CONT  TestAccRDSCluster_missingUserNameCausesError
--- PASS: TestAccRDSCluster_missingUserNameCausesError (4.73s)
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierTakeFinalSnapshot
--- PASS: TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs (274.54s)
=== CONT  TestAccRDSCluster_takeFinalSnapshot
--- PASS: TestAccRDSCluster_allocatedStorage (1483.04s)
=== CONT  TestAccRDSCluster_dbSubnetGroupName
--- PASS: TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID (1931.23s)
=== CONT  TestAccRDSCluster_pointInTimeRestoreViaResourceID
--- PASS: TestAccRDSCluster_SnapshotIdentifier_tags (383.21s)
=== CONT  TestAccRDSCluster_pointInTimeRestore
--- PASS: TestAccRDSCluster_engineMode (376.06s)
=== CONT  TestAccRDSCluster_deletionProtection
=== CONT  TestAccRDSCluster_SnapshotIdentifier_masterPassword
--- PASS: TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports (274.65s)
--- PASS: TestAccRDSCluster_dbSubnetGroupName (110.79s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
--- PASS: TestAccRDSCluster_takeFinalSnapshot (204.55s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
=== CONT  TestAccRDSCluster_SnapshotIdentifier_masterUsername
--- PASS: TestAccRDSCluster_storageTypeIo1 (1574.33s)
--- PASS: TestAccRDSCluster_storageTypeIo2 (1595.67s)
=== CONT  TestAccRDSCluster_backtrackWindow
--- PASS: TestAccRDSCluster_deletionProtection (141.89s)
=== CONT  TestAccRDSCluster_dbClusterInstanceClass
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierTakeFinalSnapshot (348.52s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
--- PASS: TestAccRDSCluster_pointInTimeRestoreViaResourceID (265.40s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
--- PASS: TestAccRDSCluster_availabilityZones_caCertificateIdentifier (1727.59s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
--- PASS: TestAccRDSCluster_backtrackWindow (151.81s)
=== CONT  TestAccRDSCluster_SnapshotIdentifier_storageType
--- PASS: TestAccRDSCluster_pointInTimeRestore (274.77s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgrade (1767.38s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterUsername (283.81s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_masterPassword (353.02s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow (384.14s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow (373.99s)
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal (279.34s)
--- PASS: TestAccRDSCluster_ReplicationSourceIdentifier_promote (2128.84s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_storageType (272.47s)
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineVersion_different (298.89s)
--- PASS: TestAccRDSCluster_SnapshotIdentifier_kmsKeyID (343.58s)
--- PASS: TestAccRDSCluster_engineVersionWithPrimaryInstance (1251.83s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm (2140.55s)
--- PASS: TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters (2186.17s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier (2903.17s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters (3058.85s)
--- PASS: TestAccRDSCluster_domain (1663.93s)
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql (2209.36s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding (3021.23s)
--- PASS: TestAccRDSCluster_dbClusterInstanceClass (3743.24s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        5906.389s
```
