### PR TITLE
[Docs]: `aws_eks_cluster.bootstrap_self_managed_addons` must be set to `false` for EKS Auto Mode

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -70,7 +70,7 @@ resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
 
 ### EKS Cluster with EKS Auto Mode
 
-~> **NOTE:** When using EKS Auto Mode `compute_config.enabled`, `kubernetes_network_config.elastic_load_balancing.enabled`, and `storage_config.block_storage.enabled` must *ALL be set to `true`. Likewise for disabling EKS Auto Mode, all three arguments must be set to `false`. Additionally, `bootstrap_self_managed_addons` must be set to `false`, as this is a required parameter for enabling EKS Auto Mode.
+~> **NOTE:** When using EKS Auto Mode `compute_config.enabled`, `kubernetes_network_config.elastic_load_balancing.enabled`, and `storage_config.block_storage.enabled` must *ALL be set to `true`. Likewise for disabling EKS Auto Mode, all three arguments must be set to `false`. Enabling EKS Auto Mode also requires that `bootstrap_self_managed_addons` is set to `false`.
 
 ```terraform
 resource "aws_eks_cluster" "example" {

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -70,7 +70,7 @@ resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
 
 ### EKS Cluster with EKS Auto Mode
 
-~> **NOTE:** When using EKS Auto Mode `compute_config.enabled`, `kubernetes_network_config.elastic_load_balancing.enabled`, and `storage_config.block_storage.enabled` must *ALL be set to `true`. Likewise for disabling EKS Auto Mode, all three arguments must be set to `false`.
+~> **NOTE:** When using EKS Auto Mode `compute_config.enabled`, `kubernetes_network_config.elastic_load_balancing.enabled`, and `storage_config.block_storage.enabled` must *ALL be set to `true`. Likewise for disabling EKS Auto Mode, all three arguments must be set to `false`. Additionally, `bootstrap_self_managed_addons` must be set to `false`, as this is a required parameter for enabling EKS Auto Mode.
 
 ```terraform
 resource "aws_eks_cluster" "example" {
@@ -82,6 +82,8 @@ resource "aws_eks_cluster" "example" {
 
   role_arn = aws_iam_role.cluster.arn
   version  = "1.31"
+
+  bootstrap_self_managed_addons = false
 
   compute_config {
     enabled       = true


### PR DESCRIPTION
### Description
This pull request updates the documentation for EKS Auto Mode to include the requirement that `bootstrap_self_managed_addons` must be set to `false`. This change is based on the following error message encountered during testing:

```shell
│ Error: creating EKS Cluster (eks-auto-mode-cluster): operation error EKS: CreateCluster, https response error StatusCode: 400, RequestID: xxxxxxxxxxxxxxx, InvalidParameterException: When EKS Auto Mode is enabled, bootstrapSelfManagedAddons must be set to false.
```
### Relations
None

### References
- AWS Error Message (see above)
