### PR TITLE
feat: allow `notebook-al2-v3` as platform_identifier

### DIFF
--- a/.changelog/40484.txt
+++ b/.changelog/40484.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_notebook_instance: Support `notebook-al2-v3` value for `platform_identifier`
+```

--- a/internal/service/sagemaker/notebook_instance.go
+++ b/internal/service/sagemaker/notebook_instance.go
@@ -124,7 +124,7 @@ func resourceNotebookInstance() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^(notebook-al1-v1|notebook-al2-v1|notebook-al2-v2)$`), ""),
+				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^(notebook-al1-v1|notebook-al2-v1|notebook-al2-v2|notebook-al2-v3)$`), ""),
 			},
 			names.AttrRoleARN: {
 				Type:         schema.TypeString,

--- a/internal/service/sagemaker/notebook_instance_test.go
+++ b/internal/service/sagemaker/notebook_instance_test.go
@@ -428,6 +428,13 @@ func TestAccSageMakerNotebookInstance_Platform_identifier(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "platform_identifier", "notebook-al2-v2"),
 				),
 			},
+			{
+				Config: testAccNotebookInstanceConfig_platformIdentifier(rName, "notebook-al2-v3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNotebookInstanceExists(ctx, resourceName, &notebook),
+					resource.TestCheckResourceAttr(resourceName, "platform_identifier", "notebook-al2-v3"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -56,7 +56,7 @@ This resource supports the following arguments:
 * `name` - (Required) The name of the notebook instance (must be unique).
 * `role_arn` - (Required) The ARN of the IAM role to be used by the notebook instance which allows SageMaker to call other services on your behalf.
 * `instance_type` - (Required) The name of ML compute instance type.
-* `platform_identifier` - (Optional) The platform identifier of the notebook instance runtime environment. This value can be either `notebook-al1-v1`, `notebook-al2-v1`, or  `notebook-al2-v2`, depending on which version of Amazon Linux you require.
+* `platform_identifier` - (Optional) The platform identifier of the notebook instance runtime environment. This value can be either `notebook-al1-v1`, `notebook-al2-v1`, `notebook-al2-v2`, or `notebook-al2-v3`, depending on which version of Amazon Linux you require.
 * `volume_size` - (Optional) The size, in GB, of the ML storage volume to attach to the notebook instance. The default value is 5 GB.
 * `subnet_id` - (Optional) The VPC subnet ID.
 * `security_groups` - (Optional) The associated security groups.


### PR DESCRIPTION
### Description

Change the plan-time validation to allow the platform identifier `notebook-al2-v3` (Amazon Linux 2 v3) for the resource `aws_sagemaker_notebook_instance`.


### Relations

Closes #40478 

### References

- [Supported notebook instances](https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-al2.html) mentioning the new type.
- [CloudFormation](https://docs.aws.amazon.com/de_de/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-notebookinstance.html#cfn-sagemaker-notebookinstance-platformidentifier) mentioning the pattern for allowed values. 

### Output from Acceptance Testing

```shell
❯ make testacc TESTS=TestAccSageMakerNotebookInstance_Platform_identifier PKG=sagemaker
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/sagemaker/... -v -count 1 -parallel 3 -run='TestAccSageMakerNotebookInstance_Platform_identifier'  -timeout 360m
2024/12/07 22:25:42 Initializing Terraform AWS Provider...
=== RUN   TestAccSageMakerNotebookInstance_Platform_identifier
=== PAUSE TestAccSageMakerNotebookInstance_Platform_identifier
=== CONT  TestAccSageMakerNotebookInstance_Platform_identifier

--- PASS: TestAccSageMakerNotebookInstance_Platform_identifier (1163.77s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  1163.999s
```

I was also trying to run

```shell
make testacc TESTS=TestAccSageMakerNotebookInstance PKG=sagemaker
```
but it failed with

```shell
    notebook_instance_test.go:645: Step 1/4 error: Error running apply: exit status 1
        
        Error: creating SageMaker Notebook Instance: operation error SageMaker: CreateNotebookInstance, https response error StatusCode: 400, RequestID: b52ab698-e767-4931-bf5a-f6c4bbf4e13a, ResourceLimitExceeded: The account-level service limit 'ml.inf1.xlarge for notebook instance usage' is 0 Instances, with current utilization of 0 Instances and a request delta of 1 Instances. Please use AWS Service Quotas to request an increase for this quota. If AWS Service Quotas is not available, contact AWS support to request an increase for this quota.
        
          with aws_sagemaker_notebook_instance.test,
          on terraform_plugin_test.tf line 29, in resource "aws_sagemaker_notebook_instance" "test":
          29: resource "aws_sagemaker_notebook_instance" "test" {
```
Will request an upgrade of the limits, so that this one can also get executed.