### PR TITLE
docs: Avoid DB proxy diffs for unsupported AZs

### DIFF
--- a/website/docs/r/db_proxy.html.markdown
+++ b/website/docs/r/db_proxy.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an RDS DB proxy resource. For additional information, see the [RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html).
 
-~> **NOTE:** Not all availability zones support a DB proxy. Including `vpc_subnet_ids` corresponding to AZs that don't support proxies won't result in an error if at least one of the `vpc_subnet_ids` is valid. However, this will cause Terraform to show a constant difference between the configuration and infrastructure. See the avoiding
+~> **Note:** Not all Availability Zones (AZs) support DB proxies. Specifying `vpc_subnet_ids` for AZs that do not support proxies will not trigger an error as long as at least one `vpc_subnet_id` is valid. However, this will cause Terraform to continuously detect differences between the configuration and the actual infrastructure. Refer to the [Unsupported Availability Zones](#unsupported-availability-zones) section below for potential workarounds.
 
 ## Example Usage
 
@@ -45,7 +45,7 @@ resource "aws_db_proxy" "example" {
 
 Terraform may report constant differences if you use `vpc_subnet_ids` that correspond to Availability Zones (AZs) that do not support a DB proxy. While this typically does not result in an error, AWS only returns `vpc_subnet_ids` for AZs that support DB proxies. As a result, Terraform detects a mismatch between your configuration and the actual infrastructure, leading it to report that changes are required. Below are some ways to avoid this issue.
 
-One solution is to exclude AZs that do not support DB proxies by using the [`aws_availability_zones` data source](/docs/providers/aws/d/availability_zones.html). The following example demonstrates how to configure this for the `us-east-1` region, excluding the `use1-az3` AZ. If the `us-east-1` region has six AZs in total and you want to configure as many subnets as possible, you would exclude one AZ and configure five subnets:
+One solution is to exclude AZs that do not support DB proxies by using the [`aws_availability_zones` data source](/docs/providers/aws/d/availability_zones.html). The example below demonstrates how to configure this for the `us-east-1` region, excluding the `use1-az3` AZ. (Keep in mind that AZ names can vary between accounts, while AZ IDs remain consistent.) If the `us-east-1` region has six AZs in total and you aim to configure the maximum number of subnets, you would exclude one AZ and configure five subnets:
 
 ```terraform
 data "aws_availability_zones" "available" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR updates the documentation to address an issue where Terraform perpetually shows a diff and recreates an RDS Proxy when one or more specified subnets are in an Availability Zone (AZ) that does not support DB proxies.  

### Problem

When creating an RDS Proxy, the proxy is successfully created but only includes subnets from supported AZs. If one of the specified subnets is in an unsupported AZ:  
1. The proxy is created with only the subnets in supported AZs (e.g., `supported_1` and `supported_2` instead of the expected three subnets).  
2. Subsequent Terraform plans detect a difference between the desired state (three subnets) and the actual state (two subnets) and attempt to recreate the proxy. This results in perpetual diffs and recreation cycles.  

### Root Causes  

- The AWS API does not return an error when unsupported AZs are included, unless fewer than two supported AZs are provided.  
- There is no definitive, up-to-date source of information listing which AZs globally support DB proxies, making it challenging to validate configurations proactively.  

### Workarounds  

Since the problem cannot be fully resolved at this time, this PR provides documentation updates with practical workarounds:  

1. **Exclude Unsupported AZs**: Use the [`aws_availability_zones` data source](https://developer.hashicorp.com/terraform/docs/providers/aws/d/availability_zones) to dynamically filter out unsupported AZs when defining subnets.  
2. **Ignore Changes**: Use the [`lifecycle` `ignore_changes`](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) meta-argument to suppress Terraform's diff detection for the `vpc_subnet_ids` argument.  

### Limitations  
- These workarounds are not foolproof. Excluding unsupported AZs relies on specific knowledge of which AZs to exclude, which is not always available.  
- Ignoring changes with `ignore_changes` prevents Terraform from managing updates to `vpc_subnet_ids`, which could lead to configuration drift.  

### Future Improvements  

The best long-term solution would be for the AWS API to return an error when unsupported AZs are included, allowing Terraform to fail fast during resource creation. However, this is not currently possible due to API behavior.  

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #17781 
Closes #23446

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
