### PR TITLE
ci: Prevent over-quota exceptions

### DIFF
--- a/.teamcity/components/generated/services_all.kt
+++ b/.teamcity/components/generated/services_all.kt
@@ -8,7 +8,7 @@ val services = mapOf(
     "amp" to ServiceSpec("AMP (Managed Prometheus)", parallelismOverride = 10),
     "amplify" to ServiceSpec("Amplify"),
     "apigateway" to ServiceSpec("API Gateway", vpcLock = true),
-    "apigatewayv2" to ServiceSpec("API Gateway V2", vpcLock = true),
+    "apigatewayv2" to ServiceSpec("API Gateway V2", vpcLock = true, parallelismOverride = 10),
     "appautoscaling" to ServiceSpec("Application Auto Scaling", vpcLock = true),
     "appconfig" to ServiceSpec("AppConfig"),
     "appfabric" to ServiceSpec("AppFabric", regionOverride = "us-east-1"),

--- a/internal/generate/teamcity/acctest_services.hcl
+++ b/internal/generate/teamcity/acctest_services.hcl
@@ -11,7 +11,8 @@ service "apigateway" {
 }
 
 service "apigatewayv2" {
-  vpc_lock = true
+  vpc_lock    = true
+  parallelism = 10
 }
 
 service "appautoscaling" {


### PR DESCRIPTION
### Description

Reduce parallelism for `apigatewayv2` to 10 to prevent

> BadRequestException: There are too many Vpc Links defined for this account. Limit is 10.
