### PR TITLE
resource/aws_apigatewayv2_domain_name: Fixes domain name ARN check in acceptance tests

### DIFF
--- a/internal/service/apigatewayv2/domain_name_test.go
+++ b/internal/service/apigatewayv2/domain_name_test.go
@@ -183,7 +183,7 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_basic(t *testing.T) {
 				Config: testAccDomainNameConfig_mutualTLSAuthenticationObjectVersion(rName, rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainNameExists(ctx, resourceName, &v),
-					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", fmt.Sprintf("/domainnames/%s.example.com", rName)),
+					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", "/domainnames/"+domain),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, acmCertificateResourceName, names.AttrDomainName),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_arn", acmCertificateResourceName, names.AttrARN),
@@ -201,7 +201,7 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_basic(t *testing.T) {
 				Config: testAccDomainNameConfig_mutualTLSAuthenticationObjectVersion(rName, rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainNameExists(ctx, resourceName, &v),
-					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", fmt.Sprintf("/domainnames/%s.example.com", rName)),
+					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", "/domainnames/"+domain),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, acmCertificateResourceName, names.AttrDomainName),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_arn", acmCertificateResourceName, names.AttrARN),
@@ -225,7 +225,7 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_basic(t *testing.T) {
 				Config: testAccDomainNameConfig_mutualTLSAuthenticationMissing(rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainNameExists(ctx, resourceName, &v),
-					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", fmt.Sprintf("/domainnames/%s.example.com", rName)),
+					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", "/domainnames/"+domain),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, acmCertificateResourceName, names.AttrDomainName),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_arn", acmCertificateResourceName, names.AttrARN),
@@ -241,7 +241,7 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_basic(t *testing.T) {
 				Config: testAccDomainNameConfig_mutualTLSAuthenticationObjectVersion(rName, rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainNameExists(ctx, resourceName, &v),
-					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", fmt.Sprintf("/domainnames/%s.example.com", rName)),
+					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", "/domainnames/"+domain),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, acmCertificateResourceName, names.AttrDomainName),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_arn", acmCertificateResourceName, names.AttrARN),
@@ -278,7 +278,7 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_noVersion(t *testing.
 				Config: testAccDomainNameConfig_mutualTLSAuthenticationNoObjectVersion(rName, rootDomain, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainNameExists(ctx, resourceName, &v),
-					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", fmt.Sprintf("/domainnames/%s.example.com", rName)),
+					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", "/domainnames/"+domain),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, acmCertificateResourceName, names.AttrDomainName),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_arn", acmCertificateResourceName, names.AttrARN),
@@ -291,6 +291,11 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_noVersion(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "mutual_tls_authentication.0.truststore_version", ""),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -319,7 +324,7 @@ func TestAccAPIGatewayV2DomainName_MutualTLSAuthentication_ownership(t *testing.
 				Config: testAccDomainNameConfig_mutualTLSAuthenticationOwnershipVerificationCert(rName, rootDomain, domain, certificate, key),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainNameExists(ctx, resourceName, &v),
-					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", fmt.Sprintf("/domainnames/%s.example.com", rName)),
+					acctest.CheckResourceAttrRegionalARNNoAccount(resourceName, names.AttrARN, "apigateway", "/domainnames/"+domain),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDomainName, publicAcmCertificateResourceName, names.AttrDomainName),
 					resource.TestCheckResourceAttr(resourceName, "domain_name_configuration.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "domain_name_configuration.0.certificate_arn", importedAcmCertificateResourceName, names.AttrARN),


### PR DESCRIPTION
### Description

Fixes domain name ARN check in `aws_apigatewayv2_domain_name ` acceptance tests


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apigatewayv2 TESTS=TestAccAPIGatewayV2DomainName_

--- PASS: TestAccAPIGatewayV2DomainName_basic (70.85s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_DefaultTags_nullNonOverlappingResourceTag (130.96s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_ComputedTag_OnUpdate_Replace (154.81s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_DefaultTags_updateToProviderOnly (162.76s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_ComputedTag_OnCreate (60.86s)
--- PASS: TestAccAPIGatewayV2DomainName_disappears (126.15s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_IgnoreTags_Overlap_DefaultTag (172.07s)
--- PASS: TestAccAPIGatewayV2DomainName_tags (444.04s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_IgnoreTags_Overlap_ResourceTag (492.95s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_EmptyTag_OnUpdate_Add (517.04s)
--- PASS: TestAccAPIGatewayV2DomainName_updateCertificate (584.94s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_DefaultTags_nullOverlappingResourceTag (608.44s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_DefaultTags_emptyProviderOnlyTag (680.02s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_DefaultTags_overlapping (700.58s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_AddOnUpdate (708.07s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_DefaultTags_nonOverlapping (763.60s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_EmptyMap (781.21s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_DefaultTags_emptyResourceTag (924.37s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_null (959.97s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_EmptyTag_OnCreate (989.87s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_DefaultTags_providerOnly (1022.14s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_DefaultTags_updateToResourceOnly (1137.37s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_EmptyTag_OnUpdate_Replace (1267.45s)
--- PASS: TestAccAPIGatewayV2DomainName_tags_ComputedTag_OnUpdate_Add (1252.35s)
```
