### PR TITLE
`aws_rds_cluster`: Fix Regression in `serverlessv2_scaling_configuration` Handling

### DIFF
--- a/.changelog/40511.txt
+++ b/.changelog/40511.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix `InvalidParameterValue: Serverless v2 maximum capacity 0.0 isn't valid. The maximum capacity must be at least 1.0.` errors when removing `serverlessv2_scaling_configuration` in an update
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -547,7 +547,7 @@ func resourceCluster() *schema.Resource {
 						names.AttrMaxCapacity: {
 							Type:         schema.TypeFloat,
 							Required:     true,
-							ValidateFunc: validation.FloatBetween(0.5, 256),
+							ValidateFunc: validation.FloatBetween(1, 256),
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								// Handles a breaking regression. On v5.79.0 and earlier,
 								// serverlessv2_scaling_configuration block could be removed from


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR addresses a breaking regression introduced in v5.80.0 that affects the removal of the `serverlessv2_scaling_configuration` block in RDS cluster configurations.

#### Problem

Prior to v5.80.0, users could remove the `serverlessv2_scaling_configuration` block from their configuration without errors or perpetual diffs. While AWS does not remove the scaling configuration metadata when the block is deleted, Terraform allowed users to remove the block without errors.  

However, v5.80.0 and #40230 introduced two issues:
1. `max_capacity` could be explicitly set to `0`, an invalid value for AWS.
2. Terraform sent `max_capacity: 0` to the AWS API when the `serverlessv2_scaling_configuration` block was removed, causing the error:  
   `InvalidParameterValue: Serverless v2 maximum capacity 0.0 isn't valid. The maximum capacity must be at least 1.0.`  

These issues occurred because removing the block caused Terraform to default all arguments to `0`, including `max_capacity`, which was then sent to the AWS API.

#### Steps to Reproduce
1. Apply an RDS cluster configuration with a `serverlessv2_scaling_configuration` block.
2. Remove the `serverlessv2_scaling_configuration` block from the configuration.
3. Apply again.  

On v5.79.0 and earlier, this succeeded. On v5.80.0 and later, it fails due to the invalid `max_capacity: 0` error.

#### Solution

This PR resolves the regression with the following changes:
1. Prevents `max_capacity` from being explicitly set to `0`.
2. Ensures `max_capacity` is not sent to the AWS API when its value is `0`, such as when the `serverlessv2_scaling_configuration` block is removed.  

Additionally, to restore compatibility with behavior prior to v5.80.0, this PR suppresses diffs caused by the removal of the `serverlessv2_scaling_configuration` block. AWS does not allow updating a cluster to remove its serverless v2 scaling configuration once it has been set, even if the cluster no longer uses the configuration or serverless instances. Suppressing these diffs ensures users can manage their configurations without encountering perpetual mismatches between Terraform and the infrastructure state.  

#### Impact

This PR restores the expected behavior from v5.79.0 and earlier, allowing users to remove the `serverlessv2_scaling_configuration` block from their configurations without errors or unnecessary diffs, while ensuring invalid values are not sent to the AWS API.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40473
Relates to changes made in #40230

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccRDSCluster_serverlessV2ScalingRemoved K=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_serverlessV2ScalingRemoved'  -timeout 360m
2024/12/10 16:25:57 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSCluster_serverlessV2ScalingRemoved
=== PAUSE TestAccRDSCluster_serverlessV2ScalingRemoved
=== CONT  TestAccRDSCluster_serverlessV2ScalingRemoved
--- PASS: TestAccRDSCluster_serverlessV2ScalingRemoved (189.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	193.242s
% make t T=make t T=TestAccRDSCluster_ K=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_'  -timeout 360m
2024/12/10 16:25:22 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSCluster_basic
=== PAUSE TestAccRDSCluster_basic
=== RUN   TestAccRDSCluster_disappears
=== PAUSE TestAccRDSCluster_disappears
=== RUN   TestAccRDSCluster_identifierGenerated
=== PAUSE TestAccRDSCluster_identifierGenerated
=== RUN   TestAccRDSCluster_identifierPrefix
=== PAUSE TestAccRDSCluster_identifierPrefix
=== RUN   TestAccRDSCluster_tags
=== PAUSE TestAccRDSCluster_tags
=== RUN   TestAccRDSCluster_securityGroupUpdate
=== PAUSE TestAccRDSCluster_securityGroupUpdate
=== RUN   TestAccRDSCluster_allowMajorVersionUpgrade
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgrade
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
=== RUN   TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== PAUSE TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
=== RUN   TestAccRDSCluster_onlyMajorVersion
=== PAUSE TestAccRDSCluster_onlyMajorVersion
=== RUN   TestAccRDSCluster_minorVersion
=== PAUSE TestAccRDSCluster_minorVersion
=== RUN   TestAccRDSCluster_availabilityZones
=== PAUSE TestAccRDSCluster_availabilityZones
=== RUN   TestAccRDSCluster_availabilityZones_caCertificateIdentifier
=== PAUSE TestAccRDSCluster_availabilityZones_caCertificateIdentifier
=== RUN   TestAccRDSCluster_storageTypeIo1
=== PAUSE TestAccRDSCluster_storageTypeIo1
=== RUN   TestAccRDSCluster_storageTypeIo2
=== PAUSE TestAccRDSCluster_storageTypeIo2
=== RUN   TestAccRDSCluster_storageTypeGeneralPurposeToProvisionedIOPS
=== PAUSE TestAccRDSCluster_storageTypeGeneralPurposeToProvisionedIOPS
=== RUN   TestAccRDSCluster_storageTypeAuroraReturnsBlank
=== PAUSE TestAccRDSCluster_storageTypeAuroraReturnsBlank
=== RUN   TestAccRDSCluster_storageTypeAuroraIopt1
=== PAUSE TestAccRDSCluster_storageTypeAuroraIopt1
=== RUN   TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
=== PAUSE TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1
=== RUN   TestAccRDSCluster_allocatedStorage
=== PAUSE TestAccRDSCluster_allocatedStorage
=== RUN   TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
=== PAUSE TestAccRDSCluster_storageTypeAuroraIopt1UpdateAurora
=== RUN   TestAccRDSCluster_iops
=== PAUSE TestAccRDSCluster_iops
=== RUN   TestAccRDSCluster_dbClusterInstanceClass
=== PAUSE TestAccRDSCluster_dbClusterInstanceClass
=== RUN   TestAccRDSCluster_backtrackWindow
=== PAUSE TestAccRDSCluster_backtrackWindow
=== RUN   TestAccRDSCluster_dbSubnetGroupName
=== PAUSE TestAccRDSCluster_dbSubnetGroupName
=== RUN   TestAccRDSCluster_pointInTimeRestore
=== PAUSE TestAccRDSCluster_pointInTimeRestore
=== RUN   TestAccRDSCluster_pointInTimeRestoreViaResourceID
=== PAUSE TestAccRDSCluster_pointInTimeRestoreViaResourceID
=== RUN   TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
=== PAUSE TestAccRDSCluster_PointInTimeRestore_enabledCloudWatchLogsExports
=== RUN   TestAccRDSCluster_takeFinalSnapshot
=== PAUSE TestAccRDSCluster_takeFinalSnapshot
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierTakeFinalSnapshot
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierTakeFinalSnapshot
=== RUN   TestAccRDSCluster_missingUserNameCausesError
=== PAUSE TestAccRDSCluster_missingUserNameCausesError
=== RUN   TestAccRDSCluster_domain
=== PAUSE TestAccRDSCluster_domain
=== RUN   TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
=== PAUSE TestAccRDSCluster_EnabledCloudWatchLogsExports_mySQL
=== RUN   TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
=== PAUSE TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
=== RUN   TestAccRDSCluster_updateIAMRoles
=== PAUSE TestAccRDSCluster_updateIAMRoles
=== RUN   TestAccRDSCluster_kmsKey
=== PAUSE TestAccRDSCluster_kmsKey
=== RUN   TestAccRDSCluster_networkType
=== PAUSE TestAccRDSCluster_networkType
=== RUN   TestAccRDSCluster_encrypted
=== PAUSE TestAccRDSCluster_encrypted
=== RUN   TestAccRDSCluster_copyTagsToSnapshot
=== PAUSE TestAccRDSCluster_copyTagsToSnapshot
=== RUN   TestAccRDSCluster_copyTagsToSnapshot_restorePointInTime
=== PAUSE TestAccRDSCluster_copyTagsToSnapshot_restorePointInTime
=== RUN   TestAccRDSCluster_ReplicationSourceIdentifier_promote
=== PAUSE TestAccRDSCluster_ReplicationSourceIdentifier_promote
=== RUN   TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== PAUSE TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== RUN   TestAccRDSCluster_backupsUpdate
=== PAUSE TestAccRDSCluster_backupsUpdate
=== RUN   TestAccRDSCluster_iamAuth
=== PAUSE TestAccRDSCluster_iamAuth
=== RUN   TestAccRDSCluster_deletionProtection
=== PAUSE TestAccRDSCluster_deletionProtection
=== RUN   TestAccRDSCluster_engineMode
=== PAUSE TestAccRDSCluster_engineMode
=== RUN   TestAccRDSCluster_engineVersion
=== PAUSE TestAccRDSCluster_engineVersion
=== RUN   TestAccRDSCluster_engineVersionWithPrimaryInstance
=== PAUSE TestAccRDSCluster_engineVersionWithPrimaryInstance
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_update
=== RUN   TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifierEngineMode_provisioned
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
=== RUN   TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
=== PAUSE TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
=== RUN   TestAccRDSCluster_ManagedMasterPassword_managed
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_managed
=== RUN   TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_managedSpecificKMSKey
=== RUN   TestAccRDSCluster_ManagedMasterPassword_convertToManaged
=== PAUSE TestAccRDSCluster_ManagedMasterPassword_convertToManaged
=== RUN   TestAccRDSCluster_port
=== PAUSE TestAccRDSCluster_port
=== RUN   TestAccRDSCluster_scaling
=== PAUSE TestAccRDSCluster_scaling
=== RUN   TestAccRDSCluster_serverlessV2ScalingConfiguration
=== PAUSE TestAccRDSCluster_serverlessV2ScalingConfiguration
=== RUN   TestAccRDSCluster_serverlessV2ScalingRemoved
=== PAUSE TestAccRDSCluster_serverlessV2ScalingRemoved
=== RUN   TestAccRDSCluster_Scaling_defaultMinCapacity
=== PAUSE TestAccRDSCluster_Scaling_defaultMinCapacity
=== RUN   TestAccRDSCluster_snapshotIdentifier
=== PAUSE TestAccRDSCluster_snapshotIdentifier
=== RUN   TestAccRDSCluster_SnapshotIdentifier_deletionProtection
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_deletionProtection
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineMode_serverless
    cluster_test.go:2304: serverless does not support snapshot restore on an empty volume
--- SKIP: TestAccRDSCluster_SnapshotIdentifierEngineMode_serverless (0.00s)
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineVersion_different
=== RUN   TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
=== PAUSE TestAccRDSCluster_SnapshotIdentifierEngineVersion_equal
=== RUN   TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_kmsKeyID
=== RUN   TestAccRDSCluster_SnapshotIdentifier_masterPassword
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_masterPassword
=== RUN   TestAccRDSCluster_SnapshotIdentifier_masterUsername
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_masterUsername
=== RUN   TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_preferredBackupWindow
=== RUN   TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_preferredMaintenanceWindow
=== RUN   TestAccRDSCluster_SnapshotIdentifier_storageType
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_storageType
=== RUN   TestAccRDSCluster_SnapshotIdentifier_tags
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_tags
=== RUN   TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_vpcSecurityGroupIDs
=== RUN   TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
=== PAUSE TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
=== RUN   TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
=== PAUSE TestAccRDSCluster_SnapshotIdentifier_encryptedRestore
=== RUN   TestAccRDSCluster_enableHTTPEndpoint
=== PAUSE TestAccRDSCluster_enableHTTPEndpoint
=== RUN   TestAccRDSCluster_enableHTTPEndpointProvisioned
=== PAUSE TestAccRDSCluster_enableHTTPEndpointProvisioned
=== RUN   TestAccRDSCluster_password
=== PAUSE TestAccRDSCluster_password
=== RUN   TestAccRDSCluster_NoDeleteAutomatedBackups
=== PAUSE TestAccRDSCluster_NoDeleteAutomatedBackups
=== RUN   TestAccRDSCluster_engineLifecycleSupport_disabled
=== PAUSE TestAccRDSCluster_engineLifecycleSupport_disabled
=== RUN   TestAccRDSCluster_performanceInsightsEnabled
=== PAUSE TestAccRDSCluster_performanceInsightsEnabled
=== RUN   TestAccRDSCluster_performanceInsightsKMSKeyID
=== PAUSE TestAccRDSCluster_performanceInsightsKMSKeyID
=== RUN   TestAccRDSCluster_performanceInsightsRetentionPeriod
=== PAUSE TestAccRDSCluster_performanceInsightsRetentionPeriod
=== RUN   TestAccRDSCluster_localWriteForwarding
=== PAUSE TestAccRDSCluster_localWriteForwarding
=== CONT  TestAccRDSCluster_basic
=== CONT  TestAccRDSCluster_deletionProtection
=== CONT  TestAccRDSCluster_dbClusterInstanceClass
=== CONT  TestAccRDSCluster_availabilityZones
=== CONT  TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned
=== CONT  TestAccRDSCluster_Scaling_defaultMinCapacity
=== CONT  TestAccRDSCluster_port
=== CONT  TestAccRDSCluster_storageTypeAuroraIopt1
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_secondaryClustersWriteForwarding
=== CONT  TestAccRDSCluster_SnapshotIdentifier_deletionProtection
=== CONT  TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global
=== CONT  TestAccRDSCluster_snapshotIdentifier
=== CONT  TestAccRDSCluster_engineVersionWithPrimaryInstance
=== CONT  TestAccRDSCluster_engineMode
=== CONT  TestAccRDSCluster_engineVersion
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_replicationSourceIdentifier
=== CONT  TestAccRDSCluster_GlobalClusterIdentifier_primarySecondaryClusters
--- PASS: TestAccRDSCluster_availabilityZones (107.37s)
=== CONT  TestAccRDSCluster_copyTagsToSnapshot_restorePointInTime
--- PASS: TestAccRDSCluster_storageTypeAuroraIopt1 (116.60s)
=== CONT  TestAccRDSCluster_iamAuth
--- PASS: TestAccRDSCluster_basic (117.29s)
=== CONT  TestAccRDSCluster_backupsUpdate
--- PASS: TestAccRDSCluster_port (144.17s)
=== CONT  TestAccRDSCluster_ReplicationSourceIdentifier_kmsKeyID
=== CONT  TestAccRDSCluster_ReplicationSourceIdentifier_promote
--- PASS: TestAccRDSCluster_deletionProtection (144.19s)
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_add (152.35s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgrade
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineModeGlobal_remove (207.74s)
=== CONT  TestAccRDSCluster_minorVersion
--- PASS: TestAccRDSCluster_Scaling_defaultMinCapacity (208.01s)
=== CONT  TestAccRDSCluster_onlyMajorVersion
--- PASS: TestAccRDSCluster_GlobalClusterIdentifierEngineMode_global (209.25s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParameters
--- PASS: TestAccRDSCluster_snapshotIdentifier (285.83s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeWithCustomParametersApplyImm
--- PASS: TestAccRDSCluster_iamAuth (173.05s)
=== CONT  TestAccRDSCluster_allowMajorVersionUpgradeNoApplyImmediately
--- PASS: TestAccRDSCluster_backupsUpdate (180.52s)
=== CONT  TestAccRDSCluster_SnapshotIdentifierVPCSecurityGroupIDs_tags
--- PASS: TestAccRDSCluster_engineMode (308.06s)
=== CONT  TestAccRDSCluster_localWriteForwarding
--- PASS: TestAccRDSCluster_SnapshotIdentifierEngineMode_provisioned (336.60s)
=== CONT  TestAccRDSCluster_performanceInsightsRetentionPeriod
--- PASS: TestAccRDSCluster_SnapshotIdentifier_deletionProtection (375.96s)
...
```
