### PR TITLE
resource/aws_elasticache_replication_group: Make `at_rest_encryption_enabled` nullable Bool

### DIFF
--- a/.changelog/40514.txt
+++ b/.changelog/40514.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Prevent perpetual diff which triggers resource replacement on `at_rest_encryption_enabled` when `engine` is `valkey`.
+```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,10 +68,11 @@ func resourceReplicationGroup() *schema.Resource {
 				Computed: true,
 			},
 			"at_rest_encryption_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:         nullable.TypeNullableBool,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: nullable.ValidateTypeStringNullableBool,
 			},
 			"auth_token": {
 				Type:          schema.TypeString,
@@ -434,8 +436,10 @@ func resourceReplicationGroupCreate(ctx context.Context, d *schema.ResourceData,
 		Tags:               getTagsIn(ctx),
 	}
 
-	if _, ok := d.GetOk("at_rest_encryption_enabled"); ok {
-		input.AtRestEncryptionEnabled = aws.Bool(d.Get("at_rest_encryption_enabled").(bool))
+	if v, ok := d.GetOk("at_rest_encryption_enabled"); ok {
+		if v, null, _ := nullable.Bool(v.(string)).ValueBool(); !null {
+			input.AtRestEncryptionEnabled = aws.Bool(v)
+		}
 	}
 
 	if v, ok := d.GetOk("auth_token"); ok {
@@ -764,7 +768,7 @@ func resourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData, m
 			return sdkdiag.AppendErrorf(diags, "reading ElastiCache Replication Group (%s): reading Cache Cluster (%s): %s", d.Id(), aws.ToString(cacheCluster.CacheClusterId), err)
 		}
 
-		d.Set("at_rest_encryption_enabled", c.AtRestEncryptionEnabled)
+		d.Set("at_rest_encryption_enabled", strconv.FormatBool(aws.ToBool(c.AtRestEncryptionEnabled)))
 		// `aws_elasticache_cluster` resource doesn't define `security_group_names`, but `aws_elasticache_replication_group` does.
 		// The value for that comes from []CacheSecurityGroupMembership which is part of CacheCluster object in AWS API.
 		// We need to set it here, as it is not set in setFromCacheCluster, and we cannot add it to that function

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -1628,7 +1628,7 @@ func TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken(t *testin
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "auth_token", authToken),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
-					resource.TestCheckResourceAttrSet(resourceName, "transit_encryption_mode"),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", string(awstypes.TransitEncryptionModeRequired)),
 				),
 			},
 			{
@@ -1662,7 +1662,7 @@ func TestAccElastiCacheReplicationGroup_transitEncryption5x(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg1),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
-					resource.TestCheckResourceAttrSet(resourceName, "transit_encryption_mode"),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", string(awstypes.TransitEncryptionModeRequired)),
 				),
 			},
 			{
@@ -1679,6 +1679,7 @@ func TestAccElastiCacheReplicationGroup_transitEncryption5x(t *testing.T) {
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg2),
 					testAccCheckReplicationGroupRecreated(&rg1, &rg2),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", ""),
 				),
 			},
 		},
@@ -1742,6 +1743,7 @@ func TestAccElastiCacheReplicationGroup_transitEncryption7x(t *testing.T) {
 					testAccCheckReplicationGroupExists(ctx, resourceName, &rg4),
 					testAccCheckReplicationGroupNotRecreated(&rg3, &rg4),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", ""),
 				),
 			},
 		},

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -63,6 +63,7 @@ func TestAccElastiCacheReplicationGroup_Redis_basic(t *testing.T) {
 					testCheckEngineStuffRedisDefault(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "data_tiering_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtFalse),
 				),
 			},
 			{
@@ -100,6 +101,7 @@ func TestAccElastiCacheReplicationGroup_Redis_basic_v5(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
 					// Even though it is ignored, the API returns `true` in this case
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtFalse),
 				),
 			},
 			{
@@ -144,6 +146,7 @@ func TestAccElastiCacheReplicationGroup_Valkey_basic(t *testing.T) {
 					testCheckEngineStuffValkeyDefault(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "data_tiering_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtTrue),
 				),
 			},
 			{
@@ -363,6 +366,7 @@ func TestAccElastiCacheReplicationGroup_Engine_RedisToValkey(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
+					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtFalse),
 				),
 			},
 			{
@@ -380,6 +384,7 @@ func TestAccElastiCacheReplicationGroup_Engine_RedisToValkey(t *testing.T) {
 					testAccCheckReplicationGroupExists(ctx, resourceName, &v2),
 					testAccCheckReplicationGroupNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "valkey"),
+					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtFalse),
 				),
 			},
 		},

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -64,6 +64,8 @@ func TestAccElastiCacheReplicationGroup_Redis_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "data_tiering_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", ""),
 				),
 			},
 			{
@@ -102,6 +104,8 @@ func TestAccElastiCacheReplicationGroup_Redis_basic_v5(t *testing.T) {
 					// Even though it is ignored, the API returns `true` in this case
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", ""),
 				),
 			},
 			{
@@ -147,6 +151,8 @@ func TestAccElastiCacheReplicationGroup_Valkey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "data_tiering_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", ""),
 				),
 			},
 			{

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -195,6 +195,8 @@ The following arguments are optional:
 
 * `apply_immediately` - (Optional) Specifies whether any modifications are applied immediately, or during the next maintenance window. Default is `false`.
 * `at_rest_encryption_enabled` - (Optional) Whether to enable encryption at rest.
+  When `engine` is `redis`, default is `false`.
+  When `engine` is `valkey`, default is `true`.
 * `auth_token` - (Optional) Password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`.
 * `auth_token_update_strategy` - (Optional) Strategy to use when updating the `auth_token`. Valid values are `SET`, `ROTATE`, and `DELETE`. Defaults to `ROTATE`.
 * `auto_minor_version_upgrade` - (Optional) Specifies whether minor version engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window.
@@ -203,7 +205,9 @@ The following arguments are optional:
 * `automatic_failover_enabled` - (Optional) Specifies whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, `num_cache_clusters` must be greater than 1. Must be enabled for Redis (cluster mode enabled) replication groups. Defaults to `false`.
 * `cluster_mode` - (Optional) Specifies whether cluster mode is enabled or disabled. Valid values are `enabled` or `disabled` or `compatible`
 * `data_tiering_enabled` - (Optional) Enables data tiering. Data tiering is only supported for replication groups using the r6gd node type. This parameter must be set to `true` when using r6gd nodes.
-* `engine` - (Optional) Name of the cache engine to be used for the clusters in this replication group. Valid values are `redis` or `valkey`.
+* `engine` - (Optional) Name of the cache engine to be used for the clusters in this replication group.
+  Valid values are `redis` or `valkey`.
+  Default is `redis`.
 * `engine_version` - (Optional) Version number of the cache engine to be used for the cache clusters in this replication group.
   If the version is 7 or higher, the major and minor version should be set, e.g., `7.2`.
   If the version is 6, the major and minor version can be set, e.g., `6.2`,


### PR DESCRIPTION
### Description

Converts `at_rest_encryption_enabled` to nullable Bool so that default of `true` when `engine` is `valkey` does not cause perpetual diff which triggers replacement.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39955

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheReplicationGroup_

--- PASS: TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup (5.71s)
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (6.32s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (793.40s)
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic (854.78s)
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (873.22s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (1351.93s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (1426.94s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (1456.45s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (1491.58s)
--- PASS: TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters (1.61s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (1584.60s)
--- PASS: TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7 (876.52s)
--- PASS: TestAccElastiCacheReplicationGroup_stateUpgrade5590 (1750.08s)
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (946.35s)
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption (818.82s)
--- PASS: TestAccElastiCacheReplicationGroup_vpc (2239.35s)
--- PASS: TestAccElastiCacheReplicationGroup_stateUpgrade5270 (2307.39s)
--- PASS: TestAccElastiCacheReplicationGroup_ipDiscovery (2433.60s)
--- PASS: TestAccElastiCacheReplicationGroup_networkType (2532.98s)
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (910.48s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (2756.49s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_basic (851.07s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (3166.57s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled (3236.73s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (3311.39s)
--- PASS: TestAccElastiCacheReplicationGroup_authToken (3389.71s)
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_basic (1634.30s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled (1908.70s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (2113.38s)
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (3748.94s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (2123.07s)
--- PASS: TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption (1479.83s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (1840.50s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken (974.61s)
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (1.03s)
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (841.94s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (1159.68s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (1215.68s)
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (1374.94s)
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic_v5 (1993.83s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1389.27s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled (3466.71s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (3505.94s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable (2429.90s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (4371.82s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable (2572.72s)
--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (965.71s)
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (1068.40s)
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (5.92s)
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (957.25s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (3583.51s)
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (2639.13s)
--- PASS: TestAccElastiCacheReplicationGroup_tags (938.13s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption5x (2741.36s)
--- PASS: TestAccElastiCacheReplicationGroup_disappears (1375.65s)
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (1258.48s)
--- PASS: TestAccElastiCacheReplicationGroup_tagWithOtherModification (2475.24s)
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (2134.93s)
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (1528.72s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion (1947.33s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (3035.80s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (1984.22s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (7166.59s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_RedisToValkey (2392.07s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (2673.34s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (3613.51s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (3655.38s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (5390.74s)
```
