### PR TITLE
aws_ecs_service: availability_zone_rebalancing attribute shouldn't have a default

### DIFF
--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -557,7 +557,6 @@ func resourceService() *schema.Resource {
 			"availability_zone_rebalancing": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				Default:          awstypes.AvailabilityZoneRebalancingDisabled,
 				ValidateDiagFunc: enum.Validate[awstypes.AvailabilityZoneRebalancing](),
 			},
 			names.AttrCapacityProviderStrategy: {


### PR DESCRIPTION
### Description
An attributed `availability_zone_rebalancing` that was introduced in PR https://github.com/hashicorp/terraform-provider-aws/pull/40225 is defined as an optional, but also has a default value. For configurations where this flag is not defined, plan with `refresh=false` results in a change that would add this attribute to the state - which is not what "optional" should mean.

### Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/40349


### Output from Acceptance Testing
Local tests pass, but I do not have an AWS account I could use for acceptance testing at the moment, sorry.