### PR TITLE
r/aws_s3_bucket: Allow deletion of objects with non-XML-safe bytes in their keys

### DIFF
--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -239,7 +239,6 @@ func TestAccS3Bucket_Basic_forceDestroyWithUnusualKeyBytes(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBucketExists(ctx, resourceName),
 					testAccCheckBucketAddObjects(ctx, resourceName, "unusual-key-bytes\x10.txt"),
-					//testAccCheckBucketAddObjects(ctx, resourceName, "unusual-key-bytes\x09.txt"),
 				),
 			},
 		},
@@ -313,6 +312,7 @@ func TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBucketExists(ctx, resourceName),
 					testAccCheckBucketAddObjectsWithLegalHold(ctx, resourceName, "data.txt", "prefix/more_data.txt"),
+					testAccCheckBucketAddObjectsWithLegalHold(ctx, resourceName, "unusual-key-bytes\x10.txt"),
 				),
 			},
 		},

--- a/internal/service/s3/delete.go
+++ b/internal/service/s3/delete.go
@@ -99,7 +99,7 @@ func forEachObjectsPage(ctx context.Context, conn *s3.Client, bucket string, fn 
 	var nObjects int64
 
 	input := &s3.ListObjectsV2Input{
-		Bucket: aws.String(bucket),
+		Bucket:       aws.String(bucket),
 		EncodingType: types.EncodingTypeUrl,
 	}
 	var lastErr error

--- a/internal/service/s3/delete.go
+++ b/internal/service/s3/delete.go
@@ -149,8 +149,6 @@ func deletePageOfObjectVersions(ctx context.Context, conn *s3.Client, bucket str
 		}
 	})
 
-	fmt.Printf("deletePageOfObjectVersions\n")
-
 	return deletePage(ctx, conn, bucket, force, toDelete)
 }
 
@@ -163,8 +161,6 @@ func deletePageOfDeleteMarkers(ctx context.Context, conn *s3.Client, bucket stri
 			VersionId: v.VersionId,
 		}
 	})
-
-	fmt.Printf("deletePageOfDeleteMarkers\n")
 
 	return deletePage(ctx, conn, bucket, false, toDelete)
 }
@@ -199,8 +195,6 @@ func deletePage(ctx context.Context, conn *s3.Client, bucket string, force bool,
 			toDeleteSingly = append(toDeleteSingly, v)
 		}
 	}
-
-	fmt.Printf("toDeleteBulk: %#v\ntoDeleteSingly: %#v\n", toDeleteBulk, toDeleteSingly)
 
 	var nObjects int64
 	var outputErrs []types.Error


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR teaches `aws_s3_bucket` and `aws_s3_directory_bucket` to handle non-XML-safe characters in object keys when emptying bucket contents on destroy because `force_destroy` is true. This PR addresses #40489, which contains more details on the issue, its cause, and the resolution.

The fundamental problem is that S3 object keys can contain any Unicode characters, but XML cannot encode all Unicode characters (see [section 2.2 of the XML spec](https://www.w3.org/TR/xml/#charsets) for allowed characters). For example, U+10 is a disallowed character. As a result, ListObjectVersions can return XML containing disallowed characters when listing objects whose keys themselves contain those characters, and the AWS Go SDK correctly refuses to parse the XML.

This is a well-known issue; see the references. The solution is to tell ListObjectVersions to URL-encode returned keys, which is easily done by setting EncodingType: types.EncodingTypeUrl, then URL-decode the keys on the client side. This works, but causes a new issue: DeleteObjectVersions will silently fail to delete any object whose key contains these invalid characters. This is because DeleteObjectVersions uses an XML request body, and Go will replace invalid characters with � (U+FFFD, the replacement character) in the request body.

This PR modifies several functions in `internal/service/s3/delete.go` with two goals:

1. Request URL-escaped object keys in ListObjectVersions and ListObjectsV2 responses, and unescape those keys after they are returned.
2. Split keys to be deleted into two groups: those that are XML-safe, and those that are not. XML-safe keys can be deleted in batches of 1,000 as before, with DeleteObjects. Non-XML-safe keys must be deleted individually, with DeleteObject.

While here, I consolidated the implementations of `deletePageOfObjectVersions`, `deletePageOfDeleteMarkers`, and `deletePageOfObjects`.

### Relations

Closes #40489.

### References

Here are some issues about the challenges of listing and bulk-deleting objects whose keys contain non-XML-safe characters:

* https://github.com/boto/boto3/issues/2005
* https://github.com/aws/aws-sdk-php/issues/1106
* https://github.com/aws/aws-sdk-go/issues/1914


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS='TestAccS3Bucket_Basic_forceDestroy|TestAccS3DirectoryBucket_forceDestroy' PKG=s3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3Bucket_Basic_forceDestroy|TestAccS3DirectoryBucket_forceDestroy'  -timeout 360m
2024/12/11 15:29:56 Initializing Terraform AWS Provider...
=== RUN   TestAccS3Bucket_Basic_forceDestroy
=== PAUSE TestAccS3Bucket_Basic_forceDestroy
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithUnusualKeyBytes
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithUnusualKeyBytes
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithObjectVersions
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithObjectVersions
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithObjectVersionsUnusualKeyBytes
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithObjectVersionsUnusualKeyBytes
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== RUN   TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== PAUSE TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== RUN   TestAccS3DirectoryBucket_forceDestroy
=== PAUSE TestAccS3DirectoryBucket_forceDestroy
=== RUN   TestAccS3DirectoryBucket_forceDestroyWithUnusualKeyBytes
=== PAUSE TestAccS3DirectoryBucket_forceDestroyWithUnusualKeyBytes
=== CONT  TestAccS3Bucket_Basic_forceDestroy
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectVersions
=== CONT  TestAccS3DirectoryBucket_forceDestroy
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithObjectVersionsUnusualKeyBytes
=== CONT  TestAccS3Bucket_Basic_forceDestroyWithUnusualKeyBytes
=== CONT  TestAccS3DirectoryBucket_forceDestroyWithUnusualKeyBytes
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithUnusualKeyBytes (29.32s)
--- PASS: TestAccS3Bucket_Basic_forceDestroy (30.95s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithEmptyPrefixes (30.96s)
--- PASS: TestAccS3DirectoryBucket_forceDestroy (31.52s)
--- PASS: TestAccS3DirectoryBucket_forceDestroyWithUnusualKeyBytes (32.00s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectLockEnabled (33.76s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectVersionsUnusualKeyBytes (33.90s)
--- PASS: TestAccS3Bucket_Basic_forceDestroyWithObjectVersions (34.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	43.652s
```
