### PR TITLE
fix tls cert for `aws_codeconnections_host`

### DIFF
--- a/.changelog/40574.txt
+++ b/.changelog/40574.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codeconnections_host: Set `tls_certificate` as an optional attribute
+```

--- a/.changelog/40574.txt
+++ b/.changelog/40574.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_codeconnections_host: Set `tls_certificate` as an optional attribute
+resource/aws_codeconnections_host: Mark `vpc_configuration.tls_certificate` as Optional
 ```

--- a/internal/service/codeconnections/exports_test.go
+++ b/internal/service/codeconnections/exports_test.go
@@ -9,5 +9,5 @@ var (
 	ResourceHost       = newHostResource
 
 	FindConnectionByARN = findConnectionByARN
-	FindHostByARN       = findHostbyARN
+	FindHostByARN       = findHostByARN
 )

--- a/internal/service/codeconnections/host.go
+++ b/internal/service/codeconnections/host.go
@@ -108,7 +108,7 @@ func (r *hostResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 							ElementType: types.StringType,
 						},
 						"tls_certificate": schema.StringAttribute{
-							Required: true,
+							Optional: true,
 							Validators: []validator.String{
 								stringvalidator.LengthBetween(1, 16384),
 							},

--- a/internal/service/codeconnections/host_test.go
+++ b/internal/service/codeconnections/host_test.go
@@ -95,6 +95,27 @@ func TestAccCodeConnectionsHost_vpc(t *testing.T) {
 		CheckDestroy:             testAccCheckHostDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
+				Config: testAccHostConfig_vpcNoCertificate(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckHostExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrID, "codeconnections", regexache.MustCompile("host/.+")),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "codeconnections", regexache.MustCompile("host/.+")),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "provider_endpoint", "https://example.com"),
+					resource.TestCheckResourceAttr(resourceName, "provider_type", string(types.ProviderTypeGithubEnterpriseServer)),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.subnet_ids.#", "2"),
+					resource.TestCheckNoResourceAttr(resourceName, "vpc_configuration.0.tls_certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_configuration.0.vpc_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccHostConfig_vpc(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHostExists(ctx, resourceName, &v),
@@ -109,11 +130,6 @@ func TestAccCodeConnectionsHost_vpc(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "vpc_configuration.0.tls_certificate", "-----BEGIN CERTIFICATE-----\nMIID2jCCAsKgAwIBAgIJAJ58TJVjU7G1MA0GCSqGSIb3DQEBBQUAMFExCzAJBgNV\nBAYTAlVTMREwDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMRAwDgYD\nVQQKEwdDaGFydGVyMQwwCgYDVQQLEwNDU0UwHhcNMTcwMTMwMTkyMDA4WhcNMjYx\nMjA5MTkyMDA4WjBRMQswCQYDVQQGEwJVUzERMA8GA1UECBMIQ29sb3JhZG8xDzAN\nBgNVBAcTBkRlbnZlcjEQMA4GA1UEChMHQ2hhcnRlcjEMMAoGA1UECxMDQ1NFMIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv6dq6VLIImlAaTrckb5w3X6J\nWP7EGz2ChGAXlkEYto6dPCba0v5+f+8UlMOpeB25XGoai7gdItqNWVFpYsgmndx3\nvTad3ukO1zeElKtw5oHPH2plOaiv/gVJaDa9NTeINj0EtGZs74fCOclAzGFX5vBc\nb08ESWBceRgGjGv3nlij4JzHfqTkCKQz6P6pBivQBfk62rcOkkH5rKoaGltRHROS\nMbkwOhu2hN0KmSYTXRvts0LXnZU4N0l2ms39gmr7UNNNlKYINL2JoTs9dNBc7APD\ndZvlEHd+/FjcLCI8hC3t4g4AbfW0okIBCNG0+oVjqGb2DeONSJKsThahXt89MQID\nAQABo4G0MIGxMB0GA1UdDgQWBBQKq8JxjY1GmeZXJjfOMfW0kBIzPDCBgQYDVR0j\nBHoweIAUCqvCcY2NRpnmVyY3zjH1tJASMzyhVaRTMFExCzAJBgNVBAYTAlVTMREw\nDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMRAwDgYDVQQKEwdDaGFy\ndGVyMQwwCgYDVQQLEwNDU0WCCQCefEyVY1OxtTAMBgNVHRMEBTADAQH/MA0GCSqG\nSIb3DQEBBQUAA4IBAQAWifoMk5kbv+yuWXvFwHiB4dWUUmMlUlPU/E300yVTRl58\np6DfOgJs7MMftd1KeWqTO+uW134QlTt7+jwI8Jq0uyKCu/O2kJhVtH/Ryog14tGl\n+wLcuIPLbwJI9CwZX4WMBrq4DnYss+6F47i8NCc+Z3MAiG4vtq9ytBmaod0dj2bI\ng4/Lac0e00dql9RnqENh1+dF0V+QgTJCoPkMqDNAlSB8vOodBW81UAb2z12t+IFi\n3X9J3WtCK2+T5brXL6itzewWJ2ALvX3QpmZx7fMHJ3tE+SjjyivE1BbOlzYHx83t\nTeYnm7pS9un7A/UzTDHbs7hPUezLek+H3xTPAnnq\n-----END CERTIFICATE-----\n"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_configuration.0.vpc_id"),
 				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -269,6 +285,21 @@ resource "aws_codeconnections_host" "test" {
   provider_type     = "GitHubEnterpriseServer"
 }
 `, rName)
+}
+
+func testAccHostConfig_vpcNoCertificate(rName string) string {
+	return acctest.ConfigCompose(testAccHostVPCBaseConfig(rName), fmt.Sprintf(`
+resource "aws_codeconnections_host" "test" {
+  name              = %[1]q
+  provider_endpoint = "https://example.com"
+  provider_type     = "GitHubEnterpriseServer"
+  vpc_configuration {
+    security_group_ids = [aws_security_group.test.id]
+    subnet_ids         = aws_subnet.test[*].id
+    vpc_id             = aws_vpc.test.id
+  }
+}
+`, rName))
 }
 
 func testAccHostConfig_vpc(rName string) string {


### PR DESCRIPTION
### Description
This PR fixes the `tls_certificate` attribute in `aws_codeconnections_host`, making it optional.

### Relations
Closes #40573

### References
https://docs.aws.amazon.com/codeconnections/latest/APIReference/API_VpcConfiguration.html

### Output from Acceptance Testing

```console
make testacc TESTS=TestAccCodeConnectionsHost_ PKG=codeconnections 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/codeconnections/... -v -count 1 -parallel 20 -run='TestAccCodeConnectionsHost_'  -timeout 360m
2024/12/16 09:26:38 Initializing Terraform AWS Provider...
=== RUN   TestAccCodeConnectionsHost_basic
=== PAUSE TestAccCodeConnectionsHost_basic
=== RUN   TestAccCodeConnectionsHost_disappears
=== PAUSE TestAccCodeConnectionsHost_disappears
=== RUN   TestAccCodeConnectionsHost_vpc
=== PAUSE TestAccCodeConnectionsHost_vpc
=== RUN   TestAccCodeConnectionsHost_tags
=== PAUSE TestAccCodeConnectionsHost_tags
=== CONT  TestAccCodeConnectionsHost_basic
=== CONT  TestAccCodeConnectionsHost_vpc
=== CONT  TestAccCodeConnectionsHost_disappears
=== CONT  TestAccCodeConnectionsHost_tags
--- PASS: TestAccCodeConnectionsHost_disappears (12.07s)
--- PASS: TestAccCodeConnectionsHost_basic (13.99s)
--- PASS: TestAccCodeConnectionsHost_tags (27.98s)
--- PASS: TestAccCodeConnectionsHost_vpc (507.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/codeconnections	513.836s
```
