### PR TITLE
Various sweeper fixes

### DIFF
--- a/internal/service/directconnect/sweep.go
+++ b/internal/service/directconnect/sweep.go
@@ -180,6 +180,10 @@ func sweepGatewayAssociations(region string) error {
 				}
 
 				for _, v := range page.DirectConnectGatewayAssociations {
+					if v.AssociatedGateway == nil {
+						continue
+					}
+
 					gatewayID := aws.ToString(v.AssociatedGateway.Id)
 
 					if gatewayRegion := aws.ToString(v.AssociatedGateway.Region); gatewayRegion != region {

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -379,10 +379,10 @@ func sweepInstances(region string) error {
 			case "docdb", "neptune":
 				// These engines are handled by their respective services' sweepers.
 				continue
-			default:
+			case InstanceEngineMySQL:
 				// "InvalidParameterValue: Deleting cluster instances isn't supported for DB engine mysql".
-				if v.DBClusterIdentifier != nil {
-					log.Printf("[INFO] Skipping RDS DB Instance %s", id)
+				if clusterID := aws.ToString(v.DBClusterIdentifier); clusterID != "" {
+					log.Printf("[INFO] Skipping RDS DB Instance %s: DBClusterIdentifier=%s", id, clusterID)
 					continue
 				}
 			}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes issues with sweepers in Us Gov Cloud:

```
2024/12/16 08:27:31 [DEBUG] Sweeper (aws_rds_cluster) has dependency (aws_db_instance), running..
2024/12/16 08:27:31 [DEBUG] Sweeper (aws_db_instance) has dependency (aws_rds_global_cluster), running..
2024/12/16 08:27:31 [DEBUG] Sweeper (aws_rds_global_cluster) already ran in region (us-gov-west-1)
2024/12/16 08:27:31 [DEBUG] Sweeper (aws_db_instance) already ran in region (us-gov-west-1)
2024/12/16 08:27:31 [DEBUG] Running Sweeper (aws_rds_cluster) in region (us-gov-west-1)
2024/12/16 08:27:31 [DEBUG] Waiting for state to become: [success]
2024/12/16 08:27:31 [DEBUG] Deleting RDS Cluster: tf-acc-test-primary-7776119114942460995
2024/12/16 08:27:31 [DEBUG] Waiting for state to become: [success]
2024/12/16 08:27:31 [DEBUG] Completed Sweeper (aws_rds_cluster) in region (us-gov-west-1) in 377.914459ms
2024/12/16 08:27:31 [ERROR] Error running Sweeper (aws_rds_cluster) in region (us-gov-west-1): error sweeping RDS Clusters (us-gov-west-1): 1 error occurred:
	* deleting RDS Cluster (tf-acc-test-primary-7776119114942460995): operation error RDS: DeleteDBCluster, https response error StatusCode: 400, RequestID: 60548230-796e-4898-aa81-174bedaca4a2, InvalidDBClusterStateFault: Cluster can't be deleted. It still contains DB instances in a non-deleting state.
```

```
024/12/16 10:03:49 [DEBUG] Running Sweeper (aws_dx_gateway_association) in region (us-gov-west-1)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1147f93a0]

goroutine 1 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/directconnect.sweepGatewayAssociations.func1.1(0x14001aa3180?, 0x1)
	/Users/kewbank/altsrc.2/github.com/hashicorp/terraform-provider-aws/internal/service/directconnect/sweep.go:183 +0xd0
github.com/hashicorp/terraform-provider-aws/internal/service/directconnect.describeDirectConnectGatewayAssociationsPages({0x11c2737b0, 0x1400279dcb0}, 0x14002c36a80, 0x14001aa3180, 0x140010eeef8)
	/Users/kewbank/altsrc.2/github.com/hashicorp/terraform-provider-aws/internal/service/directconnect/list_pages_gen.go:36 +0x98
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/40333.