### PR TITLE
r/aws_resourcegroups_resource: fix crash when attempting to parse arn

### DIFF
--- a/.changelog/40579.txt
+++ b/.changelog/40579.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_resourcegroups_resource: Fix crash when parsing certain ARN formats
+```
+```release-note:enhancement
+resource/aws_resourcegroups_resource: Add import support
+```

--- a/.changelog/40579.txt
+++ b/.changelog/40579.txt
@@ -1,3 +1,6 @@
+```release-note:note
+resource/aws_resourcegroups_resource: The format of the read-only `id` attribute has changed to prevent inconsistent parsing which resulted in provider crashes under certain conditions. The new format is a comma-delimited string combining `group_arn` and `resource_arn` in their entirety. Configuarations relying on the previous format may need to be updated to continue functioning correctly.
+```
 ```release-note:bug
 resource/aws_resourcegroups_resource: Fix crash when parsing certain ARN formats
 ```

--- a/internal/service/resourcegroups/resource.go
+++ b/internal/service/resourcegroups/resource.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -21,9 +20,14 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	resourceIDPartCount = 2
 )
 
 // @SDKResource("aws_resourcegroups_resource", name="Resource")
@@ -63,7 +67,11 @@ func resourceResourceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	groupARN := d.Get("group_arn").(string)
 	resourceARN := d.Get(names.AttrResourceARN).(string)
-	id := strings.Join([]string{strings.Split(strings.ToLower(groupARN), "/")[1], strings.Split(resourceARN, "/")[1]}, "_")
+	id, err := flex.FlattenResourceId([]string{groupARN, resourceARN}, resourceIDPartCount, false)
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
+
 	input := &resourcegroups.GroupResourcesInput{
 		Group:        aws.String(groupARN),
 		ResourceArns: []string{resourceARN},

--- a/internal/service/resourcegroups/resource.go
+++ b/internal/service/resourcegroups/resource.go
@@ -46,6 +46,15 @@ func resourceResource() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceResourceConfigV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceStateUpgradeV0,
+				Version: 0,
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"group_arn": {
 				Type:     schema.TypeString,

--- a/internal/service/resourcegroups/resource_migrate.go
+++ b/internal/service/resourcegroups/resource_migrate.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcegroups
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func resourceResourceConfigV0() *schema.Resource {
+	// Resource with v0 schema (provider v5.81.0 and below)
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"group_arn": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			names.AttrResourceARN: {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			names.AttrResourceType: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	if rawState == nil {
+		rawState = map[string]interface{}{}
+	}
+
+	// Convert id to comma-delimited string combining group_arn and resource_arn
+	parts := []string{
+		rawState["group_arn"].(string),
+		rawState[names.AttrResourceARN].(string),
+	}
+
+	id, err := flex.FlattenResourceId(parts, resourceIDPartCount, false)
+	if err != nil {
+		return rawState, err
+	}
+	rawState[names.AttrID] = id
+
+	return rawState, nil
+}

--- a/internal/service/resourcegroups/resource_test.go
+++ b/internal/service/resourcegroups/resource_test.go
@@ -40,6 +40,11 @@ func TestAccResourceGroupsResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrResourceARN),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/service/resourcegroups/resource_test.go
+++ b/internal/service/resourcegroups/resource_test.go
@@ -38,8 +38,8 @@ func TestAccResourceGroupsResource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceExists(ctx, resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, names.AttrResourceType, "AWS::EC2::Host"),
-					resource.TestCheckResourceAttrPair(resourceName, "group_arn", groupResourceName, "arn"),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrResourceARN, hostResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "group_arn", groupResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrResourceARN, hostResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 				),
 			},

--- a/internal/service/resourcegroups/resource_test.go
+++ b/internal/service/resourcegroups/resource_test.go
@@ -24,6 +24,8 @@ func TestAccResourceGroupsResource_basic(t *testing.T) {
 	var r types.ListGroupResourcesItem
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_resourcegroups_resource.test"
+	groupResourceName := "aws_resourcegroups_group.test"
+	hostResourceName := "aws_ec2_host.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -36,14 +38,53 @@ func TestAccResourceGroupsResource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceExists(ctx, resourceName, &r),
 					resource.TestCheckResourceAttr(resourceName, names.AttrResourceType, "AWS::EC2::Host"),
-					resource.TestCheckResourceAttrSet(resourceName, "group_arn"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrResourceARN),
+					resource.TestCheckResourceAttrPair(resourceName, "group_arn", groupResourceName, "arn"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrResourceARN, hostResourceName, "arn"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Verify the change to the id attribute formatting introduced in v5.82.0
+// do not errors in existing configurations
+func TestAccResourceGroupsResource_v5_82_0_upgrade(t *testing.T) {
+	ctx := acctest.Context(t)
+	var r types.ListGroupResourcesItem
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_resourcegroups_resource.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.ResourceGroupsServiceID),
+		CheckDestroy: testAccCheckResourceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.81.0",
+					},
+				},
+				Config: testAccResourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(ctx, resourceName, &r),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccResourceConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(ctx, resourceName, &r),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
+				),
 			},
 		},
 	})

--- a/website/docs/r/resourcegroups_resource.html.markdown
+++ b/website/docs/r/resourcegroups_resource.html.markdown
@@ -52,3 +52,20 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `create` - (Default `5m`)
 * `delete` - (Default `5m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import an AWS Resource Groups Resource using `group_arn` and `resource_arn`, separated by a comma (`,`). For example:
+
+```terraform
+import {
+  to = aws_resourcegroups_resource.example
+  id = "arn:aws:resource-groups:us-west-2:012345678901:group/example,arn:aws:lambda:us-west-2:012345678901:function:example"
+}
+```
+
+Using `terraform import`, import an AWS Resource Groups Resource using `group_arn` and `resource_arn`, separated by a comma (`,`). For example:
+
+```console
+% terraform import aws_resourcegroups_resource.example arn:aws:resource-groups:us-west-2:012345678901:group/example,arn:aws:lambda:us-west-2:012345678901:function:example
+```

--- a/website/docs/r/resourcegroups_resource.html.markdown
+++ b/website/docs/r/resourcegroups_resource.html.markdown
@@ -30,23 +30,20 @@ resource "aws_resourcegroups_resource" "example" {
   group_arn    = aws_resourcegroups_group.example.arn
   resource_arn = aws_ec2_host.example.arn
 }
-
 ```
 
 ## Argument Reference
 
 The following arguments are required:
 
-* `group_arn` - (Required) The name or the ARN of the resource group to add resources to.
-
-The following arguments are optional:
-
-* `resource_arn` - (Required) The ARN of the resource to be added to the group.
+* `group_arn` - (Required) Name or ARN of the resource group to add resources to.
+* `resource_arn` - (Required) ARN of the resource to be added to the group.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - A comma-delimited string combining `group_arn` and `resource_arn`.
 * `resource_type` - The resource type of a resource, such as `AWS::EC2::Instance`.
 
 ## Timeouts


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously the `group_arn` and `resource_arn` values were assumed to be ARNs in a format which could always be split by a `/` into at least two parts. The provider did no validation of these inputs prior to attempting to split the value, causing `index out of range` crashes when values were provided that did not match these assumptions.

Instead of attempting to split ARNs of varying formatting to construct the `id` attribute, `id` will now be composed of a comma-delimited string combining `group_arn` and `resource_arn` in their entirety. This removes the logic and assumptions around splitting the ARN and should prevent future crashes regardless of the format provided. The more complete content of the `id` attribute will also enable supporting import for this resource (also added as part of this PR).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40504
Closes #40458


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=resourcegroups TESTS=TestAccResourceGroupsResource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/resourcegroups/... -v -count 1 -parallel 20 -run='TestAccResourceGroupsResource_'  -timeout 360m
2024/12/16 11:04:35 Initializing Terraform AWS Provider...

--- PASS: TestAccResourceGroupsResource_basic (21.88s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/resourcegroups     28.172s
```
