### PR TITLE
r/aws_lakeformation_resource_lf_tag: fix destroy panic

### DIFF
--- a/.changelog/40584.txt
+++ b/.changelog/40584.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lakeformation_resource_lf_tag: Fix panic when resource tries to destroy a LFTag reference that does not exist
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Currently the `aws_lakeformation_resource_lf_tag` will panic if the referenced `aws_lakeformation_lf_tag` is removed before its replacement.

```console
Stack trace from the terraform-provider-aws_v5.80.0_x5 plugin:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x25793d7e]
goroutine 30 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation.(*resourceResourceLFTag).Delete(0xc00429f8f0, {0x2c545368, 0xc0043833b0}, {{{{0x2c5bfae0, 0xc00417bce0}, {0x2a491e40, 0xc00417aae0}}, {0x2c5e0628, 0xc00405db30}}, {{{0x0, ...}, ...}, ...}, ...}, ...)
	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation/resource_lf_tag.go:466 +0x3de
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccLakeFormation_serial/ResourceLFTag/\$" PKG=lakeformation

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/lakeformation/... -v -count 1 -parallel 20  -run=TestAccLakeFormation_serial/ResourceLFTag/ -timeout 360m
2024/12/16 13:14:46 Initializing Terraform AWS Provider...
=== RUN   TestAccLakeFormation_serial
=== PAUSE TestAccLakeFormation_serial
=== CONT  TestAccLakeFormation_serial
=== RUN   TestAccLakeFormation_serial/ResourceLFTag
=== RUN   TestAccLakeFormation_serial/ResourceLFTag/basic
=== RUN   TestAccLakeFormation_serial/ResourceLFTag/disappears
=== RUN   TestAccLakeFormation_serial/ResourceLFTag/table
=== RUN   TestAccLakeFormation_serial/ResourceLFTag/tableWithColumns
=== RUN   TestAccLakeFormation_serial/ResourceLFTags
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/hierarchy
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/table
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/basic
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/database
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/databaseMultipleTags
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/disappears
--- PASS: TestAccLakeFormation_serial (212.62s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTag (58.10s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/basic (14.36s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/disappears (14.51s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/table (14.64s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTag/tableWithColumns (14.59s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTags (154.52s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/hierarchy (29.45s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/table (25.09s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns (25.27s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/basic (13.67s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/database (23.57s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/databaseMultipleTags (23.70s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/disappears (13.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	218.854s
```
