### PR TITLE
resource/certificate_settings: Multiple bug fixes

### DIFF
--- a/.changelog/placeholder.txt
+++ b/.changelog/placeholder.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_amplify_domain_association: Prevent permanent diff when `certificate_settings` not set.
+```

--- a/.changelog/placeholder.txt
+++ b/.changelog/placeholder.txt
@@ -13,3 +13,7 @@ resource/aws_amplify_domain_association: Prevent "unexpected state" error when s
 ```release-note:bug
 resource/aws_amplify_domain_association: No longer ignores changes to `certificate_settings` when updating.
 ```
+
+```release-note:bug
+resource/aws_amplify_domain_association: Prevents panic in some circumstances when `certificate_settings` is not set during update.
+```

--- a/.changelog/placeholder.txt
+++ b/.changelog/placeholder.txt
@@ -5,3 +5,7 @@ resource/aws_amplify_domain_association: Prevent permanent diff when `certificat
 ```release-note:bug
 resource/aws_amplify_domain_association: Prevent `ValidationException` when setting `certificate_settings.type` to `AMPLIFY_MANAGED`.
 ```
+
+```release-note:bug
+resource/aws_amplify_domain_association: Prevent "unexpected state" error when setting `certificate_settings.type` to `CUSTOM`.
+```

--- a/.changelog/placeholder.txt
+++ b/.changelog/placeholder.txt
@@ -9,3 +9,7 @@ resource/aws_amplify_domain_association: Prevent `ValidationException` when sett
 ```release-note:bug
 resource/aws_amplify_domain_association: Prevent "unexpected state" error when setting `certificate_settings.type` to `CUSTOM`.
 ```
+
+```release-note:bug
+resource/aws_amplify_domain_association: No longer ignores changes to `certificate_settings` when updating.
+```

--- a/.changelog/placeholder.txt
+++ b/.changelog/placeholder.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_amplify_domain_association: Prevent permanent diff when `certificate_settings` not set.
 ```
+
+```release-note:bug
+resource/aws_amplify_domain_association: Prevent `ValidationException` when setting `certificate_settings.type` to `AMPLIFY_MANAGED`.
+```

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -69,6 +69,7 @@ project {
 
         if (acmCertificateRootDomain != "") {
             text("env.ACM_CERTIFICATE_ROOT_DOMAIN", acmCertificateRootDomain, display = ParameterDisplay.HIDDEN)
+            text("env.AMPLIFY_DOMAIN_NAME", acmCertificateRootDomain, display = ParameterDisplay.HIDDEN)
         }
 
         val securityGroupRulesPerGroup = DslContext.getParameter("security_group_rules_per_group", "")

--- a/internal/service/amplify/amplify_test.go
+++ b/internal/service/amplify/amplify_test.go
@@ -46,10 +46,11 @@ func TestAccAmplify_serial(t *testing.T) {
 			"OptionalArguments":    testAccBranch_OptionalArguments,
 		},
 		"DomainAssociation": {
-			acctest.CtBasic:       testAccDomainAssociation_basic,
-			"certificateSettings": testAccDomainAssociation_certificateSettings,
-			acctest.CtDisappears:  testAccDomainAssociation_disappears,
-			"update":              testAccDomainAssociation_update,
+			acctest.CtBasic:               testAccDomainAssociation_basic,
+			"certificateSettings_Managed": testAccDomainAssociation_certificateSettings_Managed,
+			"certificateSettings_Custom":  testAccDomainAssociation_certificateSettings_Custom,
+			acctest.CtDisappears:          testAccDomainAssociation_disappears,
+			"update":                      testAccDomainAssociation_update,
 		},
 		"Webhook": {
 			acctest.CtBasic:      testAccWebhook_basic,

--- a/internal/service/amplify/domain_association.go
+++ b/internal/service/amplify/domain_association.go
@@ -214,7 +214,9 @@ func resourceDomainAssociationUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if d.HasChange("certificate_settings") {
-			input.CertificateSettings = expandCertificateSettings(d.Get("certificate_settings").([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("certificate_settings"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.CertificateSettings = expandCertificateSettings(d.Get("certificate_settings").([]interface{})[0].(map[string]interface{}))
+			}
 		}
 
 		if d.HasChange("enable_auto_sub_domain") {

--- a/internal/service/amplify/domain_association.go
+++ b/internal/service/amplify/domain_association.go
@@ -373,7 +373,7 @@ func waitDomainAssociationVerified(ctx context.Context, conn *amplify.Client, ap
 	return nil, err
 }
 
-func waitDomainAssociationAvailable(ctx context.Context, conn *amplify.Client, appID, domainName string) (*types.DomainAssociation, error) { //nolint:unparam
+func waitDomainAssociationAvailable(ctx context.Context, conn *amplify.Client, appID, domainName string) (*types.DomainAssociation, error) {
 	const (
 		timeout = 15 * time.Minute
 	)

--- a/internal/service/amplify/domain_association.go
+++ b/internal/service/amplify/domain_association.go
@@ -52,6 +52,7 @@ func resourceDomainAssociation() *schema.Resource {
 			"certificate_settings": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/internal/service/amplify/domain_association.go
+++ b/internal/service/amplify/domain_association.go
@@ -314,7 +314,7 @@ func waitDomainAssociationCreated(ctx context.Context, conn *amplify.Client, app
 		timeout = 5 * time.Minute
 	)
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(types.DomainStatusCreating, types.DomainStatusInProgress, types.DomainStatusRequestingCertificate),
+		Pending: enum.Slice(types.DomainStatusCreating, types.DomainStatusInProgress, types.DomainStatusRequestingCertificate, types.DomainStatusImportingCustomCertificate),
 		Target:  enum.Slice(types.DomainStatusPendingVerification, types.DomainStatusPendingDeployment, types.DomainStatusAvailable),
 		Refresh: statusDomainAssociation(ctx, conn, appID, domainName),
 		Timeout: timeout,

--- a/internal/service/amplify/domain_association.go
+++ b/internal/service/amplify/domain_association.go
@@ -430,7 +430,7 @@ func expandCertificateSettings(tfMap map[string]interface{}) *types.CertificateS
 		Type: types.CertificateType(tfMap[names.AttrType].(string)),
 	}
 
-	if v, ok := tfMap["custom_certificate_arn"].(string); ok {
+	if v, ok := tfMap["custom_certificate_arn"].(string); ok && v != "" {
 		apiObject.CustomCertificateArn = aws.String(v)
 	}
 

--- a/internal/service/amplify/domain_association_test.go
+++ b/internal/service/amplify/domain_association_test.go
@@ -44,6 +44,10 @@ func testAccDomainAssociation_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(`apps/.+/domains/.+`)),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_settings.0.certificate_verification_dns_record"),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.custom_certificate_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.type", "AMPLIFY_MANAGED"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
 					resource.TestCheckResourceAttr(resourceName, "enable_auto_sub_domain", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "sub_domain.#", "1"),

--- a/internal/service/amplify/domain_association_test.go
+++ b/internal/service/amplify/domain_association_test.go
@@ -43,7 +43,7 @@ func testAccDomainAssociation_basic(t *testing.T) {
 				Config: testAccDomainAssociationConfig_basic(rName, domainName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(`apps/.+/domains/.+`)),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_settings.0.certificate_verification_dns_record"),
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.custom_certificate_arn", ""),
@@ -120,7 +120,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 				Config: testAccDomainAssociationConfig_basic(rName, domainName, false, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(`apps/.+/domains/.+`)),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
 					resource.TestCheckResourceAttr(resourceName, "enable_auto_sub_domain", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "sub_domain.#", "1"),
@@ -141,7 +141,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 				Config: testAccDomainAssociationConfig_updated(rName, domainName, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(`apps/.+/domains/.+`)),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
 					resource.TestCheckResourceAttr(resourceName, "enable_auto_sub_domain", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "sub_domain.#", "2"),
@@ -182,7 +182,7 @@ func testAccDomainAssociation_certificateSettings(t *testing.T) {
 				Config: testAccDomainAssociationConfig_certificateSettings(rName, domainName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(`apps/.+/domains/.+`)),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.type", "AMPLIFY_MANAGED"),

--- a/internal/service/amplify/domain_association_test.go
+++ b/internal/service/amplify/domain_association_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -160,7 +161,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 	})
 }
 
-func testAccDomainAssociation_certificateSettings(t *testing.T) {
+func testAccDomainAssociation_certificateSettings_Managed(t *testing.T) {
 	ctx := acctest.Context(t)
 	key := "AMPLIFY_DOMAIN_NAME"
 	domainName := os.Getenv(key)
@@ -179,7 +180,7 @@ func testAccDomainAssociation_certificateSettings(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainAssociationConfig_certificateSettings(rName, domainName, false, false),
+				Config: testAccDomainAssociationConfig_certificateSettings_Managed(rName, domainName, false, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
@@ -187,6 +188,51 @@ func testAccDomainAssociation_certificateSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.type", "AMPLIFY_MANAGED"),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_settings.0.certificate_verification_dns_record"),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.custom_certificate_arn", ""),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_verification"},
+			},
+		},
+	})
+}
+
+func TestAccDomainAssociation_certificateSettings_Custom(t *testing.T) {
+	ctx := acctest.Context(t)
+	key := "AMPLIFY_DOMAIN_NAME"
+	domainName := os.Getenv(key)
+	if domainName == "" {
+		t.Skipf("Environment variable %s is not set", key)
+	}
+
+	var domain types.DomainAssociation
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_amplify_domain_association.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(t)
+			acctest.PreCheckAlternateRegion(t, endpoints.UsEast1RegionID) // ACM certificate must be created in us-east-1
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
+		CheckDestroy:             testAccCheckDomainAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainAssociationConfig_certificateSettings_Custom(rName, domainName, false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.certificate_verification_dns_record", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "certificate_settings.0.custom_certificate_arn", "aws_acm_certificate.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.type", "CUSTOM"),
 				),
 			},
 			{
@@ -308,7 +354,7 @@ resource "aws_amplify_domain_association" "test" {
 `, rName, domainName, enableAutoSubDomain, waitForVerification)
 }
 
-func testAccDomainAssociationConfig_certificateSettings(rName, domainName string, enableAutoSubDomain bool, waitForVerification bool) string {
+func testAccDomainAssociationConfig_certificateSettings_Managed(rName, domainName string, enableAutoSubDomain bool, waitForVerification bool) string {
 	return fmt.Sprintf(`
 resource "aws_amplify_app" "test" {
   name = %[1]q
@@ -336,4 +382,69 @@ resource "aws_amplify_domain_association" "test" {
   wait_for_verification  = %[4]t
 }
 `, rName, domainName, enableAutoSubDomain, waitForVerification)
+}
+
+func testAccDomainAssociationConfig_certificateSettings_Custom(rName, domainName string, enableAutoSubDomain bool, waitForVerification bool) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigMultipleRegionProvider(2),
+		fmt.Sprintf(`
+resource "aws_amplify_domain_association" "test" {
+  app_id      = aws_amplify_app.test.id
+  domain_name = %[2]q
+
+  sub_domain {
+    branch_name = aws_amplify_branch.test.branch_name
+    prefix      = ""
+  }
+
+  certificate_settings {
+    type                   = "CUSTOM"
+    custom_certificate_arn = aws_acm_certificate_validation.test.certificate_arn
+  }
+
+  enable_auto_sub_domain = %[3]t
+  wait_for_verification  = %[4]t
+}
+
+resource "aws_amplify_app" "test" {
+  name = %[1]q
+}
+
+resource "aws_amplify_branch" "test" {
+  app_id      = aws_amplify_app.test.id
+  branch_name = %[1]q
+}
+
+data "aws_route53_zone" "test" {
+  provider = "awsalternate"
+
+  name         = %[2]q
+  private_zone = false
+}
+
+resource "aws_acm_certificate" "test" {
+  provider = "awsalternate"
+
+  domain_name       = %[2]q
+  validation_method = "DNS"
+}
+
+resource "aws_route53_record" "test" {
+  provider = "awsalternate"
+
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_value]
+  ttl             = 60
+  type            = tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_type
+  zone_id         = data.aws_route53_zone.test.zone_id
+}
+
+resource "aws_acm_certificate_validation" "test" {
+  provider = "awsalternate"
+
+  depends_on      = [aws_route53_record.test]
+  certificate_arn = aws_acm_certificate.test.arn
+}
+  `, rName, domainName, enableAutoSubDomain, waitForVerification))
 }

--- a/internal/service/amplify/domain_association_test.go
+++ b/internal/service/amplify/domain_association_test.go
@@ -41,7 +41,7 @@ func testAccDomainAssociation_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainAssociationConfig_basic(rName, domainName, false, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.#", "1"),
@@ -88,7 +88,7 @@ func testAccDomainAssociation_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainAssociationConfig_basic(rName, domainName, false, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfamplify.ResourceDomainAssociation(), resourceName),
 				),
@@ -118,7 +118,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainAssociationConfig_basic(rName, domainName, false, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
@@ -139,7 +139,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 			},
 			{
 				Config: testAccDomainAssociationConfig_updated(rName, domainName, true, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
@@ -180,7 +180,7 @@ func testAccDomainAssociation_certificateSettings(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainAssociationConfig_certificateSettings(rName, domainName, false, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),

--- a/internal/service/amplify/domain_association_test.go
+++ b/internal/service/amplify/domain_association_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -21,6 +22,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+// To test this resource, use a domain that is hosted in Route 53 in the same account and set the environment
+// variable "AMPLIFY_DOMAIN_NAME" to the domain name.
 
 func testAccDomainAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -107,7 +111,10 @@ func testAccDomainAssociation_update(t *testing.T) {
 		t.Skipf("Environment variable %s is not set", key)
 	}
 
-	var domain types.DomainAssociation
+	var (
+		app    types.App
+		domain types.DomainAssociation
+	)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_domain_association.test"
 
@@ -120,6 +127,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 			{
 				Config: testAccDomainAssociationConfig_basic(rName, domainName, false, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAppExists(ctx, "aws_amplify_app.test", &app),
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
@@ -128,6 +136,7 @@ func testAccDomainAssociation_update(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sub_domain.*", map[string]string{
 						"branch_name":    rName,
 						names.AttrPrefix: "",
+						"verified":       acctest.CtTrue,
 					}),
 					resource.TestCheckResourceAttr(resourceName, "wait_for_verification", acctest.CtTrue),
 				),
@@ -139,7 +148,8 @@ func testAccDomainAssociation_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"wait_for_verification"},
 			},
 			{
-				Config: testAccDomainAssociationConfig_updated(rName, domainName, true, true),
+				PreConfig: domainAssociationStatusAvailablePreConfig(ctx, t, &app, &domain),
+				Config:    testAccDomainAssociationConfig_updated(rName, domainName, true, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
@@ -149,13 +159,21 @@ func testAccDomainAssociation_update(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sub_domain.*", map[string]string{
 						"branch_name":    rName,
 						names.AttrPrefix: "",
+						// "verified":       acctest.CtTrue, // Even though we're waiting for verification, this isn't getting verified
 					}),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "sub_domain.*", map[string]string{
 						"branch_name":    fmt.Sprintf("%s-2", rName),
 						names.AttrPrefix: "www",
+						// "verified":       acctest.CtTrue, // Even though we're waiting for verification, this isn't getting verified
 					}),
 					resource.TestCheckResourceAttr(resourceName, "wait_for_verification", acctest.CtTrue),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_verification"},
 			},
 		},
 	})
@@ -169,19 +187,23 @@ func testAccDomainAssociation_certificateSettings_Managed(t *testing.T) {
 		t.Skipf("Environment variable %s is not set", key)
 	}
 
-	var domain types.DomainAssociation
+	var (
+		app    types.App
+		domain types.DomainAssociation
+	)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_domain_association.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
 		CheckDestroy:             testAccCheckDomainAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainAssociationConfig_certificateSettings_Managed(rName, domainName, false, false),
+				Config: testAccDomainAssociationConfig_certificateSettings_Managed(rName, domainName, false, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAppExists(ctx, "aws_amplify_app.test", &app),
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
@@ -197,11 +219,30 @@ func testAccDomainAssociation_certificateSettings_Managed(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"wait_for_verification"},
 			},
+			{
+				PreConfig: domainAssociationStatusAvailablePreConfig(ctx, t, &app, &domain),
+				Config:    testAccDomainAssociationConfig_certificateSettings_Custom(rName, domainName, false, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.certificate_verification_dns_record", ""),
+					resource.TestCheckResourceAttrPair(resourceName, "certificate_settings.0.custom_certificate_arn", "aws_acm_certificate.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.type", "CUSTOM"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_verification"},
+			},
 		},
 	})
 }
 
-func TestAccDomainAssociation_certificateSettings_Custom(t *testing.T) {
+func testAccDomainAssociation_certificateSettings_Custom(t *testing.T) {
 	ctx := acctest.Context(t)
 	key := "AMPLIFY_DOMAIN_NAME"
 	domainName := os.Getenv(key)
@@ -209,7 +250,10 @@ func TestAccDomainAssociation_certificateSettings_Custom(t *testing.T) {
 		t.Skipf("Environment variable %s is not set", key)
 	}
 
-	var domain types.DomainAssociation
+	var (
+		app    types.App
+		domain types.DomainAssociation
+	)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_amplify_domain_association.test"
 
@@ -224,8 +268,9 @@ func TestAccDomainAssociation_certificateSettings_Custom(t *testing.T) {
 		CheckDestroy:             testAccCheckDomainAssociationDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDomainAssociationConfig_certificateSettings_Custom(rName, domainName, false, false),
+				Config: testAccDomainAssociationConfig_certificateSettings_Custom(rName, domainName, false, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAppExists(ctx, "aws_amplify_app.test", &app),
 					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
@@ -233,6 +278,25 @@ func TestAccDomainAssociation_certificateSettings_Custom(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.certificate_verification_dns_record", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "certificate_settings.0.custom_certificate_arn", "aws_acm_certificate.test", names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.type", "CUSTOM"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_verification"},
+			},
+			{
+				PreConfig: domainAssociationStatusAvailablePreConfig(ctx, t, &app, &domain),
+				Config:    testAccDomainAssociationConfig_certificateSettings_Managed(rName, domainName, false, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDomainAssociationExists(ctx, resourceName, &domain),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "amplify", regexache.MustCompile(fmt.Sprintf(`apps/.+/domains/%s$`, domainName))),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.type", "AMPLIFY_MANAGED"),
+					resource.TestCheckResourceAttrSet(resourceName, "certificate_settings.0.certificate_verification_dns_record"),
+					resource.TestCheckResourceAttr(resourceName, "certificate_settings.0.custom_certificate_arn", ""),
 				),
 			},
 			{
@@ -447,4 +511,17 @@ resource "aws_acm_certificate_validation" "test" {
   certificate_arn = aws_acm_certificate.test.arn
 }
   `, rName, domainName, enableAutoSubDomain, waitForVerification))
+}
+
+// In practice, we don't seem to need to wait for the Domain Association to be `AVAILABLE` for the purposes of deploying infrastructure.
+// Since subsequent modifications to a Domain Association cannot occur until it is `AVAILABLE`, wait during tests.
+func domainAssociationStatusAvailablePreConfig(ctx context.Context, t *testing.T, app *types.App, domain *types.DomainAssociation) func() {
+	return func() {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AmplifyClient(ctx)
+
+		_, err := tfamplify.WaitDomainAssociationAvailable(ctx, conn, aws.ToString(app.AppId), aws.ToString(domain.DomainName))
+		if err != nil {
+			t.Fatalf("waiting for Amplify Domain Association (%s/%s) to be available: %s", aws.ToString(app.AppId), aws.ToString(domain.DomainName), err)
+		}
+	}
 }

--- a/internal/service/amplify/exports_test.go
+++ b/internal/service/amplify/exports_test.go
@@ -16,4 +16,6 @@ var (
 	FindBranchByTwoPartKey             = findBranchByTwoPartKey
 	FindDomainAssociationByTwoPartKey  = findDomainAssociationByTwoPartKey
 	FindWebhookByID                    = findWebhookByID
+
+	WaitDomainAssociationAvailable = waitDomainAssociationAvailable
 )

--- a/website/docs/r/amplify_domain_association.html.markdown
+++ b/website/docs/r/amplify_domain_association.html.markdown
@@ -60,8 +60,10 @@ This resource supports the following arguments:
 
 The `certificate_settings` configuration block supports the following arguments:
 
-* `type` - (Required) The certificate type. Valid values are `AMPLIFY_MANAGED` and `CUSTOM`.
+* `type` - (Required) The certificate type.
+  Valid values are `AMPLIFY_MANAGED` and `CUSTOM`.
 * `custom_certificate_arn` - (Optional) The Amazon resource name (ARN) for the custom certificate.
+  Required when `type` is `CUSTOM`.
 
 The `sub_domain` configuration block supports the following arguments:
 


### PR DESCRIPTION
### Description

Fixes multiple bugs in `certificate_settings`:

* Prevent permanent diff when `certificate_settings` not set.
* Prevent `ValidationException` when setting `certificate_settings.type` to `AMPLIFY_MANAGED`.
* Prevent "unexpected state" error when setting `certificate_settings.type` to `CUSTOM`.
* No longer ignores changes to `certificate_settings` when updating.
* Prevents panic in some circumstances when `certificate_settings` is not set during update.

### Relations

Closes #38387
Closes #39890

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=amplify TESTS='TestAccAmplify_serial/DomainAssociation'

--- PASS: TestAccAmplify_serial (3851.69s)
    --- PASS: TestAccAmplify_serial/DomainAssociation (3851.69s)
        --- PASS: TestAccAmplify_serial/DomainAssociation/certificateSettings_Custom (1327.02s)
        --- PASS: TestAccAmplify_serial/DomainAssociation/disappears (296.65s)
        --- PASS: TestAccAmplify_serial/DomainAssociation/update (812.72s)
        --- PASS: TestAccAmplify_serial/DomainAssociation/basic (297.96s)
        --- PASS: TestAccAmplify_serial/DomainAssociation/certificateSettings_Managed (1117.31s)
```
