### PR TITLE
Updates to `skaff` templates

### DIFF
--- a/skaff/datasource/datasourcetest.gtpl
+++ b/skaff/datasource/datasourcetest.gtpl
@@ -187,7 +187,7 @@ func TestAcc{{ .Service }}{{ .DataSource }}DataSource_basic(t *testing.T) {
 						"username":       "Test",
 						"password":       "TestTest1234",
 					}),
-					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "{{ .ServicePackage }}", regexache.MustCompile(`{{ .DataSourceLower }}:.+$`)),
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, names.AttrARN, "{{ .ServicePackage }}", regexache.MustCompile(`{{ .DataSourceLower }}:.+$`)),
 				),
 			},
 		},

--- a/skaff/datasource/datasourcetest.gtpl
+++ b/skaff/datasource/datasourcetest.gtpl
@@ -187,6 +187,12 @@ func TestAcc{{ .Service }}{{ .DataSource }}DataSource_basic(t *testing.T) {
 						"username":       "Test",
 						"password":       "TestTest1234",
 					}),
+					{{- if .IncludeComments }}
+					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
+					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
+					// Alternatively, if the data source returns the values for a corresponding resource, use `resource.TestCheckResourceAttrPair` to
+					// check that the values are the same.
+					{{- end }}
 					acctest.MatchResourceAttrRegionalARN(dataSourceName, names.AttrARN, "{{ .ServicePackage }}", regexache.MustCompile(`{{ .DataSourceLower }}:.+$`)),
 				),
 			},

--- a/skaff/datasource/datasourcetest.gtpl
+++ b/skaff/datasource/datasourcetest.gtpl
@@ -187,7 +187,7 @@ func TestAcc{{ .Service }}{{ .DataSource }}DataSource_basic(t *testing.T) {
 						"username":       "Test",
 						"password":       "TestTest1234",
 					}),
-					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "{{ .ServicePackage }}", regexache.MustCompile(`{{ .DataSourceLower }}:+.`)),
+					acctest.MatchResourceAttrRegionalARN(dataSourceName, "arn", "{{ .ServicePackage }}", regexache.MustCompile(`{{ .DataSourceLower }}:.+$`)),
 				),
 			},
 		},

--- a/skaff/datasource/datasourcetest.gtpl
+++ b/skaff/datasource/datasourcetest.gtpl
@@ -177,7 +177,7 @@ func TestAcc{{ .Service }}{{ .DataSource }}DataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAcc{{ .DataSource }}DataSourceConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheck{{ .DataSource }}Exists(ctx, dataSourceName, &{{ .DataSourceLower }}),
 					resource.TestCheckResourceAttr(dataSourceName, "auto_minor_version_upgrade", "false"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "maintenance_window_start_time.0.day_of_week"),

--- a/skaff/datasource/datasourcetest.gtpl
+++ b/skaff/datasource/datasourcetest.gtpl
@@ -193,7 +193,7 @@ func TestAcc{{ .Service }}{{ .DataSource }}DataSource_basic(t *testing.T) {
 					// Alternatively, if the data source returns the values for a corresponding resource, use `resource.TestCheckResourceAttrPair` to
 					// check that the values are the same.
 					{{- end }}
-					acctest.MatchResourceAttrRegionalARN(dataSourceName, names.AttrARN, "{{ .ServicePackage }}", regexache.MustCompile(`{{ .DataSourceLower }}:.+$`)),
+					acctest.MatchResourceAttrRegionalARN(ctx, dataSourceName, names.AttrARN, "{{ .ServicePackage }}", regexache.MustCompile(`{{ .DataSourceLower }}:.+$`)),
 				),
 			},
 		},

--- a/skaff/resource/resourcefw.gtpl
+++ b/skaff/resource/resourcefw.gtpl
@@ -159,6 +159,13 @@ func (r *resource{{ .Resource }}) Schema(ctx context.Context, req resource.Schem
 			"description": schema.StringAttribute{
 				Optional: true,
 			},
+			{{- if .IncludeComments }}
+			// TIP: ==== "ID" ATTRIBUTE ====
+			// When using the Terraform Plugin Framework, there is no required "id" attribute.
+			// This is different from the Terraform Plugin SDK. 
+			//
+			// Only include an "id" attribute if the AWS API has an "Id" field, such as "{{ .Resource }}Id"
+			{{- end }}
 			"id": framework.IDAttribute(),
 			"name": schema.StringAttribute{
 				Required: true,

--- a/skaff/resource/resourcetest.gtpl
+++ b/skaff/resource/resourcetest.gtpl
@@ -190,7 +190,7 @@ func TestAcc{{ .Service }}{{ .Resource }}_basic(t *testing.T) {
 					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
 					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
 					{{- end }}
-					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "{{ .ServicePackage }}", regexache.MustCompile(`{{ .ResourceLower }}:.+$`)),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "{{ .ServicePackage }}", regexache.MustCompile(`{{ .ResourceLower }}:.+$`)),
 				),
 			},
 			{

--- a/skaff/resource/resourcetest.gtpl
+++ b/skaff/resource/resourcetest.gtpl
@@ -186,6 +186,10 @@ func TestAcc{{ .Service }}{{ .Resource }}_basic(t *testing.T) {
 						"username":       "Test",
 						"password":       "TestTest1234",
 					}),
+					{{- if .IncludeComments }}
+					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
+					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
+					{{- end }}
 					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "{{ .ServicePackage }}", regexache.MustCompile(`{{ .ResourceLower }}:.+$`)),
 				),
 			},

--- a/skaff/resource/resourcetest.gtpl
+++ b/skaff/resource/resourcetest.gtpl
@@ -186,7 +186,7 @@ func TestAcc{{ .Service }}{{ .Resource }}_basic(t *testing.T) {
 						"username":       "Test",
 						"password":       "TestTest1234",
 					}),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "{{ .ServicePackage }}", regexache.MustCompile(`{{ .ResourceLower }}:+.`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "{{ .ServicePackage }}", regexache.MustCompile(`{{ .ResourceLower }}:.+$`)),
 				),
 			},
 			{

--- a/skaff/resource/resourcetest.gtpl
+++ b/skaff/resource/resourcetest.gtpl
@@ -186,7 +186,7 @@ func TestAcc{{ .Service }}{{ .Resource }}_basic(t *testing.T) {
 						"username":       "Test",
 						"password":       "TestTest1234",
 					}),
-					acctest.MatchResourceAttrRegionalARN(resourceName, "arn", "{{ .ServicePackage }}", regexache.MustCompile(`{{ .ResourceLower }}:.+$`)),
+					acctest.MatchResourceAttrRegionalARN(resourceName, names.AttrARN, "{{ .ServicePackage }}", regexache.MustCompile(`{{ .ResourceLower }}:.+$`)),
 				),
 			},
 			{

--- a/skaff/resource/resourcetest.gtpl
+++ b/skaff/resource/resourcetest.gtpl
@@ -176,7 +176,7 @@ func TestAcc{{ .Service }}{{ .Resource }}_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAcc{{ .Resource }}Config_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheck{{ .Resource }}Exists(ctx, resourceName, &{{ .ResourceLower }}),
 					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
@@ -221,7 +221,7 @@ func TestAcc{{ .Service }}{{ .Resource }}_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAcc{{ .Resource }}Config_basic(rName, testAcc{{ .Resource }}VersionNewer),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheck{{ .Resource }}Exists(ctx, resourceName, &{{ .ResourceLower }}),
 					{{- if .PluginFramework }}
 					{{- if .IncludeComments }}


### PR DESCRIPTION
### Description

* Uses `resource.ComposeAggregateTestCheckFunc` instead of `resource.ComposeTestCheckFunc` in acceptance tests
* Corrects repetition and uses attribute constant in ARN checks
* Adds instruction to only use `id` attribute if corresponding AWS API structs have `...Id` field
* Suggests alternatives to regex for ARN checks if appropriate 
