### PR TITLE
r/rds_cluster: fix wait error when modifying `allocated_storage`

### DIFF
--- a/.changelog/40601.txt
+++ b/.changelog/40601.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_rds_cluster: Fix issue with waiter when modifying `allocated_storage`
+```

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -2050,6 +2050,7 @@ func waitDBClusterUpdated(ctx context.Context, conn *rds.Client, id string, wait
 		clusterStatusRenaming,
 		clusterStatusResettingMasterCredentials,
 		clusterStatusScalingCompute,
+		clusterStatusScalingStorage,
 		clusterStatusUpgrading,
 	}
 	if waitNoPendingModifiedValues {

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -729,7 +729,7 @@ func TestAccRDSCluster_storageTypeAuroraUpdateAuroraIopt1(t *testing.T) {
 	})
 }
 
-func TestAccRDSCluster_allocatedStorage(t *testing.T) {
+func TestAccRDSCluster_allocatedStorage_io1(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
 	}
@@ -746,10 +746,44 @@ func TestAccRDSCluster_allocatedStorage(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_allocatedStorage(rName),
+				Config: testAccClusterConfig_allocatedStorage(rName, "io1", 100, 1000),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAllocatedStorage, "100"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSCluster_allocatedStorage_gp3(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	var dbCluster types.DBCluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_allocatedStorage(rName, "gp3", 400, 12000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAllocatedStorage, "400"),
+				),
+			},
+			{
+				Config: testAccClusterConfig_allocatedStorage(rName, "gp3", 500, 12000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
+					resource.TestCheckResourceAttr(resourceName, names.AttrAllocatedStorage, "500"),
 				),
 			},
 		},
@@ -3669,7 +3703,7 @@ resource "aws_db_instance" "test" {
 `, tfrds.ClusterEnginePostgres, mainInstanceClasses, rName, sType))
 }
 
-func testAccClusterConfig_allocatedStorage(rName string) string {
+func testAccClusterConfig_allocatedStorage(rName, storageType string, allocatedStorage, iops int) string {
 	return acctest.ConfigCompose(
 		testAccConfig_ClusterSubnetGroup(rName),
 		fmt.Sprintf(`
@@ -3677,7 +3711,7 @@ data "aws_rds_orderable_db_instance" "test" {
   engine                     = %[1]q
   engine_latest_version      = true
   preferred_instance_classes = [%[2]s]
-  storage_type               = "io1"
+  storage_type               = %[4]q
   supports_iops              = true
   supports_clusters          = true
 }
@@ -3690,13 +3724,13 @@ resource "aws_rds_cluster" "test" {
   engine                    = data.aws_rds_orderable_db_instance.test.engine
   engine_version            = data.aws_rds_orderable_db_instance.test.engine_version
   storage_type              = data.aws_rds_orderable_db_instance.test.storage_type
-  allocated_storage         = 100
-  iops                      = 1000
+  allocated_storage         = %[5]d
+  iops                      = %[6]d
   master_password           = "mustbeeightcharaters"
   master_username           = "test"
   skip_final_snapshot       = true
 }
-`, tfrds.ClusterEngineMySQL, mainInstanceClasses, rName))
+`, tfrds.ClusterEngineMySQL, mainInstanceClasses, rName, storageType, allocatedStorage, iops))
 }
 
 func testAccClusterConfig_iops(rName string) string {

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -30,6 +30,7 @@ const (
 	clusterStatusRenaming                      = "renaming"
 	clusterStatusResettingMasterCredentials    = "resetting-master-credentials"
 	clusterStatusScalingCompute                = "scaling-compute"
+	clusterStatusScalingStorage                = "scaling-storage"
 	clusterStatusUpgrading                     = "upgrading"
 
 	// Non-standard status values.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modifying `allocated_storage` could produce the following error:

```console
│ Error: waiting for RDS Cluster (random-name) update: unexpected state 'scaling-storage', wanted target 'available'. last error: %!s(<nil>)
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccRDSCluster_allocatedStorage_\|TestAccRDSCluster_basic\|TestAccRDSCluster_disappears' PKG=rds

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSCluster_allocatedStorage_\|TestAccRDSCluster_basic\|TestAccRDSCluster_disappears -timeout 360m
2024/12/17 12:27:13 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSCluster_basic
=== PAUSE TestAccRDSCluster_basic
=== RUN   TestAccRDSCluster_disappears
=== PAUSE TestAccRDSCluster_disappears
=== RUN   TestAccRDSCluster_allocatedStorage_io1
=== PAUSE TestAccRDSCluster_allocatedStorage_io1
=== RUN   TestAccRDSCluster_allocatedStorage_gp3
=== PAUSE TestAccRDSCluster_allocatedStorage_gp3
=== CONT  TestAccRDSCluster_basic
=== CONT  TestAccRDSCluster_allocatedStorage_io1
=== CONT  TestAccRDSCluster_disappears
=== CONT  TestAccRDSCluster_allocatedStorage_gp3
--- PASS: TestAccRDSCluster_disappears (103.87s)
--- PASS: TestAccRDSCluster_basic (115.78s)
--- PASS: TestAccRDSCluster_allocatedStorage_io1 (1181.23s)
--- PASS: TestAccRDSCluster_allocatedStorage_gp3 (1316.35s)
PASS
```
