### PR TITLE
Reduces small allocations on heap

### DIFF
--- a/docs/resource-filtering.md
+++ b/docs/resource-filtering.md
@@ -33,7 +33,7 @@ Add the AWS Go SDK service name (e.g., `rds`) to `sliceServiceNames` in `interna
 
 === "Terraform Plugin SDK V2"
     ```go
-    input := &ec2.DescribeInternetGatewaysInput{}
+    input := ec2.DescribeInternetGatewaysInput{}
 
     // Filters based on attributes.
     filters := namevaluesfilters.New(map[string]string{

--- a/docs/resource-tagging.md
+++ b/docs/resource-tagging.md
@@ -226,7 +226,7 @@ use the `getTagsIn` function to get any configured tags.
 
 === "Terraform Plugin Framework (Preferred)"
     ```go
-    input := &service.CreateExampleInput{
+    input := service.CreateExampleInput{
       /* ... other configuration ... */
       Tags: getTagsIn(ctx),
     }
@@ -234,7 +234,7 @@ use the `getTagsIn` function to get any configured tags.
 
 === "Terraform Plugin SDK V2"
     ```go
-    input := &service.CreateExampleInput{
+    input := service.CreateExampleInput{
       /* ... other configuration ... */
       Tags: getTagsIn(ctx),
     }
@@ -332,7 +332,7 @@ implement the logic to convert the configuration tags into the service tags, e.g
     defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig(ctx)
     tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-    input := &eks.CreateClusterInput{
+    input := eks.CreateClusterInput{
       /* ... other configuration ... */
       Tags: Tags(tags.IgnoreAWS()),
     }
@@ -346,7 +346,7 @@ If the service API does not allow passing an empty list, the logic can be adjust
     defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig(ctx)
     tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-    input := &eks.CreateClusterInput{
+    input := eks.CreateClusterInput{
       /* ...other configuration... */
     }
 
@@ -383,7 +383,7 @@ This example shows using `TagSpecifications`:
     defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig(ctx)
     tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("tags").(map[string]interface{})))
 
-    input := &ec2.CreateFleetInput{
+    input := ec2.CreateFleetInput{
         /* ... other configuration ... */
         TagSpecifications: tagSpecificationsFromKeyValue(tags, ec2.ResourceTypeFleet),
     }
@@ -460,7 +460,7 @@ If the resource `Update` function applies specific updates to attributes regardl
     ```go
     if d.HasChangesExcept("tags", "tags_all") {
       /* ... other logic ...*/
-      request := &iam.CreatePolicyVersionInput{
+      request := iam.CreatePolicyVersionInput{
         PolicyArn:      aws.String(d.Id()),
         PolicyDocument: aws.String(d.Get("policy").(string)),
         SetAsDefault:   aws.Bool(true),

--- a/docs/retries-and-waiters.md
+++ b/docs/retries-and-waiters.md
@@ -306,13 +306,13 @@ const (
 
     	// ...Creation steps...
 
-    	input := &example.OperationInput{/* ... */}
+    	input := example.OperationInput{/* ... */}
 
     	var output *example.OperationOutput
         createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
     	err := retry.RetryContext(ctx, createTimeout, func() *retry.RetryError {
     		var err error
-    		output, err = conn.Operation(input)
+    		output, err = conn.Operation(ctx, &input)
 
     		if errs.IsA[*types.ResourceNotFoundException(err) {
     			return retry.RetryableError(err)
@@ -327,7 +327,7 @@ const (
 
     	// Retry AWS Go SDK operation if no response from automatic retries.
     	if tfresource.TimedOut(err) {
-    		output, err = exampleconn.Operation(input)
+    		output, err = conn.Operation(ctx, &input)
     	}
 
     	if err != nil {
@@ -366,12 +366,12 @@ const (
 
     	conn := meta.(*AWSClient).ExampleConn()
 
-    	input := &example.OperationInput{/* ... */}
+    	input := example.OperationInput{/* ... */}
 
     	var output *example.OperationOutput
     	err := retry.RetryContext(ctx, ThingCreationTimeout, func() *retry.RetryError {
     		var err error
-    		output, err = conn.Operation(input)
+    		output, err = conn.Operation(ctx, &input)
 
     		// Retry on any API "not found" errors, but only on new resources.
     		if d.IsNewResource() && tfawserr.ErrorCodeEquals(err, example.ErrCodeResourceNotFoundException) {
@@ -387,7 +387,7 @@ const (
 
     	// Retry AWS Go SDK operation if no response from automatic retries.
     	if tfresource.TimedOut(err) {
-    		output, err = exampleconn.Operation(input)
+    		output, err = conn.Operation(ctx, &input)
     	}
 
     	// Prevent confusing Terraform error messaging to operators by

--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -647,8 +647,8 @@ func TestAccExampleThing_basic(t *testing.T) {
 
 func testAccPreCheckExample(ctx context.Context, t *testing.T) {
   conn := acctest.Provider.Meta().(*conns.AWSClient).ExampleConn(ctx)
-	input := &example.ListThingsInput{}
-	_, err := conn.ListThingsWithContext(ctx, input)
+	input := example.ListThingsInput{}
+	_, err := conn.ListThingsWithContext(ctx, &input)
 	if testAccPreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)
 	}
@@ -1149,12 +1149,12 @@ func sweepThings(region string) error {
   }
 
   conn := client.ExampleConn(ctx)
-  sweepResources := make([]sweep.Sweepable, 0)
+  var sweepResources []sweep.Sweepable
   var errs *multierror.Error
 
-  input := &example.ListThingsInput{}
+  input := example.ListThingsInput{}
 
-  err = conn.ListThingsPages(input, func(page *example.ListThingsOutput, lastPage bool) bool {
+  err = conn.ListThingsPages(ctx, input, func(page *example.ListThingsOutput, lastPage bool) bool {
     if page == nil {
       return !lastPage
     }
@@ -1216,13 +1216,13 @@ func sweepThings(region string) error {
   }
 
   conn := client.ExampleConn(ctx)
-  sweepResources := make([]sweep.Sweepable, 0)
+  var sweepResources []sweep.Sweepable
   var errs *multierror.Error
 
-  input := &example.ListThingsInput{}
+  input := example.ListThingsInput{}
 
   for {
-    output, err := conn.ListThings(input)
+    output, err := conn.ListThings(ctx, &input)
     if awsv1.SkipSweepError(err) {
       log.Printf("[WARN] Skipping Example Thing sweep for %s: %s", region, errs)
       return nil

--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -1154,7 +1154,7 @@ func sweepThings(region string) error {
 
   input := example.ListThingsInput{}
 
-  err = conn.ListThingsPages(ctx, input, func(page *example.ListThingsOutput, lastPage bool) bool {
+  err = conn.ListThingsPages(ctx, &input, func(page *example.ListThingsOutput, lastPage bool) bool {
     if page == nil {
       return !lastPage
     }

--- a/internal/generate/serviceendpointtests/file.gtpl
+++ b/internal/generate/serviceendpointtests/file.gtpl
@@ -521,9 +521,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.{{ .APICall }}(ctx, &{{ .GoPackage }}.{{ .APICall }}Input{
+	input := {{ .GoPackage }}.{{ .APICall }}Input{
 	{{ if ne .APICallParams "" }}{{ .APICallParams }},{{ end }}
-	},
+	}
+	_, err := client.{{ .APICall }}(ctx, &input,
 		func(opts *{{ .GoPackage }}.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/generate/tags/templates/get_tag_body.gtpl
+++ b/internal/generate/tags/templates/get_tag_body.gtpl
@@ -9,7 +9,7 @@ func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{
 func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}, key string, optFns ...func(*{{ .AWSService }}.Options)) (*string, error) {
 {{- end }}
 	{{- if .ListTagsInFiltIDName }}
-	input := &{{ .AWSService  }}.{{ .ListTagsOp }}Input{
+	input := {{ .AWSService  }}.{{ .ListTagsOp }}Input{
 		Filters: []awstypes.Filter{
 			{
 				Name:   aws.String("{{ .ListTagsInFiltIDName }}"),
@@ -22,7 +22,7 @@ func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{
 		},
 	}
 
-	output, err := conn.{{ .ListTagsOp }}(ctx, input, optFns...)
+	output, err := conn.{{ .ListTagsOp }}(ctx, &input, optFns...)
 
 	if err != nil {
 		return nil, err

--- a/internal/generate/tags/templates/list_tags_body.gtpl
+++ b/internal/generate/tags/templates/list_tags_body.gtpl
@@ -2,7 +2,7 @@
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }} string, optFns ...func(*{{ .AWSService }}.Options)) (tftags.KeyValueTags, error) {
-	input := &{{ .TagPackage  }}.{{ .ListTagsOp }}Input{
+	input := {{ .TagPackage  }}.{{ .ListTagsOp }}Input{
 		{{- if .ListTagsInFiltIDName }}
 		Filters: []awstypes.Filter{
 			{
@@ -28,7 +28,7 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 {{- if .ListTagsOpPaginated }}
 	var output []awstypes.{{ or .TagType2 .TagType }}
 
-	pages := {{ .TagPackage  }}.New{{ .ListTagsOp }}Paginator(conn, input)
+	pages := {{ .TagPackage  }}.New{{ .ListTagsOp }}Paginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx, optFns...)
 
@@ -36,14 +36,14 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 			if tfawserr.ErrMessageContains(err, "{{ .ParentNotFoundErrCode }}", "{{ .ParentNotFoundErrMsg }}") {
 				return nil, &retry.NotFoundError{
 					LastError:   err,
-					LastRequest: input,
+					LastRequest: &input,
 				}
 			}
 	{{- else if ( .ParentNotFoundErrCode ) }}
 			if tfawserr.ErrCodeEquals(err, "{{ .ParentNotFoundErrCode }}") {
 				return nil, &retry.NotFoundError{
 					LastError:   err,
-					LastRequest: input,
+					LastRequest: &input,
 				}
 			}
 	{{- end }}
@@ -60,20 +60,20 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 	return {{ .KeyValueTagsFunc }}(ctx, output{{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }}), nil
 {{- else }}
 
-	output, err := conn.{{ .ListTagsOp }}(ctx, input, optFns...)
+	output, err := conn.{{ .ListTagsOp }}(ctx, &input, optFns...)
 
 	{{ if and ( .ParentNotFoundErrCode ) ( .ParentNotFoundErrMsg ) }}
 			if tfawserr.ErrMessageContains(err, "{{ .ParentNotFoundErrCode }}", "{{ .ParentNotFoundErrMsg }}") {
 				return nil, &retry.NotFoundError{
 					LastError:   err,
-					LastRequest: input,
+					LastRequest: &input,
 				}
 			}
 	{{- else if ( .ParentNotFoundErrCode ) }}
 			if tfawserr.ErrCodeEquals(err, "{{ .ParentNotFoundErrCode }}") {
 				return nil, &retry.NotFoundError{
 					LastError:   err,
-					LastRequest: input,
+					LastRequest: &input,
 				}
 			}
 	{{- end }}

--- a/internal/generate/tags/templates/update_tags_body.gtpl
+++ b/internal/generate/tags/templates/update_tags_body.gtpl
@@ -29,7 +29,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		return nil
 	}
 
-	input := &{{ .AWSService }}.{{ .TagOp }}Input{
+	input := {{ .AWSService }}.{{ .TagOp }}Input{
 		{{- if not ( .TagTypeIDElem ) }}
 		{{- if .TagInIDNeedValueSlice }}
 		{{ .TagInIDElem }}: []string{identifier},
@@ -62,7 +62,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		{{- end }}
 	}
 
-	_, err := conn.{{ .TagOp }}(ctx, input, optFns...)
+	_, err := conn.{{ .TagOp }}(ctx, &input, optFns...)
 
 	if err != nil {
 		return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -78,7 +78,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		{{- if .TagOpBatchSize }}
 		for _, removedTags := range removedTags.Chunks({{ .TagOpBatchSize }}) {
 		{{- end }}
-		input := &{{ .TagPackage }}.{{ .UntagOp }}Input{
+		input := {{ .TagPackage }}.{{ .UntagOp }}Input{
 			{{- if not ( .TagTypeIDElem ) }}
 			{{- if .TagInIDNeedValueSlice }}
 			{{ .TagInIDElem }}: []string{identifier},
@@ -104,7 +104,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- end }}
 		}
 
-		_, err := conn.{{ .UntagOp }}(ctx, input, optFns...)
+		_, err := conn.{{ .UntagOp }}(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -122,7 +122,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		{{- if .TagOpBatchSize }}
 		for _, updatedTags := range updatedTags.Chunks({{ .TagOpBatchSize }}) {
 		{{- end }}
-		input := &{{ .TagPackage }}.{{ .TagOp }}Input{
+		input := {{ .TagPackage }}.{{ .TagOp }}Input{
 			{{- if not ( .TagTypeIDElem ) }}
 			{{- if .TagInIDNeedValueSlice }}
 			{{ .TagInIDElem }}: []string{identifier},
@@ -144,7 +144,7 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- end }}
 		}
 
-		_, err := conn.{{ .TagOp }}(ctx, input, optFns...)
+		_, err := conn.{{ .TagOp }}(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/provider/provider_acc_test.go
+++ b/internal/provider/provider_acc_test.go
@@ -727,7 +727,8 @@ func testAccCheckSTSRegion(ctx context.Context, t *testing.T, p **schema.Provide
 		var stsRegion string
 
 		stsClient := (*p).Meta().(*conns.AWSClient).STSClient(ctx)
-		_, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{},
+		input := sts.GetCallerIdentityInput{}
+		_, err := stsClient.GetCallerIdentity(ctx, &input,
 			func(opts *sts.Options) {
 				opts.APIOptions = append(opts.APIOptions,
 					addRegionRetrieverMiddleware(&stsRegion),

--- a/internal/service/accessanalyzer/service_endpoints_gen_test.go
+++ b/internal/service/accessanalyzer/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAnalyzers(ctx, &accessanalyzer.ListAnalyzersInput{},
+	input := accessanalyzer.ListAnalyzersInput{}
+	_, err := client.ListAnalyzers(ctx, &input,
 		func(opts *accessanalyzer.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/accessanalyzer/tags_gen.go
+++ b/internal/service/accessanalyzer/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *accessanalyzer.Client, identifier string, optFns ...func(*accessanalyzer.Options)) (tftags.KeyValueTags, error) {
-	input := &accessanalyzer.ListTagsForResourceInput{
+	input := accessanalyzer.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *accessanalyzer.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AccessAnalyzer)
 	if len(removedTags) > 0 {
-		input := &accessanalyzer.UntagResourceInput{
+		input := accessanalyzer.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *accessanalyzer.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AccessAnalyzer)
 	if len(updatedTags) > 0 {
-		input := &accessanalyzer.TagResourceInput{
+		input := accessanalyzer.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/account/service_endpoints_gen_test.go
+++ b/internal/service/account/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRegions(ctx, &account.ListRegionsInput{},
+	input := account.ListRegionsInput{}
+	_, err := client.ListRegions(ctx, &input,
 		func(opts *account.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/acm/service_endpoints_gen_test.go
+++ b/internal/service/acm/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListCertificates(ctx, &acm.ListCertificatesInput{},
+	input := acm.ListCertificatesInput{}
+	_, err := client.ListCertificates(ctx, &input,
 		func(opts *acm.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/acm/tags_gen.go
+++ b/internal/service/acm/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *acm.Client, identifier string, optFns ...func(*acm.Options)) (tftags.KeyValueTags, error) {
-	input := &acm.ListTagsForCertificateInput{
+	input := acm.ListTagsForCertificateInput{
 		CertificateArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForCertificate(ctx, input, optFns...)
+	output, err := conn.ListTagsForCertificate(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *acm.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ACM)
 	if len(removedTags) > 0 {
-		input := &acm.RemoveTagsFromCertificateInput{
+		input := acm.RemoveTagsFromCertificateInput{
 			CertificateArn: aws.String(identifier),
 			Tags:           Tags(removedTags),
 		}
 
-		_, err := conn.RemoveTagsFromCertificate(ctx, input, optFns...)
+		_, err := conn.RemoveTagsFromCertificate(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *acm.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ACM)
 	if len(updatedTags) > 0 {
-		input := &acm.AddTagsToCertificateInput{
+		input := acm.AddTagsToCertificateInput{
 			CertificateArn: aws.String(identifier),
 			Tags:           Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToCertificate(ctx, input, optFns...)
+		_, err := conn.AddTagsToCertificate(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/acmpca/service_endpoints_gen_test.go
+++ b/internal/service/acmpca/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListCertificateAuthorities(ctx, &acmpca.ListCertificateAuthoritiesInput{},
+	input := acmpca.ListCertificateAuthoritiesInput{}
+	_, err := client.ListCertificateAuthorities(ctx, &input,
 		func(opts *acmpca.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/acmpca/tags_gen.go
+++ b/internal/service/acmpca/tags_gen.go
@@ -20,12 +20,12 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *acmpca.Client, identifier string, optFns ...func(*acmpca.Options)) (tftags.KeyValueTags, error) {
-	input := &acmpca.ListTagsInput{
+	input := acmpca.ListTagsInput{
 		CertificateAuthorityArn: aws.String(identifier),
 	}
 	var output []awstypes.Tag
 
-	pages := acmpca.NewListTagsPaginator(conn, input)
+	pages := acmpca.NewListTagsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx, optFns...)
 
@@ -117,12 +117,12 @@ func updateTags(ctx context.Context, conn *acmpca.Client, identifier string, old
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ACMPCA)
 	if len(removedTags) > 0 {
-		input := &acmpca.UntagCertificateAuthorityInput{
+		input := acmpca.UntagCertificateAuthorityInput{
 			CertificateAuthorityArn: aws.String(identifier),
 			Tags:                    Tags(removedTags),
 		}
 
-		_, err := conn.UntagCertificateAuthority(ctx, input, optFns...)
+		_, err := conn.UntagCertificateAuthority(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -132,12 +132,12 @@ func updateTags(ctx context.Context, conn *acmpca.Client, identifier string, old
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ACMPCA)
 	if len(updatedTags) > 0 {
-		input := &acmpca.TagCertificateAuthorityInput{
+		input := acmpca.TagCertificateAuthorityInput{
 			CertificateAuthorityArn: aws.String(identifier),
 			Tags:                    Tags(updatedTags),
 		}
 
-		_, err := conn.TagCertificateAuthority(ctx, input, optFns...)
+		_, err := conn.TagCertificateAuthority(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/amp/service_endpoints_gen_test.go
+++ b/internal/service/amp/service_endpoints_gen_test.go
@@ -396,7 +396,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListScrapers(ctx, &amp.ListScrapersInput{},
+	input := amp.ListScrapersInput{}
+	_, err := client.ListScrapers(ctx, &input,
 		func(opts *amp.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/amp/tags_gen.go
+++ b/internal/service/amp/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *amp.Client, identifier string, optFns ...func(*amp.Options)) (tftags.KeyValueTags, error) {
-	input := &amp.ListTagsForResourceInput{
+	input := amp.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *amp.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AMP)
 	if len(removedTags) > 0 {
-		input := &amp.UntagResourceInput{
+		input := amp.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *amp.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AMP)
 	if len(updatedTags) > 0 {
-		input := &amp.TagResourceInput{
+		input := amp.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/amplify/service_endpoints_gen_test.go
+++ b/internal/service/amplify/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApps(ctx, &amplify.ListAppsInput{},
+	input := amplify.ListAppsInput{}
+	_, err := client.ListApps(ctx, &input,
 		func(opts *amplify.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/amplify/tags_gen.go
+++ b/internal/service/amplify/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *amplify.Client, identifier string, optFns ...func(*amplify.Options)) (tftags.KeyValueTags, error) {
-	input := &amplify.ListTagsForResourceInput{
+	input := amplify.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *amplify.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Amplify)
 	if len(removedTags) > 0 {
-		input := &amplify.UntagResourceInput{
+		input := amplify.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *amplify.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Amplify)
 	if len(updatedTags) > 0 {
-		input := &amplify.TagResourceInput{
+		input := amplify.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/apigateway/service_endpoints_gen_test.go
+++ b/internal/service/apigateway/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetAccount(ctx, &apigateway.GetAccountInput{},
+	input := apigateway.GetAccountInput{}
+	_, err := client.GetAccount(ctx, &input,
 		func(opts *apigateway.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/apigateway/tags_gen.go
+++ b/internal/service/apigateway/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *apigateway.Client, identifier string, optFns ...func(*apigateway.Options)) (tftags.KeyValueTags, error) {
-	input := &apigateway.GetTagsInput{
+	input := apigateway.GetTagsInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.GetTags(ctx, input, optFns...)
+	output, err := conn.GetTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *apigateway.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.APIGateway)
 	if len(removedTags) > 0 {
-		input := &apigateway.UntagResourceInput{
+		input := apigateway.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *apigateway.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.APIGateway)
 	if len(updatedTags) > 0 {
-		input := &apigateway.TagResourceInput{
+		input := apigateway.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/apigatewayv2/service_endpoints_gen_test.go
+++ b/internal/service/apigatewayv2/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetApis(ctx, &apigatewayv2.GetApisInput{},
+	input := apigatewayv2.GetApisInput{}
+	_, err := client.GetApis(ctx, &input,
 		func(opts *apigatewayv2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/apigatewayv2/tags_gen.go
+++ b/internal/service/apigatewayv2/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *apigatewayv2.Client, identifier string, optFns ...func(*apigatewayv2.Options)) (tftags.KeyValueTags, error) {
-	input := &apigatewayv2.GetTagsInput{
+	input := apigatewayv2.GetTagsInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.GetTags(ctx, input, optFns...)
+	output, err := conn.GetTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *apigatewayv2.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.APIGatewayV2)
 	if len(removedTags) > 0 {
-		input := &apigatewayv2.UntagResourceInput{
+		input := apigatewayv2.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *apigatewayv2.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.APIGatewayV2)
 	if len(updatedTags) > 0 {
-		input := &apigatewayv2.TagResourceInput{
+		input := apigatewayv2.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/appautoscaling/service_endpoints_gen_test.go
+++ b/internal/service/appautoscaling/service_endpoints_gen_test.go
@@ -338,9 +338,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeScalableTargets(ctx, &applicationautoscaling.DescribeScalableTargetsInput{
+	input := applicationautoscaling.DescribeScalableTargetsInput{
 		ServiceNamespace: awstypes.ServiceNamespaceEcs,
-	},
+	}
+	_, err := client.DescribeScalableTargets(ctx, &input,
 		func(opts *applicationautoscaling.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/appautoscaling/tags_gen.go
+++ b/internal/service/appautoscaling/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *applicationautoscaling.Client, identifier string, optFns ...func(*applicationautoscaling.Options)) (tftags.KeyValueTags, error) {
-	input := &applicationautoscaling.ListTagsForResourceInput{
+	input := applicationautoscaling.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *applicationautoscaling.Client, identi
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AppAutoScaling)
 	if len(removedTags) > 0 {
-		input := &applicationautoscaling.UntagResourceInput{
+		input := applicationautoscaling.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *applicationautoscaling.Client, identi
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AppAutoScaling)
 	if len(updatedTags) > 0 {
-		input := &applicationautoscaling.TagResourceInput{
+		input := applicationautoscaling.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/appconfig/service_endpoints_gen_test.go
+++ b/internal/service/appconfig/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &appconfig.ListApplicationsInput{},
+	input := appconfig.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *appconfig.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/appconfig/tags_gen.go
+++ b/internal/service/appconfig/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *appconfig.Client, identifier string, optFns ...func(*appconfig.Options)) (tftags.KeyValueTags, error) {
-	input := &appconfig.ListTagsForResourceInput{
+	input := appconfig.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *appconfig.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AppConfig)
 	if len(removedTags) > 0 {
-		input := &appconfig.UntagResourceInput{
+		input := appconfig.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *appconfig.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AppConfig)
 	if len(updatedTags) > 0 {
-		input := &appconfig.TagResourceInput{
+		input := appconfig.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/appfabric/service_endpoints_gen_test.go
+++ b/internal/service/appfabric/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAppBundles(ctx, &appfabric.ListAppBundlesInput{},
+	input := appfabric.ListAppBundlesInput{}
+	_, err := client.ListAppBundles(ctx, &input,
 		func(opts *appfabric.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/appfabric/tags_gen.go
+++ b/internal/service/appfabric/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *appfabric.Client, identifier string, optFns ...func(*appfabric.Options)) (tftags.KeyValueTags, error) {
-	input := &appfabric.ListTagsForResourceInput{
+	input := appfabric.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *appfabric.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AppFabric)
 	if len(removedTags) > 0 {
-		input := &appfabric.UntagResourceInput{
+		input := appfabric.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *appfabric.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AppFabric)
 	if len(updatedTags) > 0 {
-		input := &appfabric.TagResourceInput{
+		input := appfabric.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/appflow/service_endpoints_gen_test.go
+++ b/internal/service/appflow/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListFlows(ctx, &appflow.ListFlowsInput{},
+	input := appflow.ListFlowsInput{}
+	_, err := client.ListFlows(ctx, &input,
 		func(opts *appflow.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/appflow/tags_gen.go
+++ b/internal/service/appflow/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *appflow.Client, identifier string, optFns ...func(*appflow.Options)) (tftags.KeyValueTags, error) {
-	input := &appflow.ListTagsForResourceInput{
+	input := appflow.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *appflow.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AppFlow)
 	if len(removedTags) > 0 {
-		input := &appflow.UntagResourceInput{
+		input := appflow.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *appflow.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AppFlow)
 	if len(updatedTags) > 0 {
-		input := &appflow.TagResourceInput{
+		input := appflow.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/appintegrations/service_endpoints_gen_test.go
+++ b/internal/service/appintegrations/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &appintegrations.ListApplicationsInput{},
+	input := appintegrations.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *appintegrations.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/appintegrations/tags_gen.go
+++ b/internal/service/appintegrations/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *appintegrations.Client, identifier string, optFns ...func(*appintegrations.Options)) (tftags.KeyValueTags, error) {
-	input := &appintegrations.ListTagsForResourceInput{
+	input := appintegrations.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *appintegrations.Client, identifier st
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AppIntegrations)
 	if len(removedTags) > 0 {
-		input := &appintegrations.UntagResourceInput{
+		input := appintegrations.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *appintegrations.Client, identifier st
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AppIntegrations)
 	if len(updatedTags) > 0 {
-		input := &appintegrations.TagResourceInput{
+		input := appintegrations.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/applicationinsights/service_endpoints_gen_test.go
+++ b/internal/service/applicationinsights/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.CreateApplication(ctx, &applicationinsights.CreateApplicationInput{},
+	input := applicationinsights.CreateApplicationInput{}
+	_, err := client.CreateApplication(ctx, &input,
 		func(opts *applicationinsights.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/applicationinsights/tags_gen.go
+++ b/internal/service/applicationinsights/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *applicationinsights.Client, identifier string, optFns ...func(*applicationinsights.Options)) (tftags.KeyValueTags, error) {
-	input := &applicationinsights.ListTagsForResourceInput{
+	input := applicationinsights.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *applicationinsights.Client, identifie
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ApplicationInsights)
 	if len(removedTags) > 0 {
-		input := &applicationinsights.UntagResourceInput{
+		input := applicationinsights.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *applicationinsights.Client, identifie
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ApplicationInsights)
 	if len(updatedTags) > 0 {
-		input := &applicationinsights.TagResourceInput{
+		input := applicationinsights.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/applicationsignals/service_endpoints_gen_test.go
+++ b/internal/service/applicationsignals/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListServiceLevelObjectives(ctx, &applicationsignals.ListServiceLevelObjectivesInput{},
+	input := applicationsignals.ListServiceLevelObjectivesInput{}
+	_, err := client.ListServiceLevelObjectives(ctx, &input,
 		func(opts *applicationsignals.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/applicationsignals/tags_gen.go
+++ b/internal/service/applicationsignals/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *applicationsignals.Client, identifier string, optFns ...func(*applicationsignals.Options)) (tftags.KeyValueTags, error) {
-	input := &applicationsignals.ListTagsForResourceInput{
+	input := applicationsignals.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *applicationsignals.Client, identifier
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ApplicationSignals)
 	if len(removedTags) > 0 {
-		input := &applicationsignals.UntagResourceInput{
+		input := applicationsignals.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *applicationsignals.Client, identifier
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ApplicationSignals)
 	if len(updatedTags) > 0 {
-		input := &applicationsignals.TagResourceInput{
+		input := applicationsignals.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/appmesh/service_endpoints_gen_test.go
+++ b/internal/service/appmesh/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListMeshes(ctx, &appmesh.ListMeshesInput{},
+	input := appmesh.ListMeshesInput{}
+	_, err := client.ListMeshes(ctx, &input,
 		func(opts *appmesh.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/appmesh/tags_gen.go
+++ b/internal/service/appmesh/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *appmesh.Client, identifier string, optFns ...func(*appmesh.Options)) (tftags.KeyValueTags, error) {
-	input := &appmesh.ListTagsForResourceInput{
+	input := appmesh.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *appmesh.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AppMesh)
 	if len(removedTags) > 0 {
-		input := &appmesh.UntagResourceInput{
+		input := appmesh.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *appmesh.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AppMesh)
 	if len(updatedTags) > 0 {
-		input := &appmesh.TagResourceInput{
+		input := appmesh.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/apprunner/service_endpoints_gen_test.go
+++ b/internal/service/apprunner/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListConnections(ctx, &apprunner.ListConnectionsInput{},
+	input := apprunner.ListConnectionsInput{}
+	_, err := client.ListConnections(ctx, &input,
 		func(opts *apprunner.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/apprunner/tags_gen.go
+++ b/internal/service/apprunner/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *apprunner.Client, identifier string, optFns ...func(*apprunner.Options)) (tftags.KeyValueTags, error) {
-	input := &apprunner.ListTagsForResourceInput{
+	input := apprunner.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *apprunner.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AppRunner)
 	if len(removedTags) > 0 {
-		input := &apprunner.UntagResourceInput{
+		input := apprunner.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *apprunner.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AppRunner)
 	if len(updatedTags) > 0 {
-		input := &apprunner.TagResourceInput{
+		input := apprunner.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/appstream/service_endpoints_gen_test.go
+++ b/internal/service/appstream/service_endpoints_gen_test.go
@@ -283,9 +283,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAssociatedFleets(ctx, &appstream.ListAssociatedFleetsInput{
+	input := appstream.ListAssociatedFleetsInput{
 		StackName: aws.String("test"),
-	},
+	}
+	_, err := client.ListAssociatedFleets(ctx, &input,
 		func(opts *appstream.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/appstream/tags_gen.go
+++ b/internal/service/appstream/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *appstream.Client, identifier string, optFns ...func(*appstream.Options)) (tftags.KeyValueTags, error) {
-	input := &appstream.ListTagsForResourceInput{
+	input := appstream.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *appstream.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AppStream)
 	if len(removedTags) > 0 {
-		input := &appstream.UntagResourceInput{
+		input := appstream.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *appstream.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AppStream)
 	if len(updatedTags) > 0 {
-		input := &appstream.TagResourceInput{
+		input := appstream.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/appsync/service_endpoints_gen_test.go
+++ b/internal/service/appsync/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDomainNames(ctx, &appsync.ListDomainNamesInput{},
+	input := appsync.ListDomainNamesInput{}
+	_, err := client.ListDomainNames(ctx, &input,
 		func(opts *appsync.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/appsync/tags_gen.go
+++ b/internal/service/appsync/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *appsync.Client, identifier string, optFns ...func(*appsync.Options)) (tftags.KeyValueTags, error) {
-	input := &appsync.ListTagsForResourceInput{
+	input := appsync.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *appsync.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AppSync)
 	if len(removedTags) > 0 {
-		input := &appsync.UntagResourceInput{
+		input := appsync.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *appsync.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AppSync)
 	if len(updatedTags) > 0 {
-		input := &appsync.TagResourceInput{
+		input := appsync.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/athena/service_endpoints_gen_test.go
+++ b/internal/service/athena/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDataCatalogs(ctx, &athena.ListDataCatalogsInput{},
+	input := athena.ListDataCatalogsInput{}
+	_, err := client.ListDataCatalogs(ctx, &input,
 		func(opts *athena.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/athena/tags_gen.go
+++ b/internal/service/athena/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *athena.Client, identifier string, optFns ...func(*athena.Options)) (tftags.KeyValueTags, error) {
-	input := &athena.ListTagsForResourceInput{
+	input := athena.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *athena.Client, identifier string, old
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Athena)
 	if len(removedTags) > 0 {
-		input := &athena.UntagResourceInput{
+		input := athena.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *athena.Client, identifier string, old
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Athena)
 	if len(updatedTags) > 0 {
-		input := &athena.TagResourceInput{
+		input := athena.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/auditmanager/service_endpoints_gen_test.go
+++ b/internal/service/auditmanager/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetAccountStatus(ctx, &auditmanager.GetAccountStatusInput{},
+	input := auditmanager.GetAccountStatusInput{}
+	_, err := client.GetAccountStatus(ctx, &input,
 		func(opts *auditmanager.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/auditmanager/tags_gen.go
+++ b/internal/service/auditmanager/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *auditmanager.Client, identifier string, optFns ...func(*auditmanager.Options)) (tftags.KeyValueTags, error) {
-	input := &auditmanager.ListTagsForResourceInput{
+	input := auditmanager.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *auditmanager.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AuditManager)
 	if len(removedTags) > 0 {
-		input := &auditmanager.UntagResourceInput{
+		input := auditmanager.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *auditmanager.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AuditManager)
 	if len(updatedTags) > 0 {
-		input := &auditmanager.TagResourceInput{
+		input := auditmanager.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/autoscaling/service_endpoints_gen_test.go
+++ b/internal/service/autoscaling/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeAutoScalingGroups(ctx, &autoscaling.DescribeAutoScalingGroupsInput{},
+	input := autoscaling.DescribeAutoScalingGroupsInput{}
+	_, err := client.DescribeAutoScalingGroups(ctx, &input,
 		func(opts *autoscaling.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/autoscaling/tags_gen.go
+++ b/internal/service/autoscaling/tags_gen.go
@@ -25,7 +25,7 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func findTag(ctx context.Context, conn *autoscaling.Client, identifier, resourceType, key string, optFns ...func(*autoscaling.Options)) (*tftags.TagData, error) {
-	input := &autoscaling.DescribeTagsInput{
+	input := autoscaling.DescribeTagsInput{
 		Filters: []awstypes.Filter{
 			{
 				Name:   aws.String("auto-scaling-group"),
@@ -38,7 +38,7 @@ func findTag(ctx context.Context, conn *autoscaling.Client, identifier, resource
 		},
 	}
 
-	output, err := conn.DescribeTags(ctx, input, optFns...)
+	output, err := conn.DescribeTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func findTag(ctx context.Context, conn *autoscaling.Client, identifier, resource
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *autoscaling.Client, identifier, resourceType string, optFns ...func(*autoscaling.Options)) (tftags.KeyValueTags, error) {
-	input := &autoscaling.DescribeTagsInput{
+	input := autoscaling.DescribeTagsInput{
 		Filters: []awstypes.Filter{
 			{
 				Name:   aws.String("auto-scaling-group"),
@@ -67,7 +67,7 @@ func listTags(ctx context.Context, conn *autoscaling.Client, identifier, resourc
 	}
 	var output []awstypes.TagDescription
 
-	pages := autoscaling.NewDescribeTagsPaginator(conn, input)
+	pages := autoscaling.NewDescribeTagsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx, optFns...)
 
@@ -253,11 +253,11 @@ func updateTags(ctx context.Context, conn *autoscaling.Client, identifier, resou
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.AutoScaling)
 	if len(removedTags) > 0 {
-		input := &autoscaling.DeleteTagsInput{
+		input := autoscaling.DeleteTagsInput{
 			Tags: Tags(removedTags),
 		}
 
-		_, err := conn.DeleteTags(ctx, input, optFns...)
+		_, err := conn.DeleteTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -267,11 +267,11 @@ func updateTags(ctx context.Context, conn *autoscaling.Client, identifier, resou
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.AutoScaling)
 	if len(updatedTags) > 0 {
-		input := &autoscaling.CreateOrUpdateTagsInput{
+		input := autoscaling.CreateOrUpdateTagsInput{
 			Tags: Tags(updatedTags),
 		}
 
-		_, err := conn.CreateOrUpdateTags(ctx, input, optFns...)
+		_, err := conn.CreateOrUpdateTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/autoscalingplans/service_endpoints_gen_test.go
+++ b/internal/service/autoscalingplans/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeScalingPlans(ctx, &autoscalingplans.DescribeScalingPlansInput{},
+	input := autoscalingplans.DescribeScalingPlansInput{}
+	_, err := client.DescribeScalingPlans(ctx, &input,
 		func(opts *autoscalingplans.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/backup/service_endpoints_gen_test.go
+++ b/internal/service/backup/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListBackupPlans(ctx, &backup.ListBackupPlansInput{},
+	input := backup.ListBackupPlansInput{}
+	_, err := client.ListBackupPlans(ctx, &input,
 		func(opts *backup.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/backup/tags_gen.go
+++ b/internal/service/backup/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *backup.Client, identifier string, optFns ...func(*backup.Options)) (tftags.KeyValueTags, error) {
-	input := &backup.ListTagsInput{
+	input := backup.ListTagsInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTags(ctx, input, optFns...)
+	output, err := conn.ListTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *backup.Client, identifier string, old
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Backup)
 	if len(removedTags) > 0 {
-		input := &backup.UntagResourceInput{
+		input := backup.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeyList:  removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *backup.Client, identifier string, old
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Backup)
 	if len(updatedTags) > 0 {
-		input := &backup.TagResourceInput{
+		input := backup.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/batch/service_endpoints_gen_test.go
+++ b/internal/service/batch/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListJobs(ctx, &batch.ListJobsInput{},
+	input := batch.ListJobsInput{}
+	_, err := client.ListJobs(ctx, &input,
 		func(opts *batch.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/batch/tags_gen.go
+++ b/internal/service/batch/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *batch.Client, identifier string, optFns ...func(*batch.Options)) (tftags.KeyValueTags, error) {
-	input := &batch.ListTagsForResourceInput{
+	input := batch.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *batch.Client, identifier string, oldT
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Batch)
 	if len(removedTags) > 0 {
-		input := &batch.UntagResourceInput{
+		input := batch.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *batch.Client, identifier string, oldT
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Batch)
 	if len(updatedTags) > 0 {
-		input := &batch.TagResourceInput{
+		input := batch.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/bcmdataexports/service_endpoints_gen_test.go
+++ b/internal/service/bcmdataexports/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListExports(ctx, &bcmdataexports.ListExportsInput{},
+	input := bcmdataexports.ListExportsInput{}
+	_, err := client.ListExports(ctx, &input,
 		func(opts *bcmdataexports.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/bcmdataexports/tags_gen.go
+++ b/internal/service/bcmdataexports/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *bcmdataexports.Client, identifier string, optFns ...func(*bcmdataexports.Options)) (tftags.KeyValueTags, error) {
-	input := &bcmdataexports.ListTagsForResourceInput{
+	input := bcmdataexports.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *bcmdataexports.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.BCMDataExports)
 	if len(removedTags) > 0 {
-		input := &bcmdataexports.UntagResourceInput{
+		input := bcmdataexports.UntagResourceInput{
 			ResourceArn:     aws.String(identifier),
 			ResourceTagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *bcmdataexports.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.BCMDataExports)
 	if len(updatedTags) > 0 {
-		input := &bcmdataexports.TagResourceInput{
+		input := bcmdataexports.TagResourceInput{
 			ResourceArn:  aws.String(identifier),
 			ResourceTags: Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/bedrock/service_endpoints_gen_test.go
+++ b/internal/service/bedrock/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListFoundationModels(ctx, &bedrock.ListFoundationModelsInput{},
+	input := bedrock.ListFoundationModelsInput{}
+	_, err := client.ListFoundationModels(ctx, &input,
 		func(opts *bedrock.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/bedrock/tags_gen.go
+++ b/internal/service/bedrock/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *bedrock.Client, identifier string, optFns ...func(*bedrock.Options)) (tftags.KeyValueTags, error) {
-	input := &bedrock.ListTagsForResourceInput{
+	input := bedrock.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *bedrock.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Bedrock)
 	if len(removedTags) > 0 {
-		input := &bedrock.UntagResourceInput{
+		input := bedrock.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *bedrock.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Bedrock)
 	if len(updatedTags) > 0 {
-		input := &bedrock.TagResourceInput{
+		input := bedrock.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/bedrockagent/service_endpoints_gen_test.go
+++ b/internal/service/bedrockagent/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAgents(ctx, &bedrockagent.ListAgentsInput{},
+	input := bedrockagent.ListAgentsInput{}
+	_, err := client.ListAgents(ctx, &input,
 		func(opts *bedrockagent.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/bedrockagent/tags_gen.go
+++ b/internal/service/bedrockagent/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *bedrockagent.Client, identifier string, optFns ...func(*bedrockagent.Options)) (tftags.KeyValueTags, error) {
-	input := &bedrockagent.ListTagsForResourceInput{
+	input := bedrockagent.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *bedrockagent.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.BedrockAgent)
 	if len(removedTags) > 0 {
-		input := &bedrockagent.UntagResourceInput{
+		input := bedrockagent.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *bedrockagent.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.BedrockAgent)
 	if len(updatedTags) > 0 {
-		input := &bedrockagent.TagResourceInput{
+		input := bedrockagent.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/budgets/service_endpoints_gen_test.go
+++ b/internal/service/budgets/service_endpoints_gen_test.go
@@ -284,9 +284,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeBudgets(ctx, &budgets.DescribeBudgetsInput{
+	input := budgets.DescribeBudgetsInput{
 		AccountId: aws.String(acctest.Ct12Digit),
-	},
+	}
+	_, err := client.DescribeBudgets(ctx, &input,
 		func(opts *budgets.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/budgets/tags_gen.go
+++ b/internal/service/budgets/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *budgets.Client, identifier string, optFns ...func(*budgets.Options)) (tftags.KeyValueTags, error) {
-	input := &budgets.ListTagsForResourceInput{
+	input := budgets.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *budgets.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Budgets)
 	if len(removedTags) > 0 {
-		input := &budgets.UntagResourceInput{
+		input := budgets.UntagResourceInput{
 			ResourceARN:     aws.String(identifier),
 			ResourceTagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *budgets.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Budgets)
 	if len(updatedTags) > 0 {
-		input := &budgets.TagResourceInput{
+		input := budgets.TagResourceInput{
 			ResourceARN:  aws.String(identifier),
 			ResourceTags: Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ce/service_endpoints_gen_test.go
+++ b/internal/service/ce/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListCostCategoryDefinitions(ctx, &costexplorer.ListCostCategoryDefinitionsInput{},
+	input := costexplorer.ListCostCategoryDefinitionsInput{}
+	_, err := client.ListCostCategoryDefinitions(ctx, &input,
 		func(opts *costexplorer.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ce/tags_gen.go
+++ b/internal/service/ce/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *costexplorer.Client, identifier string, optFns ...func(*costexplorer.Options)) (tftags.KeyValueTags, error) {
-	input := &costexplorer.ListTagsForResourceInput{
+	input := costexplorer.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *costexplorer.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CE)
 	if len(removedTags) > 0 {
-		input := &costexplorer.UntagResourceInput{
+		input := costexplorer.UntagResourceInput{
 			ResourceArn:     aws.String(identifier),
 			ResourceTagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *costexplorer.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CE)
 	if len(updatedTags) > 0 {
-		input := &costexplorer.TagResourceInput{
+		input := costexplorer.TagResourceInput{
 			ResourceArn:  aws.String(identifier),
 			ResourceTags: Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/chatbot/service_endpoints_gen_test.go
+++ b/internal/service/chatbot/service_endpoints_gen_test.go
@@ -285,7 +285,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetAccountPreferences(ctx, &chatbot.GetAccountPreferencesInput{},
+	input := chatbot.GetAccountPreferencesInput{}
+	_, err := client.GetAccountPreferences(ctx, &input,
 		func(opts *chatbot.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/chatbot/tags_gen.go
+++ b/internal/service/chatbot/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *chatbot.Client, identifier string, optFns ...func(*chatbot.Options)) (tftags.KeyValueTags, error) {
-	input := &chatbot.ListTagsForResourceInput{
+	input := chatbot.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *chatbot.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Chatbot)
 	if len(removedTags) > 0 {
-		input := &chatbot.UntagResourceInput{
+		input := chatbot.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *chatbot.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Chatbot)
 	if len(updatedTags) > 0 {
-		input := &chatbot.TagResourceInput{
+		input := chatbot.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/chime/service_endpoints_gen_test.go
+++ b/internal/service/chime/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAccounts(ctx, &chime.ListAccountsInput{},
+	input := chime.ListAccountsInput{}
+	_, err := client.ListAccounts(ctx, &input,
 		func(opts *chime.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/chime/tags_gen.go
+++ b/internal/service/chime/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string, optFns ...func(*chimesdkvoice.Options)) (tftags.KeyValueTags, error) {
-	input := &chimesdkvoice.ListTagsForResourceInput{
+	input := chimesdkvoice.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ChimeSDKVoice)
 	if len(removedTags) > 0 {
-		input := &chimesdkvoice.UntagResourceInput{
+		input := chimesdkvoice.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ChimeSDKVoice)
 	if len(updatedTags) > 0 {
-		input := &chimesdkvoice.TagResourceInput{
+		input := chimesdkvoice.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/chimesdkmediapipelines/service_endpoints_gen_test.go
+++ b/internal/service/chimesdkmediapipelines/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListMediaPipelines(ctx, &chimesdkmediapipelines.ListMediaPipelinesInput{},
+	input := chimesdkmediapipelines.ListMediaPipelinesInput{}
+	_, err := client.ListMediaPipelines(ctx, &input,
 		func(opts *chimesdkmediapipelines.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/chimesdkmediapipelines/tags_gen.go
+++ b/internal/service/chimesdkmediapipelines/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *chimesdkmediapipelines.Client, identifier string, optFns ...func(*chimesdkmediapipelines.Options)) (tftags.KeyValueTags, error) {
-	input := &chimesdkmediapipelines.ListTagsForResourceInput{
+	input := chimesdkmediapipelines.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *chimesdkmediapipelines.Client, identi
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ChimeSDKMediaPipelines)
 	if len(removedTags) > 0 {
-		input := &chimesdkmediapipelines.UntagResourceInput{
+		input := chimesdkmediapipelines.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *chimesdkmediapipelines.Client, identi
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ChimeSDKMediaPipelines)
 	if len(updatedTags) > 0 {
-		input := &chimesdkmediapipelines.TagResourceInput{
+		input := chimesdkmediapipelines.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/chimesdkvoice/service_endpoints_gen_test.go
+++ b/internal/service/chimesdkvoice/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListPhoneNumbers(ctx, &chimesdkvoice.ListPhoneNumbersInput{},
+	input := chimesdkvoice.ListPhoneNumbersInput{}
+	_, err := client.ListPhoneNumbers(ctx, &input,
 		func(opts *chimesdkvoice.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/chimesdkvoice/tags_gen.go
+++ b/internal/service/chimesdkvoice/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *chimesdkvoice.Client, identifier string, optFns ...func(*chimesdkvoice.Options)) (tftags.KeyValueTags, error) {
-	input := &chimesdkvoice.ListTagsForResourceInput{
+	input := chimesdkvoice.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ChimeSDKVoice)
 	if len(removedTags) > 0 {
-		input := &chimesdkvoice.UntagResourceInput{
+		input := chimesdkvoice.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *chimesdkvoice.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ChimeSDKVoice)
 	if len(updatedTags) > 0 {
-		input := &chimesdkvoice.TagResourceInput{
+		input := chimesdkvoice.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/cleanrooms/service_endpoints_gen_test.go
+++ b/internal/service/cleanrooms/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListCollaborations(ctx, &cleanrooms.ListCollaborationsInput{},
+	input := cleanrooms.ListCollaborationsInput{}
+	_, err := client.ListCollaborations(ctx, &input,
 		func(opts *cleanrooms.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cleanrooms/tags_gen.go
+++ b/internal/service/cleanrooms/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *cleanrooms.Client, identifier string, optFns ...func(*cleanrooms.Options)) (tftags.KeyValueTags, error) {
-	input := &cleanrooms.ListTagsForResourceInput{
+	input := cleanrooms.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *cleanrooms.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CleanRooms)
 	if len(removedTags) > 0 {
-		input := &cleanrooms.UntagResourceInput{
+		input := cleanrooms.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *cleanrooms.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CleanRooms)
 	if len(updatedTags) > 0 {
-		input := &cleanrooms.TagResourceInput{
+		input := cleanrooms.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/cloud9/service_endpoints_gen_test.go
+++ b/internal/service/cloud9/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListEnvironments(ctx, &cloud9.ListEnvironmentsInput{},
+	input := cloud9.ListEnvironmentsInput{}
+	_, err := client.ListEnvironments(ctx, &input,
 		func(opts *cloud9.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cloud9/tags_gen.go
+++ b/internal/service/cloud9/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *cloud9.Client, identifier string, optFns ...func(*cloud9.Options)) (tftags.KeyValueTags, error) {
-	input := &cloud9.ListTagsForResourceInput{
+	input := cloud9.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *cloud9.Client, identifier string, old
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Cloud9)
 	if len(removedTags) > 0 {
-		input := &cloud9.UntagResourceInput{
+		input := cloud9.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *cloud9.Client, identifier string, old
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Cloud9)
 	if len(updatedTags) > 0 {
-		input := &cloud9.TagResourceInput{
+		input := cloud9.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/cloudcontrol/service_endpoints_gen_test.go
+++ b/internal/service/cloudcontrol/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListResourceRequests(ctx, &cloudcontrol.ListResourceRequestsInput{},
+	input := cloudcontrol.ListResourceRequestsInput{}
+	_, err := client.ListResourceRequests(ctx, &input,
 		func(opts *cloudcontrol.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cloudformation/service_endpoints_gen_test.go
+++ b/internal/service/cloudformation/service_endpoints_gen_test.go
@@ -283,9 +283,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListStackInstances(ctx, &cloudformation.ListStackInstancesInput{
+	input := cloudformation.ListStackInstancesInput{
 		StackSetName: aws.String("test"),
-	},
+	}
+	_, err := client.ListStackInstances(ctx, &input,
 		func(opts *cloudformation.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cloudfront/service_endpoints_gen_test.go
+++ b/internal/service/cloudfront/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDistributions(ctx, &cloudfront.ListDistributionsInput{},
+	input := cloudfront.ListDistributionsInput{}
+	_, err := client.ListDistributions(ctx, &input,
 		func(opts *cloudfront.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cloudfront/tags_gen.go
+++ b/internal/service/cloudfront/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *cloudfront.Client, identifier string, optFns ...func(*cloudfront.Options)) (tftags.KeyValueTags, error) {
-	input := &cloudfront.ListTagsForResourceInput{
+	input := cloudfront.ListTagsForResourceInput{
 		Resource: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *cloudfront.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CloudFront)
 	if len(removedTags) > 0 {
-		input := &cloudfront.UntagResourceInput{
+		input := cloudfront.UntagResourceInput{
 			Resource: aws.String(identifier),
 			TagKeys:  &awstypes.TagKeys{Items: removedTags.Keys()},
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *cloudfront.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CloudFront)
 	if len(updatedTags) > 0 {
-		input := &cloudfront.TagResourceInput{
+		input := cloudfront.TagResourceInput{
 			Resource: aws.String(identifier),
 			Tags:     &awstypes.Tags{Items: Tags(updatedTags)},
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/cloudhsmv2/service_endpoints_gen_test.go
+++ b/internal/service/cloudhsmv2/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeClusters(ctx, &cloudhsmv2.DescribeClustersInput{},
+	input := cloudhsmv2.DescribeClustersInput{}
+	_, err := client.DescribeClusters(ctx, &input,
 		func(opts *cloudhsmv2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cloudhsmv2/tags_gen.go
+++ b/internal/service/cloudhsmv2/tags_gen.go
@@ -20,12 +20,12 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *cloudhsmv2.Client, identifier string, optFns ...func(*cloudhsmv2.Options)) (tftags.KeyValueTags, error) {
-	input := &cloudhsmv2.ListTagsInput{
+	input := cloudhsmv2.ListTagsInput{
 		ResourceId: aws.String(identifier),
 	}
 	var output []awstypes.Tag
 
-	pages := cloudhsmv2.NewListTagsPaginator(conn, input)
+	pages := cloudhsmv2.NewListTagsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx, optFns...)
 
@@ -117,12 +117,12 @@ func updateTags(ctx context.Context, conn *cloudhsmv2.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CloudHSMV2)
 	if len(removedTags) > 0 {
-		input := &cloudhsmv2.UntagResourceInput{
+		input := cloudhsmv2.UntagResourceInput{
 			ResourceId: aws.String(identifier),
 			TagKeyList: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -132,12 +132,12 @@ func updateTags(ctx context.Context, conn *cloudhsmv2.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CloudHSMV2)
 	if len(updatedTags) > 0 {
-		input := &cloudhsmv2.TagResourceInput{
+		input := cloudhsmv2.TagResourceInput{
 			ResourceId: aws.String(identifier),
 			TagList:    Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/cloudsearch/service_endpoints_gen_test.go
+++ b/internal/service/cloudsearch/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDomainNames(ctx, &cloudsearch.ListDomainNamesInput{},
+	input := cloudsearch.ListDomainNamesInput{}
+	_, err := client.ListDomainNames(ctx, &input,
 		func(opts *cloudsearch.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cloudtrail/service_endpoints_gen_test.go
+++ b/internal/service/cloudtrail/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListChannels(ctx, &cloudtrail.ListChannelsInput{},
+	input := cloudtrail.ListChannelsInput{}
+	_, err := client.ListChannels(ctx, &input,
 		func(opts *cloudtrail.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cloudtrail/tags_gen.go
+++ b/internal/service/cloudtrail/tags_gen.go
@@ -20,12 +20,12 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *cloudtrail.Client, identifier string, optFns ...func(*cloudtrail.Options)) (tftags.KeyValueTags, error) {
-	input := &cloudtrail.ListTagsInput{
+	input := cloudtrail.ListTagsInput{
 		ResourceIdList: []string{identifier},
 	}
 	var output []awstypes.Tag
 
-	pages := cloudtrail.NewListTagsPaginator(conn, input)
+	pages := cloudtrail.NewListTagsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx, optFns...)
 
@@ -117,12 +117,12 @@ func updateTags(ctx context.Context, conn *cloudtrail.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CloudTrail)
 	if len(removedTags) > 0 {
-		input := &cloudtrail.RemoveTagsInput{
+		input := cloudtrail.RemoveTagsInput{
 			ResourceId: aws.String(identifier),
 			TagsList:   Tags(removedTags),
 		}
 
-		_, err := conn.RemoveTags(ctx, input, optFns...)
+		_, err := conn.RemoveTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -132,12 +132,12 @@ func updateTags(ctx context.Context, conn *cloudtrail.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CloudTrail)
 	if len(updatedTags) > 0 {
-		input := &cloudtrail.AddTagsInput{
+		input := cloudtrail.AddTagsInput{
 			ResourceId: aws.String(identifier),
 			TagsList:   Tags(updatedTags),
 		}
 
-		_, err := conn.AddTags(ctx, input, optFns...)
+		_, err := conn.AddTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/cloudwatch/service_endpoints_gen_test.go
+++ b/internal/service/cloudwatch/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDashboards(ctx, &cloudwatch.ListDashboardsInput{},
+	input := cloudwatch.ListDashboardsInput{}
+	_, err := client.ListDashboards(ctx, &input,
 		func(opts *cloudwatch.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cloudwatch/tags_gen.go
+++ b/internal/service/cloudwatch/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *cloudwatch.Client, identifier string, optFns ...func(*cloudwatch.Options)) (tftags.KeyValueTags, error) {
-	input := &cloudwatch.ListTagsForResourceInput{
+	input := cloudwatch.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *cloudwatch.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CloudWatch)
 	if len(removedTags) > 0 {
-		input := &cloudwatch.UntagResourceInput{
+		input := cloudwatch.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *cloudwatch.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CloudWatch)
 	if len(updatedTags) > 0 {
-		input := &cloudwatch.TagResourceInput{
+		input := cloudwatch.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codeartifact/service_endpoints_gen_test.go
+++ b/internal/service/codeartifact/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDomains(ctx, &codeartifact.ListDomainsInput{},
+	input := codeartifact.ListDomainsInput{}
+	_, err := client.ListDomains(ctx, &input,
 		func(opts *codeartifact.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/codeartifact/tags_gen.go
+++ b/internal/service/codeartifact/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *codeartifact.Client, identifier string, optFns ...func(*codeartifact.Options)) (tftags.KeyValueTags, error) {
-	input := &codeartifact.ListTagsForResourceInput{
+	input := codeartifact.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *codeartifact.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CodeArtifact)
 	if len(removedTags) > 0 {
-		input := &codeartifact.UntagResourceInput{
+		input := codeartifact.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *codeartifact.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CodeArtifact)
 	if len(updatedTags) > 0 {
-		input := &codeartifact.TagResourceInput{
+		input := codeartifact.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codebuild/service_endpoints_gen_test.go
+++ b/internal/service/codebuild/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListBuildBatches(ctx, &codebuild.ListBuildBatchesInput{},
+	input := codebuild.ListBuildBatchesInput{}
+	_, err := client.ListBuildBatches(ctx, &input,
 		func(opts *codebuild.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/codecommit/service_endpoints_gen_test.go
+++ b/internal/service/codecommit/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRepositories(ctx, &codecommit.ListRepositoriesInput{},
+	input := codecommit.ListRepositoriesInput{}
+	_, err := client.ListRepositories(ctx, &input,
 		func(opts *codecommit.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/codecommit/tags_gen.go
+++ b/internal/service/codecommit/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *codecommit.Client, identifier string, optFns ...func(*codecommit.Options)) (tftags.KeyValueTags, error) {
-	input := &codecommit.ListTagsForResourceInput{
+	input := codecommit.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *codecommit.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CodeCommit)
 	if len(removedTags) > 0 {
-		input := &codecommit.UntagResourceInput{
+		input := codecommit.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *codecommit.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CodeCommit)
 	if len(updatedTags) > 0 {
-		input := &codecommit.TagResourceInput{
+		input := codecommit.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codeconnections/service_endpoints_gen_test.go
+++ b/internal/service/codeconnections/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListConnections(ctx, &codeconnections.ListConnectionsInput{},
+	input := codeconnections.ListConnectionsInput{}
+	_, err := client.ListConnections(ctx, &input,
 		func(opts *codeconnections.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/codeconnections/tags_gen.go
+++ b/internal/service/codeconnections/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *codeconnections.Client, identifier string, optFns ...func(*codeconnections.Options)) (tftags.KeyValueTags, error) {
-	input := &codeconnections.ListTagsForResourceInput{
+	input := codeconnections.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *codeconnections.Client, identifier st
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CodeConnections)
 	if len(removedTags) > 0 {
-		input := &codeconnections.UntagResourceInput{
+		input := codeconnections.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *codeconnections.Client, identifier st
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CodeConnections)
 	if len(updatedTags) > 0 {
-		input := &codeconnections.TagResourceInput{
+		input := codeconnections.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codeguruprofiler/service_endpoints_gen_test.go
+++ b/internal/service/codeguruprofiler/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListProfilingGroups(ctx, &codeguruprofiler.ListProfilingGroupsInput{},
+	input := codeguruprofiler.ListProfilingGroupsInput{}
+	_, err := client.ListProfilingGroups(ctx, &input,
 		func(opts *codeguruprofiler.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/codeguruprofiler/tags_gen.go
+++ b/internal/service/codeguruprofiler/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *codeguruprofiler.Client, identifier string, optFns ...func(*codeguruprofiler.Options)) (tftags.KeyValueTags, error) {
-	input := &codeguruprofiler.ListTagsForResourceInput{
+	input := codeguruprofiler.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *codeguruprofiler.Client, identifier s
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CodeGuruProfiler)
 	if len(removedTags) > 0 {
-		input := &codeguruprofiler.UntagResourceInput{
+		input := codeguruprofiler.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *codeguruprofiler.Client, identifier s
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CodeGuruProfiler)
 	if len(updatedTags) > 0 {
-		input := &codeguruprofiler.TagResourceInput{
+		input := codeguruprofiler.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codegurureviewer/service_endpoints_gen_test.go
+++ b/internal/service/codegurureviewer/service_endpoints_gen_test.go
@@ -284,9 +284,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListCodeReviews(ctx, &codegurureviewer.ListCodeReviewsInput{
+	input := codegurureviewer.ListCodeReviewsInput{
 		Type: awstypes.TypePullRequest,
-	},
+	}
+	_, err := client.ListCodeReviews(ctx, &input,
 		func(opts *codegurureviewer.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/codegurureviewer/tags_gen.go
+++ b/internal/service/codegurureviewer/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *codegurureviewer.Client, identifier string, optFns ...func(*codegurureviewer.Options)) (tftags.KeyValueTags, error) {
-	input := &codegurureviewer.ListTagsForResourceInput{
+	input := codegurureviewer.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *codegurureviewer.Client, identifier s
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CodeGuruReviewer)
 	if len(removedTags) > 0 {
-		input := &codegurureviewer.UntagResourceInput{
+		input := codegurureviewer.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *codegurureviewer.Client, identifier s
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CodeGuruReviewer)
 	if len(updatedTags) > 0 {
-		input := &codegurureviewer.TagResourceInput{
+		input := codegurureviewer.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codepipeline/service_endpoints_gen_test.go
+++ b/internal/service/codepipeline/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListPipelines(ctx, &codepipeline.ListPipelinesInput{},
+	input := codepipeline.ListPipelinesInput{}
+	_, err := client.ListPipelines(ctx, &input,
 		func(opts *codepipeline.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/codepipeline/tags_gen.go
+++ b/internal/service/codepipeline/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *codepipeline.Client, identifier string, optFns ...func(*codepipeline.Options)) (tftags.KeyValueTags, error) {
-	input := &codepipeline.ListTagsForResourceInput{
+	input := codepipeline.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *codepipeline.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CodePipeline)
 	if len(removedTags) > 0 {
-		input := &codepipeline.UntagResourceInput{
+		input := codepipeline.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *codepipeline.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CodePipeline)
 	if len(updatedTags) > 0 {
-		input := &codepipeline.TagResourceInput{
+		input := codepipeline.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codestarconnections/service_endpoints_gen_test.go
+++ b/internal/service/codestarconnections/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListConnections(ctx, &codestarconnections.ListConnectionsInput{},
+	input := codestarconnections.ListConnectionsInput{}
+	_, err := client.ListConnections(ctx, &input,
 		func(opts *codestarconnections.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/codestarconnections/tags_gen.go
+++ b/internal/service/codestarconnections/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *codestarconnections.Client, identifier string, optFns ...func(*codestarconnections.Options)) (tftags.KeyValueTags, error) {
-	input := &codestarconnections.ListTagsForResourceInput{
+	input := codestarconnections.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *codestarconnections.Client, identifie
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CodeStarConnections)
 	if len(removedTags) > 0 {
-		input := &codestarconnections.UntagResourceInput{
+		input := codestarconnections.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *codestarconnections.Client, identifie
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CodeStarConnections)
 	if len(updatedTags) > 0 {
-		input := &codestarconnections.TagResourceInput{
+		input := codestarconnections.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/codestarnotifications/service_endpoints_gen_test.go
+++ b/internal/service/codestarnotifications/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListTargets(ctx, &codestarnotifications.ListTargetsInput{},
+	input := codestarnotifications.ListTargetsInput{}
+	_, err := client.ListTargets(ctx, &input,
 		func(opts *codestarnotifications.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/codestarnotifications/tags_gen.go
+++ b/internal/service/codestarnotifications/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *codestarnotifications.Client, identifier string, optFns ...func(*codestarnotifications.Options)) (tftags.KeyValueTags, error) {
-	input := &codestarnotifications.ListTagsForResourceInput{
+	input := codestarnotifications.ListTagsForResourceInput{
 		Arn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *codestarnotifications.Client, identif
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CodeStarNotifications)
 	if len(removedTags) > 0 {
-		input := &codestarnotifications.UntagResourceInput{
+		input := codestarnotifications.UntagResourceInput{
 			Arn:     aws.String(identifier),
 			TagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *codestarnotifications.Client, identif
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CodeStarNotifications)
 	if len(updatedTags) > 0 {
-		input := &codestarnotifications.TagResourceInput{
+		input := codestarnotifications.TagResourceInput{
 			Arn:  aws.String(identifier),
 			Tags: Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/cognitoidentity/service_endpoints_gen_test.go
+++ b/internal/service/cognitoidentity/service_endpoints_gen_test.go
@@ -283,9 +283,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListIdentityPools(ctx, &cognitoidentity.ListIdentityPoolsInput{
+	input := cognitoidentity.ListIdentityPoolsInput{
 		MaxResults: aws.Int32(1),
-	},
+	}
+	_, err := client.ListIdentityPools(ctx, &input,
 		func(opts *cognitoidentity.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cognitoidentity/tags_gen.go
+++ b/internal/service/cognitoidentity/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *cognitoidentity.Client, identifier string, optFns ...func(*cognitoidentity.Options)) (tftags.KeyValueTags, error) {
-	input := &cognitoidentity.ListTagsForResourceInput{
+	input := cognitoidentity.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *cognitoidentity.Client, identifier st
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CognitoIdentity)
 	if len(removedTags) > 0 {
-		input := &cognitoidentity.UntagResourceInput{
+		input := cognitoidentity.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *cognitoidentity.Client, identifier st
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CognitoIdentity)
 	if len(updatedTags) > 0 {
-		input := &cognitoidentity.TagResourceInput{
+		input := cognitoidentity.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/cognitoidp/service_endpoints_gen_test.go
+++ b/internal/service/cognitoidp/service_endpoints_gen_test.go
@@ -337,9 +337,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListUserPools(ctx, &cognitoidentityprovider.ListUserPoolsInput{
+	input := cognitoidentityprovider.ListUserPoolsInput{
 		MaxResults: aws.Int32(1),
-	},
+	}
+	_, err := client.ListUserPools(ctx, &input,
 		func(opts *cognitoidentityprovider.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cognitoidp/tags_gen.go
+++ b/internal/service/cognitoidp/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *cognitoidentityprovider.Client, identifier string, optFns ...func(*cognitoidentityprovider.Options)) (tftags.KeyValueTags, error) {
-	input := &cognitoidentityprovider.ListTagsForResourceInput{
+	input := cognitoidentityprovider.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *cognitoidentityprovider.Client, ident
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CognitoIDP)
 	if len(removedTags) > 0 {
-		input := &cognitoidentityprovider.UntagResourceInput{
+		input := cognitoidentityprovider.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *cognitoidentityprovider.Client, ident
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CognitoIDP)
 	if len(updatedTags) > 0 {
-		input := &cognitoidentityprovider.TagResourceInput{
+		input := cognitoidentityprovider.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/comprehend/service_endpoints_gen_test.go
+++ b/internal/service/comprehend/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDocumentClassifiers(ctx, &comprehend.ListDocumentClassifiersInput{},
+	input := comprehend.ListDocumentClassifiersInput{}
+	_, err := client.ListDocumentClassifiers(ctx, &input,
 		func(opts *comprehend.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/comprehend/tags_gen.go
+++ b/internal/service/comprehend/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *comprehend.Client, identifier string, optFns ...func(*comprehend.Options)) (tftags.KeyValueTags, error) {
-	input := &comprehend.ListTagsForResourceInput{
+	input := comprehend.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *comprehend.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Comprehend)
 	if len(removedTags) > 0 {
-		input := &comprehend.UntagResourceInput{
+		input := comprehend.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *comprehend.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Comprehend)
 	if len(updatedTags) > 0 {
-		input := &comprehend.TagResourceInput{
+		input := comprehend.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/computeoptimizer/service_endpoints_gen_test.go
+++ b/internal/service/computeoptimizer/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetEnrollmentStatus(ctx, &computeoptimizer.GetEnrollmentStatusInput{},
+	input := computeoptimizer.GetEnrollmentStatusInput{}
+	_, err := client.GetEnrollmentStatus(ctx, &input,
 		func(opts *computeoptimizer.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/configservice/service_endpoints_gen_test.go
+++ b/internal/service/configservice/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListStoredQueries(ctx, &configservice.ListStoredQueriesInput{},
+	input := configservice.ListStoredQueriesInput{}
+	_, err := client.ListStoredQueries(ctx, &input,
 		func(opts *configservice.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/configservice/tags_gen.go
+++ b/internal/service/configservice/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *configservice.Client, identifier string, optFns ...func(*configservice.Options)) (tftags.KeyValueTags, error) {
-	input := &configservice.ListTagsForResourceInput{
+	input := configservice.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *configservice.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ConfigService)
 	if len(removedTags) > 0 {
-		input := &configservice.UntagResourceInput{
+		input := configservice.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *configservice.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ConfigService)
 	if len(updatedTags) > 0 {
-		input := &configservice.TagResourceInput{
+		input := configservice.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/connect/service_endpoints_gen_test.go
+++ b/internal/service/connect/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListInstances(ctx, &connect.ListInstancesInput{},
+	input := connect.ListInstancesInput{}
+	_, err := client.ListInstances(ctx, &input,
 		func(opts *connect.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/connect/tags_gen.go
+++ b/internal/service/connect/tags_gen.go
@@ -58,12 +58,12 @@ func updateTags(ctx context.Context, conn *connect.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Connect)
 	if len(removedTags) > 0 {
-		input := &connect.UntagResourceInput{
+		input := connect.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -73,12 +73,12 @@ func updateTags(ctx context.Context, conn *connect.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Connect)
 	if len(updatedTags) > 0 {
-		input := &connect.TagResourceInput{
+		input := connect.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/connectcases/service_endpoints_gen_test.go
+++ b/internal/service/connectcases/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDomains(ctx, &connectcases.ListDomainsInput{},
+	input := connectcases.ListDomainsInput{}
+	_, err := client.ListDomains(ctx, &input,
 		func(opts *connectcases.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/controltower/service_endpoints_gen_test.go
+++ b/internal/service/controltower/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListLandingZones(ctx, &controltower.ListLandingZonesInput{},
+	input := controltower.ListLandingZonesInput{}
+	_, err := client.ListLandingZones(ctx, &input,
 		func(opts *controltower.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/controltower/tags_gen.go
+++ b/internal/service/controltower/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *controltower.Client, identifier string, optFns ...func(*controltower.Options)) (tftags.KeyValueTags, error) {
-	input := &controltower.ListTagsForResourceInput{
+	input := controltower.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *controltower.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ControlTower)
 	if len(removedTags) > 0 {
-		input := &controltower.UntagResourceInput{
+		input := controltower.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *controltower.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ControlTower)
 	if len(updatedTags) > 0 {
-		input := &controltower.TagResourceInput{
+		input := controltower.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/costoptimizationhub/service_endpoints_gen_test.go
+++ b/internal/service/costoptimizationhub/service_endpoints_gen_test.go
@@ -285,7 +285,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetPreferences(ctx, &costoptimizationhub.GetPreferencesInput{},
+	input := costoptimizationhub.GetPreferencesInput{}
+	_, err := client.GetPreferences(ctx, &input,
 		func(opts *costoptimizationhub.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cur/service_endpoints_gen_test.go
+++ b/internal/service/cur/service_endpoints_gen_test.go
@@ -339,7 +339,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeReportDefinitions(ctx, &costandusagereportservice.DescribeReportDefinitionsInput{},
+	input := costandusagereportservice.DescribeReportDefinitionsInput{}
+	_, err := client.DescribeReportDefinitions(ctx, &input,
 		func(opts *costandusagereportservice.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/cur/tags_gen.go
+++ b/internal/service/cur/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *costandusagereportservice.Client, identifier string, optFns ...func(*costandusagereportservice.Options)) (tftags.KeyValueTags, error) {
-	input := &costandusagereportservice.ListTagsForResourceInput{
+	input := costandusagereportservice.ListTagsForResourceInput{
 		ReportName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *costandusagereportservice.Client, ide
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CUR)
 	if len(removedTags) > 0 {
-		input := &costandusagereportservice.UntagResourceInput{
+		input := costandusagereportservice.UntagResourceInput{
 			ReportName: aws.String(identifier),
 			TagKeys:    removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *costandusagereportservice.Client, ide
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CUR)
 	if len(updatedTags) > 0 {
-		input := &costandusagereportservice.TagResourceInput{
+		input := costandusagereportservice.TagResourceInput{
 			ReportName: aws.String(identifier),
 			Tags:       Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/customerprofiles/service_endpoints_gen_test.go
+++ b/internal/service/customerprofiles/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDomains(ctx, &customerprofiles.ListDomainsInput{},
+	input := customerprofiles.ListDomainsInput{}
+	_, err := client.ListDomains(ctx, &input,
 		func(opts *customerprofiles.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/customerprofiles/tags_gen.go
+++ b/internal/service/customerprofiles/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *customerprofiles.Client, identifier string, optFns ...func(*customerprofiles.Options)) (tftags.KeyValueTags, error) {
-	input := &customerprofiles.ListTagsForResourceInput{
+	input := customerprofiles.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *customerprofiles.Client, identifier s
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.CustomerProfiles)
 	if len(removedTags) > 0 {
-		input := &customerprofiles.UntagResourceInput{
+		input := customerprofiles.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *customerprofiles.Client, identifier s
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.CustomerProfiles)
 	if len(updatedTags) > 0 {
-		input := &customerprofiles.TagResourceInput{
+		input := customerprofiles.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/databrew/service_endpoints_gen_test.go
+++ b/internal/service/databrew/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListProjects(ctx, &databrew.ListProjectsInput{},
+	input := databrew.ListProjectsInput{}
+	_, err := client.ListProjects(ctx, &input,
 		func(opts *databrew.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/databrew/tags_gen.go
+++ b/internal/service/databrew/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *databrew.Client, identifier string, optFns ...func(*databrew.Options)) (tftags.KeyValueTags, error) {
-	input := &databrew.ListTagsForResourceInput{
+	input := databrew.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *databrew.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DataBrew)
 	if len(removedTags) > 0 {
-		input := &databrew.UntagResourceInput{
+		input := databrew.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *databrew.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DataBrew)
 	if len(updatedTags) > 0 {
-		input := &databrew.TagResourceInput{
+		input := databrew.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/dataexchange/service_endpoints_gen_test.go
+++ b/internal/service/dataexchange/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDataSets(ctx, &dataexchange.ListDataSetsInput{},
+	input := dataexchange.ListDataSetsInput{}
+	_, err := client.ListDataSets(ctx, &input,
 		func(opts *dataexchange.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/dataexchange/tags_gen.go
+++ b/internal/service/dataexchange/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *dataexchange.Client, identifier string, optFns ...func(*dataexchange.Options)) (tftags.KeyValueTags, error) {
-	input := &dataexchange.ListTagsForResourceInput{
+	input := dataexchange.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *dataexchange.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DataExchange)
 	if len(removedTags) > 0 {
-		input := &dataexchange.UntagResourceInput{
+		input := dataexchange.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *dataexchange.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DataExchange)
 	if len(updatedTags) > 0 {
-		input := &dataexchange.TagResourceInput{
+		input := dataexchange.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/datapipeline/service_endpoints_gen_test.go
+++ b/internal/service/datapipeline/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListPipelines(ctx, &datapipeline.ListPipelinesInput{},
+	input := datapipeline.ListPipelinesInput{}
+	_, err := client.ListPipelines(ctx, &input,
 		func(opts *datapipeline.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/datapipeline/tags_gen.go
+++ b/internal/service/datapipeline/tags_gen.go
@@ -76,12 +76,12 @@ func updateTags(ctx context.Context, conn *datapipeline.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DataPipeline)
 	if len(removedTags) > 0 {
-		input := &datapipeline.RemoveTagsInput{
+		input := datapipeline.RemoveTagsInput{
 			PipelineId: aws.String(identifier),
 			TagKeys:    removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTags(ctx, input, optFns...)
+		_, err := conn.RemoveTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *datapipeline.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DataPipeline)
 	if len(updatedTags) > 0 {
-		input := &datapipeline.AddTagsInput{
+		input := datapipeline.AddTagsInput{
 			PipelineId: aws.String(identifier),
 			Tags:       Tags(updatedTags),
 		}
 
-		_, err := conn.AddTags(ctx, input, optFns...)
+		_, err := conn.AddTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/datasync/service_endpoints_gen_test.go
+++ b/internal/service/datasync/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAgents(ctx, &datasync.ListAgentsInput{},
+	input := datasync.ListAgentsInput{}
+	_, err := client.ListAgents(ctx, &input,
 		func(opts *datasync.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/datasync/tags_gen.go
+++ b/internal/service/datasync/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *datasync.Client, identifier string, optFns ...func(*datasync.Options)) (tftags.KeyValueTags, error) {
-	input := &datasync.ListTagsForResourceInput{
+	input := datasync.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *datasync.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DataSync)
 	if len(removedTags) > 0 {
-		input := &datasync.UntagResourceInput{
+		input := datasync.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Keys:        removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *datasync.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DataSync)
 	if len(updatedTags) > 0 {
-		input := &datasync.TagResourceInput{
+		input := datasync.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/datazone/service_endpoints_gen_test.go
+++ b/internal/service/datazone/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDomains(ctx, &datazone.ListDomainsInput{},
+	input := datazone.ListDomainsInput{}
+	_, err := client.ListDomains(ctx, &input,
 		func(opts *datazone.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/datazone/tags_gen.go
+++ b/internal/service/datazone/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *datazone.Client, identifier string, optFns ...func(*datazone.Options)) (tftags.KeyValueTags, error) {
-	input := &datazone.ListTagsForResourceInput{
+	input := datazone.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *datazone.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DataZone)
 	if len(removedTags) > 0 {
-		input := &datazone.UntagResourceInput{
+		input := datazone.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *datazone.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DataZone)
 	if len(updatedTags) > 0 {
-		input := &datazone.TagResourceInput{
+		input := datazone.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/dax/service_endpoints_gen_test.go
+++ b/internal/service/dax/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeClusters(ctx, &dax.DescribeClustersInput{},
+	input := dax.DescribeClustersInput{}
+	_, err := client.DescribeClusters(ctx, &input,
 		func(opts *dax.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/dax/tags_gen.go
+++ b/internal/service/dax/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *dax.Client, identifier string, optFns ...func(*dax.Options)) (tftags.KeyValueTags, error) {
-	input := &dax.ListTagsInput{
+	input := dax.ListTagsInput{
 		ResourceName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTags(ctx, input, optFns...)
+	output, err := conn.ListTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *dax.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DAX)
 	if len(removedTags) > 0 {
-		input := &dax.UntagResourceInput{
+		input := dax.UntagResourceInput{
 			ResourceName: aws.String(identifier),
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *dax.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DAX)
 	if len(updatedTags) > 0 {
-		input := &dax.TagResourceInput{
+		input := dax.TagResourceInput{
 			ResourceName: aws.String(identifier),
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/deploy/service_endpoints_gen_test.go
+++ b/internal/service/deploy/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &codedeploy.ListApplicationsInput{},
+	input := codedeploy.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *codedeploy.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/deploy/tags_gen.go
+++ b/internal/service/deploy/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *codedeploy.Client, identifier string, optFns ...func(*codedeploy.Options)) (tftags.KeyValueTags, error) {
-	input := &codedeploy.ListTagsForResourceInput{
+	input := codedeploy.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *codedeploy.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Deploy)
 	if len(removedTags) > 0 {
-		input := &codedeploy.UntagResourceInput{
+		input := codedeploy.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *codedeploy.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Deploy)
 	if len(updatedTags) > 0 {
-		input := &codedeploy.TagResourceInput{
+		input := codedeploy.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/detective/service_endpoints_gen_test.go
+++ b/internal/service/detective/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListGraphs(ctx, &detective.ListGraphsInput{},
+	input := detective.ListGraphsInput{}
+	_, err := client.ListGraphs(ctx, &input,
 		func(opts *detective.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/detective/tags_gen.go
+++ b/internal/service/detective/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *detective.Client, identifier string, optFns ...func(*detective.Options)) (tftags.KeyValueTags, error) {
-	input := &detective.ListTagsForResourceInput{
+	input := detective.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *detective.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Detective)
 	if len(removedTags) > 0 {
-		input := &detective.UntagResourceInput{
+		input := detective.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *detective.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Detective)
 	if len(updatedTags) > 0 {
-		input := &detective.TagResourceInput{
+		input := detective.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/devicefarm/service_endpoints_gen_test.go
+++ b/internal/service/devicefarm/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDeviceInstances(ctx, &devicefarm.ListDeviceInstancesInput{},
+	input := devicefarm.ListDeviceInstancesInput{}
+	_, err := client.ListDeviceInstances(ctx, &input,
 		func(opts *devicefarm.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/devicefarm/tags_gen.go
+++ b/internal/service/devicefarm/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *devicefarm.Client, identifier string, optFns ...func(*devicefarm.Options)) (tftags.KeyValueTags, error) {
-	input := &devicefarm.ListTagsForResourceInput{
+	input := devicefarm.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *devicefarm.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DeviceFarm)
 	if len(removedTags) > 0 {
-		input := &devicefarm.UntagResourceInput{
+		input := devicefarm.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *devicefarm.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DeviceFarm)
 	if len(updatedTags) > 0 {
-		input := &devicefarm.TagResourceInput{
+		input := devicefarm.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/devopsguru/service_endpoints_gen_test.go
+++ b/internal/service/devopsguru/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeAccountHealth(ctx, &devopsguru.DescribeAccountHealthInput{},
+	input := devopsguru.DescribeAccountHealthInput{}
+	_, err := client.DescribeAccountHealth(ctx, &input,
 		func(opts *devopsguru.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/directconnect/service_endpoints_gen_test.go
+++ b/internal/service/directconnect/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeConnections(ctx, &directconnect.DescribeConnectionsInput{},
+	input := directconnect.DescribeConnectionsInput{}
+	_, err := client.DescribeConnections(ctx, &input,
 		func(opts *directconnect.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/directconnect/tags_gen.go
+++ b/internal/service/directconnect/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *directconnect.Client, identifier string, optFns ...func(*directconnect.Options)) (tftags.KeyValueTags, error) {
-	input := &directconnect.DescribeTagsInput{
+	input := directconnect.DescribeTagsInput{
 		ResourceArns: []string{identifier},
 	}
 
-	output, err := conn.DescribeTags(ctx, input, optFns...)
+	output, err := conn.DescribeTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *directconnect.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DirectConnect)
 	if len(removedTags) > 0 {
-		input := &directconnect.UntagResourceInput{
+		input := directconnect.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *directconnect.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DirectConnect)
 	if len(updatedTags) > 0 {
-		input := &directconnect.TagResourceInput{
+		input := directconnect.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/dlm/service_endpoints_gen_test.go
+++ b/internal/service/dlm/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetLifecyclePolicies(ctx, &dlm.GetLifecyclePoliciesInput{},
+	input := dlm.GetLifecyclePoliciesInput{}
+	_, err := client.GetLifecyclePolicies(ctx, &input,
 		func(opts *dlm.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/dlm/tags_gen.go
+++ b/internal/service/dlm/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *dlm.Client, identifier string, optFns ...func(*dlm.Options)) (tftags.KeyValueTags, error) {
-	input := &dlm.ListTagsForResourceInput{
+	input := dlm.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *dlm.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DLM)
 	if len(removedTags) > 0 {
-		input := &dlm.UntagResourceInput{
+		input := dlm.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *dlm.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DLM)
 	if len(updatedTags) > 0 {
-		input := &dlm.TagResourceInput{
+		input := dlm.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/dms/service_endpoints_gen_test.go
+++ b/internal/service/dms/service_endpoints_gen_test.go
@@ -396,7 +396,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeCertificates(ctx, &databasemigrationservice.DescribeCertificatesInput{},
+	input := databasemigrationservice.DescribeCertificatesInput{}
+	_, err := client.DescribeCertificates(ctx, &input,
 		func(opts *databasemigrationservice.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/dms/tags_gen.go
+++ b/internal/service/dms/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *databasemigrationservice.Client, identifier string, optFns ...func(*databasemigrationservice.Options)) (tftags.KeyValueTags, error) {
-	input := &databasemigrationservice.ListTagsForResourceInput{
+	input := databasemigrationservice.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *databasemigrationservice.Client, iden
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DMS)
 	if len(removedTags) > 0 {
-		input := &databasemigrationservice.RemoveTagsFromResourceInput{
+		input := databasemigrationservice.RemoveTagsFromResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTagsFromResource(ctx, input, optFns...)
+		_, err := conn.RemoveTagsFromResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *databasemigrationservice.Client, iden
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DMS)
 	if len(updatedTags) > 0 {
-		input := &databasemigrationservice.AddTagsToResourceInput{
+		input := databasemigrationservice.AddTagsToResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToResource(ctx, input, optFns...)
+		_, err := conn.AddTagsToResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/docdb/service_endpoints_gen_test.go
+++ b/internal/service/docdb/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeDBClusters(ctx, &docdb.DescribeDBClustersInput{},
+	input := docdb.DescribeDBClustersInput{}
+	_, err := client.DescribeDBClusters(ctx, &input,
 		func(opts *docdb.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/docdb/tags_gen.go
+++ b/internal/service/docdb/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *docdb.Client, identifier string, optFns ...func(*docdb.Options)) (tftags.KeyValueTags, error) {
-	input := &docdb.ListTagsForResourceInput{
+	input := docdb.ListTagsForResourceInput{
 		ResourceName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *docdb.Client, identifier string, oldT
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DocDB)
 	if len(removedTags) > 0 {
-		input := &docdb.RemoveTagsFromResourceInput{
+		input := docdb.RemoveTagsFromResourceInput{
 			ResourceName: aws.String(identifier),
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTagsFromResource(ctx, input, optFns...)
+		_, err := conn.RemoveTagsFromResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *docdb.Client, identifier string, oldT
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DocDB)
 	if len(updatedTags) > 0 {
-		input := &docdb.AddTagsToResourceInput{
+		input := docdb.AddTagsToResourceInput{
 			ResourceName: aws.String(identifier),
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToResource(ctx, input, optFns...)
+		_, err := conn.AddTagsToResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/docdbelastic/service_endpoints_gen_test.go
+++ b/internal/service/docdbelastic/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListClusters(ctx, &docdbelastic.ListClustersInput{},
+	input := docdbelastic.ListClustersInput{}
+	_, err := client.ListClusters(ctx, &input,
 		func(opts *docdbelastic.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/docdbelastic/tags_gen.go
+++ b/internal/service/docdbelastic/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *docdbelastic.Client, identifier string, optFns ...func(*docdbelastic.Options)) (tftags.KeyValueTags, error) {
-	input := &docdbelastic.ListTagsForResourceInput{
+	input := docdbelastic.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *docdbelastic.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DocDBElastic)
 	if len(removedTags) > 0 {
-		input := &docdbelastic.UntagResourceInput{
+		input := docdbelastic.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *docdbelastic.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DocDBElastic)
 	if len(updatedTags) > 0 {
-		input := &docdbelastic.TagResourceInput{
+		input := docdbelastic.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/drs/service_endpoints_gen_test.go
+++ b/internal/service/drs/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeJobs(ctx, &drs.DescribeJobsInput{},
+	input := drs.DescribeJobsInput{}
+	_, err := client.DescribeJobs(ctx, &input,
 		func(opts *drs.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/drs/tags_gen.go
+++ b/internal/service/drs/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *drs.Client, identifier string, optFns ...func(*drs.Options)) (tftags.KeyValueTags, error) {
-	input := &drs.ListTagsForResourceInput{
+	input := drs.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,12 +100,12 @@ func updateTags(ctx context.Context, conn *drs.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DRS)
 	if len(removedTags) > 0 {
-		input := &drs.UntagResourceInput{
+		input := drs.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -115,12 +115,12 @@ func updateTags(ctx context.Context, conn *drs.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DRS)
 	if len(updatedTags) > 0 {
-		input := &drs.TagResourceInput{
+		input := drs.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ds/service_endpoints_gen_test.go
+++ b/internal/service/ds/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeDirectories(ctx, &directoryservice.DescribeDirectoriesInput{},
+	input := directoryservice.DescribeDirectoriesInput{}
+	_, err := client.DescribeDirectories(ctx, &input,
 		func(opts *directoryservice.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ds/tags_gen.go
+++ b/internal/service/ds/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *directoryservice.Client, identifier string, optFns ...func(*directoryservice.Options)) (tftags.KeyValueTags, error) {
-	input := &directoryservice.ListTagsForResourceInput{
+	input := directoryservice.ListTagsForResourceInput{
 		ResourceId: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *directoryservice.Client, identifier s
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DS)
 	if len(removedTags) > 0 {
-		input := &directoryservice.RemoveTagsFromResourceInput{
+		input := directoryservice.RemoveTagsFromResourceInput{
 			ResourceId: aws.String(identifier),
 			TagKeys:    removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTagsFromResource(ctx, input, optFns...)
+		_, err := conn.RemoveTagsFromResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *directoryservice.Client, identifier s
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DS)
 	if len(updatedTags) > 0 {
-		input := &directoryservice.AddTagsToResourceInput{
+		input := directoryservice.AddTagsToResourceInput{
 			ResourceId: aws.String(identifier),
 			Tags:       Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToResource(ctx, input, optFns...)
+		_, err := conn.AddTagsToResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/dynamodb/service_endpoints_gen_test.go
+++ b/internal/service/dynamodb/service_endpoints_gen_test.go
@@ -393,7 +393,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListTables(ctx, &dynamodb.ListTablesInput{},
+	input := dynamodb.ListTablesInput{}
+	_, err := client.ListTables(ctx, &input,
 		func(opts *dynamodb.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/dynamodb/tags_gen.go
+++ b/internal/service/dynamodb/tags_gen.go
@@ -43,16 +43,16 @@ func findTag(ctx context.Context, conn *dynamodb.Client, identifier, key string,
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *dynamodb.Client, identifier string, optFns ...func(*dynamodb.Options)) (tftags.KeyValueTags, error) {
-	input := &dynamodb.ListTagsOfResourceInput{
+	input := dynamodb.ListTagsOfResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsOfResource(ctx, input, optFns...)
+	output, err := conn.ListTagsOfResource(ctx, &input, optFns...)
 
 	if tfawserr.ErrCodeEquals(err, "ResourceNotFoundException") {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
-			LastRequest: input,
+			LastRequest: &input,
 		}
 	}
 
@@ -148,12 +148,12 @@ func updateTags(ctx context.Context, conn *dynamodb.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DynamoDB)
 	if len(removedTags) > 0 {
-		input := &dynamodb.UntagResourceInput{
+		input := dynamodb.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -163,12 +163,12 @@ func updateTags(ctx context.Context, conn *dynamodb.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DynamoDB)
 	if len(updatedTags) > 0 {
-		input := &dynamodb.TagResourceInput{
+		input := dynamodb.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/dynamodb/update_tags_for_resource_gen.go
+++ b/internal/service/dynamodb/update_tags_for_resource_gen.go
@@ -27,12 +27,12 @@ func updateTagsResource(ctx context.Context, conn *dynamodb.Client, identifier s
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.DynamoDB)
 	if len(removedTags) > 0 {
-		input := &dynamodb.UntagResourceInput{
+		input := dynamodb.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -42,12 +42,12 @@ func updateTagsResource(ctx context.Context, conn *dynamodb.Client, identifier s
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.DynamoDB)
 	if len(updatedTags) > 0 {
-		input := &dynamodb.TagResourceInput{
+		input := dynamodb.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ec2/service_endpoints_gen_test.go
+++ b/internal/service/ec2/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{},
+	input := ec2.DescribeVpcsInput{}
+	_, err := client.DescribeVpcs(ctx, &input,
 		func(opts *ec2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ec2/tags_gen.go
+++ b/internal/service/ec2/tags_gen.go
@@ -23,7 +23,7 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func findTag(ctx context.Context, conn *ec2.Client, identifier, key string, optFns ...func(*ec2.Options)) (*string, error) {
-	input := &ec2.DescribeTagsInput{
+	input := ec2.DescribeTagsInput{
 		Filters: []awstypes.Filter{
 			{
 				Name:   aws.String("resource-id"),
@@ -36,7 +36,7 @@ func findTag(ctx context.Context, conn *ec2.Client, identifier, key string, optF
 		},
 	}
 
-	output, err := conn.DescribeTags(ctx, input, optFns...)
+	output, err := conn.DescribeTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func findTag(ctx context.Context, conn *ec2.Client, identifier, key string, optF
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *ec2.Client, identifier string, optFns ...func(*ec2.Options)) (tftags.KeyValueTags, error) {
-	input := &ec2.DescribeTagsInput{
+	input := ec2.DescribeTagsInput{
 		Filters: []awstypes.Filter{
 			{
 				Name:   aws.String("resource-id"),
@@ -65,7 +65,7 @@ func listTags(ctx context.Context, conn *ec2.Client, identifier string, optFns .
 	}
 	var output []awstypes.TagDescription
 
-	pages := ec2.NewDescribeTagsPaginator(conn, input)
+	pages := ec2.NewDescribeTagsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx, optFns...)
 
@@ -174,12 +174,12 @@ func updateTags(ctx context.Context, conn *ec2.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.EC2)
 	if len(removedTags) > 0 {
-		input := &ec2.DeleteTagsInput{
+		input := ec2.DeleteTagsInput{
 			Resources: []string{identifier},
 			Tags:      Tags(removedTags),
 		}
 
-		_, err := conn.DeleteTags(ctx, input, optFns...)
+		_, err := conn.DeleteTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -189,12 +189,12 @@ func updateTags(ctx context.Context, conn *ec2.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.EC2)
 	if len(updatedTags) > 0 {
-		input := &ec2.CreateTagsInput{
+		input := ec2.CreateTagsInput{
 			Resources: []string{identifier},
 			Tags:      Tags(updatedTags),
 		}
 
-		_, err := conn.CreateTags(ctx, input, optFns...)
+		_, err := conn.CreateTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ecr/service_endpoints_gen_test.go
+++ b/internal/service/ecr/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeRepositories(ctx, &ecr.DescribeRepositoriesInput{},
+	input := ecr.DescribeRepositoriesInput{}
+	_, err := client.DescribeRepositories(ctx, &input,
 		func(opts *ecr.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ecr/tags_gen.go
+++ b/internal/service/ecr/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *ecr.Client, identifier string, optFns ...func(*ecr.Options)) (tftags.KeyValueTags, error) {
-	input := &ecr.ListTagsForResourceInput{
+	input := ecr.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *ecr.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ECR)
 	if len(removedTags) > 0 {
-		input := &ecr.UntagResourceInput{
+		input := ecr.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *ecr.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ECR)
 	if len(updatedTags) > 0 {
-		input := &ecr.TagResourceInput{
+		input := ecr.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ecrpublic/service_endpoints_gen_test.go
+++ b/internal/service/ecrpublic/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeRepositories(ctx, &ecrpublic.DescribeRepositoriesInput{},
+	input := ecrpublic.DescribeRepositoriesInput{}
+	_, err := client.DescribeRepositories(ctx, &input,
 		func(opts *ecrpublic.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ecrpublic/tags_gen.go
+++ b/internal/service/ecrpublic/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *ecrpublic.Client, identifier string, optFns ...func(*ecrpublic.Options)) (tftags.KeyValueTags, error) {
-	input := &ecrpublic.ListTagsForResourceInput{
+	input := ecrpublic.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *ecrpublic.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ECRPublic)
 	if len(removedTags) > 0 {
-		input := &ecrpublic.UntagResourceInput{
+		input := ecrpublic.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *ecrpublic.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ECRPublic)
 	if len(updatedTags) > 0 {
-		input := &ecrpublic.TagResourceInput{
+		input := ecrpublic.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ecs/service_endpoints_gen_test.go
+++ b/internal/service/ecs/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListClusters(ctx, &ecs.ListClustersInput{},
+	input := ecs.ListClustersInput{}
+	_, err := client.ListClusters(ctx, &input,
 		func(opts *ecs.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/efs/service_endpoints_gen_test.go
+++ b/internal/service/efs/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeFileSystems(ctx, &efs.DescribeFileSystemsInput{},
+	input := efs.DescribeFileSystemsInput{}
+	_, err := client.DescribeFileSystems(ctx, &input,
 		func(opts *efs.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/efs/tags_gen.go
+++ b/internal/service/efs/tags_gen.go
@@ -20,12 +20,12 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *efs.Client, identifier string, optFns ...func(*efs.Options)) (tftags.KeyValueTags, error) {
-	input := &efs.DescribeTagsInput{
+	input := efs.DescribeTagsInput{
 		FileSystemId: aws.String(identifier),
 	}
 	var output []awstypes.Tag
 
-	pages := efs.NewDescribeTagsPaginator(conn, input)
+	pages := efs.NewDescribeTagsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx, optFns...)
 
@@ -117,12 +117,12 @@ func updateTags(ctx context.Context, conn *efs.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.EFS)
 	if len(removedTags) > 0 {
-		input := &efs.UntagResourceInput{
+		input := efs.UntagResourceInput{
 			ResourceId: aws.String(identifier),
 			TagKeys:    removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -132,12 +132,12 @@ func updateTags(ctx context.Context, conn *efs.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.EFS)
 	if len(updatedTags) > 0 {
-		input := &efs.TagResourceInput{
+		input := efs.TagResourceInput{
 			ResourceId: aws.String(identifier),
 			Tags:       Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/eks/service_endpoints_gen_test.go
+++ b/internal/service/eks/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListClusters(ctx, &eks.ListClustersInput{},
+	input := eks.ListClustersInput{}
+	_, err := client.ListClusters(ctx, &input,
 		func(opts *eks.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/eks/tags_gen.go
+++ b/internal/service/eks/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *eks.Client, identifier string, optFns ...func(*eks.Options)) (tftags.KeyValueTags, error) {
-	input := &eks.ListTagsForResourceInput{
+	input := eks.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *eks.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.EKS)
 	if len(removedTags) > 0 {
-		input := &eks.UntagResourceInput{
+		input := eks.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *eks.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.EKS)
 	if len(updatedTags) > 0 {
-		input := &eks.TagResourceInput{
+		input := eks.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/elasticache/service_endpoints_gen_test.go
+++ b/internal/service/elasticache/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeCacheClusters(ctx, &elasticache.DescribeCacheClustersInput{},
+	input := elasticache.DescribeCacheClustersInput{}
+	_, err := client.DescribeCacheClusters(ctx, &input,
 		func(opts *elasticache.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/elasticache/tags_gen.go
+++ b/internal/service/elasticache/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *elasticache.Client, identifier string, optFns ...func(*elasticache.Options)) (tftags.KeyValueTags, error) {
-	input := &elasticache.ListTagsForResourceInput{
+	input := elasticache.ListTagsForResourceInput{
 		ResourceName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *elasticache.Client, identifier string
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ElastiCache)
 	if len(removedTags) > 0 {
-		input := &elasticache.RemoveTagsFromResourceInput{
+		input := elasticache.RemoveTagsFromResourceInput{
 			ResourceName: aws.String(identifier),
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTagsFromResource(ctx, input, optFns...)
+		_, err := conn.RemoveTagsFromResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *elasticache.Client, identifier string
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ElastiCache)
 	if len(updatedTags) > 0 {
-		input := &elasticache.AddTagsToResourceInput{
+		input := elasticache.AddTagsToResourceInput{
 			ResourceName: aws.String(identifier),
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToResource(ctx, input, optFns...)
+		_, err := conn.AddTagsToResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/elasticbeanstalk/service_endpoints_gen_test.go
+++ b/internal/service/elasticbeanstalk/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAvailableSolutionStacks(ctx, &elasticbeanstalk.ListAvailableSolutionStacksInput{},
+	input := elasticbeanstalk.ListAvailableSolutionStacksInput{}
+	_, err := client.ListAvailableSolutionStacks(ctx, &input,
 		func(opts *elasticbeanstalk.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/elasticbeanstalk/tags_gen.go
+++ b/internal/service/elasticbeanstalk/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *elasticbeanstalk.Client, identifier string, optFns ...func(*elasticbeanstalk.Options)) (tftags.KeyValueTags, error) {
-	input := &elasticbeanstalk.ListTagsForResourceInput{
+	input := elasticbeanstalk.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -116,7 +116,7 @@ func updateTags(ctx context.Context, conn *elasticbeanstalk.Client, identifier s
 		return nil
 	}
 
-	input := &elasticbeanstalk.UpdateTagsForResourceInput{
+	input := elasticbeanstalk.UpdateTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
@@ -128,7 +128,7 @@ func updateTags(ctx context.Context, conn *elasticbeanstalk.Client, identifier s
 		input.TagsToRemove = removedTags.Keys()
 	}
 
-	_, err := conn.UpdateTagsForResource(ctx, input, optFns...)
+	_, err := conn.UpdateTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/elasticsearch/service_endpoints_gen_test.go
+++ b/internal/service/elasticsearch/service_endpoints_gen_test.go
@@ -396,7 +396,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDomainNames(ctx, &elasticsearchservice.ListDomainNamesInput{},
+	input := elasticsearchservice.ListDomainNamesInput{}
+	_, err := client.ListDomainNames(ctx, &input,
 		func(opts *elasticsearchservice.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/elasticsearch/tags_gen.go
+++ b/internal/service/elasticsearch/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *elasticsearchservice.Client, identifier string, optFns ...func(*elasticsearchservice.Options)) (tftags.KeyValueTags, error) {
-	input := &elasticsearchservice.ListTagsInput{
+	input := elasticsearchservice.ListTagsInput{
 		ARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTags(ctx, input, optFns...)
+	output, err := conn.ListTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *elasticsearchservice.Client, identifi
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Elasticsearch)
 	if len(removedTags) > 0 {
-		input := &elasticsearchservice.RemoveTagsInput{
+		input := elasticsearchservice.RemoveTagsInput{
 			ARN:     aws.String(identifier),
 			TagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTags(ctx, input, optFns...)
+		_, err := conn.RemoveTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *elasticsearchservice.Client, identifi
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Elasticsearch)
 	if len(updatedTags) > 0 {
-		input := &elasticsearchservice.AddTagsInput{
+		input := elasticsearchservice.AddTagsInput{
 			ARN:     aws.String(identifier),
 			TagList: Tags(updatedTags),
 		}
 
-		_, err := conn.AddTags(ctx, input, optFns...)
+		_, err := conn.AddTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/elastictranscoder/service_endpoints_gen_test.go
+++ b/internal/service/elastictranscoder/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListPipelines(ctx, &elastictranscoder.ListPipelinesInput{},
+	input := elastictranscoder.ListPipelinesInput{}
+	_, err := client.ListPipelines(ctx, &input,
 		func(opts *elastictranscoder.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/elb/service_endpoints_gen_test.go
+++ b/internal/service/elb/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeLoadBalancers(ctx, &elasticloadbalancing.DescribeLoadBalancersInput{},
+	input := elasticloadbalancing.DescribeLoadBalancersInput{}
+	_, err := client.DescribeLoadBalancers(ctx, &input,
 		func(opts *elasticloadbalancing.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/elb/tags_gen.go
+++ b/internal/service/elb/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *elasticloadbalancing.Client, identifier string, optFns ...func(*elasticloadbalancing.Options)) (tftags.KeyValueTags, error) {
-	input := &elasticloadbalancing.DescribeTagsInput{
+	input := elasticloadbalancing.DescribeTagsInput{
 		LoadBalancerNames: []string{identifier},
 	}
 
-	output, err := conn.DescribeTags(ctx, input, optFns...)
+	output, err := conn.DescribeTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *elasticloadbalancing.Client, identifi
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ELB)
 	if len(removedTags) > 0 {
-		input := &elasticloadbalancing.RemoveTagsInput{
+		input := elasticloadbalancing.RemoveTagsInput{
 			LoadBalancerNames: []string{identifier},
 			Tags:              TagKeys(removedTags),
 		}
 
-		_, err := conn.RemoveTags(ctx, input, optFns...)
+		_, err := conn.RemoveTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -139,12 +139,12 @@ func updateTags(ctx context.Context, conn *elasticloadbalancing.Client, identifi
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ELB)
 	if len(updatedTags) > 0 {
-		input := &elasticloadbalancing.AddTagsInput{
+		input := elasticloadbalancing.AddTagsInput{
 			LoadBalancerNames: []string{identifier},
 			Tags:              Tags(updatedTags),
 		}
 
-		_, err := conn.AddTags(ctx, input, optFns...)
+		_, err := conn.AddTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/elbv2/service_endpoints_gen_test.go
+++ b/internal/service/elbv2/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeLoadBalancers(ctx, &elasticloadbalancingv2.DescribeLoadBalancersInput{},
+	input := elasticloadbalancingv2.DescribeLoadBalancersInput{}
+	_, err := client.DescribeLoadBalancers(ctx, &input,
 		func(opts *elasticloadbalancingv2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/elbv2/tags_gen.go
+++ b/internal/service/elbv2/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *elasticloadbalancingv2.Client, identifier string, optFns ...func(*elasticloadbalancingv2.Options)) (tftags.KeyValueTags, error) {
-	input := &elasticloadbalancingv2.DescribeTagsInput{
+	input := elasticloadbalancingv2.DescribeTagsInput{
 		ResourceArns: []string{identifier},
 	}
 
-	output, err := conn.DescribeTags(ctx, input, optFns...)
+	output, err := conn.DescribeTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *elasticloadbalancingv2.Client, identi
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ELBV2)
 	if len(removedTags) > 0 {
-		input := &elasticloadbalancingv2.RemoveTagsInput{
+		input := elasticloadbalancingv2.RemoveTagsInput{
 			ResourceArns: []string{identifier},
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTags(ctx, input, optFns...)
+		_, err := conn.RemoveTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *elasticloadbalancingv2.Client, identi
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ELBV2)
 	if len(updatedTags) > 0 {
-		input := &elasticloadbalancingv2.AddTagsInput{
+		input := elasticloadbalancingv2.AddTagsInput{
 			ResourceArns: []string{identifier},
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.AddTags(ctx, input, optFns...)
+		_, err := conn.AddTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/emr/service_endpoints_gen_test.go
+++ b/internal/service/emr/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListClusters(ctx, &emr.ListClustersInput{},
+	input := emr.ListClustersInput{}
+	_, err := client.ListClusters(ctx, &input,
 		func(opts *emr.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/emr/tags_gen.go
+++ b/internal/service/emr/tags_gen.go
@@ -76,12 +76,12 @@ func updateTags(ctx context.Context, conn *emr.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.EMR)
 	if len(removedTags) > 0 {
-		input := &emr.RemoveTagsInput{
+		input := emr.RemoveTagsInput{
 			ResourceId: aws.String(identifier),
 			TagKeys:    removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTags(ctx, input, optFns...)
+		_, err := conn.RemoveTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *emr.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.EMR)
 	if len(updatedTags) > 0 {
-		input := &emr.AddTagsInput{
+		input := emr.AddTagsInput{
 			ResourceId: aws.String(identifier),
 			Tags:       Tags(updatedTags),
 		}
 
-		_, err := conn.AddTags(ctx, input, optFns...)
+		_, err := conn.AddTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/emrcontainers/service_endpoints_gen_test.go
+++ b/internal/service/emrcontainers/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListVirtualClusters(ctx, &emrcontainers.ListVirtualClustersInput{},
+	input := emrcontainers.ListVirtualClustersInput{}
+	_, err := client.ListVirtualClusters(ctx, &input,
 		func(opts *emrcontainers.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/emrcontainers/tags_gen.go
+++ b/internal/service/emrcontainers/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *emrcontainers.Client, identifier string, optFns ...func(*emrcontainers.Options)) (tftags.KeyValueTags, error) {
-	input := &emrcontainers.ListTagsForResourceInput{
+	input := emrcontainers.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *emrcontainers.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.EMRContainers)
 	if len(removedTags) > 0 {
-		input := &emrcontainers.UntagResourceInput{
+		input := emrcontainers.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *emrcontainers.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.EMRContainers)
 	if len(updatedTags) > 0 {
-		input := &emrcontainers.TagResourceInput{
+		input := emrcontainers.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/emrserverless/service_endpoints_gen_test.go
+++ b/internal/service/emrserverless/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &emrserverless.ListApplicationsInput{},
+	input := emrserverless.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *emrserverless.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/emrserverless/tags_gen.go
+++ b/internal/service/emrserverless/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *emrserverless.Client, identifier string, optFns ...func(*emrserverless.Options)) (tftags.KeyValueTags, error) {
-	input := &emrserverless.ListTagsForResourceInput{
+	input := emrserverless.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *emrserverless.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.EMRServerless)
 	if len(removedTags) > 0 {
-		input := &emrserverless.UntagResourceInput{
+		input := emrserverless.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *emrserverless.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.EMRServerless)
 	if len(updatedTags) > 0 {
-		input := &emrserverless.TagResourceInput{
+		input := emrserverless.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/events/service_endpoints_gen_test.go
+++ b/internal/service/events/service_endpoints_gen_test.go
@@ -396,7 +396,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListEventBuses(ctx, &eventbridge.ListEventBusesInput{},
+	input := eventbridge.ListEventBusesInput{}
+	_, err := client.ListEventBuses(ctx, &input,
 		func(opts *eventbridge.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/events/tags_gen.go
+++ b/internal/service/events/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *eventbridge.Client, identifier string, optFns ...func(*eventbridge.Options)) (tftags.KeyValueTags, error) {
-	input := &eventbridge.ListTagsForResourceInput{
+	input := eventbridge.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *eventbridge.Client, identifier string
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Events)
 	if len(removedTags) > 0 {
-		input := &eventbridge.UntagResourceInput{
+		input := eventbridge.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *eventbridge.Client, identifier string
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Events)
 	if len(updatedTags) > 0 {
-		input := &eventbridge.TagResourceInput{
+		input := eventbridge.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/evidently/service_endpoints_gen_test.go
+++ b/internal/service/evidently/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListProjects(ctx, &evidently.ListProjectsInput{},
+	input := evidently.ListProjectsInput{}
+	_, err := client.ListProjects(ctx, &input,
 		func(opts *evidently.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/evidently/tags_gen.go
+++ b/internal/service/evidently/tags_gen.go
@@ -58,12 +58,12 @@ func updateTags(ctx context.Context, conn *evidently.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Evidently)
 	if len(removedTags) > 0 {
-		input := &evidently.UntagResourceInput{
+		input := evidently.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -73,12 +73,12 @@ func updateTags(ctx context.Context, conn *evidently.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Evidently)
 	if len(updatedTags) > 0 {
-		input := &evidently.TagResourceInput{
+		input := evidently.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/finspace/service_endpoints_gen_test.go
+++ b/internal/service/finspace/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListEnvironments(ctx, &finspace.ListEnvironmentsInput{},
+	input := finspace.ListEnvironmentsInput{}
+	_, err := client.ListEnvironments(ctx, &input,
 		func(opts *finspace.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/finspace/tags_gen.go
+++ b/internal/service/finspace/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *finspace.Client, identifier string, optFns ...func(*finspace.Options)) (tftags.KeyValueTags, error) {
-	input := &finspace.ListTagsForResourceInput{
+	input := finspace.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,12 +100,12 @@ func updateTags(ctx context.Context, conn *finspace.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.FinSpace)
 	if len(removedTags) > 0 {
-		input := &finspace.UntagResourceInput{
+		input := finspace.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -115,12 +115,12 @@ func updateTags(ctx context.Context, conn *finspace.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.FinSpace)
 	if len(updatedTags) > 0 {
-		input := &finspace.TagResourceInput{
+		input := finspace.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/firehose/service_endpoints_gen_test.go
+++ b/internal/service/firehose/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDeliveryStreams(ctx, &firehose.ListDeliveryStreamsInput{},
+	input := firehose.ListDeliveryStreamsInput{}
+	_, err := client.ListDeliveryStreams(ctx, &input,
 		func(opts *firehose.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/firehose/tags_gen.go
+++ b/internal/service/firehose/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *firehose.Client, identifier string, optFns ...func(*firehose.Options)) (tftags.KeyValueTags, error) {
-	input := &firehose.ListTagsForDeliveryStreamInput{
+	input := firehose.ListTagsForDeliveryStreamInput{
 		DeliveryStreamName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForDeliveryStream(ctx, input, optFns...)
+	output, err := conn.ListTagsForDeliveryStream(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *firehose.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Firehose)
 	if len(removedTags) > 0 {
-		input := &firehose.UntagDeliveryStreamInput{
+		input := firehose.UntagDeliveryStreamInput{
 			DeliveryStreamName: aws.String(identifier),
 			TagKeys:            removedTags.Keys(),
 		}
 
-		_, err := conn.UntagDeliveryStream(ctx, input, optFns...)
+		_, err := conn.UntagDeliveryStream(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *firehose.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Firehose)
 	if len(updatedTags) > 0 {
-		input := &firehose.TagDeliveryStreamInput{
+		input := firehose.TagDeliveryStreamInput{
 			DeliveryStreamName: aws.String(identifier),
 			Tags:               Tags(updatedTags),
 		}
 
-		_, err := conn.TagDeliveryStream(ctx, input, optFns...)
+		_, err := conn.TagDeliveryStream(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/fis/service_endpoints_gen_test.go
+++ b/internal/service/fis/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListExperiments(ctx, &fis.ListExperimentsInput{},
+	input := fis.ListExperimentsInput{}
+	_, err := client.ListExperiments(ctx, &input,
 		func(opts *fis.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/fis/tags_gen.go
+++ b/internal/service/fis/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *fis.Client, identifier string, optFns ...func(*fis.Options)) (tftags.KeyValueTags, error) {
-	input := &fis.ListTagsForResourceInput{
+	input := fis.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *fis.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.FIS)
 	if len(removedTags) > 0 {
-		input := &fis.UntagResourceInput{
+		input := fis.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *fis.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.FIS)
 	if len(updatedTags) > 0 {
-		input := &fis.TagResourceInput{
+		input := fis.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/fms/service_endpoints_gen_test.go
+++ b/internal/service/fms/service_endpoints_gen_test.go
@@ -283,9 +283,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAppsLists(ctx, &fms.ListAppsListsInput{
+	input := fms.ListAppsListsInput{
 		MaxResults: aws.Int32(1),
-	},
+	}
+	_, err := client.ListAppsLists(ctx, &input,
 		func(opts *fms.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/fms/tags_gen.go
+++ b/internal/service/fms/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *fms.Client, identifier string, optFns ...func(*fms.Options)) (tftags.KeyValueTags, error) {
-	input := &fms.ListTagsForResourceInput{
+	input := fms.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *fms.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.FMS)
 	if len(removedTags) > 0 {
-		input := &fms.UntagResourceInput{
+		input := fms.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *fms.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.FMS)
 	if len(updatedTags) > 0 {
-		input := &fms.TagResourceInput{
+		input := fms.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagList:     Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/fsx/service_endpoints_gen_test.go
+++ b/internal/service/fsx/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeFileSystems(ctx, &fsx.DescribeFileSystemsInput{},
+	input := fsx.DescribeFileSystemsInput{}
+	_, err := client.DescribeFileSystems(ctx, &input,
 		func(opts *fsx.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/fsx/tags_gen.go
+++ b/internal/service/fsx/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *fsx.Client, identifier string, optFns ...func(*fsx.Options)) (tftags.KeyValueTags, error) {
-	input := &fsx.ListTagsForResourceInput{
+	input := fsx.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *fsx.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.FSx)
 	if len(removedTags) > 0 {
-		input := &fsx.UntagResourceInput{
+		input := fsx.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *fsx.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.FSx)
 	if len(updatedTags) > 0 {
-		input := &fsx.TagResourceInput{
+		input := fsx.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/gamelift/service_endpoints_gen_test.go
+++ b/internal/service/gamelift/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListGameServerGroups(ctx, &gamelift.ListGameServerGroupsInput{},
+	input := gamelift.ListGameServerGroupsInput{}
+	_, err := client.ListGameServerGroups(ctx, &input,
 		func(opts *gamelift.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/gamelift/tags_gen.go
+++ b/internal/service/gamelift/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *gamelift.Client, identifier string, optFns ...func(*gamelift.Options)) (tftags.KeyValueTags, error) {
-	input := &gamelift.ListTagsForResourceInput{
+	input := gamelift.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *gamelift.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.GameLift)
 	if len(removedTags) > 0 {
-		input := &gamelift.UntagResourceInput{
+		input := gamelift.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *gamelift.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.GameLift)
 	if len(updatedTags) > 0 {
-		input := &gamelift.TagResourceInput{
+		input := gamelift.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/glacier/service_endpoints_gen_test.go
+++ b/internal/service/glacier/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListVaults(ctx, &glacier.ListVaultsInput{},
+	input := glacier.ListVaultsInput{}
+	_, err := client.ListVaults(ctx, &input,
 		func(opts *glacier.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/glacier/tags_gen.go
+++ b/internal/service/glacier/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *glacier.Client, identifier string, optFns ...func(*glacier.Options)) (tftags.KeyValueTags, error) {
-	input := &glacier.ListTagsForVaultInput{
+	input := glacier.ListTagsForVaultInput{
 		VaultName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForVault(ctx, input, optFns...)
+	output, err := conn.ListTagsForVault(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,12 +100,12 @@ func updateTags(ctx context.Context, conn *glacier.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Glacier)
 	if len(removedTags) > 0 {
-		input := &glacier.RemoveTagsFromVaultInput{
+		input := glacier.RemoveTagsFromVaultInput{
 			VaultName: aws.String(identifier),
 			TagKeys:   removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTagsFromVault(ctx, input, optFns...)
+		_, err := conn.RemoveTagsFromVault(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -115,12 +115,12 @@ func updateTags(ctx context.Context, conn *glacier.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Glacier)
 	if len(updatedTags) > 0 {
-		input := &glacier.AddTagsToVaultInput{
+		input := glacier.AddTagsToVaultInput{
 			VaultName: aws.String(identifier),
 			Tags:      Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToVault(ctx, input, optFns...)
+		_, err := conn.AddTagsToVault(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/globalaccelerator/service_endpoints_gen_test.go
+++ b/internal/service/globalaccelerator/service_endpoints_gen_test.go
@@ -285,7 +285,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAccelerators(ctx, &globalaccelerator.ListAcceleratorsInput{},
+	input := globalaccelerator.ListAcceleratorsInput{}
+	_, err := client.ListAccelerators(ctx, &input,
 		func(opts *globalaccelerator.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/globalaccelerator/tags_gen.go
+++ b/internal/service/globalaccelerator/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *globalaccelerator.Client, identifier string, optFns ...func(*globalaccelerator.Options)) (tftags.KeyValueTags, error) {
-	input := &globalaccelerator.ListTagsForResourceInput{
+	input := globalaccelerator.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *globalaccelerator.Client, identifier 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.GlobalAccelerator)
 	if len(removedTags) > 0 {
-		input := &globalaccelerator.UntagResourceInput{
+		input := globalaccelerator.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *globalaccelerator.Client, identifier 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.GlobalAccelerator)
 	if len(updatedTags) > 0 {
-		input := &globalaccelerator.TagResourceInput{
+		input := globalaccelerator.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/glue/service_endpoints_gen_test.go
+++ b/internal/service/glue/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRegistries(ctx, &glue.ListRegistriesInput{},
+	input := glue.ListRegistriesInput{}
+	_, err := client.ListRegistries(ctx, &input,
 		func(opts *glue.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/glue/tags_gen.go
+++ b/internal/service/glue/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *glue.Client, identifier string, optFns ...func(*glue.Options)) (tftags.KeyValueTags, error) {
-	input := &glue.GetTagsInput{
+	input := glue.GetTagsInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.GetTags(ctx, input, optFns...)
+	output, err := conn.GetTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *glue.Client, identifier string, oldTa
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Glue)
 	if len(removedTags) > 0 {
-		input := &glue.UntagResourceInput{
+		input := glue.UntagResourceInput{
 			ResourceArn:  aws.String(identifier),
 			TagsToRemove: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *glue.Client, identifier string, oldTa
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Glue)
 	if len(updatedTags) > 0 {
-		input := &glue.TagResourceInput{
+		input := glue.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagsToAdd:   Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/grafana/service_endpoints_gen_test.go
+++ b/internal/service/grafana/service_endpoints_gen_test.go
@@ -396,7 +396,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListWorkspaces(ctx, &grafana.ListWorkspacesInput{},
+	input := grafana.ListWorkspacesInput{}
+	_, err := client.ListWorkspaces(ctx, &input,
 		func(opts *grafana.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/grafana/tags_gen.go
+++ b/internal/service/grafana/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *grafana.Client, identifier string, optFns ...func(*grafana.Options)) (tftags.KeyValueTags, error) {
-	input := &grafana.ListTagsForResourceInput{
+	input := grafana.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *grafana.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Grafana)
 	if len(removedTags) > 0 {
-		input := &grafana.UntagResourceInput{
+		input := grafana.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *grafana.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Grafana)
 	if len(updatedTags) > 0 {
-		input := &grafana.TagResourceInput{
+		input := grafana.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/greengrass/service_endpoints_gen_test.go
+++ b/internal/service/greengrass/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListGroups(ctx, &greengrass.ListGroupsInput{},
+	input := greengrass.ListGroupsInput{}
+	_, err := client.ListGroups(ctx, &input,
 		func(opts *greengrass.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/greengrass/tags_gen.go
+++ b/internal/service/greengrass/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *greengrass.Client, identifier string, optFns ...func(*greengrass.Options)) (tftags.KeyValueTags, error) {
-	input := &greengrass.ListTagsForResourceInput{
+	input := greengrass.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *greengrass.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Greengrass)
 	if len(removedTags) > 0 {
-		input := &greengrass.UntagResourceInput{
+		input := greengrass.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *greengrass.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Greengrass)
 	if len(updatedTags) > 0 {
-		input := &greengrass.TagResourceInput{
+		input := greengrass.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/groundstation/service_endpoints_gen_test.go
+++ b/internal/service/groundstation/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListConfigs(ctx, &groundstation.ListConfigsInput{},
+	input := groundstation.ListConfigsInput{}
+	_, err := client.ListConfigs(ctx, &input,
 		func(opts *groundstation.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/guardduty/service_endpoints_gen_test.go
+++ b/internal/service/guardduty/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDetectors(ctx, &guardduty.ListDetectorsInput{},
+	input := guardduty.ListDetectorsInput{}
+	_, err := client.ListDetectors(ctx, &input,
 		func(opts *guardduty.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/guardduty/tags_gen.go
+++ b/internal/service/guardduty/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *guardduty.Client, identifier string, optFns ...func(*guardduty.Options)) (tftags.KeyValueTags, error) {
-	input := &guardduty.ListTagsForResourceInput{
+	input := guardduty.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *guardduty.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.GuardDuty)
 	if len(removedTags) > 0 {
-		input := &guardduty.UntagResourceInput{
+		input := guardduty.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *guardduty.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.GuardDuty)
 	if len(updatedTags) > 0 {
-		input := &guardduty.TagResourceInput{
+		input := guardduty.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/healthlake/service_endpoints_gen_test.go
+++ b/internal/service/healthlake/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListFHIRDatastores(ctx, &healthlake.ListFHIRDatastoresInput{},
+	input := healthlake.ListFHIRDatastoresInput{}
+	_, err := client.ListFHIRDatastores(ctx, &input,
 		func(opts *healthlake.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/healthlake/tags_gen.go
+++ b/internal/service/healthlake/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *healthlake.Client, identifier string, optFns ...func(*healthlake.Options)) (tftags.KeyValueTags, error) {
-	input := &healthlake.ListTagsForResourceInput{
+	input := healthlake.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *healthlake.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.HealthLake)
 	if len(removedTags) > 0 {
-		input := &healthlake.UntagResourceInput{
+		input := healthlake.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *healthlake.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.HealthLake)
 	if len(updatedTags) > 0 {
-		input := &healthlake.TagResourceInput{
+		input := healthlake.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/iam/service_endpoints_gen_test.go
+++ b/internal/service/iam/service_endpoints_gen_test.go
@@ -393,7 +393,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRoles(ctx, &iam.ListRolesInput{},
+	input := iam.ListRolesInput{}
+	_, err := client.ListRoles(ctx, &input,
 		func(opts *iam.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/identitystore/service_endpoints_gen_test.go
+++ b/internal/service/identitystore/service_endpoints_gen_test.go
@@ -283,9 +283,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListUsers(ctx, &identitystore.ListUsersInput{
+	input := identitystore.ListUsersInput{
 		IdentityStoreId: aws.String("d-1234567890"),
-	},
+	}
+	_, err := client.ListUsers(ctx, &input,
 		func(opts *identitystore.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/imagebuilder/service_endpoints_gen_test.go
+++ b/internal/service/imagebuilder/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListImages(ctx, &imagebuilder.ListImagesInput{},
+	input := imagebuilder.ListImagesInput{}
+	_, err := client.ListImages(ctx, &input,
 		func(opts *imagebuilder.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/imagebuilder/tags_gen.go
+++ b/internal/service/imagebuilder/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *imagebuilder.Client, identifier string, optFns ...func(*imagebuilder.Options)) (tftags.KeyValueTags, error) {
-	input := &imagebuilder.ListTagsForResourceInput{
+	input := imagebuilder.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *imagebuilder.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ImageBuilder)
 	if len(removedTags) > 0 {
-		input := &imagebuilder.UntagResourceInput{
+		input := imagebuilder.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *imagebuilder.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ImageBuilder)
 	if len(updatedTags) > 0 {
-		input := &imagebuilder.TagResourceInput{
+		input := imagebuilder.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/inspector/service_endpoints_gen_test.go
+++ b/internal/service/inspector/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRulesPackages(ctx, &inspector.ListRulesPackagesInput{},
+	input := inspector.ListRulesPackagesInput{}
+	_, err := client.ListRulesPackages(ctx, &input,
 		func(opts *inspector.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/inspector/tags_gen.go
+++ b/internal/service/inspector/tags_gen.go
@@ -16,11 +16,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *inspector.Client, identifier string, optFns ...func(*inspector.Options)) (tftags.KeyValueTags, error) {
-	input := &inspector.ListTagsForResourceInput{
+	input := inspector.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err

--- a/internal/service/inspector2/service_endpoints_gen_test.go
+++ b/internal/service/inspector2/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAccountPermissions(ctx, &inspector2.ListAccountPermissionsInput{},
+	input := inspector2.ListAccountPermissionsInput{}
+	_, err := client.ListAccountPermissions(ctx, &input,
 		func(opts *inspector2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/internetmonitor/service_endpoints_gen_test.go
+++ b/internal/service/internetmonitor/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListMonitors(ctx, &internetmonitor.ListMonitorsInput{},
+	input := internetmonitor.ListMonitorsInput{}
+	_, err := client.ListMonitors(ctx, &input,
 		func(opts *internetmonitor.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/internetmonitor/tags_gen.go
+++ b/internal/service/internetmonitor/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *internetmonitor.Client, identifier string, optFns ...func(*internetmonitor.Options)) (tftags.KeyValueTags, error) {
-	input := &internetmonitor.ListTagsForResourceInput{
+	input := internetmonitor.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *internetmonitor.Client, identifier st
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.InternetMonitor)
 	if len(removedTags) > 0 {
-		input := &internetmonitor.UntagResourceInput{
+		input := internetmonitor.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *internetmonitor.Client, identifier st
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.InternetMonitor)
 	if len(updatedTags) > 0 {
-		input := &internetmonitor.TagResourceInput{
+		input := internetmonitor.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/iot/service_endpoints_gen_test.go
+++ b/internal/service/iot/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeDefaultAuthorizer(ctx, &iot.DescribeDefaultAuthorizerInput{},
+	input := iot.DescribeDefaultAuthorizerInput{}
+	_, err := client.DescribeDefaultAuthorizer(ctx, &input,
 		func(opts *iot.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/iot/tags_gen.go
+++ b/internal/service/iot/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *iot.Client, identifier string, optFns ...func(*iot.Options)) (tftags.KeyValueTags, error) {
-	input := &iot.ListTagsForResourceInput{
+	input := iot.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *iot.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.IoT)
 	if len(removedTags) > 0 {
-		input := &iot.UntagResourceInput{
+		input := iot.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *iot.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.IoT)
 	if len(updatedTags) > 0 {
-		input := &iot.TagResourceInput{
+		input := iot.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/iotanalytics/service_endpoints_gen_test.go
+++ b/internal/service/iotanalytics/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListChannels(ctx, &iotanalytics.ListChannelsInput{},
+	input := iotanalytics.ListChannelsInput{}
+	_, err := client.ListChannels(ctx, &input,
 		func(opts *iotanalytics.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/iotanalytics/tags_gen.go
+++ b/internal/service/iotanalytics/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *iotanalytics.Client, identifier string, optFns ...func(*iotanalytics.Options)) (tftags.KeyValueTags, error) {
-	input := &iotanalytics.ListTagsForResourceInput{
+	input := iotanalytics.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *iotanalytics.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.IoTAnalytics)
 	if len(removedTags) > 0 {
-		input := &iotanalytics.UntagResourceInput{
+		input := iotanalytics.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *iotanalytics.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.IoTAnalytics)
 	if len(updatedTags) > 0 {
-		input := &iotanalytics.TagResourceInput{
+		input := iotanalytics.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/iotevents/service_endpoints_gen_test.go
+++ b/internal/service/iotevents/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAlarmModels(ctx, &iotevents.ListAlarmModelsInput{},
+	input := iotevents.ListAlarmModelsInput{}
+	_, err := client.ListAlarmModels(ctx, &input,
 		func(opts *iotevents.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/iotevents/tags_gen.go
+++ b/internal/service/iotevents/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *iotevents.Client, identifier string, optFns ...func(*iotevents.Options)) (tftags.KeyValueTags, error) {
-	input := &iotevents.ListTagsForResourceInput{
+	input := iotevents.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *iotevents.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.IoTEvents)
 	if len(removedTags) > 0 {
-		input := &iotevents.UntagResourceInput{
+		input := iotevents.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *iotevents.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.IoTEvents)
 	if len(updatedTags) > 0 {
-		input := &iotevents.TagResourceInput{
+		input := iotevents.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ivs/service_endpoints_gen_test.go
+++ b/internal/service/ivs/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListChannels(ctx, &ivs.ListChannelsInput{},
+	input := ivs.ListChannelsInput{}
+	_, err := client.ListChannels(ctx, &input,
 		func(opts *ivs.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ivs/tags_gen.go
+++ b/internal/service/ivs/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *ivs.Client, identifier string, optFns ...func(*ivs.Options)) (tftags.KeyValueTags, error) {
-	input := &ivs.ListTagsForResourceInput{
+	input := ivs.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *ivs.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.IVS)
 	if len(removedTags) > 0 {
-		input := &ivs.UntagResourceInput{
+		input := ivs.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *ivs.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.IVS)
 	if len(updatedTags) > 0 {
-		input := &ivs.TagResourceInput{
+		input := ivs.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ivschat/service_endpoints_gen_test.go
+++ b/internal/service/ivschat/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRooms(ctx, &ivschat.ListRoomsInput{},
+	input := ivschat.ListRoomsInput{}
+	_, err := client.ListRooms(ctx, &input,
 		func(opts *ivschat.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ivschat/tags_gen.go
+++ b/internal/service/ivschat/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *ivschat.Client, identifier string, optFns ...func(*ivschat.Options)) (tftags.KeyValueTags, error) {
-	input := &ivschat.ListTagsForResourceInput{
+	input := ivschat.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *ivschat.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.IVSChat)
 	if len(removedTags) > 0 {
-		input := &ivschat.UntagResourceInput{
+		input := ivschat.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *ivschat.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.IVSChat)
 	if len(updatedTags) > 0 {
-		input := &ivschat.TagResourceInput{
+		input := ivschat.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/kafka/service_endpoints_gen_test.go
+++ b/internal/service/kafka/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListClusters(ctx, &kafka.ListClustersInput{},
+	input := kafka.ListClustersInput{}
+	_, err := client.ListClusters(ctx, &input,
 		func(opts *kafka.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/kafka/tags_gen.go
+++ b/internal/service/kafka/tags_gen.go
@@ -58,12 +58,12 @@ func updateTags(ctx context.Context, conn *kafka.Client, identifier string, oldT
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Kafka)
 	if len(removedTags) > 0 {
-		input := &kafka.UntagResourceInput{
+		input := kafka.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -73,12 +73,12 @@ func updateTags(ctx context.Context, conn *kafka.Client, identifier string, oldT
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Kafka)
 	if len(updatedTags) > 0 {
-		input := &kafka.TagResourceInput{
+		input := kafka.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/kafkaconnect/service_endpoints_gen_test.go
+++ b/internal/service/kafkaconnect/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListConnectors(ctx, &kafkaconnect.ListConnectorsInput{},
+	input := kafkaconnect.ListConnectorsInput{}
+	_, err := client.ListConnectors(ctx, &input,
 		func(opts *kafkaconnect.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/kafkaconnect/tags_gen.go
+++ b/internal/service/kafkaconnect/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *kafkaconnect.Client, identifier string, optFns ...func(*kafkaconnect.Options)) (tftags.KeyValueTags, error) {
-	input := &kafkaconnect.ListTagsForResourceInput{
+	input := kafkaconnect.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *kafkaconnect.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.KafkaConnect)
 	if len(removedTags) > 0 {
-		input := &kafkaconnect.UntagResourceInput{
+		input := kafkaconnect.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *kafkaconnect.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.KafkaConnect)
 	if len(updatedTags) > 0 {
-		input := &kafkaconnect.TagResourceInput{
+		input := kafkaconnect.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/kendra/service_endpoints_gen_test.go
+++ b/internal/service/kendra/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListIndices(ctx, &kendra.ListIndicesInput{},
+	input := kendra.ListIndicesInput{}
+	_, err := client.ListIndices(ctx, &input,
 		func(opts *kendra.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/kendra/tags_gen.go
+++ b/internal/service/kendra/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *kendra.Client, identifier string, optFns ...func(*kendra.Options)) (tftags.KeyValueTags, error) {
-	input := &kendra.ListTagsForResourceInput{
+	input := kendra.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *kendra.Client, identifier string, old
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Kendra)
 	if len(removedTags) > 0 {
-		input := &kendra.UntagResourceInput{
+		input := kendra.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *kendra.Client, identifier string, old
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Kendra)
 	if len(updatedTags) > 0 {
-		input := &kendra.TagResourceInput{
+		input := kendra.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/keyspaces/service_endpoints_gen_test.go
+++ b/internal/service/keyspaces/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListKeyspaces(ctx, &keyspaces.ListKeyspacesInput{},
+	input := keyspaces.ListKeyspacesInput{}
+	_, err := client.ListKeyspaces(ctx, &input,
 		func(opts *keyspaces.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/keyspaces/tags_gen.go
+++ b/internal/service/keyspaces/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *keyspaces.Client, identifier string, optFns ...func(*keyspaces.Options)) (tftags.KeyValueTags, error) {
-	input := &keyspaces.ListTagsForResourceInput{
+	input := keyspaces.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *keyspaces.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Keyspaces)
 	if len(removedTags) > 0 {
-		input := &keyspaces.UntagResourceInput{
+		input := keyspaces.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(removedTags),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *keyspaces.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Keyspaces)
 	if len(updatedTags) > 0 {
-		input := &keyspaces.TagResourceInput{
+		input := keyspaces.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/kinesis/service_endpoints_gen_test.go
+++ b/internal/service/kinesis/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListStreams(ctx, &kinesis.ListStreamsInput{},
+	input := kinesis.ListStreamsInput{}
+	_, err := client.ListStreams(ctx, &input,
 		func(opts *kinesis.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/kinesis/tags_gen.go
+++ b/internal/service/kinesis/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *kinesis.Client, identifier string, optFns ...func(*kinesis.Options)) (tftags.KeyValueTags, error) {
-	input := &kinesis.ListTagsForStreamInput{
+	input := kinesis.ListTagsForStreamInput{
 		StreamName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForStream(ctx, input, optFns...)
+	output, err := conn.ListTagsForStream(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -110,12 +110,12 @@ func updateTags(ctx context.Context, conn *kinesis.Client, identifier string, ol
 	removedTags = removedTags.IgnoreSystem(names.Kinesis)
 	if len(removedTags) > 0 {
 		for _, removedTags := range removedTags.Chunks(10) {
-			input := &kinesis.RemoveTagsFromStreamInput{
+			input := kinesis.RemoveTagsFromStreamInput{
 				StreamName: aws.String(identifier),
 				TagKeys:    removedTags.Keys(),
 			}
 
-			_, err := conn.RemoveTagsFromStream(ctx, input, optFns...)
+			_, err := conn.RemoveTagsFromStream(ctx, &input, optFns...)
 
 			if err != nil {
 				return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -127,12 +127,12 @@ func updateTags(ctx context.Context, conn *kinesis.Client, identifier string, ol
 	updatedTags = updatedTags.IgnoreSystem(names.Kinesis)
 	if len(updatedTags) > 0 {
 		for _, updatedTags := range updatedTags.Chunks(10) {
-			input := &kinesis.AddTagsToStreamInput{
+			input := kinesis.AddTagsToStreamInput{
 				StreamName: aws.String(identifier),
 				Tags:       updatedTags.IgnoreAWS().Map(),
 			}
 
-			_, err := conn.AddTagsToStream(ctx, input, optFns...)
+			_, err := conn.AddTagsToStream(ctx, &input, optFns...)
 
 			if err != nil {
 				return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/kinesisanalytics/service_endpoints_gen_test.go
+++ b/internal/service/kinesisanalytics/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &kinesisanalytics.ListApplicationsInput{},
+	input := kinesisanalytics.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *kinesisanalytics.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/kinesisanalytics/tags_gen.go
+++ b/internal/service/kinesisanalytics/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *kinesisanalytics.Client, identifier string, optFns ...func(*kinesisanalytics.Options)) (tftags.KeyValueTags, error) {
-	input := &kinesisanalytics.ListTagsForResourceInput{
+	input := kinesisanalytics.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *kinesisanalytics.Client, identifier s
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.KinesisAnalytics)
 	if len(removedTags) > 0 {
-		input := &kinesisanalytics.UntagResourceInput{
+		input := kinesisanalytics.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *kinesisanalytics.Client, identifier s
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.KinesisAnalytics)
 	if len(updatedTags) > 0 {
-		input := &kinesisanalytics.TagResourceInput{
+		input := kinesisanalytics.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/kinesisanalyticsv2/service_endpoints_gen_test.go
+++ b/internal/service/kinesisanalyticsv2/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &kinesisanalyticsv2.ListApplicationsInput{},
+	input := kinesisanalyticsv2.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *kinesisanalyticsv2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/kinesisanalyticsv2/tags_gen.go
+++ b/internal/service/kinesisanalyticsv2/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *kinesisanalyticsv2.Client, identifier string, optFns ...func(*kinesisanalyticsv2.Options)) (tftags.KeyValueTags, error) {
-	input := &kinesisanalyticsv2.ListTagsForResourceInput{
+	input := kinesisanalyticsv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *kinesisanalyticsv2.Client, identifier
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.KinesisAnalyticsV2)
 	if len(removedTags) > 0 {
-		input := &kinesisanalyticsv2.UntagResourceInput{
+		input := kinesisanalyticsv2.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *kinesisanalyticsv2.Client, identifier
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.KinesisAnalyticsV2)
 	if len(updatedTags) > 0 {
-		input := &kinesisanalyticsv2.TagResourceInput{
+		input := kinesisanalyticsv2.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/kinesisvideo/service_endpoints_gen_test.go
+++ b/internal/service/kinesisvideo/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListStreams(ctx, &kinesisvideo.ListStreamsInput{},
+	input := kinesisvideo.ListStreamsInput{}
+	_, err := client.ListStreams(ctx, &input,
 		func(opts *kinesisvideo.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/kinesisvideo/tags_gen.go
+++ b/internal/service/kinesisvideo/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *kinesisvideo.Client, identifier string, optFns ...func(*kinesisvideo.Options)) (tftags.KeyValueTags, error) {
-	input := &kinesisvideo.ListTagsForStreamInput{
+	input := kinesisvideo.ListTagsForStreamInput{
 		StreamARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForStream(ctx, input, optFns...)
+	output, err := conn.ListTagsForStream(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *kinesisvideo.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.KinesisVideo)
 	if len(removedTags) > 0 {
-		input := &kinesisvideo.UntagStreamInput{
+		input := kinesisvideo.UntagStreamInput{
 			StreamARN:  aws.String(identifier),
 			TagKeyList: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagStream(ctx, input, optFns...)
+		_, err := conn.UntagStream(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *kinesisvideo.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.KinesisVideo)
 	if len(updatedTags) > 0 {
-		input := &kinesisvideo.TagStreamInput{
+		input := kinesisvideo.TagStreamInput{
 			StreamARN: aws.String(identifier),
 			Tags:      Tags(updatedTags),
 		}
 
-		_, err := conn.TagStream(ctx, input, optFns...)
+		_, err := conn.TagStream(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/kms/service_endpoints_gen_test.go
+++ b/internal/service/kms/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListKeys(ctx, &kms.ListKeysInput{},
+	input := kms.ListKeysInput{}
+	_, err := client.ListKeys(ctx, &input,
 		func(opts *kms.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/lakeformation/service_endpoints_gen_test.go
+++ b/internal/service/lakeformation/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListResources(ctx, &lakeformation.ListResourcesInput{},
+	input := lakeformation.ListResourcesInput{}
+	_, err := client.ListResources(ctx, &input,
 		func(opts *lakeformation.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/lambda/service_endpoints_gen_test.go
+++ b/internal/service/lambda/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListFunctions(ctx, &lambda.ListFunctionsInput{},
+	input := lambda.ListFunctionsInput{}
+	_, err := client.ListFunctions(ctx, &input,
 		func(opts *lambda.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/lambda/tags_gen.go
+++ b/internal/service/lambda/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *lambda.Client, identifier string, optFns ...func(*lambda.Options)) (tftags.KeyValueTags, error) {
-	input := &lambda.ListTagsInput{
+	input := lambda.ListTagsInput{
 		Resource: aws.String(identifier),
 	}
 
-	output, err := conn.ListTags(ctx, input, optFns...)
+	output, err := conn.ListTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *lambda.Client, identifier string, old
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Lambda)
 	if len(removedTags) > 0 {
-		input := &lambda.UntagResourceInput{
+		input := lambda.UntagResourceInput{
 			Resource: aws.String(identifier),
 			TagKeys:  removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *lambda.Client, identifier string, old
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Lambda)
 	if len(updatedTags) > 0 {
-		input := &lambda.TagResourceInput{
+		input := lambda.TagResourceInput{
 			Resource: aws.String(identifier),
 			Tags:     Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/launchwizard/service_endpoints_gen_test.go
+++ b/internal/service/launchwizard/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListWorkloads(ctx, &launchwizard.ListWorkloadsInput{},
+	input := launchwizard.ListWorkloadsInput{}
+	_, err := client.ListWorkloads(ctx, &input,
 		func(opts *launchwizard.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/lexmodels/service_endpoints_gen_test.go
+++ b/internal/service/lexmodels/service_endpoints_gen_test.go
@@ -463,7 +463,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetBots(ctx, &lexmodelbuildingservice.GetBotsInput{},
+	input := lexmodelbuildingservice.GetBotsInput{}
+	_, err := client.GetBots(ctx, &input,
 		func(opts *lexmodelbuildingservice.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/lexv2models/service_endpoints_gen_test.go
+++ b/internal/service/lexv2models/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListBots(ctx, &lexmodelsv2.ListBotsInput{},
+	input := lexmodelsv2.ListBotsInput{}
+	_, err := client.ListBots(ctx, &input,
 		func(opts *lexmodelsv2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/lexv2models/tags_gen.go
+++ b/internal/service/lexv2models/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string, optFns ...func(*lexmodelsv2.Options)) (tftags.KeyValueTags, error) {
-	input := &lexmodelsv2.ListTagsForResourceInput{
+	input := lexmodelsv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.LexV2Models)
 	if len(removedTags) > 0 {
-		input := &lexmodelsv2.UntagResourceInput{
+		input := lexmodelsv2.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *lexmodelsv2.Client, identifier string
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.LexV2Models)
 	if len(updatedTags) > 0 {
-		input := &lexmodelsv2.TagResourceInput{
+		input := lexmodelsv2.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/licensemanager/service_endpoints_gen_test.go
+++ b/internal/service/licensemanager/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListLicenseConfigurations(ctx, &licensemanager.ListLicenseConfigurationsInput{},
+	input := licensemanager.ListLicenseConfigurationsInput{}
+	_, err := client.ListLicenseConfigurations(ctx, &input,
 		func(opts *licensemanager.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/licensemanager/tags_gen.go
+++ b/internal/service/licensemanager/tags_gen.go
@@ -76,12 +76,12 @@ func updateTags(ctx context.Context, conn *licensemanager.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.LicenseManager)
 	if len(removedTags) > 0 {
-		input := &licensemanager.UntagResourceInput{
+		input := licensemanager.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *licensemanager.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.LicenseManager)
 	if len(updatedTags) > 0 {
-		input := &licensemanager.TagResourceInput{
+		input := licensemanager.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/lightsail/service_endpoints_gen_test.go
+++ b/internal/service/lightsail/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetInstances(ctx, &lightsail.GetInstancesInput{},
+	input := lightsail.GetInstancesInput{}
+	_, err := client.GetInstances(ctx, &input,
 		func(opts *lightsail.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/lightsail/tags_gen.go
+++ b/internal/service/lightsail/tags_gen.go
@@ -85,12 +85,12 @@ func updateTags(ctx context.Context, conn *lightsail.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Lightsail)
 	if len(removedTags) > 0 {
-		input := &lightsail.UntagResourceInput{
+		input := lightsail.UntagResourceInput{
 			ResourceName: aws.String(identifier),
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -100,12 +100,12 @@ func updateTags(ctx context.Context, conn *lightsail.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Lightsail)
 	if len(updatedTags) > 0 {
-		input := &lightsail.TagResourceInput{
+		input := lightsail.TagResourceInput{
 			ResourceName: aws.String(identifier),
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/location/tags_gen.go
+++ b/internal/service/location/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *location.Client, identifier string, optFns ...func(*location.Options)) (tftags.KeyValueTags, error) {
-	input := &location.ListTagsForResourceInput{
+	input := location.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *location.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Location)
 	if len(removedTags) > 0 {
-		input := &location.UntagResourceInput{
+		input := location.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *location.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Location)
 	if len(updatedTags) > 0 {
-		input := &location.TagResourceInput{
+		input := location.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/logs/service_endpoints_gen_test.go
+++ b/internal/service/logs/service_endpoints_gen_test.go
@@ -396,7 +396,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAnomalies(ctx, &cloudwatchlogs.ListAnomaliesInput{},
+	input := cloudwatchlogs.ListAnomaliesInput{}
+	_, err := client.ListAnomalies(ctx, &input,
 		func(opts *cloudwatchlogs.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/logs/tags_gen.go
+++ b/internal/service/logs/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier string, optFns ...func(*cloudwatchlogs.Options)) (tftags.KeyValueTags, error) {
-	input := &cloudwatchlogs.ListTagsForResourceInput{
+	input := cloudwatchlogs.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,12 +100,12 @@ func updateTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Logs)
 	if len(removedTags) > 0 {
-		input := &cloudwatchlogs.UntagResourceInput{
+		input := cloudwatchlogs.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -115,12 +115,12 @@ func updateTags(ctx context.Context, conn *cloudwatchlogs.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Logs)
 	if len(updatedTags) > 0 {
-		input := &cloudwatchlogs.TagResourceInput{
+		input := cloudwatchlogs.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/lookoutmetrics/service_endpoints_gen_test.go
+++ b/internal/service/lookoutmetrics/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListMetricSets(ctx, &lookoutmetrics.ListMetricSetsInput{},
+	input := lookoutmetrics.ListMetricSetsInput{}
+	_, err := client.ListMetricSets(ctx, &input,
 		func(opts *lookoutmetrics.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/lookoutmetrics/tags_gen.go
+++ b/internal/service/lookoutmetrics/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *lookoutmetrics.Client, identifier string, optFns ...func(*lookoutmetrics.Options)) (tftags.KeyValueTags, error) {
-	input := &lookoutmetrics.ListTagsForResourceInput{
+	input := lookoutmetrics.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *lookoutmetrics.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.LookoutMetrics)
 	if len(removedTags) > 0 {
-		input := &lookoutmetrics.UntagResourceInput{
+		input := lookoutmetrics.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *lookoutmetrics.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.LookoutMetrics)
 	if len(updatedTags) > 0 {
-		input := &lookoutmetrics.TagResourceInput{
+		input := lookoutmetrics.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/m2/service_endpoints_gen_test.go
+++ b/internal/service/m2/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &m2.ListApplicationsInput{},
+	input := m2.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *m2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/m2/tags_gen.go
+++ b/internal/service/m2/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *m2.Client, identifier string, optFns ...func(*m2.Options)) (tftags.KeyValueTags, error) {
-	input := &m2.ListTagsForResourceInput{
+	input := m2.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *m2.Client, identifier string, oldTags
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.M2)
 	if len(removedTags) > 0 {
-		input := &m2.UntagResourceInput{
+		input := m2.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *m2.Client, identifier string, oldTags
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.M2)
 	if len(updatedTags) > 0 {
-		input := &m2.TagResourceInput{
+		input := m2.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/macie2/service_endpoints_gen_test.go
+++ b/internal/service/macie2/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListFindings(ctx, &macie2.ListFindingsInput{},
+	input := macie2.ListFindingsInput{}
+	_, err := client.ListFindings(ctx, &input,
 		func(opts *macie2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/mediaconnect/service_endpoints_gen_test.go
+++ b/internal/service/mediaconnect/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListBridges(ctx, &mediaconnect.ListBridgesInput{},
+	input := mediaconnect.ListBridgesInput{}
+	_, err := client.ListBridges(ctx, &input,
 		func(opts *mediaconnect.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/mediaconnect/tags_gen.go
+++ b/internal/service/mediaconnect/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *mediaconnect.Client, identifier string, optFns ...func(*mediaconnect.Options)) (tftags.KeyValueTags, error) {
-	input := &mediaconnect.ListTagsForResourceInput{
+	input := mediaconnect.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *mediaconnect.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.MediaConnect)
 	if len(removedTags) > 0 {
-		input := &mediaconnect.UntagResourceInput{
+		input := mediaconnect.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *mediaconnect.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.MediaConnect)
 	if len(updatedTags) > 0 {
-		input := &mediaconnect.TagResourceInput{
+		input := mediaconnect.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/mediaconvert/service_endpoints_gen_test.go
+++ b/internal/service/mediaconvert/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListJobs(ctx, &mediaconvert.ListJobsInput{},
+	input := mediaconvert.ListJobsInput{}
+	_, err := client.ListJobs(ctx, &input,
 		func(opts *mediaconvert.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/mediaconvert/tags_gen.go
+++ b/internal/service/mediaconvert/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *mediaconvert.Client, identifier string, optFns ...func(*mediaconvert.Options)) (tftags.KeyValueTags, error) {
-	input := &mediaconvert.ListTagsForResourceInput{
+	input := mediaconvert.ListTagsForResourceInput{
 		Arn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *mediaconvert.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.MediaConvert)
 	if len(removedTags) > 0 {
-		input := &mediaconvert.UntagResourceInput{
+		input := mediaconvert.UntagResourceInput{
 			Arn:     aws.String(identifier),
 			TagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *mediaconvert.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.MediaConvert)
 	if len(updatedTags) > 0 {
-		input := &mediaconvert.TagResourceInput{
+		input := mediaconvert.TagResourceInput{
 			Arn:  aws.String(identifier),
 			Tags: Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/medialive/service_endpoints_gen_test.go
+++ b/internal/service/medialive/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListOfferings(ctx, &medialive.ListOfferingsInput{},
+	input := medialive.ListOfferingsInput{}
+	_, err := client.ListOfferings(ctx, &input,
 		func(opts *medialive.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/medialive/tags_gen.go
+++ b/internal/service/medialive/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *medialive.Client, identifier string, optFns ...func(*medialive.Options)) (tftags.KeyValueTags, error) {
-	input := &medialive.ListTagsForResourceInput{
+	input := medialive.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *medialive.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.MediaLive)
 	if len(removedTags) > 0 {
-		input := &medialive.DeleteTagsInput{
+		input := medialive.DeleteTagsInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.DeleteTags(ctx, input, optFns...)
+		_, err := conn.DeleteTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *medialive.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.MediaLive)
 	if len(updatedTags) > 0 {
-		input := &medialive.CreateTagsInput{
+		input := medialive.CreateTagsInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.CreateTags(ctx, input, optFns...)
+		_, err := conn.CreateTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/mediapackage/service_endpoints_gen_test.go
+++ b/internal/service/mediapackage/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListChannels(ctx, &mediapackage.ListChannelsInput{},
+	input := mediapackage.ListChannelsInput{}
+	_, err := client.ListChannels(ctx, &input,
 		func(opts *mediapackage.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/mediapackage/tags_gen.go
+++ b/internal/service/mediapackage/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *mediapackage.Client, identifier string, optFns ...func(*mediapackage.Options)) (tftags.KeyValueTags, error) {
-	input := &mediapackage.ListTagsForResourceInput{
+	input := mediapackage.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *mediapackage.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.MediaPackage)
 	if len(removedTags) > 0 {
-		input := &mediapackage.UntagResourceInput{
+		input := mediapackage.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *mediapackage.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.MediaPackage)
 	if len(updatedTags) > 0 {
-		input := &mediapackage.TagResourceInput{
+		input := mediapackage.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/mediapackagev2/service_endpoints_gen_test.go
+++ b/internal/service/mediapackagev2/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListChannelGroups(ctx, &mediapackagev2.ListChannelGroupsInput{},
+	input := mediapackagev2.ListChannelGroupsInput{}
+	_, err := client.ListChannelGroups(ctx, &input,
 		func(opts *mediapackagev2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/mediastore/service_endpoints_gen_test.go
+++ b/internal/service/mediastore/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListContainers(ctx, &mediastore.ListContainersInput{},
+	input := mediastore.ListContainersInput{}
+	_, err := client.ListContainers(ctx, &input,
 		func(opts *mediastore.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/mediastore/tags_gen.go
+++ b/internal/service/mediastore/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *mediastore.Client, identifier string, optFns ...func(*mediastore.Options)) (tftags.KeyValueTags, error) {
-	input := &mediastore.ListTagsForResourceInput{
+	input := mediastore.ListTagsForResourceInput{
 		Resource: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *mediastore.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.MediaStore)
 	if len(removedTags) > 0 {
-		input := &mediastore.UntagResourceInput{
+		input := mediastore.UntagResourceInput{
 			Resource: aws.String(identifier),
 			TagKeys:  removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *mediastore.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.MediaStore)
 	if len(updatedTags) > 0 {
-		input := &mediastore.TagResourceInput{
+		input := mediastore.TagResourceInput{
 			Resource: aws.String(identifier),
 			Tags:     Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/memorydb/service_endpoints_gen_test.go
+++ b/internal/service/memorydb/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeClusters(ctx, &memorydb.DescribeClustersInput{},
+	input := memorydb.DescribeClustersInput{}
+	_, err := client.DescribeClusters(ctx, &input,
 		func(opts *memorydb.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/memorydb/tags_gen.go
+++ b/internal/service/memorydb/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *memorydb.Client, identifier string, optFns ...func(*memorydb.Options)) (tftags.KeyValueTags, error) {
-	input := &memorydb.ListTagsInput{
+	input := memorydb.ListTagsInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTags(ctx, input, optFns...)
+	output, err := conn.ListTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *memorydb.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.MemoryDB)
 	if len(removedTags) > 0 {
-		input := &memorydb.UntagResourceInput{
+		input := memorydb.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *memorydb.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.MemoryDB)
 	if len(updatedTags) > 0 {
-		input := &memorydb.TagResourceInput{
+		input := memorydb.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/mgn/service_endpoints_gen_test.go
+++ b/internal/service/mgn/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &mgn.ListApplicationsInput{},
+	input := mgn.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *mgn.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/mq/service_endpoints_gen_test.go
+++ b/internal/service/mq/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListBrokers(ctx, &mq.ListBrokersInput{},
+	input := mq.ListBrokersInput{}
+	_, err := client.ListBrokers(ctx, &input,
 		func(opts *mq.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/mq/tags_gen.go
+++ b/internal/service/mq/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *mq.Client, identifier string, optFns ...func(*mq.Options)) (tftags.KeyValueTags, error) {
-	input := &mq.ListTagsInput{
+	input := mq.ListTagsInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTags(ctx, input, optFns...)
+	output, err := conn.ListTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *mq.Client, identifier string, oldTags
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.MQ)
 	if len(removedTags) > 0 {
-		input := &mq.DeleteTagsInput{
+		input := mq.DeleteTagsInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.DeleteTags(ctx, input, optFns...)
+		_, err := conn.DeleteTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *mq.Client, identifier string, oldTags
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.MQ)
 	if len(updatedTags) > 0 {
-		input := &mq.CreateTagsInput{
+		input := mq.CreateTagsInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.CreateTags(ctx, input, optFns...)
+		_, err := conn.CreateTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/mwaa/tags_gen.go
+++ b/internal/service/mwaa/tags_gen.go
@@ -58,12 +58,12 @@ func updateTags(ctx context.Context, conn *mwaa.Client, identifier string, oldTa
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.MWAA)
 	if len(removedTags) > 0 {
-		input := &mwaa.UntagResourceInput{
+		input := mwaa.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -73,12 +73,12 @@ func updateTags(ctx context.Context, conn *mwaa.Client, identifier string, oldTa
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.MWAA)
 	if len(updatedTags) > 0 {
-		input := &mwaa.TagResourceInput{
+		input := mwaa.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/neptune/service_endpoints_gen_test.go
+++ b/internal/service/neptune/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeDBClusters(ctx, &neptune.DescribeDBClustersInput{},
+	input := neptune.DescribeDBClustersInput{}
+	_, err := client.DescribeDBClusters(ctx, &input,
 		func(opts *neptune.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/neptune/tags_gen.go
+++ b/internal/service/neptune/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *neptune.Client, identifier string, optFns ...func(*neptune.Options)) (tftags.KeyValueTags, error) {
-	input := &neptune.ListTagsForResourceInput{
+	input := neptune.ListTagsForResourceInput{
 		ResourceName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *neptune.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Neptune)
 	if len(removedTags) > 0 {
-		input := &neptune.RemoveTagsFromResourceInput{
+		input := neptune.RemoveTagsFromResourceInput{
 			ResourceName: aws.String(identifier),
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTagsFromResource(ctx, input, optFns...)
+		_, err := conn.RemoveTagsFromResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *neptune.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Neptune)
 	if len(updatedTags) > 0 {
-		input := &neptune.AddTagsToResourceInput{
+		input := neptune.AddTagsToResourceInput{
 			ResourceName: aws.String(identifier),
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToResource(ctx, input, optFns...)
+		_, err := conn.AddTagsToResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/networkfirewall/service_endpoints_gen_test.go
+++ b/internal/service/networkfirewall/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListFirewalls(ctx, &networkfirewall.ListFirewallsInput{},
+	input := networkfirewall.ListFirewallsInput{}
+	_, err := client.ListFirewalls(ctx, &input,
 		func(opts *networkfirewall.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/networkfirewall/tags_gen.go
+++ b/internal/service/networkfirewall/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *networkfirewall.Client, identifier string, optFns ...func(*networkfirewall.Options)) (tftags.KeyValueTags, error) {
-	input := &networkfirewall.ListTagsForResourceInput{
+	input := networkfirewall.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *networkfirewall.Client, identifier st
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.NetworkFirewall)
 	if len(removedTags) > 0 {
-		input := &networkfirewall.UntagResourceInput{
+		input := networkfirewall.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *networkfirewall.Client, identifier st
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.NetworkFirewall)
 	if len(updatedTags) > 0 {
-		input := &networkfirewall.TagResourceInput{
+		input := networkfirewall.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/networkmanager/service_endpoints_gen_test.go
+++ b/internal/service/networkmanager/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListCoreNetworks(ctx, &networkmanager.ListCoreNetworksInput{},
+	input := networkmanager.ListCoreNetworksInput{}
+	_, err := client.ListCoreNetworks(ctx, &input,
 		func(opts *networkmanager.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/networkmanager/tags_gen.go
+++ b/internal/service/networkmanager/tags_gen.go
@@ -76,12 +76,12 @@ func updateTags(ctx context.Context, conn *networkmanager.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.NetworkManager)
 	if len(removedTags) > 0 {
-		input := &networkmanager.UntagResourceInput{
+		input := networkmanager.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *networkmanager.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.NetworkManager)
 	if len(updatedTags) > 0 {
-		input := &networkmanager.TagResourceInput{
+		input := networkmanager.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/networkmonitor/service_endpoints_gen_test.go
+++ b/internal/service/networkmonitor/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListMonitors(ctx, &networkmonitor.ListMonitorsInput{},
+	input := networkmonitor.ListMonitorsInput{}
+	_, err := client.ListMonitors(ctx, &input,
 		func(opts *networkmonitor.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/networkmonitor/tags_gen.go
+++ b/internal/service/networkmonitor/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *networkmonitor.Client, identifier string, optFns ...func(*networkmonitor.Options)) (tftags.KeyValueTags, error) {
-	input := &networkmonitor.ListTagsForResourceInput{
+	input := networkmonitor.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *networkmonitor.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.NetworkMonitor)
 	if len(removedTags) > 0 {
-		input := &networkmonitor.UntagResourceInput{
+		input := networkmonitor.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *networkmonitor.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.NetworkMonitor)
 	if len(updatedTags) > 0 {
-		input := &networkmonitor.TagResourceInput{
+		input := networkmonitor.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/oam/service_endpoints_gen_test.go
+++ b/internal/service/oam/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListLinks(ctx, &oam.ListLinksInput{},
+	input := oam.ListLinksInput{}
+	_, err := client.ListLinks(ctx, &input,
 		func(opts *oam.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/oam/tags_gen.go
+++ b/internal/service/oam/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *oam.Client, identifier string, optFns ...func(*oam.Options)) (tftags.KeyValueTags, error) {
-	input := &oam.ListTagsForResourceInput{
+	input := oam.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *oam.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ObservabilityAccessManager)
 	if len(removedTags) > 0 {
-		input := &oam.UntagResourceInput{
+		input := oam.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *oam.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ObservabilityAccessManager)
 	if len(updatedTags) > 0 {
-		input := &oam.TagResourceInput{
+		input := oam.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/opensearch/service_endpoints_gen_test.go
+++ b/internal/service/opensearch/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDomainNames(ctx, &opensearch.ListDomainNamesInput{},
+	input := opensearch.ListDomainNamesInput{}
+	_, err := client.ListDomainNames(ctx, &input,
 		func(opts *opensearch.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/opensearch/tags_gen.go
+++ b/internal/service/opensearch/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *opensearch.Client, identifier string, optFns ...func(*opensearch.Options)) (tftags.KeyValueTags, error) {
-	input := &opensearch.ListTagsInput{
+	input := opensearch.ListTagsInput{
 		ARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTags(ctx, input, optFns...)
+	output, err := conn.ListTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *opensearch.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.OpenSearch)
 	if len(removedTags) > 0 {
-		input := &opensearch.RemoveTagsInput{
+		input := opensearch.RemoveTagsInput{
 			ARN:     aws.String(identifier),
 			TagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTags(ctx, input, optFns...)
+		_, err := conn.RemoveTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *opensearch.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.OpenSearch)
 	if len(updatedTags) > 0 {
-		input := &opensearch.AddTagsInput{
+		input := opensearch.AddTagsInput{
 			ARN:     aws.String(identifier),
 			TagList: Tags(updatedTags),
 		}
 
-		_, err := conn.AddTags(ctx, input, optFns...)
+		_, err := conn.AddTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/opensearchserverless/service_endpoints_gen_test.go
+++ b/internal/service/opensearchserverless/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListCollections(ctx, &opensearchserverless.ListCollectionsInput{},
+	input := opensearchserverless.ListCollectionsInput{}
+	_, err := client.ListCollections(ctx, &input,
 		func(opts *opensearchserverless.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/opensearchserverless/tags_gen.go
+++ b/internal/service/opensearchserverless/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *opensearchserverless.Client, identifier string, optFns ...func(*opensearchserverless.Options)) (tftags.KeyValueTags, error) {
-	input := &opensearchserverless.ListTagsForResourceInput{
+	input := opensearchserverless.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *opensearchserverless.Client, identifi
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.OpenSearchServerless)
 	if len(removedTags) > 0 {
-		input := &opensearchserverless.UntagResourceInput{
+		input := opensearchserverless.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *opensearchserverless.Client, identifi
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.OpenSearchServerless)
 	if len(updatedTags) > 0 {
-		input := &opensearchserverless.TagResourceInput{
+		input := opensearchserverless.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/opsworks/service_endpoints_gen_test.go
+++ b/internal/service/opsworks/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeApps(ctx, &opsworks.DescribeAppsInput{},
+	input := opsworks.DescribeAppsInput{}
+	_, err := client.DescribeApps(ctx, &input,
 		func(opts *opsworks.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/opsworks/tags_gen.go
+++ b/internal/service/opsworks/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *opsworks.Client, identifier string, optFns ...func(*opsworks.Options)) (tftags.KeyValueTags, error) {
-	input := &opsworks.ListTagsInput{
+	input := opsworks.ListTagsInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTags(ctx, input, optFns...)
+	output, err := conn.ListTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,12 +100,12 @@ func updateTags(ctx context.Context, conn *opsworks.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.OpsWorks)
 	if len(removedTags) > 0 {
-		input := &opsworks.UntagResourceInput{
+		input := opsworks.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -115,12 +115,12 @@ func updateTags(ctx context.Context, conn *opsworks.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.OpsWorks)
 	if len(updatedTags) > 0 {
-		input := &opsworks.TagResourceInput{
+		input := opsworks.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/organizations/service_endpoints_gen_test.go
+++ b/internal/service/organizations/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAccounts(ctx, &organizations.ListAccountsInput{},
+	input := organizations.ListAccountsInput{}
+	_, err := client.ListAccounts(ctx, &input,
 		func(opts *organizations.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/organizations/tags_gen.go
+++ b/internal/service/organizations/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *organizations.Client, identifier string, optFns ...func(*organizations.Options)) (tftags.KeyValueTags, error) {
-	input := &organizations.ListTagsForResourceInput{
+	input := organizations.ListTagsForResourceInput{
 		ResourceId: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *organizations.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Organizations)
 	if len(removedTags) > 0 {
-		input := &organizations.UntagResourceInput{
+		input := organizations.UntagResourceInput{
 			ResourceId: aws.String(identifier),
 			TagKeys:    removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *organizations.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Organizations)
 	if len(updatedTags) > 0 {
-		input := &organizations.TagResourceInput{
+		input := organizations.TagResourceInput{
 			ResourceId: aws.String(identifier),
 			Tags:       Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/osis/service_endpoints_gen_test.go
+++ b/internal/service/osis/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListPipelines(ctx, &osis.ListPipelinesInput{},
+	input := osis.ListPipelinesInput{}
+	_, err := client.ListPipelines(ctx, &input,
 		func(opts *osis.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/osis/tags_gen.go
+++ b/internal/service/osis/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *osis.Client, identifier string, optFns ...func(*osis.Options)) (tftags.KeyValueTags, error) {
-	input := &osis.ListTagsForResourceInput{
+	input := osis.ListTagsForResourceInput{
 		Arn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *osis.Client, identifier string, oldTa
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.OpenSearchIngestion)
 	if len(removedTags) > 0 {
-		input := &osis.UntagResourceInput{
+		input := osis.UntagResourceInput{
 			Arn:     aws.String(identifier),
 			TagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *osis.Client, identifier string, oldTa
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.OpenSearchIngestion)
 	if len(updatedTags) > 0 {
-		input := &osis.TagResourceInput{
+		input := osis.TagResourceInput{
 			Arn:  aws.String(identifier),
 			Tags: Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/outposts/service_endpoints_gen_test.go
+++ b/internal/service/outposts/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListSites(ctx, &outposts.ListSitesInput{},
+	input := outposts.ListSitesInput{}
+	_, err := client.ListSites(ctx, &input,
 		func(opts *outposts.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/outposts/tags_gen.go
+++ b/internal/service/outposts/tags_gen.go
@@ -58,12 +58,12 @@ func updateTags(ctx context.Context, conn *outposts.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Outposts)
 	if len(removedTags) > 0 {
-		input := &outposts.UntagResourceInput{
+		input := outposts.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -73,12 +73,12 @@ func updateTags(ctx context.Context, conn *outposts.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Outposts)
 	if len(updatedTags) > 0 {
-		input := &outposts.TagResourceInput{
+		input := outposts.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/paymentcryptography/tags_gen.go
+++ b/internal/service/paymentcryptography/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *paymentcryptography.Client, identifier string, optFns ...func(*paymentcryptography.Options)) (tftags.KeyValueTags, error) {
-	input := &paymentcryptography.ListTagsForResourceInput{
+	input := paymentcryptography.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *paymentcryptography.Client, identifie
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.PaymentCryptography)
 	if len(removedTags) > 0 {
-		input := &paymentcryptography.UntagResourceInput{
+		input := paymentcryptography.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *paymentcryptography.Client, identifie
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.PaymentCryptography)
 	if len(updatedTags) > 0 {
-		input := &paymentcryptography.TagResourceInput{
+		input := paymentcryptography.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/pcaconnectorad/service_endpoints_gen_test.go
+++ b/internal/service/pcaconnectorad/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListConnectors(ctx, &pcaconnectorad.ListConnectorsInput{},
+	input := pcaconnectorad.ListConnectorsInput{}
+	_, err := client.ListConnectors(ctx, &input,
 		func(opts *pcaconnectorad.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/pcs/service_endpoints_gen_test.go
+++ b/internal/service/pcs/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListClusters(ctx, &pcs.ListClustersInput{},
+	input := pcs.ListClustersInput{}
+	_, err := client.ListClusters(ctx, &input,
 		func(opts *pcs.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/pinpoint/service_endpoints_gen_test.go
+++ b/internal/service/pinpoint/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetApps(ctx, &pinpoint.GetAppsInput{},
+	input := pinpoint.GetAppsInput{}
+	_, err := client.GetApps(ctx, &input,
 		func(opts *pinpoint.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/pinpoint/tags_gen.go
+++ b/internal/service/pinpoint/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *pinpoint.Client, identifier string, optFns ...func(*pinpoint.Options)) (tftags.KeyValueTags, error) {
-	input := &pinpoint.ListTagsForResourceInput{
+	input := pinpoint.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -92,12 +92,12 @@ func updateTags(ctx context.Context, conn *pinpoint.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Pinpoint)
 	if len(removedTags) > 0 {
-		input := &pinpoint.UntagResourceInput{
+		input := pinpoint.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -107,12 +107,12 @@ func updateTags(ctx context.Context, conn *pinpoint.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Pinpoint)
 	if len(updatedTags) > 0 {
-		input := &pinpoint.TagResourceInput{
+		input := pinpoint.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagsModel:   &awstypes.TagsModel{Tags: Tags(updatedTags.IgnoreAWS())},
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/pinpointsmsvoicev2/service_endpoints_gen_test.go
+++ b/internal/service/pinpointsmsvoicev2/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribePhoneNumbers(ctx, &pinpointsmsvoicev2.DescribePhoneNumbersInput{},
+	input := pinpointsmsvoicev2.DescribePhoneNumbersInput{}
+	_, err := client.DescribePhoneNumbers(ctx, &input,
 		func(opts *pinpointsmsvoicev2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/pinpointsmsvoicev2/tags_gen.go
+++ b/internal/service/pinpointsmsvoicev2/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *pinpointsmsvoicev2.Client, identifier string, optFns ...func(*pinpointsmsvoicev2.Options)) (tftags.KeyValueTags, error) {
-	input := &pinpointsmsvoicev2.ListTagsForResourceInput{
+	input := pinpointsmsvoicev2.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *pinpointsmsvoicev2.Client, identifier
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.PinpointSMSVoiceV2)
 	if len(removedTags) > 0 {
-		input := &pinpointsmsvoicev2.UntagResourceInput{
+		input := pinpointsmsvoicev2.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *pinpointsmsvoicev2.Client, identifier
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.PinpointSMSVoiceV2)
 	if len(updatedTags) > 0 {
-		input := &pinpointsmsvoicev2.TagResourceInput{
+		input := pinpointsmsvoicev2.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/pipes/service_endpoints_gen_test.go
+++ b/internal/service/pipes/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListPipes(ctx, &pipes.ListPipesInput{},
+	input := pipes.ListPipesInput{}
+	_, err := client.ListPipes(ctx, &input,
 		func(opts *pipes.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/pipes/tags_gen.go
+++ b/internal/service/pipes/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *pipes.Client, identifier string, optFns ...func(*pipes.Options)) (tftags.KeyValueTags, error) {
-	input := &pipes.ListTagsForResourceInput{
+	input := pipes.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *pipes.Client, identifier string, oldT
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Pipes)
 	if len(removedTags) > 0 {
-		input := &pipes.UntagResourceInput{
+		input := pipes.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *pipes.Client, identifier string, oldT
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Pipes)
 	if len(updatedTags) > 0 {
-		input := &pipes.TagResourceInput{
+		input := pipes.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/polly/service_endpoints_gen_test.go
+++ b/internal/service/polly/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListLexicons(ctx, &polly.ListLexiconsInput{},
+	input := polly.ListLexiconsInput{}
+	_, err := client.ListLexicons(ctx, &input,
 		func(opts *polly.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/pricing/service_endpoints_gen_test.go
+++ b/internal/service/pricing/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeServices(ctx, &pricing.DescribeServicesInput{},
+	input := pricing.DescribeServicesInput{}
+	_, err := client.DescribeServices(ctx, &input,
 		func(opts *pricing.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/qbusiness/service_endpoints_gen_test.go
+++ b/internal/service/qbusiness/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &qbusiness.ListApplicationsInput{},
+	input := qbusiness.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *qbusiness.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/qldb/service_endpoints_gen_test.go
+++ b/internal/service/qldb/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListLedgers(ctx, &qldb.ListLedgersInput{},
+	input := qldb.ListLedgersInput{}
+	_, err := client.ListLedgers(ctx, &input,
 		func(opts *qldb.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/qldb/tags_gen.go
+++ b/internal/service/qldb/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *qldb.Client, identifier string, optFns ...func(*qldb.Options)) (tftags.KeyValueTags, error) {
-	input := &qldb.ListTagsForResourceInput{
+	input := qldb.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *qldb.Client, identifier string, oldTa
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.QLDB)
 	if len(removedTags) > 0 {
-		input := &qldb.UntagResourceInput{
+		input := qldb.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *qldb.Client, identifier string, oldTa
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.QLDB)
 	if len(updatedTags) > 0 {
-		input := &qldb.TagResourceInput{
+		input := qldb.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/quicksight/service_endpoints_gen_test.go
+++ b/internal/service/quicksight/service_endpoints_gen_test.go
@@ -284,9 +284,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDashboards(ctx, &quicksight.ListDashboardsInput{
+	input := quicksight.ListDashboardsInput{
 		AwsAccountId: aws.String(acctest.Ct12Digit),
-	},
+	}
+	_, err := client.ListDashboards(ctx, &input,
 		func(opts *quicksight.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/quicksight/tags_gen.go
+++ b/internal/service/quicksight/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *quicksight.Client, identifier string, optFns ...func(*quicksight.Options)) (tftags.KeyValueTags, error) {
-	input := &quicksight.ListTagsForResourceInput{
+	input := quicksight.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *quicksight.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.QuickSight)
 	if len(removedTags) > 0 {
-		input := &quicksight.UntagResourceInput{
+		input := quicksight.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *quicksight.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.QuickSight)
 	if len(updatedTags) > 0 {
-		input := &quicksight.TagResourceInput{
+		input := quicksight.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ram/service_endpoints_gen_test.go
+++ b/internal/service/ram/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListPermissions(ctx, &ram.ListPermissionsInput{},
+	input := ram.ListPermissionsInput{}
+	_, err := client.ListPermissions(ctx, &input,
 		func(opts *ram.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ram/tags_gen.go
+++ b/internal/service/ram/tags_gen.go
@@ -76,12 +76,12 @@ func updateTags(ctx context.Context, conn *ram.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.RAM)
 	if len(removedTags) > 0 {
-		input := &ram.UntagResourceInput{
+		input := ram.UntagResourceInput{
 			ResourceShareArn: aws.String(identifier),
 			TagKeys:          removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *ram.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.RAM)
 	if len(updatedTags) > 0 {
-		input := &ram.TagResourceInput{
+		input := ram.TagResourceInput{
 			ResourceShareArn: aws.String(identifier),
 			Tags:             Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/rbin/service_endpoints_gen_test.go
+++ b/internal/service/rbin/service_endpoints_gen_test.go
@@ -338,9 +338,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRules(ctx, &rbin.ListRulesInput{
+	input := rbin.ListRulesInput{
 		ResourceType: awstypes.ResourceTypeEc2Image,
-	},
+	}
+	_, err := client.ListRules(ctx, &input,
 		func(opts *rbin.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/rbin/tags_gen.go
+++ b/internal/service/rbin/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *rbin.Client, identifier string, optFns ...func(*rbin.Options)) (tftags.KeyValueTags, error) {
-	input := &rbin.ListTagsForResourceInput{
+	input := rbin.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *rbin.Client, identifier string, oldTa
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.RBin)
 	if len(removedTags) > 0 {
-		input := &rbin.UntagResourceInput{
+		input := rbin.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *rbin.Client, identifier string, oldTa
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.RBin)
 	if len(updatedTags) > 0 {
-		input := &rbin.TagResourceInput{
+		input := rbin.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/rds/service_endpoints_gen_test.go
+++ b/internal/service/rds/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{},
+	input := rds.DescribeDBInstancesInput{}
+	_, err := client.DescribeDBInstances(ctx, &input,
 		func(opts *rds.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/rds/tags_gen.go
+++ b/internal/service/rds/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *rds.Client, identifier string, optFns ...func(*rds.Options)) (tftags.KeyValueTags, error) {
-	input := &rds.ListTagsForResourceInput{
+	input := rds.ListTagsForResourceInput{
 		ResourceName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *rds.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.RDS)
 	if len(removedTags) > 0 {
-		input := &rds.RemoveTagsFromResourceInput{
+		input := rds.RemoveTagsFromResourceInput{
 			ResourceName: aws.String(identifier),
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTagsFromResource(ctx, input, optFns...)
+		_, err := conn.RemoveTagsFromResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *rds.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.RDS)
 	if len(updatedTags) > 0 {
-		input := &rds.AddTagsToResourceInput{
+		input := rds.AddTagsToResourceInput{
 			ResourceName: aws.String(identifier),
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToResource(ctx, input, optFns...)
+		_, err := conn.AddTagsToResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/redshift/service_endpoints_gen_test.go
+++ b/internal/service/redshift/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeClusters(ctx, &redshift.DescribeClustersInput{},
+	input := redshift.DescribeClustersInput{}
+	_, err := client.DescribeClusters(ctx, &input,
 		func(opts *redshift.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/redshift/tags_gen.go
+++ b/internal/service/redshift/tags_gen.go
@@ -76,12 +76,12 @@ func updateTags(ctx context.Context, conn *redshift.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Redshift)
 	if len(removedTags) > 0 {
-		input := &redshift.DeleteTagsInput{
+		input := redshift.DeleteTagsInput{
 			ResourceName: aws.String(identifier),
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := conn.DeleteTags(ctx, input, optFns...)
+		_, err := conn.DeleteTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *redshift.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Redshift)
 	if len(updatedTags) > 0 {
-		input := &redshift.CreateTagsInput{
+		input := redshift.CreateTagsInput{
 			ResourceName: aws.String(identifier),
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.CreateTags(ctx, input, optFns...)
+		_, err := conn.CreateTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/redshiftdata/service_endpoints_gen_test.go
+++ b/internal/service/redshiftdata/service_endpoints_gen_test.go
@@ -337,9 +337,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDatabases(ctx, &redshiftdata.ListDatabasesInput{
+	input := redshiftdata.ListDatabasesInput{
 		Database: aws.String("test"),
-	},
+	}
+	_, err := client.ListDatabases(ctx, &input,
 		func(opts *redshiftdata.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/redshiftserverless/service_endpoints_gen_test.go
+++ b/internal/service/redshiftserverless/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListNamespaces(ctx, &redshiftserverless.ListNamespacesInput{},
+	input := redshiftserverless.ListNamespacesInput{}
+	_, err := client.ListNamespaces(ctx, &input,
 		func(opts *redshiftserverless.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/redshiftserverless/tags_gen.go
+++ b/internal/service/redshiftserverless/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *redshiftserverless.Client, identifier string, optFns ...func(*redshiftserverless.Options)) (tftags.KeyValueTags, error) {
-	input := &redshiftserverless.ListTagsForResourceInput{
+	input := redshiftserverless.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *redshiftserverless.Client, identifier
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.RedshiftServerless)
 	if len(removedTags) > 0 {
-		input := &redshiftserverless.UntagResourceInput{
+		input := redshiftserverless.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *redshiftserverless.Client, identifier
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.RedshiftServerless)
 	if len(updatedTags) > 0 {
-		input := &redshiftserverless.TagResourceInput{
+		input := redshiftserverless.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/rekognition/service_endpoints_gen_test.go
+++ b/internal/service/rekognition/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListCollections(ctx, &rekognition.ListCollectionsInput{},
+	input := rekognition.ListCollectionsInput{}
+	_, err := client.ListCollections(ctx, &input,
 		func(opts *rekognition.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/rekognition/tags_gen.go
+++ b/internal/service/rekognition/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *rekognition.Client, identifier string, optFns ...func(*rekognition.Options)) (tftags.KeyValueTags, error) {
-	input := &rekognition.ListTagsForResourceInput{
+	input := rekognition.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *rekognition.Client, identifier string
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Rekognition)
 	if len(removedTags) > 0 {
-		input := &rekognition.UntagResourceInput{
+		input := rekognition.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *rekognition.Client, identifier string
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Rekognition)
 	if len(updatedTags) > 0 {
-		input := &rekognition.TagResourceInput{
+		input := rekognition.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/resiliencehub/service_endpoints_gen_test.go
+++ b/internal/service/resiliencehub/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApps(ctx, &resiliencehub.ListAppsInput{},
+	input := resiliencehub.ListAppsInput{}
+	_, err := client.ListApps(ctx, &input,
 		func(opts *resiliencehub.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/resiliencehub/tags_gen.go
+++ b/internal/service/resiliencehub/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *resiliencehub.Client, identifier string, optFns ...func(*resiliencehub.Options)) (tftags.KeyValueTags, error) {
-	input := &resiliencehub.ListTagsForResourceInput{
+	input := resiliencehub.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *resiliencehub.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ResilienceHub)
 	if len(removedTags) > 0 {
-		input := &resiliencehub.UntagResourceInput{
+		input := resiliencehub.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *resiliencehub.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ResilienceHub)
 	if len(updatedTags) > 0 {
-		input := &resiliencehub.TagResourceInput{
+		input := resiliencehub.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/resourceexplorer2/service_endpoints_gen_test.go
+++ b/internal/service/resourceexplorer2/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListIndexes(ctx, &resourceexplorer2.ListIndexesInput{},
+	input := resourceexplorer2.ListIndexesInput{}
+	_, err := client.ListIndexes(ctx, &input,
 		func(opts *resourceexplorer2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/resourceexplorer2/tags_gen.go
+++ b/internal/service/resourceexplorer2/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *resourceexplorer2.Client, identifier string, optFns ...func(*resourceexplorer2.Options)) (tftags.KeyValueTags, error) {
-	input := &resourceexplorer2.ListTagsForResourceInput{
+	input := resourceexplorer2.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *resourceexplorer2.Client, identifier 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ResourceExplorer2)
 	if len(removedTags) > 0 {
-		input := &resourceexplorer2.UntagResourceInput{
+		input := resourceexplorer2.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *resourceexplorer2.Client, identifier 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ResourceExplorer2)
 	if len(updatedTags) > 0 {
-		input := &resourceexplorer2.TagResourceInput{
+		input := resourceexplorer2.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/resourcegroups/service_endpoints_gen_test.go
+++ b/internal/service/resourcegroups/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListGroups(ctx, &resourcegroups.ListGroupsInput{},
+	input := resourcegroups.ListGroupsInput{}
+	_, err := client.ListGroups(ctx, &input,
 		func(opts *resourcegroups.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/resourcegroups/tags_gen.go
+++ b/internal/service/resourcegroups/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *resourcegroups.Client, identifier string, optFns ...func(*resourcegroups.Options)) (tftags.KeyValueTags, error) {
-	input := &resourcegroups.GetTagsInput{
+	input := resourcegroups.GetTagsInput{
 		Arn: aws.String(identifier),
 	}
 
-	output, err := conn.GetTags(ctx, input, optFns...)
+	output, err := conn.GetTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *resourcegroups.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ResourceGroups)
 	if len(removedTags) > 0 {
-		input := &resourcegroups.UntagInput{
+		input := resourcegroups.UntagInput{
 			Arn:  aws.String(identifier),
 			Keys: removedTags.Keys(),
 		}
 
-		_, err := conn.Untag(ctx, input, optFns...)
+		_, err := conn.Untag(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *resourcegroups.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ResourceGroups)
 	if len(updatedTags) > 0 {
-		input := &resourcegroups.TagInput{
+		input := resourcegroups.TagInput{
 			Arn:  aws.String(identifier),
 			Tags: Tags(updatedTags),
 		}
 
-		_, err := conn.Tag(ctx, input, optFns...)
+		_, err := conn.Tag(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/resourcegroupstaggingapi/service_endpoints_gen_test.go
+++ b/internal/service/resourcegroupstaggingapi/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{},
+	input := resourcegroupstaggingapi.GetResourcesInput{}
+	_, err := client.GetResources(ctx, &input,
 		func(opts *resourcegroupstaggingapi.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/rolesanywhere/service_endpoints_gen_test.go
+++ b/internal/service/rolesanywhere/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListProfiles(ctx, &rolesanywhere.ListProfilesInput{},
+	input := rolesanywhere.ListProfilesInput{}
+	_, err := client.ListProfiles(ctx, &input,
 		func(opts *rolesanywhere.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/rolesanywhere/tags_gen.go
+++ b/internal/service/rolesanywhere/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *rolesanywhere.Client, identifier string, optFns ...func(*rolesanywhere.Options)) (tftags.KeyValueTags, error) {
-	input := &rolesanywhere.ListTagsForResourceInput{
+	input := rolesanywhere.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *rolesanywhere.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.RolesAnywhere)
 	if len(removedTags) > 0 {
-		input := &rolesanywhere.UntagResourceInput{
+		input := rolesanywhere.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *rolesanywhere.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.RolesAnywhere)
 	if len(updatedTags) > 0 {
-		input := &rolesanywhere.TagResourceInput{
+		input := rolesanywhere.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/route53/service_endpoints_gen_test.go
+++ b/internal/service/route53/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListHostedZones(ctx, &route53.ListHostedZonesInput{},
+	input := route53.ListHostedZonesInput{}
+	_, err := client.ListHostedZones(ctx, &input,
 		func(opts *route53.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/route53/tags_gen.go
+++ b/internal/service/route53/tags_gen.go
@@ -20,12 +20,12 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *route53.Client, identifier, resourceType string, optFns ...func(*route53.Options)) (tftags.KeyValueTags, error) {
-	input := &route53.ListTagsForResourceInput{
+	input := route53.ListTagsForResourceInput{
 		ResourceId:   aws.String(identifier),
 		ResourceType: awstypes.TagResourceType(resourceType),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -126,7 +126,7 @@ func updateTags(ctx context.Context, conn *route53.Client, identifier, resourceT
 		return nil
 	}
 
-	input := &route53.ChangeTagsForResourceInput{
+	input := route53.ChangeTagsForResourceInput{
 		ResourceId:   aws.String(identifier),
 		ResourceType: awstypes.TagResourceType(resourceType),
 	}
@@ -139,7 +139,7 @@ func updateTags(ctx context.Context, conn *route53.Client, identifier, resourceT
 		input.RemoveTagKeys = removedTags.Keys()
 	}
 
-	_, err := conn.ChangeTagsForResource(ctx, input, optFns...)
+	_, err := conn.ChangeTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/route53domains/service_endpoints_gen_test.go
+++ b/internal/service/route53domains/service_endpoints_gen_test.go
@@ -285,7 +285,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDomains(ctx, &route53domains.ListDomainsInput{},
+	input := route53domains.ListDomainsInput{}
+	_, err := client.ListDomains(ctx, &input,
 		func(opts *route53domains.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/route53domains/tags_gen.go
+++ b/internal/service/route53domains/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *route53domains.Client, identifier string, optFns ...func(*route53domains.Options)) (tftags.KeyValueTags, error) {
-	input := &route53domains.ListTagsForDomainInput{
+	input := route53domains.ListTagsForDomainInput{
 		DomainName: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForDomain(ctx, input, optFns...)
+	output, err := conn.ListTagsForDomain(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *route53domains.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Route53Domains)
 	if len(removedTags) > 0 {
-		input := &route53domains.DeleteTagsForDomainInput{
+		input := route53domains.DeleteTagsForDomainInput{
 			DomainName:   aws.String(identifier),
 			TagsToDelete: removedTags.Keys(),
 		}
 
-		_, err := conn.DeleteTagsForDomain(ctx, input, optFns...)
+		_, err := conn.DeleteTagsForDomain(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *route53domains.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Route53Domains)
 	if len(updatedTags) > 0 {
-		input := &route53domains.UpdateTagsForDomainInput{
+		input := route53domains.UpdateTagsForDomainInput{
 			DomainName:   aws.String(identifier),
 			TagsToUpdate: Tags(updatedTags),
 		}
 
-		_, err := conn.UpdateTagsForDomain(ctx, input, optFns...)
+		_, err := conn.UpdateTagsForDomain(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/route53profiles/tags_gen.go
+++ b/internal/service/route53profiles/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *route53profiles.Client, identifier string, optFns ...func(*route53profiles.Options)) (tftags.KeyValueTags, error) {
-	input := &route53profiles.ListTagsForResourceInput{
+	input := route53profiles.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *route53profiles.Client, identifier st
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Route53Profiles)
 	if len(removedTags) > 0 {
-		input := &route53profiles.UntagResourceInput{
+		input := route53profiles.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *route53profiles.Client, identifier st
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Route53Profiles)
 	if len(updatedTags) > 0 {
-		input := &route53profiles.TagResourceInput{
+		input := route53profiles.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/route53recoverycontrolconfig/service_endpoints_gen_test.go
+++ b/internal/service/route53recoverycontrolconfig/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListClusters(ctx, &route53recoverycontrolconfig.ListClustersInput{},
+	input := route53recoverycontrolconfig.ListClustersInput{}
+	_, err := client.ListClusters(ctx, &input,
 		func(opts *route53recoverycontrolconfig.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/route53recoveryreadiness/service_endpoints_gen_test.go
+++ b/internal/service/route53recoveryreadiness/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListCells(ctx, &route53recoveryreadiness.ListCellsInput{},
+	input := route53recoveryreadiness.ListCellsInput{}
+	_, err := client.ListCells(ctx, &input,
 		func(opts *route53recoveryreadiness.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/route53recoveryreadiness/tags_gen.go
+++ b/internal/service/route53recoveryreadiness/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *route53recoveryreadiness.Client, identifier string, optFns ...func(*route53recoveryreadiness.Options)) (tftags.KeyValueTags, error) {
-	input := &route53recoveryreadiness.ListTagsForResourcesInput{
+	input := route53recoveryreadiness.ListTagsForResourcesInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResources(ctx, input, optFns...)
+	output, err := conn.ListTagsForResources(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,12 +100,12 @@ func updateTags(ctx context.Context, conn *route53recoveryreadiness.Client, iden
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Route53RecoveryReadiness)
 	if len(removedTags) > 0 {
-		input := &route53recoveryreadiness.UntagResourceInput{
+		input := route53recoveryreadiness.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -115,12 +115,12 @@ func updateTags(ctx context.Context, conn *route53recoveryreadiness.Client, iden
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Route53RecoveryReadiness)
 	if len(updatedTags) > 0 {
-		input := &route53recoveryreadiness.TagResourceInput{
+		input := route53recoveryreadiness.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/route53resolver/service_endpoints_gen_test.go
+++ b/internal/service/route53resolver/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListFirewallDomainLists(ctx, &route53resolver.ListFirewallDomainListsInput{},
+	input := route53resolver.ListFirewallDomainListsInput{}
+	_, err := client.ListFirewallDomainLists(ctx, &input,
 		func(opts *route53resolver.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/route53resolver/tags_gen.go
+++ b/internal/service/route53resolver/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *route53resolver.Client, identifier string, optFns ...func(*route53resolver.Options)) (tftags.KeyValueTags, error) {
-	input := &route53resolver.ListTagsForResourceInput{
+	input := route53resolver.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *route53resolver.Client, identifier st
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Route53Resolver)
 	if len(removedTags) > 0 {
-		input := &route53resolver.UntagResourceInput{
+		input := route53resolver.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *route53resolver.Client, identifier st
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Route53Resolver)
 	if len(updatedTags) > 0 {
-		input := &route53resolver.TagResourceInput{
+		input := route53resolver.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/rum/service_endpoints_gen_test.go
+++ b/internal/service/rum/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAppMonitors(ctx, &rum.ListAppMonitorsInput{},
+	input := rum.ListAppMonitorsInput{}
+	_, err := client.ListAppMonitors(ctx, &input,
 		func(opts *rum.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/rum/tags_gen.go
+++ b/internal/service/rum/tags_gen.go
@@ -58,12 +58,12 @@ func updateTags(ctx context.Context, conn *rum.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.RUM)
 	if len(removedTags) > 0 {
-		input := &rum.UntagResourceInput{
+		input := rum.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -73,12 +73,12 @@ func updateTags(ctx context.Context, conn *rum.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.RUM)
 	if len(updatedTags) > 0 {
-		input := &rum.TagResourceInput{
+		input := rum.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/s3/service_endpoints_gen_test.go
+++ b/internal/service/s3/service_endpoints_gen_test.go
@@ -461,7 +461,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListBuckets(ctx, &s3.ListBucketsInput{},
+	input := s3.ListBucketsInput{}
+	_, err := client.ListBuckets(ctx, &input,
 		func(opts *s3.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/s3control/tags_gen.go
+++ b/internal/service/s3control/tags_gen.go
@@ -20,12 +20,12 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *s3control.Client, identifier, resourceType string, optFns ...func(*s3control.Options)) (tftags.KeyValueTags, error) {
-	input := &s3control.ListTagsForResourceInput{
+	input := s3control.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 		AccountId:   aws.String(resourceType),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -110,13 +110,13 @@ func updateTags(ctx context.Context, conn *s3control.Client, identifier, resourc
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.S3Control)
 	if len(removedTags) > 0 {
-		input := &s3control.UntagResourceInput{
+		input := s3control.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			AccountId:   aws.String(resourceType),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -126,13 +126,13 @@ func updateTags(ctx context.Context, conn *s3control.Client, identifier, resourc
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.S3Control)
 	if len(updatedTags) > 0 {
-		input := &s3control.TagResourceInput{
+		input := s3control.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			AccountId:   aws.String(resourceType),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/s3outposts/service_endpoints_gen_test.go
+++ b/internal/service/s3outposts/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListEndpoints(ctx, &s3outposts.ListEndpointsInput{},
+	input := s3outposts.ListEndpointsInput{}
+	_, err := client.ListEndpoints(ctx, &input,
 		func(opts *s3outposts.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/s3tables/service_endpoints_gen_test.go
+++ b/internal/service/s3tables/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListTableBuckets(ctx, &s3tables.ListTableBucketsInput{},
+	input := s3tables.ListTableBucketsInput{}
+	_, err := client.ListTableBuckets(ctx, &input,
 		func(opts *s3tables.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/sagemaker/service_endpoints_gen_test.go
+++ b/internal/service/sagemaker/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListClusters(ctx, &sagemaker.ListClustersInput{},
+	input := sagemaker.ListClustersInput{}
+	_, err := client.ListClusters(ctx, &input,
 		func(opts *sagemaker.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/sagemaker/tags_gen.go
+++ b/internal/service/sagemaker/tags_gen.go
@@ -20,12 +20,12 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *sagemaker.Client, identifier string, optFns ...func(*sagemaker.Options)) (tftags.KeyValueTags, error) {
-	input := &sagemaker.ListTagsInput{
+	input := sagemaker.ListTagsInput{
 		ResourceArn: aws.String(identifier),
 	}
 	var output []awstypes.Tag
 
-	pages := sagemaker.NewListTagsPaginator(conn, input)
+	pages := sagemaker.NewListTagsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx, optFns...)
 
@@ -117,12 +117,12 @@ func updateTags(ctx context.Context, conn *sagemaker.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SageMaker)
 	if len(removedTags) > 0 {
-		input := &sagemaker.DeleteTagsInput{
+		input := sagemaker.DeleteTagsInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.DeleteTags(ctx, input, optFns...)
+		_, err := conn.DeleteTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -132,12 +132,12 @@ func updateTags(ctx context.Context, conn *sagemaker.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SageMaker)
 	if len(updatedTags) > 0 {
-		input := &sagemaker.AddTagsInput{
+		input := sagemaker.AddTagsInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.AddTags(ctx, input, optFns...)
+		_, err := conn.AddTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/scheduler/service_endpoints_gen_test.go
+++ b/internal/service/scheduler/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListSchedules(ctx, &scheduler.ListSchedulesInput{},
+	input := scheduler.ListSchedulesInput{}
+	_, err := client.ListSchedules(ctx, &input,
 		func(opts *scheduler.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/scheduler/tags_gen.go
+++ b/internal/service/scheduler/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *scheduler.Client, identifier string, optFns ...func(*scheduler.Options)) (tftags.KeyValueTags, error) {
-	input := &scheduler.ListTagsForResourceInput{
+	input := scheduler.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *scheduler.Client, identifier string, 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Scheduler)
 	if len(removedTags) > 0 {
-		input := &scheduler.UntagResourceInput{
+		input := scheduler.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *scheduler.Client, identifier string, 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Scheduler)
 	if len(updatedTags) > 0 {
-		input := &scheduler.TagResourceInput{
+		input := scheduler.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/schemas/service_endpoints_gen_test.go
+++ b/internal/service/schemas/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRegistries(ctx, &schemas.ListRegistriesInput{},
+	input := schemas.ListRegistriesInput{}
+	_, err := client.ListRegistries(ctx, &input,
 		func(opts *schemas.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/schemas/tags_gen.go
+++ b/internal/service/schemas/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *schemas.Client, identifier string, optFns ...func(*schemas.Options)) (tftags.KeyValueTags, error) {
-	input := &schemas.ListTagsForResourceInput{
+	input := schemas.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *schemas.Client, identifier string, ol
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Schemas)
 	if len(removedTags) > 0 {
-		input := &schemas.UntagResourceInput{
+		input := schemas.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *schemas.Client, identifier string, ol
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Schemas)
 	if len(updatedTags) > 0 {
-		input := &schemas.TagResourceInput{
+		input := schemas.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/secretsmanager/service_endpoints_gen_test.go
+++ b/internal/service/secretsmanager/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListSecrets(ctx, &secretsmanager.ListSecretsInput{},
+	input := secretsmanager.ListSecretsInput{}
+	_, err := client.ListSecrets(ctx, &input,
 		func(opts *secretsmanager.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/secretsmanager/tags_gen.go
+++ b/internal/service/secretsmanager/tags_gen.go
@@ -76,12 +76,12 @@ func updateTags(ctx context.Context, conn *secretsmanager.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SecretsManager)
 	if len(removedTags) > 0 {
-		input := &secretsmanager.UntagResourceInput{
+		input := secretsmanager.UntagResourceInput{
 			SecretId: aws.String(identifier),
 			TagKeys:  removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *secretsmanager.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SecretsManager)
 	if len(updatedTags) > 0 {
-		input := &secretsmanager.TagResourceInput{
+		input := secretsmanager.TagResourceInput{
 			SecretId: aws.String(identifier),
 			Tags:     Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/securityhub/service_endpoints_gen_test.go
+++ b/internal/service/securityhub/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAutomationRules(ctx, &securityhub.ListAutomationRulesInput{},
+	input := securityhub.ListAutomationRulesInput{}
+	_, err := client.ListAutomationRules(ctx, &input,
 		func(opts *securityhub.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/securityhub/tags_gen.go
+++ b/internal/service/securityhub/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *securityhub.Client, identifier string, optFns ...func(*securityhub.Options)) (tftags.KeyValueTags, error) {
-	input := &securityhub.ListTagsForResourceInput{
+	input := securityhub.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *securityhub.Client, identifier string
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SecurityHub)
 	if len(removedTags) > 0 {
-		input := &securityhub.UntagResourceInput{
+		input := securityhub.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *securityhub.Client, identifier string
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SecurityHub)
 	if len(updatedTags) > 0 {
-		input := &securityhub.TagResourceInput{
+		input := securityhub.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/securitylake/service_endpoints_gen_test.go
+++ b/internal/service/securitylake/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDataLakes(ctx, &securitylake.ListDataLakesInput{},
+	input := securitylake.ListDataLakesInput{}
+	_, err := client.ListDataLakes(ctx, &input,
 		func(opts *securitylake.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/securitylake/tags_gen.go
+++ b/internal/service/securitylake/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *securitylake.Client, identifier string, optFns ...func(*securitylake.Options)) (tftags.KeyValueTags, error) {
-	input := &securitylake.ListTagsForResourceInput{
+	input := securitylake.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *securitylake.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SecurityLake)
 	if len(removedTags) > 0 {
-		input := &securitylake.UntagResourceInput{
+		input := securitylake.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *securitylake.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SecurityLake)
 	if len(updatedTags) > 0 {
-		input := &securitylake.TagResourceInput{
+		input := securitylake.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/serverlessrepo/service_endpoints_gen_test.go
+++ b/internal/service/serverlessrepo/service_endpoints_gen_test.go
@@ -396,7 +396,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &serverlessapplicationrepository.ListApplicationsInput{},
+	input := serverlessapplicationrepository.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *serverlessapplicationrepository.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/servicecatalog/service_endpoints_gen_test.go
+++ b/internal/service/servicecatalog/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListPortfolios(ctx, &servicecatalog.ListPortfoliosInput{},
+	input := servicecatalog.ListPortfoliosInput{}
+	_, err := client.ListPortfolios(ctx, &input,
 		func(opts *servicecatalog.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/servicecatalogappregistry/service_endpoints_gen_test.go
+++ b/internal/service/servicecatalogappregistry/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &servicecatalogappregistry.ListApplicationsInput{},
+	input := servicecatalogappregistry.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *servicecatalogappregistry.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/servicecatalogappregistry/tags_gen.go
+++ b/internal/service/servicecatalogappregistry/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *servicecatalogappregistry.Client, identifier string, optFns ...func(*servicecatalogappregistry.Options)) (tftags.KeyValueTags, error) {
-	input := &servicecatalogappregistry.ListTagsForResourceInput{
+	input := servicecatalogappregistry.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *servicecatalogappregistry.Client, ide
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ServiceCatalogAppRegistry)
 	if len(removedTags) > 0 {
-		input := &servicecatalogappregistry.UntagResourceInput{
+		input := servicecatalogappregistry.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *servicecatalogappregistry.Client, ide
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ServiceCatalogAppRegistry)
 	if len(updatedTags) > 0 {
-		input := &servicecatalogappregistry.TagResourceInput{
+		input := servicecatalogappregistry.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/servicediscovery/service_endpoints_gen_test.go
+++ b/internal/service/servicediscovery/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListNamespaces(ctx, &servicediscovery.ListNamespacesInput{},
+	input := servicediscovery.ListNamespacesInput{}
+	_, err := client.ListNamespaces(ctx, &input,
 		func(opts *servicediscovery.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/servicediscovery/tags_gen.go
+++ b/internal/service/servicediscovery/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *servicediscovery.Client, identifier string, optFns ...func(*servicediscovery.Options)) (tftags.KeyValueTags, error) {
-	input := &servicediscovery.ListTagsForResourceInput{
+	input := servicediscovery.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *servicediscovery.Client, identifier s
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.ServiceDiscovery)
 	if len(removedTags) > 0 {
-		input := &servicediscovery.UntagResourceInput{
+		input := servicediscovery.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *servicediscovery.Client, identifier s
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.ServiceDiscovery)
 	if len(updatedTags) > 0 {
-		input := &servicediscovery.TagResourceInput{
+		input := servicediscovery.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/servicequotas/service_endpoints_gen_test.go
+++ b/internal/service/servicequotas/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListServices(ctx, &servicequotas.ListServicesInput{},
+	input := servicequotas.ListServicesInput{}
+	_, err := client.ListServices(ctx, &input,
 		func(opts *servicequotas.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ses/service_endpoints_gen_test.go
+++ b/internal/service/ses/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListIdentities(ctx, &ses.ListIdentitiesInput{},
+	input := ses.ListIdentitiesInput{}
+	_, err := client.ListIdentities(ctx, &input,
 		func(opts *ses.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/sesv2/service_endpoints_gen_test.go
+++ b/internal/service/sesv2/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListContactLists(ctx, &sesv2.ListContactListsInput{},
+	input := sesv2.ListContactListsInput{}
+	_, err := client.ListContactLists(ctx, &input,
 		func(opts *sesv2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/sesv2/tags_gen.go
+++ b/internal/service/sesv2/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *sesv2.Client, identifier string, optFns ...func(*sesv2.Options)) (tftags.KeyValueTags, error) {
-	input := &sesv2.ListTagsForResourceInput{
+	input := sesv2.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *sesv2.Client, identifier string, oldT
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SESV2)
 	if len(removedTags) > 0 {
-		input := &sesv2.UntagResourceInput{
+		input := sesv2.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *sesv2.Client, identifier string, oldT
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SESV2)
 	if len(updatedTags) > 0 {
-		input := &sesv2.TagResourceInput{
+		input := sesv2.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/sfn/service_endpoints_gen_test.go
+++ b/internal/service/sfn/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListActivities(ctx, &sfn.ListActivitiesInput{},
+	input := sfn.ListActivitiesInput{}
+	_, err := client.ListActivities(ctx, &input,
 		func(opts *sfn.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/sfn/tags_gen.go
+++ b/internal/service/sfn/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *sfn.Client, identifier string, optFns ...func(*sfn.Options)) (tftags.KeyValueTags, error) {
-	input := &sfn.ListTagsForResourceInput{
+	input := sfn.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *sfn.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SFN)
 	if len(removedTags) > 0 {
-		input := &sfn.UntagResourceInput{
+		input := sfn.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *sfn.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SFN)
 	if len(updatedTags) > 0 {
-		input := &sfn.TagResourceInput{
+		input := sfn.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/shield/service_endpoints_gen_test.go
+++ b/internal/service/shield/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListProtectionGroups(ctx, &shield.ListProtectionGroupsInput{},
+	input := shield.ListProtectionGroupsInput{}
+	_, err := client.ListProtectionGroups(ctx, &input,
 		func(opts *shield.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/shield/tags_gen.go
+++ b/internal/service/shield/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *shield.Client, identifier string, optFns ...func(*shield.Options)) (tftags.KeyValueTags, error) {
-	input := &shield.ListTagsForResourceInput{
+	input := shield.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *shield.Client, identifier string, old
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Shield)
 	if len(removedTags) > 0 {
-		input := &shield.UntagResourceInput{
+		input := shield.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *shield.Client, identifier string, old
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Shield)
 	if len(updatedTags) > 0 {
-		input := &shield.TagResourceInput{
+		input := shield.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/signer/service_endpoints_gen_test.go
+++ b/internal/service/signer/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListSigningJobs(ctx, &signer.ListSigningJobsInput{},
+	input := signer.ListSigningJobsInput{}
+	_, err := client.ListSigningJobs(ctx, &input,
 		func(opts *signer.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/signer/tags_gen.go
+++ b/internal/service/signer/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *signer.Client, identifier string, optFns ...func(*signer.Options)) (tftags.KeyValueTags, error) {
-	input := &signer.ListTagsForResourceInput{
+	input := signer.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *signer.Client, identifier string, old
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Signer)
 	if len(removedTags) > 0 {
-		input := &signer.UntagResourceInput{
+		input := signer.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *signer.Client, identifier string, old
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Signer)
 	if len(updatedTags) > 0 {
-		input := &signer.TagResourceInput{
+		input := signer.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/sns/service_endpoints_gen_test.go
+++ b/internal/service/sns/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListSubscriptions(ctx, &sns.ListSubscriptionsInput{},
+	input := sns.ListSubscriptionsInput{}
+	_, err := client.ListSubscriptions(ctx, &input,
 		func(opts *sns.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/sns/tags_gen.go
+++ b/internal/service/sns/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *sns.Client, identifier string, optFns ...func(*sns.Options)) (tftags.KeyValueTags, error) {
-	input := &sns.ListTagsForResourceInput{
+	input := sns.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *sns.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SNS)
 	if len(removedTags) > 0 {
-		input := &sns.UntagResourceInput{
+		input := sns.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *sns.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SNS)
 	if len(updatedTags) > 0 {
-		input := &sns.TagResourceInput{
+		input := sns.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/sqs/service_endpoints_gen_test.go
+++ b/internal/service/sqs/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListQueues(ctx, &sqs.ListQueuesInput{},
+	input := sqs.ListQueuesInput{}
+	_, err := client.ListQueues(ctx, &input,
 		func(opts *sqs.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/sqs/tags_gen.go
+++ b/internal/service/sqs/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *sqs.Client, identifier string, optFns ...func(*sqs.Options)) (tftags.KeyValueTags, error) {
-	input := &sqs.ListQueueTagsInput{
+	input := sqs.ListQueueTagsInput{
 		QueueUrl: aws.String(identifier),
 	}
 
-	output, err := conn.ListQueueTags(ctx, input, optFns...)
+	output, err := conn.ListQueueTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -100,12 +100,12 @@ func updateTags(ctx context.Context, conn *sqs.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SQS)
 	if len(removedTags) > 0 {
-		input := &sqs.UntagQueueInput{
+		input := sqs.UntagQueueInput{
 			QueueUrl: aws.String(identifier),
 			TagKeys:  removedTags.Keys(),
 		}
 
-		_, err := conn.UntagQueue(ctx, input, optFns...)
+		_, err := conn.UntagQueue(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -115,12 +115,12 @@ func updateTags(ctx context.Context, conn *sqs.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SQS)
 	if len(updatedTags) > 0 {
-		input := &sqs.TagQueueInput{
+		input := sqs.TagQueueInput{
 			QueueUrl: aws.String(identifier),
 			Tags:     Tags(updatedTags),
 		}
 
-		_, err := conn.TagQueue(ctx, input, optFns...)
+		_, err := conn.TagQueue(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ssm/service_endpoints_gen_test.go
+++ b/internal/service/ssm/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDocuments(ctx, &ssm.ListDocumentsInput{},
+	input := ssm.ListDocumentsInput{}
+	_, err := client.ListDocuments(ctx, &input,
 		func(opts *ssm.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ssm/tags_gen.go
+++ b/internal/service/ssm/tags_gen.go
@@ -85,13 +85,13 @@ func updateTags(ctx context.Context, conn *ssm.Client, identifier, resourceType 
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SSM)
 	if len(removedTags) > 0 {
-		input := &ssm.RemoveTagsFromResourceInput{
+		input := ssm.RemoveTagsFromResourceInput{
 			ResourceId:   aws.String(identifier),
 			ResourceType: awstypes.ResourceTypeForTagging(resourceType),
 			TagKeys:      removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTagsFromResource(ctx, input, optFns...)
+		_, err := conn.RemoveTagsFromResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -101,13 +101,13 @@ func updateTags(ctx context.Context, conn *ssm.Client, identifier, resourceType 
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SSM)
 	if len(updatedTags) > 0 {
-		input := &ssm.AddTagsToResourceInput{
+		input := ssm.AddTagsToResourceInput{
 			ResourceId:   aws.String(identifier),
 			ResourceType: awstypes.ResourceTypeForTagging(resourceType),
 			Tags:         Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToResource(ctx, input, optFns...)
+		_, err := conn.AddTagsToResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ssmcontacts/service_endpoints_gen_test.go
+++ b/internal/service/ssmcontacts/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListContacts(ctx, &ssmcontacts.ListContactsInput{},
+	input := ssmcontacts.ListContactsInput{}
+	_, err := client.ListContacts(ctx, &input,
 		func(opts *ssmcontacts.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ssmcontacts/tags_gen.go
+++ b/internal/service/ssmcontacts/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *ssmcontacts.Client, identifier string, optFns ...func(*ssmcontacts.Options)) (tftags.KeyValueTags, error) {
-	input := &ssmcontacts.ListTagsForResourceInput{
+	input := ssmcontacts.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *ssmcontacts.Client, identifier string
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SSMContacts)
 	if len(removedTags) > 0 {
-		input := &ssmcontacts.UntagResourceInput{
+		input := ssmcontacts.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *ssmcontacts.Client, identifier string
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SSMContacts)
 	if len(updatedTags) > 0 {
-		input := &ssmcontacts.TagResourceInput{
+		input := ssmcontacts.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ssmincidents/service_endpoints_gen_test.go
+++ b/internal/service/ssmincidents/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListResponsePlans(ctx, &ssmincidents.ListResponsePlansInput{},
+	input := ssmincidents.ListResponsePlansInput{}
+	_, err := client.ListResponsePlans(ctx, &input,
 		func(opts *ssmincidents.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ssmincidents/tags_gen.go
+++ b/internal/service/ssmincidents/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *ssmincidents.Client, identifier string, optFns ...func(*ssmincidents.Options)) (tftags.KeyValueTags, error) {
-	input := &ssmincidents.ListTagsForResourceInput{
+	input := ssmincidents.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *ssmincidents.Client, identifier strin
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SSMIncidents)
 	if len(removedTags) > 0 {
-		input := &ssmincidents.UntagResourceInput{
+		input := ssmincidents.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *ssmincidents.Client, identifier strin
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SSMIncidents)
 	if len(updatedTags) > 0 {
-		input := &ssmincidents.TagResourceInput{
+		input := ssmincidents.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ssmquicksetup/service_endpoints_gen_test.go
+++ b/internal/service/ssmquicksetup/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListConfigurationManagers(ctx, &ssmquicksetup.ListConfigurationManagersInput{},
+	input := ssmquicksetup.ListConfigurationManagersInput{}
+	_, err := client.ListConfigurationManagers(ctx, &input,
 		func(opts *ssmquicksetup.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ssmquicksetup/tags_gen.go
+++ b/internal/service/ssmquicksetup/tags_gen.go
@@ -58,12 +58,12 @@ func updateTags(ctx context.Context, conn *ssmquicksetup.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SSMQuickSetup)
 	if len(removedTags) > 0 {
-		input := &ssmquicksetup.UntagResourceInput{
+		input := ssmquicksetup.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -73,12 +73,12 @@ func updateTags(ctx context.Context, conn *ssmquicksetup.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SSMQuickSetup)
 	if len(updatedTags) > 0 {
-		input := &ssmquicksetup.TagResourceInput{
+		input := ssmquicksetup.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/ssmquicksetup/tags_slice_gen.go
+++ b/internal/service/ssmquicksetup/tags_slice_gen.go
@@ -16,11 +16,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *ssmquicksetup.Client, identifier string, optFns ...func(*ssmquicksetup.Options)) (tftags.KeyValueTags, error) {
-	input := &ssmquicksetup.ListTagsForResourceInput{
+	input := ssmquicksetup.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err

--- a/internal/service/ssmsap/service_endpoints_gen_test.go
+++ b/internal/service/ssmsap/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListApplications(ctx, &ssmsap.ListApplicationsInput{},
+	input := ssmsap.ListApplicationsInput{}
+	_, err := client.ListApplications(ctx, &input,
 		func(opts *ssmsap.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/sso/service_endpoints_gen_test.go
+++ b/internal/service/sso/service_endpoints_gen_test.go
@@ -283,9 +283,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListAccounts(ctx, &sso.ListAccountsInput{
+	input := sso.ListAccountsInput{
 		AccessToken: aws.String("mock-access-token"),
-	},
+	}
+	_, err := client.ListAccounts(ctx, &input,
 		func(opts *sso.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ssoadmin/service_endpoints_gen_test.go
+++ b/internal/service/ssoadmin/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListInstances(ctx, &ssoadmin.ListInstancesInput{},
+	input := ssoadmin.ListInstancesInput{}
+	_, err := client.ListInstances(ctx, &input,
 		func(opts *ssoadmin.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/ssoadmin/tags_gen.go
+++ b/internal/service/ssoadmin/tags_gen.go
@@ -20,12 +20,12 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *ssoadmin.Client, identifier, resourceType string, optFns ...func(*ssoadmin.Options)) (tftags.KeyValueTags, error) {
-	input := &ssoadmin.ListTagsForResourceInput{
+	input := ssoadmin.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 		InstanceArn: aws.String(resourceType),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -110,13 +110,13 @@ func updateTags(ctx context.Context, conn *ssoadmin.Client, identifier, resource
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SSOAdmin)
 	if len(removedTags) > 0 {
-		input := &ssoadmin.UntagResourceInput{
+		input := ssoadmin.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			InstanceArn: aws.String(resourceType),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -126,13 +126,13 @@ func updateTags(ctx context.Context, conn *ssoadmin.Client, identifier, resource
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SSOAdmin)
 	if len(updatedTags) > 0 {
-		input := &ssoadmin.TagResourceInput{
+		input := ssoadmin.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			InstanceArn: aws.String(resourceType),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/storagegateway/service_endpoints_gen_test.go
+++ b/internal/service/storagegateway/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListGateways(ctx, &storagegateway.ListGatewaysInput{},
+	input := storagegateway.ListGatewaysInput{}
+	_, err := client.ListGateways(ctx, &input,
 		func(opts *storagegateway.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/storagegateway/tags_gen.go
+++ b/internal/service/storagegateway/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *storagegateway.Client, identifier string, optFns ...func(*storagegateway.Options)) (tftags.KeyValueTags, error) {
-	input := &storagegateway.ListTagsForResourceInput{
+	input := storagegateway.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *storagegateway.Client, identifier str
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.StorageGateway)
 	if len(removedTags) > 0 {
-		input := &storagegateway.RemoveTagsFromResourceInput{
+		input := storagegateway.RemoveTagsFromResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.RemoveTagsFromResource(ctx, input, optFns...)
+		_, err := conn.RemoveTagsFromResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *storagegateway.Client, identifier str
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.StorageGateway)
 	if len(updatedTags) > 0 {
-		input := &storagegateway.AddTagsToResourceInput{
+		input := storagegateway.AddTagsToResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.AddTagsToResource(ctx, input, optFns...)
+		_, err := conn.AddTagsToResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/sts/service_endpoints_gen_test.go
+++ b/internal/service/sts/service_endpoints_gen_test.go
@@ -393,7 +393,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{},
+	input := sts.GetCallerIdentityInput{}
+	_, err := client.GetCallerIdentity(ctx, &input,
 		func(opts *sts.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/swf/service_endpoints_gen_test.go
+++ b/internal/service/swf/service_endpoints_gen_test.go
@@ -283,9 +283,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDomains(ctx, &swf.ListDomainsInput{
+	input := swf.ListDomainsInput{
 		RegistrationStatus: "REGISTERED",
-	},
+	}
+	_, err := client.ListDomains(ctx, &input,
 		func(opts *swf.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/swf/tags_gen.go
+++ b/internal/service/swf/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *swf.Client, identifier string, optFns ...func(*swf.Options)) (tftags.KeyValueTags, error) {
-	input := &swf.ListTagsForResourceInput{
+	input := swf.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *swf.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.SWF)
 	if len(removedTags) > 0 {
-		input := &swf.UntagResourceInput{
+		input := swf.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *swf.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.SWF)
 	if len(updatedTags) > 0 {
-		input := &swf.TagResourceInput{
+		input := swf.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/synthetics/service_endpoints_gen_test.go
+++ b/internal/service/synthetics/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListGroups(ctx, &synthetics.ListGroupsInput{},
+	input := synthetics.ListGroupsInput{}
+	_, err := client.ListGroups(ctx, &input,
 		func(opts *synthetics.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/synthetics/tags_gen.go
+++ b/internal/service/synthetics/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *synthetics.Client, identifier string, optFns ...func(*synthetics.Options)) (tftags.KeyValueTags, error) {
-	input := &synthetics.ListTagsForResourceInput{
+	input := synthetics.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *synthetics.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Synthetics)
 	if len(removedTags) > 0 {
-		input := &synthetics.UntagResourceInput{
+		input := synthetics.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *synthetics.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Synthetics)
 	if len(updatedTags) > 0 {
-		input := &synthetics.TagResourceInput{
+		input := synthetics.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/taxsettings/service_endpoints_gen_test.go
+++ b/internal/service/taxsettings/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListTaxRegistrations(ctx, &taxsettings.ListTaxRegistrationsInput{},
+	input := taxsettings.ListTaxRegistrationsInput{}
+	_, err := client.ListTaxRegistrations(ctx, &input,
 		func(opts *taxsettings.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/timestreaminfluxdb/service_endpoints_gen_test.go
+++ b/internal/service/timestreaminfluxdb/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListDbInstances(ctx, &timestreaminfluxdb.ListDbInstancesInput{},
+	input := timestreaminfluxdb.ListDbInstancesInput{}
+	_, err := client.ListDbInstances(ctx, &input,
 		func(opts *timestreaminfluxdb.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/timestreaminfluxdb/tags_gen.go
+++ b/internal/service/timestreaminfluxdb/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *timestreaminfluxdb.Client, identifier string, optFns ...func(*timestreaminfluxdb.Options)) (tftags.KeyValueTags, error) {
-	input := &timestreaminfluxdb.ListTagsForResourceInput{
+	input := timestreaminfluxdb.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *timestreaminfluxdb.Client, identifier
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.TimestreamInfluxDB)
 	if len(removedTags) > 0 {
-		input := &timestreaminfluxdb.UntagResourceInput{
+		input := timestreaminfluxdb.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *timestreaminfluxdb.Client, identifier
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.TimestreamInfluxDB)
 	if len(updatedTags) > 0 {
-		input := &timestreaminfluxdb.TagResourceInput{
+		input := timestreaminfluxdb.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/timestreamquery/service_endpoints_gen_test.go
+++ b/internal/service/timestreamquery/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeEndpoints(ctx, &timestreamquery.DescribeEndpointsInput{},
+	input := timestreamquery.DescribeEndpointsInput{}
+	_, err := client.DescribeEndpoints(ctx, &input,
 		func(opts *timestreamquery.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/timestreamwrite/tags_gen.go
+++ b/internal/service/timestreamwrite/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *timestreamwrite.Client, identifier string, optFns ...func(*timestreamwrite.Options)) (tftags.KeyValueTags, error) {
-	input := &timestreamwrite.ListTagsForResourceInput{
+	input := timestreamwrite.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *timestreamwrite.Client, identifier st
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.TimestreamWrite)
 	if len(removedTags) > 0 {
-		input := &timestreamwrite.UntagResourceInput{
+		input := timestreamwrite.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *timestreamwrite.Client, identifier st
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.TimestreamWrite)
 	if len(updatedTags) > 0 {
-		input := &timestreamwrite.TagResourceInput{
+		input := timestreamwrite.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/transcribe/service_endpoints_gen_test.go
+++ b/internal/service/transcribe/service_endpoints_gen_test.go
@@ -337,7 +337,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListLanguageModels(ctx, &transcribe.ListLanguageModelsInput{},
+	input := transcribe.ListLanguageModelsInput{}
+	_, err := client.ListLanguageModels(ctx, &input,
 		func(opts *transcribe.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/transcribe/tags_gen.go
+++ b/internal/service/transcribe/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *transcribe.Client, identifier string, optFns ...func(*transcribe.Options)) (tftags.KeyValueTags, error) {
-	input := &transcribe.ListTagsForResourceInput{
+	input := transcribe.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *transcribe.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Transcribe)
 	if len(removedTags) > 0 {
-		input := &transcribe.UntagResourceInput{
+		input := transcribe.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *transcribe.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Transcribe)
 	if len(updatedTags) > 0 {
-		input := &transcribe.TagResourceInput{
+		input := transcribe.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/transfer/service_endpoints_gen_test.go
+++ b/internal/service/transfer/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListConnectors(ctx, &transfer.ListConnectorsInput{},
+	input := transfer.ListConnectorsInput{}
+	_, err := client.ListConnectors(ctx, &input,
 		func(opts *transfer.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/transfer/tags_gen.go
+++ b/internal/service/transfer/tags_gen.go
@@ -40,11 +40,11 @@ func findTag(ctx context.Context, conn *transfer.Client, identifier, key string,
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *transfer.Client, identifier string, optFns ...func(*transfer.Options)) (tftags.KeyValueTags, error) {
-	input := &transfer.ListTagsForResourceInput{
+	input := transfer.ListTagsForResourceInput{
 		Arn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -129,12 +129,12 @@ func updateTags(ctx context.Context, conn *transfer.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.Transfer)
 	if len(removedTags) > 0 {
-		input := &transfer.UntagResourceInput{
+		input := transfer.UntagResourceInput{
 			Arn:     aws.String(identifier),
 			TagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -144,12 +144,12 @@ func updateTags(ctx context.Context, conn *transfer.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.Transfer)
 	if len(updatedTags) > 0 {
-		input := &transfer.TagResourceInput{
+		input := transfer.TagResourceInput{
 			Arn:  aws.String(identifier),
 			Tags: Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/transfer/update_tags_no_system_ignore_gen.go
+++ b/internal/service/transfer/update_tags_no_system_ignore_gen.go
@@ -23,12 +23,12 @@ func updateTagsNoIgnoreSystem(ctx context.Context, conn *transfer.Client, identi
 
 	removedTags := oldTags.Removed(newTags)
 	if len(removedTags) > 0 {
-		input := &transfer.UntagResourceInput{
+		input := transfer.UntagResourceInput{
 			Arn:     aws.String(identifier),
 			TagKeys: removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -37,12 +37,12 @@ func updateTagsNoIgnoreSystem(ctx context.Context, conn *transfer.Client, identi
 
 	updatedTags := oldTags.Updated(newTags)
 	if len(updatedTags) > 0 {
-		input := &transfer.TagResourceInput{
+		input := transfer.TagResourceInput{
 			Arn:  aws.String(identifier),
 			Tags: Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/verifiedpermissions/service_endpoints_gen_test.go
+++ b/internal/service/verifiedpermissions/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListPolicyStores(ctx, &verifiedpermissions.ListPolicyStoresInput{},
+	input := verifiedpermissions.ListPolicyStoresInput{}
+	_, err := client.ListPolicyStores(ctx, &input,
 		func(opts *verifiedpermissions.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/vpclattice/service_endpoints_gen_test.go
+++ b/internal/service/vpclattice/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListServices(ctx, &vpclattice.ListServicesInput{},
+	input := vpclattice.ListServicesInput{}
+	_, err := client.ListServices(ctx, &input,
 		func(opts *vpclattice.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/vpclattice/tags_gen.go
+++ b/internal/service/vpclattice/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *vpclattice.Client, identifier string, optFns ...func(*vpclattice.Options)) (tftags.KeyValueTags, error) {
-	input := &vpclattice.ListTagsForResourceInput{
+	input := vpclattice.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *vpclattice.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.VPCLattice)
 	if len(removedTags) > 0 {
-		input := &vpclattice.UntagResourceInput{
+		input := vpclattice.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *vpclattice.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.VPCLattice)
 	if len(updatedTags) > 0 {
-		input := &vpclattice.TagResourceInput{
+		input := vpclattice.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/waf/service_endpoints_gen_test.go
+++ b/internal/service/waf/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRules(ctx, &waf.ListRulesInput{},
+	input := waf.ListRulesInput{}
+	_, err := client.ListRules(ctx, &input,
 		func(opts *waf.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/waf/tags_gen.go
+++ b/internal/service/waf/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *waf.Client, identifier string, optFns ...func(*waf.Options)) (tftags.KeyValueTags, error) {
-	input := &waf.ListTagsForResourceInput{
+	input := waf.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *waf.Client, identifier string, oldTag
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.WAF)
 	if len(removedTags) > 0 {
-		input := &waf.UntagResourceInput{
+		input := waf.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *waf.Client, identifier string, oldTag
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.WAF)
 	if len(updatedTags) > 0 {
-		input := &waf.TagResourceInput{
+		input := waf.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/wafregional/service_endpoints_gen_test.go
+++ b/internal/service/wafregional/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRules(ctx, &wafregional.ListRulesInput{},
+	input := wafregional.ListRulesInput{}
+	_, err := client.ListRules(ctx, &input,
 		func(opts *wafregional.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/wafregional/tags_gen.go
+++ b/internal/service/wafregional/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *wafregional.Client, identifier string, optFns ...func(*wafregional.Options)) (tftags.KeyValueTags, error) {
-	input := &wafregional.ListTagsForResourceInput{
+	input := wafregional.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *wafregional.Client, identifier string
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.WAFRegional)
 	if len(removedTags) > 0 {
-		input := &wafregional.UntagResourceInput{
+		input := wafregional.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *wafregional.Client, identifier string
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.WAFRegional)
 	if len(updatedTags) > 0 {
-		input := &wafregional.TagResourceInput{
+		input := wafregional.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/wafv2/service_endpoints_gen_test.go
+++ b/internal/service/wafv2/service_endpoints_gen_test.go
@@ -284,9 +284,10 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListRuleGroups(ctx, &wafv2.ListRuleGroupsInput{
+	input := wafv2.ListRuleGroupsInput{
 		Scope: awstypes.ScopeRegional,
-	},
+	}
+	_, err := client.ListRuleGroups(ctx, &input,
 		func(opts *wafv2.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/wafv2/tags_gen.go
+++ b/internal/service/wafv2/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *wafv2.Client, identifier string, optFns ...func(*wafv2.Options)) (tftags.KeyValueTags, error) {
-	input := &wafv2.ListTagsForResourceInput{
+	input := wafv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *wafv2.Client, identifier string, oldT
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.WAFV2)
 	if len(removedTags) > 0 {
-		input := &wafv2.UntagResourceInput{
+		input := wafv2.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *wafv2.Client, identifier string, oldT
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.WAFV2)
 	if len(updatedTags) > 0 {
-		input := &wafv2.TagResourceInput{
+		input := wafv2.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/wellarchitected/service_endpoints_gen_test.go
+++ b/internal/service/wellarchitected/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListProfiles(ctx, &wellarchitected.ListProfilesInput{},
+	input := wellarchitected.ListProfilesInput{}
+	_, err := client.ListProfiles(ctx, &input,
 		func(opts *wellarchitected.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/wellarchitected/tags_gen.go
+++ b/internal/service/wellarchitected/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *wellarchitected.Client, identifier string, optFns ...func(*wellarchitected.Options)) (tftags.KeyValueTags, error) {
-	input := &wellarchitected.ListTagsForResourceInput{
+	input := wellarchitected.ListTagsForResourceInput{
 		WorkloadArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *wellarchitected.Client, identifier st
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.WellArchitected)
 	if len(removedTags) > 0 {
-		input := &wellarchitected.UntagResourceInput{
+		input := wellarchitected.UntagResourceInput{
 			WorkloadArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *wellarchitected.Client, identifier st
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.WellArchitected)
 	if len(updatedTags) > 0 {
-		input := &wellarchitected.TagResourceInput{
+		input := wellarchitected.TagResourceInput{
 			WorkloadArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/worklink/service_endpoints_gen_test.go
+++ b/internal/service/worklink/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListFleets(ctx, &worklink.ListFleetsInput{},
+	input := worklink.ListFleetsInput{}
+	_, err := client.ListFleets(ctx, &input,
 		func(opts *worklink.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/worklink/tags_gen.go
+++ b/internal/service/worklink/tags_gen.go
@@ -19,11 +19,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *worklink.Client, identifier string, optFns ...func(*worklink.Options)) (tftags.KeyValueTags, error) {
-	input := &worklink.ListTagsForResourceInput{
+	input := worklink.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -91,12 +91,12 @@ func updateTags(ctx context.Context, conn *worklink.Client, identifier string, o
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.WorkLink)
 	if len(removedTags) > 0 {
-		input := &worklink.UntagResourceInput{
+		input := worklink.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -106,12 +106,12 @@ func updateTags(ctx context.Context, conn *worklink.Client, identifier string, o
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.WorkLink)
 	if len(updatedTags) > 0 {
-		input := &worklink.TagResourceInput{
+		input := worklink.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/workspaces/service_endpoints_gen_test.go
+++ b/internal/service/workspaces/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.DescribeWorkspaces(ctx, &workspaces.DescribeWorkspacesInput{},
+	input := workspaces.DescribeWorkspacesInput{}
+	_, err := client.DescribeWorkspaces(ctx, &input,
 		func(opts *workspaces.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/workspaces/tags_gen.go
+++ b/internal/service/workspaces/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *workspaces.Client, identifier string, optFns ...func(*workspaces.Options)) (tftags.KeyValueTags, error) {
-	input := &workspaces.DescribeTagsInput{
+	input := workspaces.DescribeTagsInput{
 		ResourceId: aws.String(identifier),
 	}
 
-	output, err := conn.DescribeTags(ctx, input, optFns...)
+	output, err := conn.DescribeTags(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *workspaces.Client, identifier string,
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.WorkSpaces)
 	if len(removedTags) > 0 {
-		input := &workspaces.DeleteTagsInput{
+		input := workspaces.DeleteTagsInput{
 			ResourceId: aws.String(identifier),
 			TagKeys:    removedTags.Keys(),
 		}
 
-		_, err := conn.DeleteTags(ctx, input, optFns...)
+		_, err := conn.DeleteTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *workspaces.Client, identifier string,
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.WorkSpaces)
 	if len(updatedTags) > 0 {
-		input := &workspaces.CreateTagsInput{
+		input := workspaces.CreateTagsInput{
 			ResourceId: aws.String(identifier),
 			Tags:       Tags(updatedTags),
 		}
 
-		_, err := conn.CreateTags(ctx, input, optFns...)
+		_, err := conn.CreateTags(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/workspacesweb/service_endpoints_gen_test.go
+++ b/internal/service/workspacesweb/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListPortals(ctx, &workspacesweb.ListPortalsInput{},
+	input := workspacesweb.ListPortalsInput{}
+	_, err := client.ListPortals(ctx, &input,
 		func(opts *workspacesweb.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/workspacesweb/tags_gen.go
+++ b/internal/service/workspacesweb/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *workspacesweb.Client, identifier string, optFns ...func(*workspacesweb.Options)) (tftags.KeyValueTags, error) {
-	input := &workspacesweb.ListTagsForResourceInput{
+	input := workspacesweb.ListTagsForResourceInput{
 		ResourceArn: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -118,12 +118,12 @@ func updateTags(ctx context.Context, conn *workspacesweb.Client, identifier stri
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.WorkSpacesWeb)
 	if len(removedTags) > 0 {
-		input := &workspacesweb.UntagResourceInput{
+		input := workspacesweb.UntagResourceInput{
 			ResourceArn: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -133,12 +133,12 @@ func updateTags(ctx context.Context, conn *workspacesweb.Client, identifier stri
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.WorkSpacesWeb)
 	if len(updatedTags) > 0 {
-		input := &workspacesweb.TagResourceInput{
+		input := workspacesweb.TagResourceInput{
 			ResourceArn: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/xray/encryption_config.go
+++ b/internal/service/xray/encryption_config.go
@@ -53,7 +53,7 @@ func resourceEncryptionPutConfig(ctx context.Context, d *schema.ResourceData, me
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).XRayClient(ctx)
 
-	input := &xray.PutEncryptionConfigInput{
+	input := xray.PutEncryptionConfigInput{
 		Type: types.EncryptionType(d.Get(names.AttrType).(string)),
 	}
 
@@ -61,7 +61,7 @@ func resourceEncryptionPutConfig(ctx context.Context, d *schema.ResourceData, me
 		input.KeyId = aws.String(v.(string))
 	}
 
-	_, err := conn.PutEncryptionConfig(ctx, input)
+	_, err := conn.PutEncryptionConfig(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating XRay Encryption Config: %s", err)
@@ -99,9 +99,9 @@ func resourceEncryptionConfigRead(ctx context.Context, d *schema.ResourceData, m
 }
 
 func findEncryptionConfig(ctx context.Context, conn *xray.Client) (*types.EncryptionConfig, error) {
-	input := &xray.GetEncryptionConfigInput{}
+	input := xray.GetEncryptionConfigInput{}
 
-	output, err := conn.GetEncryptionConfig(ctx, input)
+	output, err := conn.GetEncryptionConfig(ctx, &input)
 
 	if err != nil {
 		return nil, err

--- a/internal/service/xray/sampling_rule.go
+++ b/internal/service/xray/sampling_rule.go
@@ -137,12 +137,12 @@ func resourceSamplingRuleCreate(ctx context.Context, d *schema.ResourceData, met
 		samplingRule.Attributes = flex.ExpandStringValueMap(v.(map[string]interface{}))
 	}
 
-	input := &xray.CreateSamplingRuleInput{
+	input := xray.CreateSamplingRuleInput{
 		SamplingRule: samplingRule,
 		Tags:         getTagsIn(ctx),
 	}
 
-	output, err := conn.CreateSamplingRule(ctx, input)
+	output, err := conn.CreateSamplingRule(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating XRay Sampling Rule (%s): %s", name, err)
@@ -208,11 +208,11 @@ func resourceSamplingRuleUpdate(ctx context.Context, d *schema.ResourceData, met
 			samplingRuleUpdate.Attributes = flex.ExpandStringValueMap(d.Get(names.AttrAttributes).(map[string]interface{}))
 		}
 
-		input := &xray.UpdateSamplingRuleInput{
+		input := xray.UpdateSamplingRuleInput{
 			SamplingRuleUpdate: samplingRuleUpdate,
 		}
 
-		_, err := conn.UpdateSamplingRule(ctx, input)
+		_, err := conn.UpdateSamplingRule(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating XRay Sampling Rule (%s): %s", d.Id(), err)
@@ -227,9 +227,10 @@ func resourceSamplingRuleDelete(ctx context.Context, d *schema.ResourceData, met
 	conn := meta.(*conns.AWSClient).XRayClient(ctx)
 
 	log.Printf("[INFO] Deleting XRay Sampling Rule: %s", d.Id())
-	_, err := conn.DeleteSamplingRule(ctx, &xray.DeleteSamplingRuleInput{
+	input := xray.DeleteSamplingRuleInput{
 		RuleName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteSamplingRule(ctx, &input)
 
 	if errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "Sampling rule does not exist") {
 		return diags
@@ -243,9 +244,9 @@ func resourceSamplingRuleDelete(ctx context.Context, d *schema.ResourceData, met
 }
 
 func findSamplingRuleByName(ctx context.Context, conn *xray.Client, name string) (*types.SamplingRule, error) {
-	input := &xray.GetSamplingRulesInput{}
+	input := xray.GetSamplingRulesInput{}
 
-	pages := xray.NewGetSamplingRulesPaginator(conn, input)
+	pages := xray.NewGetSamplingRulesPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 

--- a/internal/service/xray/service_endpoints_gen_test.go
+++ b/internal/service/xray/service_endpoints_gen_test.go
@@ -283,7 +283,8 @@ func callService(ctx context.Context, t *testing.T, meta *conns.AWSClient) apiCa
 
 	var result apiCallParams
 
-	_, err := client.ListResourcePolicies(ctx, &xray.ListResourcePoliciesInput{},
+	input := xray.ListResourcePoliciesInput{}
+	_, err := client.ListResourcePolicies(ctx, &input,
 		func(opts *xray.Options) {
 			opts.APIOptions = append(opts.APIOptions,
 				addRetrieveEndpointURLMiddleware(t, &result.endpoint),

--- a/internal/service/xray/tags_gen.go
+++ b/internal/service/xray/tags_gen.go
@@ -20,11 +20,11 @@ import (
 // The identifier is typically the Amazon Resource Name (ARN), although
 // it may also be a different identifier depending on the service.
 func listTags(ctx context.Context, conn *xray.Client, identifier string, optFns ...func(*xray.Options)) (tftags.KeyValueTags, error) {
-	input := &xray.ListTagsForResourceInput{
+	input := xray.ListTagsForResourceInput{
 		ResourceARN: aws.String(identifier),
 	}
 
-	output, err := conn.ListTagsForResource(ctx, input, optFns...)
+	output, err := conn.ListTagsForResource(ctx, &input, optFns...)
 
 	if err != nil {
 		return tftags.New(ctx, nil), err
@@ -109,12 +109,12 @@ func updateTags(ctx context.Context, conn *xray.Client, identifier string, oldTa
 	removedTags := oldTags.Removed(newTags)
 	removedTags = removedTags.IgnoreSystem(names.XRay)
 	if len(removedTags) > 0 {
-		input := &xray.UntagResourceInput{
+		input := xray.UntagResourceInput{
 			ResourceARN: aws.String(identifier),
 			TagKeys:     removedTags.Keys(),
 		}
 
-		_, err := conn.UntagResource(ctx, input, optFns...)
+		_, err := conn.UntagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -124,12 +124,12 @@ func updateTags(ctx context.Context, conn *xray.Client, identifier string, oldTa
 	updatedTags := oldTags.Updated(newTags)
 	updatedTags = updatedTags.IgnoreSystem(names.XRay)
 	if len(updatedTags) > 0 {
-		input := &xray.TagResourceInput{
+		input := xray.TagResourceInput{
 			ResourceARN: aws.String(identifier),
 			Tags:        Tags(updatedTags),
 		}
 
-		_, err := conn.TagResource(ctx, input, optFns...)
+		_, err := conn.TagResource(ctx, &input, optFns...)
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)


### PR DESCRIPTION
### Description

Reduces small allocations on heap so that they don't have to be garbage collected later. In generated tagging and service endpoint tests as well as `acctest`, `provider` and `xray` service.
