### PR TITLE
rds: import name_prefix for aws_db_parameter_group

### DIFF
--- a/internal/service/rds/parameter_group.go
+++ b/internal/service/rds/parameter_group.go
@@ -158,6 +158,7 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set(names.AttrDescription, dbParameterGroup.Description)
 	d.Set(names.AttrFamily, dbParameterGroup.DBParameterGroupFamily)
 	d.Set(names.AttrName, dbParameterGroup.DBParameterGroupName)
+	d.Set(names.AttrNamePrefix, create.NamePrefixFromName(aws.ToString(dbParameterGroup.DBParameterGroupName)))
 
 	input := &rds.DescribeDBParametersInput{
 		DBParameterGroupName: aws.String(d.Id()),


### PR DESCRIPTION
### Description
Use the shared naming module to match the name and the prefix.
Acceptance test was updated to test the import.

### Relations
Reference #24687
Closes #38014

### Output from Acceptance Testing

```console
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSParameterGroup_'  -timeout 360m
2024/12/18 11:31:59 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSParameterGroup_basic
=== PAUSE TestAccRDSParameterGroup_basic
=== RUN   TestAccRDSParameterGroup_disappears
=== PAUSE TestAccRDSParameterGroup_disappears
=== RUN   TestAccRDSParameterGroup_tags
=== PAUSE TestAccRDSParameterGroup_tags
=== RUN   TestAccRDSParameterGroup_caseWithMixedParameters
=== PAUSE TestAccRDSParameterGroup_caseWithMixedParameters
=== RUN   TestAccRDSParameterGroup_limit
=== PAUSE TestAccRDSParameterGroup_limit
=== RUN   TestAccRDSParameterGroup_namePrefix
=== PAUSE TestAccRDSParameterGroup_namePrefix
=== RUN   TestAccRDSParameterGroup_generatedName
=== PAUSE TestAccRDSParameterGroup_generatedName
=== RUN   TestAccRDSParameterGroup_withApplyMethod
=== PAUSE TestAccRDSParameterGroup_withApplyMethod
=== RUN   TestAccRDSParameterGroup_only
=== PAUSE TestAccRDSParameterGroup_only
=== RUN   TestAccRDSParameterGroup_matchDefault
=== PAUSE TestAccRDSParameterGroup_matchDefault
=== RUN   TestAccRDSParameterGroup_updateParameters
=== PAUSE TestAccRDSParameterGroup_updateParameters
=== RUN   TestAccRDSParameterGroup_updateParameters2
=== PAUSE TestAccRDSParameterGroup_updateParameters2
=== RUN   TestAccRDSParameterGroup_caseParameters
=== PAUSE TestAccRDSParameterGroup_caseParameters
=== RUN   TestAccRDSParameterGroup_skipDestroy
=== PAUSE TestAccRDSParameterGroup_skipDestroy
=== CONT  TestAccRDSParameterGroup_basic
=== CONT  TestAccRDSParameterGroup_only
=== CONT  TestAccRDSParameterGroup_matchDefault
=== CONT  TestAccRDSParameterGroup_updateParameters2
=== CONT  TestAccRDSParameterGroup_limit
=== CONT  TestAccRDSParameterGroup_skipDestroy
=== CONT  TestAccRDSParameterGroup_updateParameters
=== CONT  TestAccRDSParameterGroup_withApplyMethod
=== CONT  TestAccRDSParameterGroup_generatedName
=== CONT  TestAccRDSParameterGroup_namePrefix
=== CONT  TestAccRDSParameterGroup_tags
=== CONT  TestAccRDSParameterGroup_caseWithMixedParameters
=== CONT  TestAccRDSParameterGroup_disappears
=== CONT  TestAccRDSParameterGroup_caseParameters
--- PASS: TestAccRDSParameterGroup_skipDestroy (95.72s)
--- PASS: TestAccRDSParameterGroup_generatedName (109.01s)
--- PASS: TestAccRDSParameterGroup_withApplyMethod (119.28s)
--- PASS: TestAccRDSParameterGroup_disappears (125.99s)
--- PASS: TestAccRDSParameterGroup_namePrefix (135.86s)
--- PASS: TestAccRDSParameterGroup_only (140.03s)
--- PASS: TestAccRDSParameterGroup_caseParameters (147.37s)
--- PASS: TestAccRDSParameterGroup_caseWithMixedParameters (149.19s)
--- PASS: TestAccRDSParameterGroup_updateParameters2 (163.96s)
--- PASS: TestAccRDSParameterGroup_matchDefault (164.55s)
--- PASS: TestAccRDSParameterGroup_updateParameters (168.80s)
--- PASS: TestAccRDSParameterGroup_limit (170.76s)
--- PASS: TestAccRDSParameterGroup_tags (183.26s)
--- PASS: TestAccRDSParameterGroup_basic (195.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        205.197s
...
```
