### PR TITLE
Deprecates some `id` attributes on Framework resources

### DIFF
--- a/.changelog/40626.txt
+++ b/.changelog/40626.txt
@@ -1,0 +1,11 @@
+```release-note:note
+resource/aws_api_gateway_domain_name_access_association: Deprecates `id` in favor of `arn`.
+```
+
+```release-note:note
+resource/aws_route53_cidr_location: Deprecates `id`.
+```
+
+```release-note:note
+resource/aws_s3_directory_bucket: Deprecates `id` in favor of `bucket`.
+```

--- a/internal/framework/stdattributes.go
+++ b/internal/framework/stdattributes.go
@@ -37,7 +37,7 @@ func IDAttributeDeprecatedNoReplacement() schema.StringAttribute {
 		PlanModifiers: []planmodifier.String{
 			stringplanmodifier.UseStateForUnknown(),
 		},
-		DeprecationMessage: fmt.Sprintf("This attribute will be removed in a future verion of the provider."),
+		DeprecationMessage: "This attribute will be removed in a future verion of the provider.",
 	}
 }
 

--- a/internal/framework/stdattributes.go
+++ b/internal/framework/stdattributes.go
@@ -4,6 +4,9 @@
 package framework
 
 import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -15,6 +18,16 @@ func IDAttribute() schema.StringAttribute {
 		PlanModifiers: []planmodifier.String{
 			stringplanmodifier.UseStateForUnknown(),
 		},
+	}
+}
+
+func IDAttributeDeprecatedWithAlternate(altPath path.Path) schema.StringAttribute {
+	return schema.StringAttribute{
+		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
+		DeprecationMessage: fmt.Sprintf("Use %s instead. This attribute will be removed in a future verion of the provider.", altPath.String()),
 	}
 }
 

--- a/internal/framework/stdattributes.go
+++ b/internal/framework/stdattributes.go
@@ -31,6 +31,16 @@ func IDAttributeDeprecatedWithAlternate(altPath path.Path) schema.StringAttribut
 	}
 }
 
+func IDAttributeDeprecatedNoReplacement() schema.StringAttribute {
+	return schema.StringAttribute{
+		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
+		DeprecationMessage: fmt.Sprintf("This attribute will be removed in a future verion of the provider."),
+	}
+}
+
 func ARNAttributeComputedOnly() schema.StringAttribute {
 	return schema.StringAttribute{
 		Computed: true,

--- a/internal/service/apigateway/account.go
+++ b/internal/service/apigateway/account.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -65,13 +64,7 @@ func (r *resourceAccount) Schema(ctx context.Context, request resource.SchemaReq
 				ElementType: types.StringType,
 				Computed:    true,
 			},
-			names.AttrID: schema.StringAttribute{
-				Computed:           true,
-				DeprecationMessage: `The "id" attribute is unused and will be removed in a future version of the provider`,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
+			names.AttrID: framework.IDAttributeDeprecatedNoReplacement(),
 			"reset_on_delete": schema.BoolAttribute{
 				Optional: true,
 				PlanModifiers: []planmodifier.Bool{

--- a/internal/service/apigateway/domain_name_access_association.go
+++ b/internal/service/apigateway/domain_name_access_association.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -72,7 +73,7 @@ func (r *domainNameAccessAssociationResource) Schema(ctx context.Context, reques
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			names.AttrID:      framework.IDAttribute(),
+			names.AttrID:      framework.IDAttributeDeprecatedWithAlternate(path.Root(names.AttrARN)),
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},

--- a/internal/service/appconfig/environment.go
+++ b/internal/service/appconfig/environment.go
@@ -83,13 +83,7 @@ func (r *resourceEnvironment) Schema(ctx context.Context, request resource.Schem
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			names.AttrID: schema.StringAttribute{
-				Computed:           true,
-				DeprecationMessage: "This attribute is unused and will be removed in a future version of the provider",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
+			names.AttrID: framework.IDAttributeDeprecatedNoReplacement(),
 			names.AttrName: schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{

--- a/internal/service/datazone/environment_profile.go
+++ b/internal/service/datazone/environment_profile.go
@@ -93,9 +93,7 @@ func (r *resourceEnvironmentProfile) Schema(ctx context.Context, req resource.Sc
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			names.AttrID: schema.StringAttribute{
-				Computed: true,
-			},
+			names.AttrID: framework.IDAttribute(),
 			names.AttrName: schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{

--- a/internal/service/datazone/user_profile.go
+++ b/internal/service/datazone/user_profile.go
@@ -71,12 +71,7 @@ func (r *resourceUserProfile) Schema(ctx context.Context, _ resource.SchemaReque
 					listplanmodifier.UseStateForUnknown(),
 				},
 			},
-			names.AttrID: schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
+			names.AttrID: framework.IDAttribute(),
 			names.AttrStatus: schema.StringAttribute{
 				CustomType: fwtypes.StringEnumType[awstypes.UserProfileStatus](),
 				Optional:   true,

--- a/internal/service/lexv2models/bot_locale.go
+++ b/internal/service/lexv2models/bot_locale.go
@@ -81,12 +81,7 @@ func (r *resourceBotLocale) Schema(ctx context.Context, req resource.SchemaReque
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			names.AttrID: schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
+			names.AttrID: framework.IDAttribute(),
 			"n_lu_intent_confidence_threshold": schema.Float64Attribute{
 				Required: true,
 			},

--- a/internal/service/route53/cidr_location.go
+++ b/internal/service/route53/cidr_location.go
@@ -61,7 +61,7 @@ func (r *cidrLocationResource) Schema(ctx context.Context, request resource.Sche
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			names.AttrID: framework.IDAttribute(),
+			names.AttrID: framework.IDAttributeDeprecatedNoReplacement(),
 			names.AttrName: schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{

--- a/internal/service/s3/bucket_accelerate_configuration_test.go
+++ b/internal/service/s3/bucket_accelerate_configuration_test.go
@@ -270,7 +270,7 @@ resource "aws_s3_directory_bucket" "test" {
 }
 
 resource "aws_s3_bucket_accelerate_configuration" "test" {
-  bucket = aws_s3_directory_bucket.test.id
+  bucket = aws_s3_directory_bucket.test.bucket
   status = %[1]q
 }
 `, status))

--- a/internal/service/s3/bucket_acl_test.go
+++ b/internal/service/s3/bucket_acl_test.go
@@ -866,7 +866,7 @@ resource "aws_s3_directory_bucket" "test" {
 }
 
 resource "aws_s3_bucket_acl" "test" {
-  bucket = aws_s3_directory_bucket.test.id
+  bucket = aws_s3_directory_bucket.test.bucket
   acl    = %[1]q
 }
 `, acl))

--- a/internal/service/s3/bucket_cors_configuration_test.go
+++ b/internal/service/s3/bucket_cors_configuration_test.go
@@ -516,7 +516,7 @@ resource "aws_s3_directory_bucket" "test" {
 }
 
 resource "aws_s3_bucket_cors_configuration" "test" {
-  bucket = aws_s3_directory_bucket.test.id
+  bucket = aws_s3_directory_bucket.test.bucket
 
   cors_rule {
     allowed_methods = ["PUT"]

--- a/internal/service/s3/bucket_inventory_test.go
+++ b/internal/service/s3/bucket_inventory_test.go
@@ -323,7 +323,7 @@ resource "aws_s3_directory_bucket" "test" {
 }
 
 resource "aws_s3_bucket_inventory" "test" {
-  bucket = aws_s3_directory_bucket.test.id
+  bucket = aws_s3_directory_bucket.test.bucket
   name   = %[1]q
 
   included_object_versions = "All"

--- a/internal/service/s3/directory_bucket.go
+++ b/internal/service/s3/directory_bucket.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -85,7 +86,7 @@ func (r *directoryBucketResource) Schema(ctx context.Context, request resource.S
 				Computed: true,
 				Default:  booldefault.StaticBool(false),
 			},
-			names.AttrID: framework.IDAttribute(),
+			names.AttrID: framework.IDAttributeDeprecatedWithAlternate(path.Root(names.AttrBucket)),
 			names.AttrType: schema.StringAttribute{
 				CustomType: bucketTypeType,
 				Optional:   true,

--- a/website/docs/r/api_gateway_domain_name_access_association.html.markdown
+++ b/website/docs/r/api_gateway_domain_name_access_association.html.markdown
@@ -34,7 +34,7 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the domain name access association.
-* `id` - Internal identifier assigned to this domain name access association.
+* `id` - (**Deprecated**, use `arn` instead) Internal identifier assigned to this domain name access association.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import

--- a/website/docs/r/route53_cidr_location.html.markdown
+++ b/website/docs/r/route53_cidr_location.html.markdown
@@ -36,7 +36,7 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The CIDR location ID.
+* `id` - (**Deprecated**) The ID of the CIDR collection concatenated with the name of the CIDR location.
 
 ## Import
 

--- a/website/docs/r/s3_directory_bucket.html.markdown
+++ b/website/docs/r/s3_directory_bucket.html.markdown
@@ -43,7 +43,7 @@ The `location` block supports the following:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - Name of the bucket.
+* `id` - (**Deprecated**, use `bucket` instead) Name of the bucket.
 * `arn` - ARN of the bucket.
 
 ## Import


### PR DESCRIPTION
### Description

Starts the process of deprecating unneeded `id` attributes in resource types implemented using Terraform Framework.

Note that regardless of the actual `DeprecationMessage` on the attribute, Terraform will display, e.g.

> │ Warning: Deprecated attribute
│ 
│   on main.tf line 431, in resource "aws_s3_bucket_policy" "test":
│  431:   bucket = aws_s3_directory_bucket.test.id
│ 
│ The attribute "id" is deprecated. Refer to the provider documentation for details.

Adds

* `framework.IDAttributeDeprecatedWithAlternate` when there is an alternate attribute to use
* `framework.IDAttributeDeprecatedNoReplacement` when these is no replacement attribute

Deprecates `id` from

* `aws_s3_directory_bucket`
* `aws_route53_cidr_location`
* `aws_api_gateway_domain_name_access_association`
