### PR TITLE
autoscaling: add new `availability_zone_distribution` argument

### DIFF
--- a/.archive/changelog/40634.txt
+++ b/.archive/changelog/40634.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_autoscaling_group: Add `availability_zone_distribution` argument
+```

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -365,6 +365,7 @@ func resourceGroup() *schema.Resource {
 							Type:             schema.TypeString,
 							Optional:         true,
 							Computed:         true,
+							Default:          awstypes.CapacityDistributionStrategyBalancedBestEffort,
 							ValidateDiagFunc: enum.Validate[awstypes.CapacityDistributionStrategy](),
 						},
 					},

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -4978,7 +4978,7 @@ resource "aws_autoscaling_group" "test" {
   launch_configuration = aws_launch_configuration.test.name
 
   availability_zone_distribution {
-    capacity_distribution_strategy = "balanced-best-effort" 
+    capacity_distribution_strategy = "balanced-best-effort"
   }
 
   tag {

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -406,6 +406,7 @@ This resource supports the following arguments:
 - `min_size` - (Required) Minimum size of the Auto Scaling Group.
   (See also [Waiting for Capacity](#waiting-for-capacity) below.)
 - `availability_zones` - (Optional) A list of Availability Zones where instances in the Auto Scaling group can be created. Used for launching into the default VPC subnet in each Availability Zone when not using the `vpc_zone_identifier` attribute, or for attaching a network interface when an existing network interface ID is specified in a launch template. Conflicts with `vpc_zone_identifier`.
+- `availability_zone_distribution` (Optional) The instance capacity distribution across Availability Zones. See [Availability Zone Distribution](#availability_zone_distribution) below for more details. 
 - `capacity_rebalance` - (Optional) Whether capacity rebalance is enabled. Otherwise, capacity rebalance is disabled.
 - `context` - (Optional) Reserved.
 - `default_cooldown` - (Optional) Amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
@@ -472,6 +473,10 @@ This resource supports the following arguments:
 - `warm_pool` - (Optional) If this block is configured, add a [Warm Pool](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html)
   to the specified Auto Scaling group. Defined [below](#warm_pool)
 - `force_delete_warm_pool` - (Optional) Allows deleting the Auto Scaling Group without waiting for all instances in the warm pool to terminate.
+
+### availability_zone_distribution
+
+- `capacity_distribution_strategy` - (Required) The strategy to use for distributing capacity across the Availability Zones. Valid values are `balanced-only` and `balanced-best-effort`. Default is `balanced-best-effort`.
 
 ### launch_template
 

--- a/website/docs/r/autoscaling_group.html.markdown
+++ b/website/docs/r/autoscaling_group.html.markdown
@@ -406,7 +406,7 @@ This resource supports the following arguments:
 - `min_size` - (Required) Minimum size of the Auto Scaling Group.
   (See also [Waiting for Capacity](#waiting-for-capacity) below.)
 - `availability_zones` - (Optional) A list of Availability Zones where instances in the Auto Scaling group can be created. Used for launching into the default VPC subnet in each Availability Zone when not using the `vpc_zone_identifier` attribute, or for attaching a network interface when an existing network interface ID is specified in a launch template. Conflicts with `vpc_zone_identifier`.
-- `availability_zone_distribution` (Optional) The instance capacity distribution across Availability Zones. See [Availability Zone Distribution](#availability_zone_distribution) below for more details. 
+- `availability_zone_distribution` (Optional) The instance capacity distribution across Availability Zones. See [Availability Zone Distribution](#availability_zone_distribution) below for more details.
 - `capacity_rebalance` - (Optional) Whether capacity rebalance is enabled. Otherwise, capacity rebalance is disabled.
 - `context` - (Optional) Reserved.
 - `default_cooldown` - (Optional) Amount of time, in seconds, after a scaling activity completes before another scaling activity can start.


### PR DESCRIPTION
Adds the new `availability_zone_distribution` argument, which features `capacity_distribution_strategy`.

* [Announcement](https://aws.amazon.com/about-aws/whats-new/2024/11/ec2-auto-scaling-strict-availability-zone-balance/)

Regarding some of the syntax, I've tried to stick with how we currently do things in this resource (e.g. casting a flatten to a slice) for consistency, making it easier to identity patterns during a potential migration to Plugin Framework.

```console
$  make testacc TESTARGS='-run=TestAccAutoScalingGroup_basic\|TestAccAutoScalingGroup_simple\|TestAccAutoScalingGroup_availabilityZoneDistribution' PKG=autoscaling
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/autoscaling/... -v -count 1 -parallel 20  -run=TestAccAutoScalingGroup_basic\|TestAccAutoScalingGroup_simple\|TestAccAutoScalingGroup_availabilityZoneDistribution -timeout 360m
2024/12/19 16:19:54 Initializing Terraform AWS Provider...
=== RUN   TestAccAutoScalingGroup_basic
=== PAUSE TestAccAutoScalingGroup_basic
=== RUN   TestAccAutoScalingGroup_simple
=== PAUSE TestAccAutoScalingGroup_simple
=== RUN   TestAccAutoScalingGroup_availabilityZoneDistribution
=== PAUSE TestAccAutoScalingGroup_availabilityZoneDistribution
=== CONT  TestAccAutoScalingGroup_basic
=== CONT  TestAccAutoScalingGroup_availabilityZoneDistribution
=== CONT  TestAccAutoScalingGroup_simple
--- PASS: TestAccAutoScalingGroup_basic (38.58s)
--- PASS: TestAccAutoScalingGroup_availabilityZoneDistribution (79.58s)
--- PASS: TestAccAutoScalingGroup_simple (146.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling        151.881s
```