### PR TITLE
Revert 40562 add validation for iam policy document sid

### DIFF
--- a/.changelog/40562.txt
+++ b/.changelog/40562.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_iam_policy_document: Add plan-time validation that the `statement` `sid` is valid, including on alphanumeric characters
+```

--- a/.changelog/40562.txt
+++ b/.changelog/40562.txt
@@ -1,3 +1,0 @@
-```release-note:enhancement
-data-source/aws_iam_policy_document: Add plan-time validation that the `statement` `sid` is valid, including on alphanumeric characters
-```

--- a/.changelog/40639.txt
+++ b/.changelog/40639.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-data-source/aws_iam_policy_document: Reverts 40652 due to issues. See: 40639.
+data-source/aws_iam_policy_document: Reverts plan-time validation for `statement` `sid`
 ```

--- a/.changelog/40639.txt
+++ b/.changelog/40639.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_iam_policy_document: Reverts 40652 due to issues. See: 40639.
+```

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -143,6 +143,8 @@ func dataSourcePolicyDocument() *schema.Resource {
 							"principals":        principalsSchema(),
 							names.AttrResources: setOfStringSchema(),
 							"sid": {
+								// Because policy documents are widely used outside IAM, we don't enforce
+								// IAM validation rules requiring alphanumeric and no spaces.
 								Type:     schema.TypeString,
 								Optional: true,
 							},

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -144,9 +143,8 @@ func dataSourcePolicyDocument() *schema.Resource {
 							"principals":        principalsSchema(),
 							names.AttrResources: setOfStringSchema(),
 							"sid": {
-								Type:         schema.TypeString,
-								Optional:     true,
-								ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9]*$`), "must only include alphanumeric characters"),
+								Type:     schema.TypeString,
+								Optional: true,
 							},
 						},
 					},

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -236,6 +236,21 @@ func TestAccIAMPolicyDocumentDataSource_overrideList(t *testing.T) {
 	})
 }
 
+func TestAccIAMPolicyDocumentDataSource_invalidSidValid(t *testing.T) {
+	ctx := acctest.Context(t)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:   testAccPolicyDocumentDataSourceConfig_invalidSid,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccIAMPolicyDocumentDataSource_noStatementMerge(t *testing.T) {
 	ctx := acctest.Context(t)
 	resource.ParallelTest(t, resource.TestCase{
@@ -1018,6 +1033,18 @@ data "aws_iam_policy_document" "test_source_conflicting" {
     sid       = "SourceJSONTestConflicting"
     actions   = ["*"]
     resources = ["*"]
+  }
+}
+`
+
+var testAccPolicyDocumentDataSourceConfig_invalidSid = `
+data "aws_iam_policy_document" "test" {
+  statement {
+    sid = "Invalid SID"
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
   }
 }
 `

--- a/internal/service/iam/policy_document_data_source_test.go
+++ b/internal/service/iam/policy_document_data_source_test.go
@@ -236,21 +236,6 @@ func TestAccIAMPolicyDocumentDataSource_overrideList(t *testing.T) {
 	})
 }
 
-func TestAccIAMPolicyDocumentDataSource_validateSid(t *testing.T) {
-	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccPolicyDocumentDataSourceConfig_invalidSid,
-				ExpectError: regexache.MustCompile(`must only include alphanumeric characters`),
-			},
-		},
-	})
-}
-
 func TestAccIAMPolicyDocumentDataSource_noStatementMerge(t *testing.T) {
 	ctx := acctest.Context(t)
 	resource.ParallelTest(t, resource.TestCase{
@@ -1033,18 +1018,6 @@ data "aws_iam_policy_document" "test_source_conflicting" {
     sid       = "SourceJSONTestConflicting"
     actions   = ["*"]
     resources = ["*"]
-  }
-}
-`
-
-var testAccPolicyDocumentDataSourceConfig_invalidSid = `
-data "aws_iam_policy_document" "test" {
-  statement {
-    sid = "Invalid_SID"
-    actions = [
-      "s3:ListAllMyBuckets",
-      "s3:GetBucketLocation",
-    ]
   }
 }
 `


### PR DESCRIPTION
This reverts https://github.com/hashicorp/terraform-provider-aws/pull/40562, which is causing significant issues.

Closes #40639.