### PR TITLE
docs: update argument name in resource `aws_msk_replicator`

### DIFF
--- a/website/docs/r/msk_replicator.html.markdown
+++ b/website/docs/r/msk_replicator.html.markdown
@@ -49,7 +49,7 @@ resource "aws_msk_replicator" "test" {
 
 
     topic_replication {
-      topic_configuration_name {
+      topic_name_configuration {
         type = "PREFIXED_WITH_SOURCE_CLUSTER_ALIAS"
       }
       topics_to_replicate = [".*"]
@@ -99,7 +99,7 @@ The following arguments are required:
 
 ### topic_replication Argument Reference
 
-* `topic_configuration_name` - (Optional) Configuration for specifying replicated topic names should be the same as their corresponding upstream topics or prefixed with source cluster alias.
+* `topic_name_configuration` - (Optional) Configuration for specifying replicated topic names should be the same as their corresponding upstream topics or prefixed with source cluster alias.
 * `topics_to_replicate` - (Required) List of regular expression patterns indicating the topics to copy.
 * `topics_to_exclude` - (Optional) List of regular expression patterns indicating the topics that should not be replica.
 * `detect_and_copy_new_topics` - (Optional) Whether to periodically check for new topics and partitions.
@@ -114,7 +114,7 @@ The following arguments are required:
 * `detect_and_copy_new_consumer_groups` - (Optional) Whether to periodically check for new consumer groups.
 * `synchronise_consumer_group_offsets` - (Optional) Whether to periodically write the translated offsets to __consumer_offsets topic in target cluster.
 
-### topic_configuration_name
+### topic_name_configuration
 
 * `type` - (optional) The type of topic configuration name. Supports `PREFIXED_WITH_SOURCE_CLUSTER_ALIAS` and `IDENTICAL`.
 


### PR DESCRIPTION
### Description

The argument `topic_name_configuration` is mentioned is the resource documentation wrongly as  `topic_configuration_name`.
This PR updates the resource documentation.

### Relations

Closes #40596 

### References

- [Resource documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_replicator#topic_configuration_name)
- [Argument name in provider source code](https://github.com/hashicorp/terraform-provider-aws/blob/214d10a9cf76f6344a84bfb79f59b7bfec19c130/internal/service/kafka/replicator.go#L178)

### Output from Acceptance Testing

Not applicable, only documentation is updated.