### PR TITLE
Moves API inputs off of heap

### DIFF
--- a/internal/service/accessanalyzer/accessanalyzer_test.go
+++ b/internal/service/accessanalyzer/accessanalyzer_test.go
@@ -37,9 +37,9 @@ func TestAccAccessAnalyzer_serial(t *testing.T) {
 func testAccPreCheck(ctx context.Context, t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AccessAnalyzerClient(ctx)
 
-	input := &accessanalyzer.ListAnalyzersInput{}
+	input := accessanalyzer.ListAnalyzersInput{}
 
-	_, err := conn.ListAnalyzers(ctx, input)
+	_, err := conn.ListAnalyzers(ctx, &input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/accessanalyzer/archive_rule.go
+++ b/internal/service/accessanalyzer/archive_rule.go
@@ -97,7 +97,7 @@ func resourceArchiveRuleCreate(ctx context.Context, d *schema.ResourceData, meta
 	analyzerName := d.Get("analyzer_name").(string)
 	ruleName := d.Get("rule_name").(string)
 	id := archiveRuleCreateResourceID(analyzerName, ruleName)
-	input := &accessanalyzer.CreateArchiveRuleInput{
+	input := accessanalyzer.CreateArchiveRuleInput{
 		AnalyzerName: aws.String(analyzerName),
 		ClientToken:  aws.String(sdkid.UniqueId()),
 		RuleName:     aws.String(ruleName),
@@ -107,7 +107,7 @@ func resourceArchiveRuleCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.Filter = expandFilter(v.(*schema.Set))
 	}
 
-	_, err := conn.CreateArchiveRule(ctx, input)
+	_, err := conn.CreateArchiveRule(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating IAM Access Analyzer Archive Rule (%s): %s", id, err)
@@ -159,7 +159,7 @@ func resourceArchiveRuleUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	input := &accessanalyzer.UpdateArchiveRuleInput{
+	input := accessanalyzer.UpdateArchiveRuleInput{
 		AnalyzerName: aws.String(analyzerName),
 		ClientToken:  aws.String(sdkid.UniqueId()),
 		RuleName:     aws.String(ruleName),
@@ -169,7 +169,7 @@ func resourceArchiveRuleUpdate(ctx context.Context, d *schema.ResourceData, meta
 		input.Filter = expandFilter(d.Get(names.AttrFilter).(*schema.Set))
 	}
 
-	_, err = conn.UpdateArchiveRule(ctx, input)
+	_, err = conn.UpdateArchiveRule(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating AWS IAM Access Analyzer Archive Rule (%s): %s", d.Id(), err)
@@ -190,11 +190,12 @@ func resourceArchiveRuleDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	log.Printf("[INFO] Deleting IAM Access Analyzer Archive Rule: %s", d.Id())
-	_, err = conn.DeleteArchiveRule(ctx, &accessanalyzer.DeleteArchiveRuleInput{
+	input := accessanalyzer.DeleteArchiveRuleInput{
 		AnalyzerName: aws.String(analyzerName),
 		ClientToken:  aws.String(sdkid.UniqueId()),
 		RuleName:     aws.String(ruleName),
-	})
+	}
+	_, err = conn.DeleteArchiveRule(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags
@@ -208,12 +209,12 @@ func resourceArchiveRuleDelete(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func findArchiveRuleByTwoPartKey(ctx context.Context, conn *accessanalyzer.Client, analyzerName, ruleName string) (*types.ArchiveRuleSummary, error) {
-	input := &accessanalyzer.GetArchiveRuleInput{
+	input := accessanalyzer.GetArchiveRuleInput{
 		AnalyzerName: aws.String(analyzerName),
 		RuleName:     aws.String(ruleName),
 	}
 
-	output, err := conn.GetArchiveRule(ctx, input)
+	output, err := conn.GetArchiveRule(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/accessanalyzer/sweep.go
+++ b/internal/service/accessanalyzer/sweep.go
@@ -28,10 +28,10 @@ func sweepAnalyzers(region string) error {
 		return fmt.Errorf("getting client: %s", err)
 	}
 	conn := client.AccessAnalyzerClient(ctx)
-	input := &accessanalyzer.ListAnalyzersInput{}
 	sweepResources := make([]sweep.Sweepable, 0)
 
-	pages := accessanalyzer.NewListAnalyzersPaginator(conn, input)
+	input := accessanalyzer.ListAnalyzersInput{}
+	pages := accessanalyzer.NewListAnalyzersPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 

--- a/internal/service/account/alternate_contact.go
+++ b/internal/service/account/alternate_contact.go
@@ -91,7 +91,7 @@ func resourceAlternateContactCreate(ctx context.Context, d *schema.ResourceData,
 	accountID := d.Get(names.AttrAccountID).(string)
 	contactType := d.Get("alternate_contact_type").(string)
 	id := alternateContactCreateResourceID(accountID, contactType)
-	input := &account.PutAlternateContactInput{
+	input := account.PutAlternateContactInput{
 		AlternateContactType: types.AlternateContactType(contactType),
 		EmailAddress:         aws.String(d.Get("email_address").(string)),
 		Name:                 aws.String(d.Get(names.AttrName).(string)),
@@ -103,7 +103,7 @@ func resourceAlternateContactCreate(ctx context.Context, d *schema.ResourceData,
 		input.AccountId = aws.String(accountID)
 	}
 
-	_, err := conn.PutAlternateContact(ctx, input)
+	_, err := conn.PutAlternateContact(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Account Alternate Contact (%s): %s", id, err)
@@ -174,7 +174,7 @@ func resourceAlternateContactUpdate(ctx context.Context, d *schema.ResourceData,
 	phone := d.Get("phone_number").(string)
 	title := d.Get("title").(string)
 
-	input := &account.PutAlternateContactInput{
+	input := account.PutAlternateContactInput{
 		AlternateContactType: types.AlternateContactType(contactType),
 		EmailAddress:         aws.String(email),
 		Name:                 aws.String(name),
@@ -186,7 +186,7 @@ func resourceAlternateContactUpdate(ctx context.Context, d *schema.ResourceData,
 		input.AccountId = aws.String(accountID)
 	}
 
-	_, err = conn.PutAlternateContact(ctx, input)
+	_, err = conn.PutAlternateContact(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Account Alternate Contact (%s): %s", d.Id(), err)
@@ -222,7 +222,7 @@ func resourceAlternateContactDelete(ctx context.Context, d *schema.ResourceData,
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	input := &account.DeleteAlternateContactInput{
+	input := account.DeleteAlternateContactInput{
 		AlternateContactType: types.AlternateContactType(contactType),
 	}
 	if accountID != "" {
@@ -230,7 +230,7 @@ func resourceAlternateContactDelete(ctx context.Context, d *schema.ResourceData,
 	}
 
 	log.Printf("[DEBUG] Deleting Account Alternate Contact: %s", d.Id())
-	_, err = conn.DeleteAlternateContact(ctx, input)
+	_, err = conn.DeleteAlternateContact(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags
@@ -252,14 +252,14 @@ func resourceAlternateContactDelete(ctx context.Context, d *schema.ResourceData,
 }
 
 func findAlternateContactByTwoPartKey(ctx context.Context, conn *account.Client, accountID, contactType string) (*types.AlternateContact, error) {
-	input := &account.GetAlternateContactInput{
+	input := account.GetAlternateContactInput{
 		AlternateContactType: types.AlternateContactType(contactType),
 	}
 	if accountID != "" {
 		input.AccountId = aws.String(accountID)
 	}
 
-	output, err := conn.GetAlternateContact(ctx, input)
+	output, err := conn.GetAlternateContact(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &sdkretry.NotFoundError{

--- a/internal/service/account/primary_contact.go
+++ b/internal/service/account/primary_contact.go
@@ -102,15 +102,16 @@ func resourcePrimaryContactPut(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).AccountClient(ctx)
 
 	id := "default"
-	input := &account.PutContactInformationInput{
-		ContactInformation: &types.ContactInformation{
-			AddressLine1: aws.String(d.Get("address_line_1").(string)),
-			City:         aws.String(d.Get("city").(string)),
-			CountryCode:  aws.String(d.Get("country_code").(string)),
-			FullName:     aws.String(d.Get("full_name").(string)),
-			PhoneNumber:  aws.String(d.Get("phone_number").(string)),
-			PostalCode:   aws.String(d.Get("postal_code").(string)),
-		},
+	contactInfo := types.ContactInformation{
+		AddressLine1: aws.String(d.Get("address_line_1").(string)),
+		City:         aws.String(d.Get("city").(string)),
+		CountryCode:  aws.String(d.Get("country_code").(string)),
+		FullName:     aws.String(d.Get("full_name").(string)),
+		PhoneNumber:  aws.String(d.Get("phone_number").(string)),
+		PostalCode:   aws.String(d.Get("postal_code").(string)),
+	}
+	input := account.PutContactInformationInput{
+		ContactInformation: &contactInfo,
 	}
 
 	if v, ok := d.GetOk(names.AttrAccountID); ok {
@@ -142,7 +143,7 @@ func resourcePrimaryContactPut(ctx context.Context, d *schema.ResourceData, meta
 		input.ContactInformation.WebsiteUrl = aws.String(v.(string))
 	}
 
-	_, err := conn.PutContactInformation(ctx, input)
+	_, err := conn.PutContactInformation(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Account Primary Contact (%s): %s", id, err)
@@ -190,12 +191,12 @@ func resourcePrimaryContactRead(ctx context.Context, d *schema.ResourceData, met
 }
 
 func findContactInformation(ctx context.Context, conn *account.Client, accountID string) (*types.ContactInformation, error) {
-	input := &account.GetContactInformationInput{}
+	input := account.GetContactInformationInput{}
 	if accountID != "" {
 		input.AccountId = aws.String(accountID)
 	}
 
-	output, err := conn.GetContactInformation(ctx, input)
+	output, err := conn.GetContactInformation(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/account/region.go
+++ b/internal/service/account/region.go
@@ -92,14 +92,14 @@ func resourceRegionUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if v := d.Get(names.AttrEnabled).(bool); v {
-		input := &account.EnableRegionInput{
+		input := account.EnableRegionInput{
 			RegionName: aws.String(region),
 		}
 		if accountID != "" {
 			input.AccountId = aws.String(accountID)
 		}
 
-		_, err := conn.EnableRegion(ctx, input)
+		_, err := conn.EnableRegion(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "enabling Account Region (%s): %s", id, err)
@@ -109,14 +109,14 @@ func resourceRegionUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			return sdkdiag.AppendErrorf(diags, "waiting for Account Region (%s) enable: %s", d.Id(), err)
 		}
 	} else {
-		input := &account.DisableRegionInput{
+		input := account.DisableRegionInput{
 			RegionName: aws.String(region),
 		}
 		if accountID != "" {
 			input.AccountId = aws.String(accountID)
 		}
 
-		_, err := conn.DisableRegion(ctx, input)
+		_, err := conn.DisableRegion(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "enabling Account Region (%s): %s", id, err)
@@ -166,14 +166,14 @@ func resourceRegionRead(ctx context.Context, d *schema.ResourceData, meta interf
 }
 
 func findRegionOptStatus(ctx context.Context, conn *account.Client, accountID, region string) (*account.GetRegionOptStatusOutput, error) {
-	input := &account.GetRegionOptStatusInput{
+	input := account.GetRegionOptStatusInput{
 		RegionName: aws.String(region),
 	}
 	if accountID != "" {
 		input.AccountId = aws.String(accountID)
 	}
 
-	output, err := conn.GetRegionOptStatus(ctx, input)
+	output, err := conn.GetRegionOptStatus(ctx, &input)
 
 	if err != nil {
 		return nil, err

--- a/internal/service/acm/certificate_test.go
+++ b/internal/service/acm/certificate_test.go
@@ -246,10 +246,11 @@ func TestAccACMCertificate_privateCertificate_renewable(t *testing.T) {
 				PreConfig: func() {
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-					_, err := conn.ExportCertificate(ctx, &acm.ExportCertificateInput{
+					input := acm.ExportCertificateInput{
 						CertificateArn: v1.CertificateArn,
 						Passphrase:     []byte("passphrase"),
-					})
+					}
+					_, err := conn.ExportCertificate(ctx, &input)
 					if err != nil {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
@@ -274,9 +275,10 @@ func TestAccACMCertificate_privateCertificate_renewable(t *testing.T) {
 				PreConfig: func() {
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-					_, err := conn.RenewCertificate(ctx, &acm.RenewCertificateInput{
+					input := acm.RenewCertificateInput{
 						CertificateArn: v1.CertificateArn,
-					})
+					}
+					_, err := conn.RenewCertificate(ctx, &input)
 					if err != nil {
 						t.Fatalf("renewing ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
@@ -372,10 +374,11 @@ func TestAccACMCertificate_privateCertificate_noRenewalPermission(t *testing.T) 
 				PreConfig: func() {
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-					_, err := conn.ExportCertificate(ctx, &acm.ExportCertificateInput{
+					input := acm.ExportCertificateInput{
 						CertificateArn: v1.CertificateArn,
 						Passphrase:     []byte("passphrase"),
-					})
+					}
+					_, err := conn.ExportCertificate(ctx, &input)
 					if err != nil {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
@@ -399,9 +402,10 @@ func TestAccACMCertificate_privateCertificate_noRenewalPermission(t *testing.T) 
 				PreConfig: func() {
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-					_, err := conn.RenewCertificate(ctx, &acm.RenewCertificateInput{
+					input := acm.RenewCertificateInput{
 						CertificateArn: v1.CertificateArn,
-					})
+					}
+					_, err := conn.RenewCertificate(ctx, &input)
 					if err != nil {
 						t.Fatalf("renewing ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
@@ -482,10 +486,11 @@ func TestAccACMCertificate_privateCertificate_pendingRenewalGoDuration(t *testin
 				PreConfig: func() {
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-					_, err := conn.ExportCertificate(ctx, &acm.ExportCertificateInput{
+					input := acm.ExportCertificateInput{
 						CertificateArn: v1.CertificateArn,
 						Passphrase:     []byte("passphrase"),
-					})
+					}
+					_, err := conn.ExportCertificate(ctx, &input)
 					if err != nil {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
@@ -556,10 +561,11 @@ func TestAccACMCertificate_privateCertificate_pendingRenewalRFC3339Duration(t *t
 				PreConfig: func() {
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-					_, err := conn.ExportCertificate(ctx, &acm.ExportCertificateInput{
+					input := acm.ExportCertificateInput{
 						CertificateArn: v1.CertificateArn,
 						Passphrase:     []byte("passphrase"),
-					})
+					}
+					_, err := conn.ExportCertificate(ctx, &input)
 					if err != nil {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
@@ -630,10 +636,11 @@ func TestAccACMCertificate_privateCertificate_addEarlyRenewalPast(t *testing.T) 
 				PreConfig: func() {
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-					_, err := conn.ExportCertificate(ctx, &acm.ExportCertificateInput{
+					input := acm.ExportCertificateInput{
 						CertificateArn: v1.CertificateArn,
 						Passphrase:     []byte("passphrase"),
-					})
+					}
+					_, err := conn.ExportCertificate(ctx, &input)
 					if err != nil {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
@@ -771,10 +778,11 @@ func TestAccACMCertificate_privateCertificate_addEarlyRenewalFuture(t *testing.T
 				PreConfig: func() {
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-					_, err := conn.ExportCertificate(ctx, &acm.ExportCertificateInput{
+					input := acm.ExportCertificateInput{
 						CertificateArn: v1.CertificateArn,
 						Passphrase:     []byte("passphrase"),
-					})
+					}
+					_, err := conn.ExportCertificate(ctx, &input)
 					if err != nil {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
@@ -857,10 +865,11 @@ func TestAccACMCertificate_privateCertificate_updateEarlyRenewalFuture(t *testin
 				PreConfig: func() {
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-					_, err := conn.ExportCertificate(ctx, &acm.ExportCertificateInput{
+					input := acm.ExportCertificateInput{
 						CertificateArn: v1.CertificateArn,
 						Passphrase:     []byte("passphrase"),
-					})
+					}
+					_, err := conn.ExportCertificate(ctx, &input)
 					if err != nil {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}
@@ -927,10 +936,11 @@ func TestAccACMCertificate_privateCertificate_removeEarlyRenewal(t *testing.T) {
 				PreConfig: func() {
 					conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-					_, err := conn.ExportCertificate(ctx, &acm.ExportCertificateInput{
+					input := acm.ExportCertificateInput{
 						CertificateArn: v1.CertificateArn,
 						Passphrase:     []byte("passphrase"),
-					})
+					}
+					_, err := conn.ExportCertificate(ctx, &input)
 					if err != nil {
 						t.Fatalf("exporting ACM Certificate (%s): %s", aws.ToString(v1.CertificateArn), err)
 					}

--- a/internal/service/acm/certificate_validation.go
+++ b/internal/service/acm/certificate_validation.go
@@ -149,11 +149,11 @@ func findCertificateValidationByARN(ctx context.Context, conn *acm.Client, arn s
 func statusCertificate(ctx context.Context, conn *acm.Client, arn string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		// Don't call findCertificateByARN as it maps useful status codes to NotFoundError.
-		input := &acm.DescribeCertificateInput{
+		input := acm.DescribeCertificateInput{
 			CertificateArn: aws.String(arn),
 		}
 
-		output, err := findCertificate(ctx, conn, input)
+		output, err := findCertificate(ctx, conn, &input)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/acm/sweep.go
+++ b/internal/service/acm/sweep.go
@@ -46,10 +46,10 @@ func sweepCertificates(region string) error {
 		return fmt.Errorf("error getting client: %s", err)
 	}
 	conn := client.ACMClient(ctx)
-	input := &acm.ListCertificatesInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
+	var sweepResources []sweep.Sweepable
 
-	pages := acm.NewListCertificatesPaginator(conn, input)
+	input := acm.ListCertificatesInput{}
+	pages := acm.NewListCertificatesPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
@@ -64,10 +64,10 @@ func sweepCertificates(region string) error {
 
 		for _, v := range page.CertificateSummaryList {
 			arn := aws.ToString(v.CertificateArn)
-			input := &acm.DescribeCertificateInput{
+			input := acm.DescribeCertificateInput{
 				CertificateArn: aws.String(arn),
 			}
-			certificate, err := findCertificate(ctx, conn, input)
+			certificate, err := findCertificate(ctx, conn, &input)
 
 			if err != nil {
 				log.Printf("[ERROR] Reading ACM Certificate (%s): %s", arn, err)

--- a/internal/service/acmpca/certificate.go
+++ b/internal/service/acmpca/certificate.go
@@ -140,7 +140,7 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).ACMPCAClient(ctx)
 
 	certificateAuthorityARN := d.Get("certificate_authority_arn").(string)
-	inputI := &acmpca.IssueCertificateInput{
+	inputI := acmpca.IssueCertificateInput{
 		CertificateAuthorityArn: aws.String(certificateAuthorityARN),
 		Csr:                     []byte(d.Get("certificate_signing_request").(string)),
 		IdempotencyToken:        aws.String(id.UniqueId()),
@@ -166,7 +166,7 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidStateException](ctx, certificateAuthorityActiveTimeout, func() (interface{}, error) {
-		return conn.IssueCertificate(ctx, inputI)
+		return conn.IssueCertificate(ctx, &inputI)
 	}, "The certificate authority is not in a valid state for issuing certificates")
 
 	if err != nil {
@@ -176,11 +176,11 @@ func resourceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta
 	d.SetId(aws.ToString(outputRaw.(*acmpca.IssueCertificateOutput).CertificateArn))
 
 	// Wait for certificate status to become ISSUED.
-	inputG := &acmpca.GetCertificateInput{
+	inputG := acmpca.GetCertificateInput{
 		CertificateArn:          aws.String(d.Id()),
 		CertificateAuthorityArn: aws.String(d.Get("certificate_authority_arn").(string)),
 	}
-	err = acmpca.NewCertificateIssuedWaiter(conn).Wait(ctx, inputG, certificateIssueTimeout)
+	err = acmpca.NewCertificateIssuedWaiter(conn).Wait(ctx, &inputG, certificateIssueTimeout)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for ACM PCA Certificate Authority (%s) to issue Certificate (%s), error: %s", certificateAuthorityARN, d.Id(), err)
@@ -232,11 +232,12 @@ func resourceCertificateRevoke(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	log.Printf("[INFO] Revoking ACM PCA Certificate: %s", d.Id())
-	_, err = conn.RevokeCertificate(ctx, &acmpca.RevokeCertificateInput{
+	input := acmpca.RevokeCertificateInput{
 		CertificateAuthorityArn: aws.String(d.Get("certificate_authority_arn").(string)),
 		CertificateSerial:       aws.String(serial.Text(16)), //nolint:mnd // Should be excluded, but not sure how to specify a method
 		RevocationReason:        types.RevocationReasonUnspecified,
-	})
+	}
+	_, err = conn.RevokeCertificate(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) ||
 		errs.IsA[*types.RequestAlreadyProcessedException](err) ||
@@ -253,12 +254,12 @@ func resourceCertificateRevoke(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func findCertificateByTwoPartKey(ctx context.Context, conn *acmpca.Client, certificateARN, certificateAuthorityARN string) (*acmpca.GetCertificateOutput, error) {
-	input := &acmpca.GetCertificateInput{
+	input := acmpca.GetCertificateInput{
 		CertificateArn:          aws.String(certificateARN),
 		CertificateAuthorityArn: aws.String(certificateAuthorityARN),
 	}
 
-	return findCertificate(ctx, conn, input)
+	return findCertificate(ctx, conn, &input)
 }
 
 func findCertificate(ctx context.Context, conn *acmpca.Client, input *acmpca.GetCertificateInput) (*acmpca.GetCertificateOutput, error) {

--- a/internal/service/acmpca/certificate_authority_certificate.go
+++ b/internal/service/acmpca/certificate_authority_certificate.go
@@ -61,7 +61,7 @@ func resourceCertificateAuthorityCertificateCreate(ctx context.Context, d *schem
 	conn := meta.(*conns.AWSClient).ACMPCAClient(ctx)
 
 	certificateAuthorityARN := d.Get("certificate_authority_arn").(string)
-	input := &acmpca.ImportCertificateAuthorityCertificateInput{
+	input := acmpca.ImportCertificateAuthorityCertificateInput{
 		Certificate:             []byte(d.Get(names.AttrCertificate).(string)),
 		CertificateAuthorityArn: aws.String(certificateAuthorityARN),
 	}
@@ -70,7 +70,7 @@ func resourceCertificateAuthorityCertificateCreate(ctx context.Context, d *schem
 		input.CertificateChain = []byte(v)
 	}
 
-	_, err := conn.ImportCertificateAuthorityCertificate(ctx, input)
+	_, err := conn.ImportCertificateAuthorityCertificate(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "associating ACM PCA Certificate with Certificate Authority (%s): %s", certificateAuthorityARN, err)
@@ -104,11 +104,11 @@ func resourceCertificateAuthorityCertificateRead(ctx context.Context, d *schema.
 }
 
 func findCertificateAuthorityCertificateByARN(ctx context.Context, conn *acmpca.Client, arn string) (*acmpca.GetCertificateAuthorityCertificateOutput, error) {
-	input := &acmpca.GetCertificateAuthorityCertificateInput{
+	input := acmpca.GetCertificateAuthorityCertificateInput{
 		CertificateAuthorityArn: aws.String(arn),
 	}
 
-	output, err := conn.GetCertificateAuthorityCertificate(ctx, input)
+	output, err := conn.GetCertificateAuthorityCertificate(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/acmpca/permission.go
+++ b/internal/service/acmpca/permission.go
@@ -86,7 +86,7 @@ func resourcePermissionCreate(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	input := &acmpca.CreatePermissionInput{
+	input := acmpca.CreatePermissionInput{
 		Actions:                 expandPermissionActions(d.Get(names.AttrActions).(*schema.Set)),
 		CertificateAuthorityArn: aws.String(caARN),
 		Principal:               aws.String(principal),
@@ -96,7 +96,7 @@ func resourcePermissionCreate(ctx context.Context, d *schema.ResourceData, meta 
 		input.SourceAccount = aws.String(sourceAccount)
 	}
 
-	if _, err := conn.CreatePermission(ctx, input); err != nil {
+	if _, err := conn.CreatePermission(ctx, &input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating ACM PCA Permission (%s): %s", id, err)
 	}
 
@@ -146,7 +146,7 @@ func resourcePermissionDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	caARN, principal, sourceAccount := parts[0], parts[1], parts[2]
-	input := &acmpca.DeletePermissionInput{
+	input := acmpca.DeletePermissionInput{
 		CertificateAuthorityArn: aws.String(caARN),
 		Principal:               aws.String(principal),
 	}
@@ -156,7 +156,7 @@ func resourcePermissionDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	log.Printf("[DEBUG] Deleting ACM PCA Permission: %s", d.Id())
-	_, err = conn.DeletePermission(ctx, input)
+	_, err = conn.DeletePermission(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags
@@ -170,11 +170,11 @@ func resourcePermissionDelete(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func findPermissionByThreePartKey(ctx context.Context, conn *acmpca.Client, certificateAuthorityARN, principal, sourceAccount string) (*types.Permission, error) {
-	input := &acmpca.ListPermissionsInput{
+	input := acmpca.ListPermissionsInput{
 		CertificateAuthorityArn: aws.String(certificateAuthorityARN),
 	}
 
-	return findPermission(ctx, conn, input, func(v *types.Permission) bool {
+	return findPermission(ctx, conn, &input, func(v *types.Permission) bool {
 		return aws.ToString(v.Principal) == principal && (sourceAccount == "" || aws.ToString(v.SourceAccount) == sourceAccount)
 	})
 }

--- a/internal/service/acmpca/policy.go
+++ b/internal/service/acmpca/policy.go
@@ -66,12 +66,12 @@ func resourcePolicyPut(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	resourceARN := d.Get(names.AttrResourceARN).(string)
-	input := &acmpca.PutPolicyInput{
+	input := acmpca.PutPolicyInput{
 		Policy:      aws.String(policy),
 		ResourceArn: aws.String(resourceARN),
 	}
 
-	_, err = conn.PutPolicy(ctx, input)
+	_, err = conn.PutPolicy(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "putting ACM PCA Policy (%s): %s", resourceARN, err)
@@ -111,9 +111,10 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	conn := meta.(*conns.AWSClient).ACMPCAClient(ctx)
 
 	log.Printf("[DEBUG] Deleting ACM PCA Policy: %s", d.Id())
-	_, err := conn.DeletePolicy(ctx, &acmpca.DeletePolicyInput{
+	input := acmpca.DeletePolicyInput{
 		ResourceArn: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeletePolicy(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) ||
 		errs.IsA[*types.RequestAlreadyProcessedException](err) ||
@@ -130,11 +131,11 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func findPolicyByARN(ctx context.Context, conn *acmpca.Client, arn string) (*string, error) {
-	input := &acmpca.GetPolicyInput{
+	input := acmpca.GetPolicyInput{
 		ResourceArn: aws.String(arn),
 	}
 
-	output, err := conn.GetPolicy(ctx, input)
+	output, err := conn.GetPolicy(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/acmpca/sweep.go
+++ b/internal/service/acmpca/sweep.go
@@ -28,11 +28,11 @@ func sweepCertificateAuthorities(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %w", err)
 	}
-	input := &acmpca.ListCertificateAuthoritiesInput{}
 	conn := client.ACMPCAClient(ctx)
-	sweepResources := make([]sweep.Sweepable, 0)
+	var sweepResources []sweep.Sweepable
 
-	paginator := acmpca.NewListCertificateAuthoritiesPaginator(conn, input)
+	input := acmpca.ListCertificateAuthoritiesInput{}
+	paginator := acmpca.NewListCertificateAuthoritiesPaginator(conn, &input)
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 

--- a/internal/service/amp/alert_manager_definition.go
+++ b/internal/service/amp/alert_manager_definition.go
@@ -53,12 +53,12 @@ func resourceAlertManagerDefinitionCreate(ctx context.Context, d *schema.Resourc
 	conn := meta.(*conns.AWSClient).AMPClient(ctx)
 
 	workspaceID := d.Get("workspace_id").(string)
-	input := &amp.CreateAlertManagerDefinitionInput{
+	input := amp.CreateAlertManagerDefinitionInput{
 		Data:        []byte(d.Get("definition").(string)),
 		WorkspaceId: aws.String(workspaceID),
 	}
 
-	_, err := conn.CreateAlertManagerDefinition(ctx, input)
+	_, err := conn.CreateAlertManagerDefinition(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Prometheus Alert Manager Definition (%s): %s", workspaceID, err)
@@ -99,12 +99,12 @@ func resourceAlertManagerDefinitionUpdate(ctx context.Context, d *schema.Resourc
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AMPClient(ctx)
 
-	input := &amp.PutAlertManagerDefinitionInput{
+	input := amp.PutAlertManagerDefinitionInput{
 		Data:        []byte(d.Get("definition").(string)),
 		WorkspaceId: aws.String(d.Get("workspace_id").(string)),
 	}
 
-	_, err := conn.PutAlertManagerDefinition(ctx, input)
+	_, err := conn.PutAlertManagerDefinition(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Prometheus Alert Manager Definition (%s): %s", d.Id(), err)
@@ -122,9 +122,10 @@ func resourceAlertManagerDefinitionDelete(ctx context.Context, d *schema.Resourc
 	conn := meta.(*conns.AWSClient).AMPClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Prometheus Alert Manager Definition: (%s)", d.Id())
-	_, err := conn.DeleteAlertManagerDefinition(ctx, &amp.DeleteAlertManagerDefinitionInput{
+	input := amp.DeleteAlertManagerDefinitionInput{
 		WorkspaceId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteAlertManagerDefinition(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags
@@ -142,11 +143,11 @@ func resourceAlertManagerDefinitionDelete(ctx context.Context, d *schema.Resourc
 }
 
 func findAlertManagerDefinitionByID(ctx context.Context, conn *amp.Client, id string) (*types.AlertManagerDefinitionDescription, error) {
-	input := &amp.DescribeAlertManagerDefinitionInput{
+	input := amp.DescribeAlertManagerDefinitionInput{
 		WorkspaceId: aws.String(id),
 	}
 
-	output, err := conn.DescribeAlertManagerDefinition(ctx, input)
+	output, err := conn.DescribeAlertManagerDefinition(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/amp/default_scraper_configuration_data_source.go
+++ b/internal/service/amp/default_scraper_configuration_data_source.go
@@ -62,8 +62,8 @@ func (d *defaultScraperConfigurationDataSource) Read(ctx context.Context, reques
 }
 
 func findDefaultScraperConfiguration(ctx context.Context, conn *amp.Client) ([]byte, error) {
-	input := &amp.GetDefaultScraperConfigurationInput{}
-	output, err := conn.GetDefaultScraperConfiguration(ctx, input)
+	input := amp.GetDefaultScraperConfigurationInput{}
+	output, err := conn.GetDefaultScraperConfiguration(ctx, &input)
 
 	if err != nil {
 		return nil, err

--- a/internal/service/amp/rule_group_namespace.go
+++ b/internal/service/amp/rule_group_namespace.go
@@ -62,13 +62,13 @@ func resourceRuleGroupNamespaceCreate(ctx context.Context, d *schema.ResourceDat
 
 	workspaceID := d.Get("workspace_id").(string)
 	name := d.Get(names.AttrName).(string)
-	input := &amp.CreateRuleGroupsNamespaceInput{
+	input := amp.CreateRuleGroupsNamespaceInput{
 		Data:        []byte(d.Get("data").(string)),
 		Name:        aws.String(name),
 		WorkspaceId: aws.String(workspaceID),
 	}
 
-	output, err := conn.CreateRuleGroupsNamespace(ctx, input)
+	output, err := conn.CreateRuleGroupsNamespace(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Prometheus Rule Group Namespace (%s) for Workspace (%s): %s", name, workspaceID, err)
@@ -114,13 +114,13 @@ func resourceRuleGroupNamespaceUpdate(ctx context.Context, d *schema.ResourceDat
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AMPClient(ctx)
 
-	input := &amp.PutRuleGroupsNamespaceInput{
+	input := amp.PutRuleGroupsNamespaceInput{
 		Data:        []byte(d.Get("data").(string)),
 		Name:        aws.String(d.Get(names.AttrName).(string)),
 		WorkspaceId: aws.String(d.Get("workspace_id").(string)),
 	}
 
-	_, err := conn.PutRuleGroupsNamespace(ctx, input)
+	_, err := conn.PutRuleGroupsNamespace(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Prometheus Rule Group Namespace (%s): %s", d.Id(), err)
@@ -138,10 +138,11 @@ func resourceRuleGroupNamespaceDelete(ctx context.Context, d *schema.ResourceDat
 	conn := meta.(*conns.AWSClient).AMPClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Prometheus Rule Group Namespace: (%s)", d.Id())
-	_, err := conn.DeleteRuleGroupsNamespace(ctx, &amp.DeleteRuleGroupsNamespaceInput{
+	input := amp.DeleteRuleGroupsNamespaceInput{
 		Name:        aws.String(d.Get(names.AttrName).(string)),
 		WorkspaceId: aws.String(d.Get("workspace_id").(string)),
-	})
+	}
+	_, err := conn.DeleteRuleGroupsNamespace(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags
@@ -181,12 +182,12 @@ func findRuleGroupNamespaceByARN(ctx context.Context, conn *amp.Client, arn stri
 		return nil, err
 	}
 
-	input := &amp.DescribeRuleGroupsNamespaceInput{
+	input := amp.DescribeRuleGroupsNamespaceInput{
 		Name:        aws.String(name),
 		WorkspaceId: aws.String(workspaceID),
 	}
 
-	output, err := conn.DescribeRuleGroupsNamespace(ctx, input)
+	output, err := conn.DescribeRuleGroupsNamespace(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/amp/scraper.go
+++ b/internal/service/amp/scraper.go
@@ -209,7 +209,7 @@ func (r *scraperResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	destination := &awstypes.DestinationMemberAmpConfiguration{}
+	destination := awstypes.DestinationMemberAmpConfiguration{}
 	resp.Diagnostics.Append(flex.Expand(ctx, ampDestinationData, &destination.Value)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -227,27 +227,28 @@ func (r *scraperResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	source := &awstypes.SourceMemberEksConfiguration{}
+	source := awstypes.SourceMemberEksConfiguration{}
 	resp.Diagnostics.Append(flex.Expand(ctx, eksSourceData, &source.Value)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	input := &amp.CreateScraperInput{
-		ClientToken: aws.String(sdkid.UniqueId()),
-		Destination: destination,
-		Source:      source,
-		ScrapeConfiguration: &awstypes.ScrapeConfigurationMemberConfigurationBlob{
-			Value: []byte(data.ScrapeConfiguration.ValueString()),
-		},
-		Tags: getTagsIn(ctx),
+	scrapeConfiguration := awstypes.ScrapeConfigurationMemberConfigurationBlob{
+		Value: []byte(data.ScrapeConfiguration.ValueString()),
+	}
+	input := amp.CreateScraperInput{
+		ClientToken:         aws.String(sdkid.UniqueId()),
+		Destination:         &destination,
+		Source:              &source,
+		ScrapeConfiguration: &scrapeConfiguration,
+		Tags:                getTagsIn(ctx),
 	}
 
 	if !data.Alias.IsNull() {
 		input.Alias = data.Alias.ValueStringPointer()
 	}
 
-	output, err := conn.CreateScraper(ctx, input)
+	output, err := conn.CreateScraper(ctx, &input)
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -366,10 +367,11 @@ func (r *scraperResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	_, err := conn.DeleteScraper(ctx, &amp.DeleteScraperInput{
+	input := amp.DeleteScraperInput{
 		ClientToken: aws.String(sdkid.UniqueId()),
 		ScraperId:   data.ID.ValueStringPointer(),
-	})
+	}
+	_, err := conn.DeleteScraper(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return
@@ -428,11 +430,11 @@ type scraperEKSSourceModel struct {
 }
 
 func findScraperByID(ctx context.Context, conn *amp.Client, id string) (*awstypes.ScraperDescription, error) {
-	input := &amp.DescribeScraperInput{
+	input := amp.DescribeScraperInput{
 		ScraperId: aws.String(id),
 	}
 
-	output, err := conn.DescribeScraper(ctx, input)
+	output, err := conn.DescribeScraper(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/amp/scraper_test.go
+++ b/internal/service/amp/scraper_test.go
@@ -206,9 +206,9 @@ func testAccCheckScraperExists(ctx context.Context, n string, v *types.ScraperDe
 func testAccPreCheck(ctx context.Context, t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).AMPClient(ctx)
 
-	input := &amp.ListScrapersInput{}
+	input := amp.ListScrapersInput{}
 
-	_, err := conn.ListScrapers(ctx, input)
+	_, err := conn.ListScrapers(ctx, &input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/amp/workspaces_data_source.go
+++ b/internal/service/amp/workspaces_data_source.go
@@ -72,13 +72,13 @@ func dataSourceWorkspacesRead(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func findWorkspaces(ctx context.Context, conn *amp.Client, alias string) ([]types.WorkspaceSummary, error) { // nosemgrep:ci.caps0-in-func-name
-	input := &amp.ListWorkspacesInput{}
+	input := amp.ListWorkspacesInput{}
 	if alias != "" {
 		input.Alias = aws.String(alias)
 	}
 
 	var output []types.WorkspaceSummary
-	pages := amp.NewListWorkspacesPaginator(conn, input)
+	pages := amp.NewListWorkspacesPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 

--- a/internal/service/amplify/domain_association.go
+++ b/internal/service/amplify/domain_association.go
@@ -130,7 +130,7 @@ func resourceDomainAssociationCreate(ctx context.Context, d *schema.ResourceData
 	appID := d.Get("app_id").(string)
 	domainName := d.Get(names.AttrDomainName).(string)
 	id := domainAssociationCreateResourceID(appID, domainName)
-	input := &amplify.CreateDomainAssociationInput{
+	input := amplify.CreateDomainAssociationInput{
 		AppId:               aws.String(appID),
 		DomainName:          aws.String(domainName),
 		EnableAutoSubDomain: aws.Bool(d.Get("enable_auto_sub_domain").(bool)),
@@ -141,7 +141,7 @@ func resourceDomainAssociationCreate(ctx context.Context, d *schema.ResourceData
 		input.CertificateSettings = expandCertificateSettings(v.([]interface{})[0].(map[string]interface{}))
 	}
 
-	_, err := conn.CreateDomainAssociation(ctx, input)
+	_, err := conn.CreateDomainAssociation(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Amplify Domain Association (%s): %s", id, err)
@@ -253,10 +253,11 @@ func resourceDomainAssociationDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	log.Printf("[DEBUG] Deleting Amplify Domain Association: %s", d.Id())
-	_, err = conn.DeleteDomainAssociation(ctx, &amplify.DeleteDomainAssociationInput{
+	input := amplify.DeleteDomainAssociationInput{
 		AppId:      aws.String(appID),
 		DomainName: aws.String(domainName),
-	})
+	}
+	_, err = conn.DeleteDomainAssociation(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
 		return diags
@@ -270,12 +271,12 @@ func resourceDomainAssociationDelete(ctx context.Context, d *schema.ResourceData
 }
 
 func findDomainAssociationByTwoPartKey(ctx context.Context, conn *amplify.Client, appID, domainName string) (*types.DomainAssociation, error) {
-	input := &amplify.GetDomainAssociationInput{
+	input := amplify.GetDomainAssociationInput{
 		AppId:      aws.String(appID),
 		DomainName: aws.String(domainName),
 	}
 
-	output, err := conn.GetDomainAssociation(ctx, input)
+	output, err := conn.GetDomainAssociation(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/amplify/sweep.go
+++ b/internal/service/amplify/sweep.go
@@ -27,11 +27,11 @@ func sweepApps(region string) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
-	input := &amplify.ListAppsInput{}
 	conn := client.AmplifyClient(ctx)
-	sweepResources := make([]sweep.Sweepable, 0)
+	var sweepResources []sweep.Sweepable
 
-	pages := amplify.NewListAppsPaginator(conn, input)
+	input := amplify.ListAppsInput{}
+	pages := amplify.NewListAppsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 

--- a/internal/service/amplify/webhook.go
+++ b/internal/service/amplify/webhook.go
@@ -67,7 +67,7 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta int
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AmplifyClient(ctx)
 
-	input := &amplify.CreateWebhookInput{
+	input := amplify.CreateWebhookInput{
 		AppId:      aws.String(d.Get("app_id").(string)),
 		BranchName: aws.String(d.Get("branch_name").(string)),
 	}
@@ -76,7 +76,7 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.Description = aws.String(v.(string))
 	}
 
-	output, err := conn.CreateWebhook(ctx, input)
+	output, err := conn.CreateWebhook(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Amplify Webhook: %s", err)
@@ -130,7 +130,7 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AmplifyClient(ctx)
 
-	input := &amplify.UpdateWebhookInput{
+	input := amplify.UpdateWebhookInput{
 		WebhookId: aws.String(d.Id()),
 	}
 
@@ -142,7 +142,7 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		input.Description = aws.String(d.Get(names.AttrDescription).(string))
 	}
 
-	_, err := conn.UpdateWebhook(ctx, input)
+	_, err := conn.UpdateWebhook(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Amplify Webhook (%s): %s", d.Id(), err)
@@ -156,9 +156,10 @@ func resourceWebhookDelete(ctx context.Context, d *schema.ResourceData, meta int
 	conn := meta.(*conns.AWSClient).AmplifyClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Amplify Webhook: %s", d.Id())
-	_, err := conn.DeleteWebhook(ctx, &amplify.DeleteWebhookInput{
+	input := amplify.DeleteWebhookInput{
 		WebhookId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteWebhook(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
 		return diags
@@ -172,11 +173,11 @@ func resourceWebhookDelete(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func findWebhookByID(ctx context.Context, conn *amplify.Client, id string) (*types.Webhook, error) {
-	input := &amplify.GetWebhookInput{
+	input := amplify.GetWebhookInput{
 		WebhookId: aws.String(id),
 	}
 
-	output, err := conn.GetWebhook(ctx, input)
+	output, err := conn.GetWebhook(ctx, &input)
 
 	if errs.IsA[*types.NotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/appautoscaling/target.go
+++ b/internal/service/appautoscaling/target.go
@@ -112,7 +112,7 @@ func resourceTargetCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	conn := meta.(*conns.AWSClient).AppAutoScalingClient(ctx)
 
 	resourceID := d.Get(names.AttrResourceID).(string)
-	input := &applicationautoscaling.RegisterScalableTargetInput{
+	input := applicationautoscaling.RegisterScalableTargetInput{
 		MaxCapacity:       aws.Int32(int32(d.Get(names.AttrMaxCapacity).(int))),
 		MinCapacity:       aws.Int32(int32(d.Get("min_capacity").(int))),
 		ResourceId:        aws.String(resourceID),
@@ -129,7 +129,7 @@ func resourceTargetCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		input.SuspendedState = expandSuspendedState(v.([]interface{}))
 	}
 
-	err := registerScalableTarget(ctx, conn, input)
+	err := registerScalableTarget(ctx, conn, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Application AutoScaling Target (%s): %s", resourceID, err)
@@ -182,7 +182,7 @@ func resourceTargetUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	conn := meta.(*conns.AWSClient).AppAutoScalingClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
-		input := &applicationautoscaling.RegisterScalableTargetInput{
+		input := applicationautoscaling.RegisterScalableTargetInput{
 			MaxCapacity:       aws.Int32(int32(d.Get(names.AttrMaxCapacity).(int))),
 			MinCapacity:       aws.Int32(int32(d.Get("min_capacity").(int))),
 			ResourceId:        aws.String(d.Id()),
@@ -198,7 +198,7 @@ func resourceTargetUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			input.SuspendedState = expandSuspendedState(v.([]interface{}))
 		}
 
-		err := registerScalableTarget(ctx, conn, input)
+		err := registerScalableTarget(ctx, conn, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Application AutoScaling Target (%s): %s", d.Id(), err)
@@ -212,14 +212,14 @@ func resourceTargetDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppAutoScalingClient(ctx)
 
-	input := &applicationautoscaling.DeregisterScalableTargetInput{
+	input := applicationautoscaling.DeregisterScalableTargetInput{
 		ResourceId:        aws.String(d.Id()),
 		ScalableDimension: awstypes.ScalableDimension(d.Get("scalable_dimension").(string)),
 		ServiceNamespace:  awstypes.ServiceNamespace(d.Get("service_namespace").(string)),
 	}
 
 	log.Printf("[INFO] Deleting Application AutoScaling Target: %s", d.Id())
-	_, err := conn.DeregisterScalableTarget(ctx, input)
+	_, err := conn.DeregisterScalableTarget(ctx, &input)
 
 	if errs.IsA[*awstypes.ObjectNotFoundException](err) {
 		return diags
@@ -241,14 +241,14 @@ func resourceTargetDelete(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func FindTargetByThreePartKey(ctx context.Context, conn *applicationautoscaling.Client, resourceID, namespace, dimension string) (*awstypes.ScalableTarget, error) {
-	input := &applicationautoscaling.DescribeScalableTargetsInput{
+	input := applicationautoscaling.DescribeScalableTargetsInput{
 		ResourceIds:       []string{resourceID},
 		ScalableDimension: awstypes.ScalableDimension(dimension),
 		ServiceNamespace:  awstypes.ServiceNamespace(namespace),
 	}
 	var output []awstypes.ScalableTarget
 
-	pages := applicationautoscaling.NewDescribeScalableTargetsPaginator(conn, input)
+	pages := applicationautoscaling.NewDescribeScalableTargetsPaginator(conn, &input)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
@@ -268,7 +268,7 @@ func FindTargetByThreePartKey(ctx context.Context, conn *applicationautoscaling.
 
 	if aws.ToString(target.ResourceId) != resourceID || string(target.ScalableDimension) != dimension || string(target.ServiceNamespace) != namespace {
 		return nil, &retry.NotFoundError{
-			LastRequest: input,
+			LastRequest: &input,
 		}
 	}
 


### PR DESCRIPTION
### Description

Moves API inputs off of heap and onto stack for

* `accessanalyzer`
* `account`
* `acm`
* `acmpca`
* `amp`
* `amplify`
* `appautoscaling`
