### PR TITLE
docs: update RDS Proxy client_password_auth_type supported auth type

### DIFF
--- a/website/docs/r/db_proxy.html.markdown
+++ b/website/docs/r/db_proxy.html.markdown
@@ -110,7 +110,7 @@ This resource supports the following arguments:
 `auth` blocks support the following:
 
 * `auth_scheme` - (Optional) The type of authentication that the proxy uses for connections from the proxy to the underlying database. One of `SECRETS`.
-* `client_password_auth_type` - (Optional) The type of authentication the proxy uses for connections from clients. Valid values are `MYSQL_NATIVE_PASSWORD`, `POSTGRES_SCRAM_SHA_256`, `POSTGRES_MD5`, and `SQL_SERVER_AUTHENTICATION`.
+* `client_password_auth_type` - (Optional) The type of authentication the proxy uses for connections from clients. Valid values are `MYSQL_CACHING_SHA2_PASSWORD`, `MYSQL_NATIVE_PASSWORD`, `POSTGRES_SCRAM_SHA_256`, `POSTGRES_MD5`, and `SQL_SERVER_AUTHENTICATION`.
 * `description` - (Optional) A user-specified description about the authentication used by a proxy to log in as a specific database user.
 * `iam_auth` - (Optional) Whether to require or disallow AWS Identity and Access Management (IAM) authentication for connections to the proxy. One of `DISABLED`, `REQUIRED`.
 * `secret_arn` - (Optional) The Amazon Resource Name (ARN) representing the secret that the proxy uses to authenticate to the RDS DB instance or Aurora DB cluster. These secrets are stored within Amazon Secrets Manager.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The recent aws-sdk-go-v2 RDS release adds support for `MYSQL_CACHING_SHA2_PASSWORD` auth type.
https://github.com/aws/aws-sdk-go-v2/blob/5a964704cb2640ed57a74b9b37a53dcda7b6b7dd/service/rds/CHANGELOG.md#v1930-2024-12-16
This updates the docs regarding the RDS Proxy `client_password_auth_type` supported values.

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

[Rendered version](https://github.com/yelinaung/terraform-provider-aws/blob/51ca6207093950e07ca7b2dee2b2cf5e31923f0e/website/docs/r/db_proxy.html.markdown#attribute-reference)