### PR TITLE
d/aws_cloudwatch_event_buses: new data source

### DIFF
--- a/.changelog/40662.txt
+++ b/.changelog/40662.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_cloudwatch_event_buses
+```

--- a/internal/service/events/buses_data_source.go
+++ b/internal/service/events/buses_data_source.go
@@ -85,8 +85,6 @@ func (d *dataSourceEventBuses) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	data.ID = types.StringValue(d.Meta().AccountID)
-
 	input := &eventbridge.ListEventBusesInput{
 		NamePrefix: data.NamePrefix.ValueStringPointer(),
 	}
@@ -101,6 +99,7 @@ func (d *dataSourceEventBuses) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
+	data.ID = types.StringValue(d.Meta().Region(ctx))
 	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data.EventBuses)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/service/events/buses_data_source.go
+++ b/internal/service/events/buses_data_source.go
@@ -6,6 +6,8 @@ package events
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -15,9 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
-
-	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
-	awstypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
 )
 
 // @FrameworkDataSource(name="Event Buses")

--- a/internal/service/events/buses_data_source.go
+++ b/internal/service/events/buses_data_source.go
@@ -41,7 +41,7 @@ func (d *dataSourceEventBuses) Schema(ctx context.Context, req datasource.Schema
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrID: framework.IDAttribute(),
-			"name_prefix": schema.StringAttribute{
+			names.AttrNamePrefix: schema.StringAttribute{
 				Optional: true,
 			},
 		},
@@ -50,24 +50,24 @@ func (d *dataSourceEventBuses) Schema(ctx context.Context, req datasource.Schema
 				CustomType: fwtypes.NewListNestedObjectTypeOf[eventBustModel](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
-						"arn": schema.StringAttribute{
+						names.AttrARN: schema.StringAttribute{
 							Computed: true,
 						},
-						"creation_time": schema.StringAttribute{
+						names.AttrCreationTime: schema.StringAttribute{
 							CustomType: timetypes.RFC3339Type{},
 							Computed:   true,
 						},
-						"description": schema.StringAttribute{
+						names.AttrDescription: schema.StringAttribute{
 							Computed: true,
 						},
 						"last_modified_time": schema.StringAttribute{
 							CustomType: timetypes.RFC3339Type{},
 							Computed:   true,
 						},
-						"name": schema.StringAttribute{
+						names.AttrName: schema.StringAttribute{
 							Computed: true,
 						},
-						"policy": schema.StringAttribute{
+						names.AttrPolicy: schema.StringAttribute{
 							Computed: true,
 						},
 					},

--- a/internal/service/events/buses_data_source.go
+++ b/internal/service/events/buses_data_source.go
@@ -1,0 +1,141 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package events
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+
+	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+)
+
+// @FrameworkDataSource(name="Event Buses")
+func newDataSourceEventBuses(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceEventBuses{}, nil
+}
+
+const (
+	DSNameEventBuses = "Event Buses Data Source"
+)
+
+type dataSourceEventBuses struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceEventBuses) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_cloudwatch_event_buses"
+}
+
+func (d *dataSourceEventBuses) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"name_prefix": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"event_buses": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[eventBustModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"arn": schema.StringAttribute{
+							Computed: true,
+						},
+						"creation_time": schema.StringAttribute{
+							CustomType: timetypes.RFC3339Type{},
+							Computed:   true,
+						},
+						"description": schema.StringAttribute{
+							Computed: true,
+						},
+						"last_modified_time": schema.StringAttribute{
+							CustomType: timetypes.RFC3339Type{},
+							Computed:   true,
+						},
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+						"policy": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func (d *dataSourceEventBuses) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().EventsClient(ctx)
+
+	var data dataSourceEventBusesModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.ID = types.StringValue(d.Meta().AccountID)
+
+	input := &eventbridge.ListEventBusesInput{
+		NamePrefix: data.NamePrefix.ValueStringPointer(),
+	}
+
+	out, err := findEventBuses(ctx, conn, input)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Events, create.ErrActionReading, DSNameEventBuses, data.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data.EventBuses)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceEventBusesModel struct {
+	ID         types.String                                    `tfsdk:"id"`
+	NamePrefix types.String                                    `tfsdk:"name_prefix"`
+	EventBuses fwtypes.ListNestedObjectValueOf[eventBustModel] `tfsdk:"event_buses"`
+}
+
+type eventBustModel struct {
+	Arn              types.String      `tfsdk:"arn"`
+	CreationTime     timetypes.RFC3339 `tfsdk:"creation_time"`
+	Description      types.String      `tfsdk:"description"`
+	LastModifiedTime timetypes.RFC3339 `tfsdk:"last_modified_time"`
+	Name             types.String      `tfsdk:"name"`
+	Policy           types.String      `tfsdk:"policy"`
+}
+
+func findEventBuses(ctx context.Context, conn *eventbridge.Client, input *eventbridge.ListEventBusesInput) ([]awstypes.EventBus, error) {
+	var output []awstypes.EventBus
+
+	err := listEventBusesPages(ctx, conn, input, func(page *eventbridge.ListEventBusesOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		output = append(output, page.EventBuses...)
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/internal/service/events/buses_data_source_test.go
+++ b/internal/service/events/buses_data_source_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package events_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccEventsEventBusesDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	busName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudwatch_event_bus.test"
+	dataSourceName := "data.aws_cloudwatch_event_buses.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EventsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBusDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventBusesDataSourceConfig_basic(busName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "event_buses.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "event_buses.0.arn", resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrSet(dataSourceName, "event_buses.0.creation_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "event_buses.0.last_modified_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "event_buses.0.name", resourceName, names.AttrName),
+				),
+			},
+		},
+	})
+}
+
+func testAccEventBusesDataSourceConfig_basic(busName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_event_bus" "test" {
+  name        = %[1]q
+}
+
+data "aws_cloudwatch_event_buses" "test" {
+  depends_on = [aws_cloudwatch_event_bus.test]
+
+  name_prefix = %[1]q
+}
+`, busName)
+}

--- a/internal/service/events/buses_data_source_test.go
+++ b/internal/service/events/buses_data_source_test.go
@@ -42,7 +42,7 @@ func TestAccEventsEventBusesDataSource_basic(t *testing.T) {
 func testAccEventBusesDataSourceConfig_basic(busName string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_bus" "test" {
-  name        = %[1]q
+  name = %[1]q
 }
 
 data "aws_cloudwatch_event_buses" "test" {

--- a/internal/service/events/buses_data_source_test.go
+++ b/internal/service/events/buses_data_source_test.go
@@ -28,7 +28,7 @@ func TestAccEventsEventBusesDataSource_basic(t *testing.T) {
 			{
 				Config: testAccEventBusesDataSourceConfig_basic(busName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "event_buses.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "event_buses.#", acctest.Ct1),
 					resource.TestCheckResourceAttrPair(dataSourceName, "event_buses.0.arn", resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrSet(dataSourceName, "event_buses.0.creation_time"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "event_buses.0.last_modified_time"),

--- a/internal/service/events/buses_data_source_test.go
+++ b/internal/service/events/buses_data_source_test.go
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_event_bus" "test" {
 }
 
 data "aws_cloudwatch_event_buses" "by_name_prefix" {
-  name_prefix = aws_cloudwatch_event_bus.name
+  name_prefix = aws_cloudwatch_event_bus.test.name
 }
 
 data "aws_cloudwatch_event_buses" "all" {

--- a/internal/service/events/buses_data_source_test.go
+++ b/internal/service/events/buses_data_source_test.go
@@ -28,7 +28,7 @@ func TestAccEventsEventBusesDataSource_basic(t *testing.T) {
 			{
 				Config: testAccEventBusesDataSourceConfig_basic(busName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "event_buses.#", acctest.Ct1),
+					resource.TestCheckResourceAttr(dataSourceName, "event_buses.#", "1"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "event_buses.0.arn", resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrSet(dataSourceName, "event_buses.0.creation_time"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "event_buses.0.last_modified_time"),

--- a/internal/service/events/buses_data_source_test.go
+++ b/internal/service/events/buses_data_source_test.go
@@ -17,7 +17,8 @@ func TestAccEventsEventBusesDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	busName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_event_bus.test"
-	dataSourceName := "data.aws_cloudwatch_event_buses.test"
+	dataSource1Name := "data.aws_cloudwatch_event_buses.by_name_prefix"
+	dataSource2Name := "data.aws_cloudwatch_event_buses.all"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -28,11 +29,12 @@ func TestAccEventsEventBusesDataSource_basic(t *testing.T) {
 			{
 				Config: testAccEventBusesDataSourceConfig_basic(busName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "event_buses.#", "1"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "event_buses.0.arn", resourceName, names.AttrARN),
-					resource.TestCheckResourceAttrSet(dataSourceName, "event_buses.0.creation_time"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "event_buses.0.last_modified_time"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "event_buses.0.name", resourceName, names.AttrName),
+					resource.TestCheckResourceAttr(dataSource1Name, "event_buses.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSource1Name, "event_buses.0.arn", resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrSet(dataSource1Name, "event_buses.0.creation_time"),
+					resource.TestCheckResourceAttrSet(dataSource1Name, "event_buses.0.last_modified_time"),
+					resource.TestCheckResourceAttrPair(dataSource1Name, "event_buses.0.name", resourceName, names.AttrName),
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSource2Name, "event_buses.#", 1),
 				),
 			},
 		},
@@ -45,10 +47,12 @@ resource "aws_cloudwatch_event_bus" "test" {
   name = %[1]q
 }
 
-data "aws_cloudwatch_event_buses" "test" {
-  depends_on = [aws_cloudwatch_event_bus.test]
+data "aws_cloudwatch_event_buses" "by_name_prefix" {
+  name_prefix = aws_cloudwatch_event_bus.name
+}
 
-  name_prefix = %[1]q
+data "aws_cloudwatch_event_buses" "all" {
+  depends_on = [aws_cloudwatch_event_bus.test]
 }
 `, busName)
 }

--- a/internal/service/events/service_package_gen.go
+++ b/internal/service/events/service_package_gen.go
@@ -17,7 +17,7 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
 	return []*types.ServicePackageFrameworkDataSource{
 		{
-			Factory: newDataSourceEventBuses,
+			Factory: newEventBusesDataSource,
 			Name:    "Event Buses",
 		},
 	}

--- a/internal/service/events/service_package_gen.go
+++ b/internal/service/events/service_package_gen.go
@@ -15,7 +15,12 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory: newDataSourceEventBuses,
+			Name:    "Event Buses",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/website/docs/d/cloudwatch_event_buses.html.markdown
+++ b/website/docs/d/cloudwatch_event_buses.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "EventBridge"
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_event_buses"
+description: |-
+  Terraform data source for managing an AWS EventBridge (Cloudwatch) Event Buses.
+---
+
+# Data Source: aws_cloudwatch_event_buses
+
+Terraform data source for managing an AWS EventBridge Event Buses.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_cloudwatch_event_buses" "example" {
+  name_prefix = "test"
+}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `name_prefix` - (Optional) Specifying this limits the results to only those event buses with names that start with the specified prefix.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `event_buses` - This list of event buses.
+
+### `event_buses` Attribute Reference
+
+* `arn` - The ARN of the event bus.
+* `creation_time` - The time the event bus was created.
+* `description` - The event bus description.
+* `last_modified_time` - The time the event bus was last modified.
+* `name` - The name of the event bus.
+* `policy` - The permissions policy of the event bus, describing which other AWS accounts can write events to this event bus.


### PR DESCRIPTION
### Description
This PR adds a new `aws_cloudwatch_event_buses` data source.

Closes https://github.com/hashicorp/terraform-provider-aws/issues/39209.

### References
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListEventBuses.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=events ACCTEST_PARALLELISM=1 TESTARGS="-run=TestAccEventsEventBusesDataSource_"      
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.1 test ./internal/service/events/... -v -count 1 -parallel 1  -run=TestAccEventsEventBusesDataSource_ -timeout 360m
=== RUN   TestAccEventsEventBusesDataSource_basic
=== PAUSE TestAccEventsEventBusesDataSource_basic
=== CONT  TestAccEventsEventBusesDataSource_basic
--- PASS: TestAccEventsEventBusesDataSource_basic (17.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/events	22.325s
```
