### PR TITLE
doc: fix example code in documentation for aws_lb_trust_store

### DIFF
--- a/website/docs/r/lb_trust_store.html.markdown
+++ b/website/docs/r/lb_trust_store.html.markdown
@@ -31,7 +31,7 @@ resource "aws_lb_listener" "example" {
     type             = "forward"
   }
 
-  mutual_authentication = {
+  mutual_authentication {
     mode            = "verify"
     trust_store_arn = aws_lb_trust_store.test.arn
   }


### PR DESCRIPTION
### Description

The example listed [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_trust_store) contains a load balancer description 

```hcl
[...]
resource "aws_lb_listener" "example" {
 [ ... ]
  mutual_authentication = {
    mode            = "verify"
    trust_store_arn = aws_lb_trust_store.test.arn
  }
}
```

with an invalid assignment ` mutual_authentication = {`.  
The PR fixes the invalid assignment 

### Relations

Closes #40605 

### References

- [Definition of mutual_authentication in provider source code](https://github.com/hashicorp/terraform-provider-aws/blob/23765762b7989c2e4b1fcaafb6da89c24e746565/internal/service/elbv2/listener.go#L347)
- [Code from Listener tests](https://github.com/hashicorp/terraform-provider-aws/blob/23765762b7989c2e4b1fcaafb6da89c24e746565/internal/service/elbv2/listener_test.go#L3334) showing correct usage of  `mutual_authentication` 

### Output from Acceptance Testing 

Not applicable, only documentation is updated.