### PR TITLE
r/aws_sesv2_configuration: Fix `delivery_options.max_delivery_seconds` handling

### DIFF
--- a/.changelog/40670.txt
+++ b/.changelog/40670.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sesv2_configuration_set: Fix passing max_delivery_options when unset
+```

--- a/.changelog/40670.txt
+++ b/.changelog/40670.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_sesv2_configuration_set: Fix passing max_delivery_options when unset
+resource/aws_sesv2_configuration_set: Fix handling of `delivery_options.max_delivery_seconds` when not configured
 ```

--- a/internal/service/sesv2/configuration_set.go
+++ b/internal/service/sesv2/configuration_set.go
@@ -325,7 +325,7 @@ func resourceConfigurationSetUpdate(ctx context.Context, d *schema.ResourceData,
 		if v, ok := d.GetOk("delivery_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			tfMap := v.([]interface{})[0].(map[string]interface{})
 
-			if v, ok := tfMap["max_delivery_seconds"].(int); ok {
+			if v, ok := tfMap["max_delivery_seconds"].(int); ok && v != 0 {
 				input.MaxDeliverySeconds = aws.Int64(int64(v))
 			}
 
@@ -624,7 +624,7 @@ func expandDeliveryOptions(tfMap map[string]interface{}) *types.DeliveryOptions 
 
 	apiObject := &types.DeliveryOptions{}
 
-	if v, ok := tfMap["max_delivery_seconds"].(int); ok {
+	if v, ok := tfMap["max_delivery_seconds"].(int); ok && v != 0 {
 		apiObject.MaxDeliverySeconds = aws.Int64(int64(v))
 	}
 

--- a/internal/service/sesv2/configuration_set_test.go
+++ b/internal/service/sesv2/configuration_set_test.go
@@ -83,11 +83,10 @@ func TestAccSESV2ConfigurationSet_deliveryOptions(t *testing.T) {
 		CheckDestroy:             testAccCheckConfigurationSetDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigurationSetConfig_deliveryOptions(rName, 300, string(types.TlsPolicyRequire)),
+				Config: testAccConfigurationSetConfig_deliveryOptions(rName, string(types.TlsPolicyRequire)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "delivery_options.0.max_delivery_seconds", "300"),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.0.tls_policy", string(types.TlsPolicyRequire)),
 				),
 			},
@@ -97,7 +96,16 @@ func TestAccSESV2ConfigurationSet_deliveryOptions(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigurationSetConfig_deliveryOptions(rName, 800, string(types.TlsPolicyOptional)),
+				Config: testAccConfigurationSetConfig_deliveryOptions_maxDeliverySeconds(rName, 300, string(types.TlsPolicyRequire)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConfigurationSetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_options.0.max_delivery_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "delivery_options.0.tls_policy", string(types.TlsPolicyRequire)),
+				),
+			},
+			{
+				Config: testAccConfigurationSetConfig_deliveryOptions_maxDeliverySeconds(rName, 800, string(types.TlsPolicyOptional)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckConfigurationSetExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "delivery_options.#", "1"),
@@ -383,7 +391,19 @@ resource "aws_sesv2_configuration_set" "test" {
 `, rName)
 }
 
-func testAccConfigurationSetConfig_deliveryOptions(rName string, MaxDeliverySeconds int, tlsPolicy string) string {
+func testAccConfigurationSetConfig_deliveryOptions(rName string, tlsPolicy string) string {
+	return fmt.Sprintf(`
+resource "aws_sesv2_configuration_set" "test" {
+  configuration_set_name = %[1]q
+
+  delivery_options {
+    tls_policy           = %[2]q
+  }
+}
+`, rName, tlsPolicy)
+}
+
+func testAccConfigurationSetConfig_deliveryOptions_maxDeliverySeconds(rName string, maxDeliverySeconds int, tlsPolicy string) string {
 	return fmt.Sprintf(`
 resource "aws_sesv2_configuration_set" "test" {
   configuration_set_name = %[1]q
@@ -393,7 +413,7 @@ resource "aws_sesv2_configuration_set" "test" {
     tls_policy           = %[3]q
   }
 }
-`, rName, MaxDeliverySeconds, tlsPolicy)
+`, rName, maxDeliverySeconds, tlsPolicy)
 }
 
 func testAccConfigurationSetConfig_reputationMetricsEnabled(rName string, reputationMetricsEnabled bool) string {

--- a/internal/service/sesv2/configuration_set_test.go
+++ b/internal/service/sesv2/configuration_set_test.go
@@ -397,7 +397,7 @@ resource "aws_sesv2_configuration_set" "test" {
   configuration_set_name = %[1]q
 
   delivery_options {
-    tls_policy           = %[2]q
+    tls_policy = %[2]q
   }
 }
 `, rName, tlsPolicy)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This PR fixes a bug when `MaxDeliverySeconds` was included in the API request even if not set in the configuration.

### Relations
Closes #40591.

### References
https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_DeliveryOptions.html#SES-Type-DeliveryOptions-MaxDeliverySeconds

### Output from Acceptance Testing
```console
% make testacc PKG=sesv2 ACCTEST_PARALLELISM=1 TESTARGS="-run=TestAccSESV2ConfigurationSet_deliveryOptions"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/sesv2/... -v -count 1 -parallel 1  -run=TestAccSESV2ConfigurationSet_deliveryOptions -timeout 360m
2024/12/21 16:22:19 Initializing Terraform AWS Provider...
=== RUN   TestAccSESV2ConfigurationSet_deliveryOptions
=== PAUSE TestAccSESV2ConfigurationSet_deliveryOptions
=== CONT  TestAccSESV2ConfigurationSet_deliveryOptions
--- PASS: TestAccSESV2ConfigurationSet_deliveryOptions (39.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sesv2      44.954s
```
