### PR TITLE
docs: fix example import block by quoting

### DIFF
--- a/website/docs/r/cloudfront_vpc_origin.html.markdown
+++ b/website/docs/r/cloudfront_vpc_origin.html.markdown
@@ -73,7 +73,7 @@ This resource exports the following attributes in addition to the arguments abov
 ```terraform
 import {
   to = aws_cloudfront_vpc_origin.origin
-  id = vo_JQEa410sssUFoY6wMkx69j
+  id = "vo_JQEa410sssUFoY6wMkx69j"
 }
 ```
 


### PR DESCRIPTION
### Description

An error in the [aws_cloudfront_vpc_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_vpc_origin) documentation has been corrected. Enclose `id` in double-quotes.

### Relations

Relates https://github.com/hashicorp/terraform-provider-aws/pull/40239
