### PR TITLE
docs: fix example code for resource aws_resiliencehub_resiliency_policy

### DIFF
--- a/website/docs/r/resiliencehub_resiliency_policy.html.markdown
+++ b/website/docs/r/resiliencehub_resiliency_policy.html.markdown
@@ -14,8 +14,8 @@ Terraform resource for managing an AWS Resilience Hub Resiliency Policy.
 
 ```terraform
 resource "aws_resiliencehub_resiliency_policy" "example" {
-  policy_name        = "testexample"
-  policy_description = "testexample"
+  name        = "testexample"
+  description = "testexample"
 
   tier = "NonCritical"
 


### PR DESCRIPTION
### Description

As mentioned in #40334  [this example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resiliencehub_resiliency_policy#example-usage) throws errors when running `terraform plan` respective `terraform apply`. Reason for this is that `name` as well as `description` have an invalid prefix `policy_`.

This PR removes the prefix, so that the example can be executed successfully.

### Relations

Closes #40334 

### References

- [Current Resource documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resiliencehub_resiliency_policy)
- [Field `description` in source code](https://github.com/hashicorp/terraform-provider-aws/blob/398878c25514754dd22789c985e717c45c64a513/internal/service/resiliencehub/resiliency_policy.go#L98)
- [ Field `name` in source code](https://github.com/hashicorp/terraform-provider-aws/blob/398878c25514754dd22789c985e717c45c64a513/internal/service/resiliencehub/resiliency_policy.go#L108)

### Output from Acceptance Testing

Not required. Only documentation is updated.