### PR TITLE
Remove Google Group from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,5 @@ The [AWS Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/
 - [FAQ](https://hashicorp.github.io/terraform-provider-aws/faq/)
 - [Tutorials](https://learn.hashicorp.com/collections/terraform/aws-get-started)
 - [discuss.hashicorp.com](https://discuss.hashicorp.com/c/terraform-providers/tf-aws/)
-- [Google Groups](http://groups.google.com/group/terraform-tool)
 
 _**Please note:** We take Terraform's security and our users' trust very seriously. If you believe you have found a security issue in the Terraform AWS Provider, please responsibly disclose it by contacting us at security@hashicorp.com._


### PR DESCRIPTION
### Description
Seems this group is no longer used, proposing removing
> As of July 22, 2021 inbound messages to this group have been disabled, and it will now be used for outbound announcements only.