### PR TITLE
In the resource aws_cloudfront_distribution for argumentrelated to lo…

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -372,7 +372,7 @@ argument should not be specified.
 
 #### Logging Config Arguments
 
-* `bucket` (Required) - Amazon S3 bucket to store the access logs in, for example, `myawslogbucket.s3.amazonaws.com`.
+* `bucket` (Required) - Amazon S3 bucket to store the access logs in, for example, `myawslogbucket.s3.amazonaws.com`. The bucket must have correct ACL attached with "FULL_CONTROL" permission for "awslogsdelivery" account (Canonical ID: "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0") for log transfer to work.
 * `include_cookies` (Optional) - Whether to include cookies in access logs (default: `false`).
 * `prefix` (Optional) - Prefix to the access log filenames for this distribution, for example, `myprefix/`.
 


### PR DESCRIPTION
### Description
This documentation improvement explains that for CloudFront standard logs to be transferred to provided S3 bucket that bucket should have correct ACL with correct permissions and grantee Canonical ID attached to it.

### References
Main reference is documentation of AWS related to CloudFront logging: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging-legacy-s3.html
![image](https://github.com/user-attachments/assets/1c92e8a3-7905-4ce1-bf4e-11cd7f906e81)




