### PR TITLE
Add support for supports_local_write_forwarding, supports_certificate_rotation_without_restart and supports_integrations

### DIFF
--- a/.changelog/40700.txt
+++ b/.changelog/40700.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_rds_engine_version: Add `supports_certificate_rotation_without_restart`, `supports_integrations`, and `supports_local_write_forwarding` attributes
+```

--- a/internal/service/rds/engine_version_data_source.go
+++ b/internal/service/rds/engine_version_data_source.go
@@ -117,6 +117,10 @@ func dataSourceEngineVersion() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"supports_integrations": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"supports_limitless_database": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -402,6 +406,7 @@ func dataSourceEngineVersionRead(ctx context.Context, d *schema.ResourceData, me
 	}))
 	d.Set("supports_certificate_rotation_without_restart", found.SupportsCertificateRotationWithoutRestart)
 	d.Set("supports_global_databases", found.SupportsGlobalDatabases)
+	d.Set("supports_integrations", found.SupportsIntegrations)
 	d.Set("supports_limitless_database", found.SupportsLimitlessDatabase)
 	d.Set("supports_local_write_forwarding", found.SupportsLocalWriteForwarding)
 	d.Set("supports_log_exports_to_cloudwatch", found.SupportsLogExportsToCloudwatchLogs)

--- a/internal/service/rds/engine_version_data_source.go
+++ b/internal/service/rds/engine_version_data_source.go
@@ -121,6 +121,10 @@ func dataSourceEngineVersion() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"supports_local_write_forwarding": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"supports_log_exports_to_cloudwatch": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -399,6 +403,7 @@ func dataSourceEngineVersionRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("supports_certificate_rotation_without_restart", found.SupportsCertificateRotationWithoutRestart)
 	d.Set("supports_global_databases", found.SupportsGlobalDatabases)
 	d.Set("supports_limitless_database", found.SupportsLimitlessDatabase)
+	d.Set("supports_local_write_forwarding", found.SupportsLocalWriteForwarding)
 	d.Set("supports_log_exports_to_cloudwatch", found.SupportsLogExportsToCloudwatchLogs)
 	d.Set("supports_parallel_query", found.SupportsParallelQuery)
 	d.Set("supports_read_replica", found.SupportsReadReplica)

--- a/internal/service/rds/engine_version_data_source.go
+++ b/internal/service/rds/engine_version_data_source.go
@@ -109,6 +109,10 @@ func dataSourceEngineVersion() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
 			},
+			"supports_certificate_rotation_without_restart": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"supports_global_databases": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -392,6 +396,7 @@ func dataSourceEngineVersionRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("supported_timezones", tfslices.ApplyToAll(found.SupportedTimezones, func(v awstypes.Timezone) string {
 		return aws.ToString(v.TimezoneName)
 	}))
+	d.Set("supports_certificate_rotation_without_restart", found.SupportsCertificateRotationWithoutRestart)
 	d.Set("supports_global_databases", found.SupportsGlobalDatabases)
 	d.Set("supports_limitless_database", found.SupportsLimitlessDatabase)
 	d.Set("supports_log_exports_to_cloudwatch", found.SupportsLogExportsToCloudwatchLogs)

--- a/internal/service/rds/engine_version_data_source_test.go
+++ b/internal/service/rds/engine_version_data_source_test.go
@@ -47,6 +47,7 @@ func TestAccRDSEngineVersionDataSource_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(dataSourceName, "supported_feature_names.#", regexache.MustCompile(`^[1-9][0-9]*`)),
 					resource.TestMatchResourceAttr(dataSourceName, "supported_modes.#", regexache.MustCompile(`^[0-9]*`)),
 					resource.TestMatchResourceAttr(dataSourceName, "supported_timezones.#", regexache.MustCompile(`^[0-9]*`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "supports_certificate_rotation_without_restart"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_global_databases"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_limitless_database"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_log_exports_to_cloudwatch"),

--- a/internal/service/rds/engine_version_data_source_test.go
+++ b/internal/service/rds/engine_version_data_source_test.go
@@ -50,6 +50,7 @@ func TestAccRDSEngineVersionDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_certificate_rotation_without_restart"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_global_databases"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_limitless_database"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "supports_local_write_forwarding"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_log_exports_to_cloudwatch"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_parallel_query"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_read_replica"),

--- a/internal/service/rds/engine_version_data_source_test.go
+++ b/internal/service/rds/engine_version_data_source_test.go
@@ -171,7 +171,7 @@ func TestAccRDSEngineVersionDataSource_preferredMajorTargets(t *testing.T) {
 			{
 				Config: testAccEngineVersionDataSourceConfig_preferredMajorTarget(tfrds.InstanceEngineMySQL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(dataSourceName, names.AttrVersion, regexache.MustCompile(`^5\.7\.`)),
+					resource.TestMatchResourceAttr(dataSourceName, names.AttrVersion, regexache.MustCompile(`^8\.0\.`)),
 				),
 			},
 			{

--- a/internal/service/rds/engine_version_data_source_test.go
+++ b/internal/service/rds/engine_version_data_source_test.go
@@ -49,6 +49,7 @@ func TestAccRDSEngineVersionDataSource_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(dataSourceName, "supported_timezones.#", regexache.MustCompile(`^[0-9]*`)),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_certificate_rotation_without_restart"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_global_databases"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "supports_integrations"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_limitless_database"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_local_write_forwarding"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "supports_log_exports_to_cloudwatch"),

--- a/website/docs/d/rds_engine_version.html.markdown
+++ b/website/docs/d/rds_engine_version.html.markdown
@@ -68,6 +68,7 @@ This data source exports the following attributes in addition to the arguments a
 * `supported_feature_names` - Set of features supported by the engine version.
 * `supported_modes` - Set of supported engine version modes.
 * `supported_timezones` - Set of the time zones supported by the engine version.
+* `supports_certificate_rotation_without_restart` - Whether the certificates can be rotated without restarting the Aurora instance.
 * `supports_global_databases` - Whether you can use Aurora global databases with the engine version.
 * `supports_log_exports_to_cloudwatch` - Whether the engine version supports exporting the log types specified by `exportable_log_types` to CloudWatch Logs.
 * `supports_limitless_database` - Whether the engine version supports Aurora Limitless Database.

--- a/website/docs/d/rds_engine_version.html.markdown
+++ b/website/docs/d/rds_engine_version.html.markdown
@@ -71,6 +71,7 @@ This data source exports the following attributes in addition to the arguments a
 * `supports_certificate_rotation_without_restart` - Whether the certificates can be rotated without restarting the Aurora instance.
 * `supports_global_databases` - Whether you can use Aurora global databases with the engine version.
 * `supports_log_exports_to_cloudwatch` - Whether the engine version supports exporting the log types specified by `exportable_log_types` to CloudWatch Logs.
+* `supports_local_write_forwarding` - Whether the engine version supports local write forwarding or not.
 * `supports_limitless_database` - Whether the engine version supports Aurora Limitless Database.
 * `supports_parallel_query` - Whether you can use Aurora parallel query with the engine version.
 * `supports_read_replica` - Whether the engine version supports read replicas.

--- a/website/docs/d/rds_engine_version.html.markdown
+++ b/website/docs/d/rds_engine_version.html.markdown
@@ -70,6 +70,7 @@ This data source exports the following attributes in addition to the arguments a
 * `supported_timezones` - Set of the time zones supported by the engine version.
 * `supports_certificate_rotation_without_restart` - Whether the certificates can be rotated without restarting the Aurora instance.
 * `supports_global_databases` - Whether you can use Aurora global databases with the engine version.
+* `supports_integrations` - Whether the engine version supports integrations with other AWS services.
 * `supports_log_exports_to_cloudwatch` - Whether the engine version supports exporting the log types specified by `exportable_log_types` to CloudWatch Logs.
 * `supports_local_write_forwarding` - Whether the engine version supports local write forwarding or not.
 * `supports_limitless_database` - Whether the engine version supports Aurora Limitless Database.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Add to  aws_rds_engine_version support for 
* supports_certificate_rotation_without_restart
* supports_integrations
* supports_local_write_forwarding

There is a test failure, but I do not think it is my PR:
```    engine_version_data_source_test.go:165: Step 1/2 error: Check failed: Check 1/1 error: data.aws_rds_engine_version.test: Attribute 'version' didn't match "^5\\.7\\.", got "8.0.40"``` 
I suspect the default has changed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

No related issue.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccRDSEngineVersion PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSEngineVersion'  -timeout 360m
2024/12/26 19:52:55 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSEngineVersionDataSource_basic
=== PAUSE TestAccRDSEngineVersionDataSource_basic
=== RUN   TestAccRDSEngineVersionDataSource_upgradeTargets
=== PAUSE TestAccRDSEngineVersionDataSource_upgradeTargets
=== RUN   TestAccRDSEngineVersionDataSource_preferred
=== PAUSE TestAccRDSEngineVersionDataSource_preferred
=== RUN   TestAccRDSEngineVersionDataSource_preferredVersionsPreferredUpgradeTargets
=== PAUSE TestAccRDSEngineVersionDataSource_preferredVersionsPreferredUpgradeTargets
=== RUN   TestAccRDSEngineVersionDataSource_preferredUpgradeTargetsVersion
=== PAUSE TestAccRDSEngineVersionDataSource_preferredUpgradeTargetsVersion
=== RUN   TestAccRDSEngineVersionDataSource_preferredMajorTargets
=== PAUSE TestAccRDSEngineVersionDataSource_preferredMajorTargets
=== RUN   TestAccRDSEngineVersionDataSource_defaultOnlyImplicit
=== PAUSE TestAccRDSEngineVersionDataSource_defaultOnlyImplicit
=== RUN   TestAccRDSEngineVersionDataSource_defaultOnlyExplicit
=== PAUSE TestAccRDSEngineVersionDataSource_defaultOnlyExplicit
=== RUN   TestAccRDSEngineVersionDataSource_includeAll
=== PAUSE TestAccRDSEngineVersionDataSource_includeAll
=== RUN   TestAccRDSEngineVersionDataSource_filter
=== PAUSE TestAccRDSEngineVersionDataSource_filter
=== RUN   TestAccRDSEngineVersionDataSource_latest
=== PAUSE TestAccRDSEngineVersionDataSource_latest
=== RUN   TestAccRDSEngineVersionDataSource_hasMinorMajor
=== PAUSE TestAccRDSEngineVersionDataSource_hasMinorMajor
=== CONT  TestAccRDSEngineVersionDataSource_basic
=== CONT  TestAccRDSEngineVersionDataSource_defaultOnlyImplicit
=== CONT  TestAccRDSEngineVersionDataSource_filter
=== CONT  TestAccRDSEngineVersionDataSource_preferredVersionsPreferredUpgradeTargets
=== CONT  TestAccRDSEngineVersionDataSource_preferred
=== CONT  TestAccRDSEngineVersionDataSource_includeAll
=== CONT  TestAccRDSEngineVersionDataSource_upgradeTargets
=== CONT  TestAccRDSEngineVersionDataSource_preferredUpgradeTargetsVersion
=== CONT  TestAccRDSEngineVersionDataSource_preferredMajorTargets
=== CONT  TestAccRDSEngineVersionDataSource_defaultOnlyExplicit
=== CONT  TestAccRDSEngineVersionDataSource_hasMinorMajor
=== CONT  TestAccRDSEngineVersionDataSource_latest
=== NAME  TestAccRDSEngineVersionDataSource_preferredMajorTargets
    engine_version_data_source_test.go:165: Step 1/2 error: Check failed: Check 1/1 error: data.aws_rds_engine_version.test: Attribute 'version' didn't match "^5\\.7\\.", got "8.0.40"
--- FAIL: TestAccRDSEngineVersionDataSource_preferredMajorTargets (12.74s)
--- PASS: TestAccRDSEngineVersionDataSource_basic (19.58s)
--- PASS: TestAccRDSEngineVersionDataSource_defaultOnlyImplicit (21.31s)
--- PASS: TestAccRDSEngineVersionDataSource_upgradeTargets (21.67s)
--- PASS: TestAccRDSEngineVersionDataSource_includeAll (21.70s)
--- PASS: TestAccRDSEngineVersionDataSource_defaultOnlyExplicit (21.83s)
--- PASS: TestAccRDSEngineVersionDataSource_preferredUpgradeTargetsVersion (22.02s)
--- PASS: TestAccRDSEngineVersionDataSource_filter (31.38s)
--- PASS: TestAccRDSEngineVersionDataSource_preferred (31.82s)
--- PASS: TestAccRDSEngineVersionDataSource_preferredVersionsPreferredUpgradeTargets (32.34s)
--- PASS: TestAccRDSEngineVersionDataSource_hasMinorMajor (53.35s)
--- PASS: TestAccRDSEngineVersionDataSource_latest (59.42s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/rds	59.523s
FAIL
make: *** [GNUmakefile:601: testacc] Error 1
...
```
