### PR TITLE
aws_api_gateway_domain_name - fixed issue when policy is added to private domain name after initial creation

### DIFF
--- a/.changelog/40708.txt
+++ b/.changelog/40708.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_domain_name: Fixed error when adding policy to existing private domain name
+```

--- a/internal/service/apigateway/domain_name.go
+++ b/internal/service/apigateway/domain_name.go
@@ -438,7 +438,7 @@ func resourceDomainNameUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			return sdkdiag.AppendErrorf(diags, "updating API Gateway Domain Name (%s): %s", d.Id(), err)
 		}
 
-		if _, err := waitDomainNameUpdated(ctx, conn, d.Id(), domainNameID); err != nil {
+		if _, err := waitDomainNameUpdated(ctx, conn, domainName, domainNameID); err != nil {
 			return sdkdiag.AppendErrorf(diags, "waiting for API Gateway Domain Name (%s) update: %s", d.Id(), err)
 		}
 	}


### PR DESCRIPTION
### Description

Fixes #40699 where error occurs when trying to add policy to existing private domain name

### Relations

Closes #40699

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ ACCTEST_PARALLELISM=10 make testacc TESTS=TestAccAPIGatewayDomainName PKG=apigateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/apigateway/... -v -count 1 -parallel 10 -run='TestAccAPIGatewayDomainName'  -timeout 360m
2024/12/27 16:26:57 Initializing Terraform AWS Provider...
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_null
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_null
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyMap
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyMap
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_AddOnUpdate
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_AddOnUpdate
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnCreate
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnCreate
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_providerOnly
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_providerOnly
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nonOverlapping
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_overlapping
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_overlapping
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnCreate
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnCreate
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_basic
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_basic
=== RUN   TestAccAPIGatewayDomainNameAccessAssociation_disappears
=== PAUSE TestAccAPIGatewayDomainNameAccessAssociation_disappears
=== RUN   TestAccAPIGatewayDomainNameDataSource_tags
=== PAUSE TestAccAPIGatewayDomainNameDataSource_tags
=== RUN   TestAccAPIGatewayDomainNameDataSource_tags_NullMap
=== PAUSE TestAccAPIGatewayDomainNameDataSource_tags_NullMap
=== RUN   TestAccAPIGatewayDomainNameDataSource_tags_EmptyMap
=== PAUSE TestAccAPIGatewayDomainNameDataSource_tags_EmptyMap
=== RUN   TestAccAPIGatewayDomainNameDataSource_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccAPIGatewayDomainNameDataSource_tags_DefaultTags_nonOverlapping
=== RUN   TestAccAPIGatewayDomainNameDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccAPIGatewayDomainNameDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccAPIGatewayDomainNameDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccAPIGatewayDomainNameDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccAPIGatewayDomainNameDataSource_basic
=== PAUSE TestAccAPIGatewayDomainNameDataSource_basic
=== RUN   TestAccAPIGatewayDomainName_tags
=== PAUSE TestAccAPIGatewayDomainName_tags
=== RUN   TestAccAPIGatewayDomainName_tags_null
=== PAUSE TestAccAPIGatewayDomainName_tags_null
=== RUN   TestAccAPIGatewayDomainName_tags_EmptyMap
=== PAUSE TestAccAPIGatewayDomainName_tags_EmptyMap
=== RUN   TestAccAPIGatewayDomainName_tags_AddOnUpdate
=== PAUSE TestAccAPIGatewayDomainName_tags_AddOnUpdate
=== RUN   TestAccAPIGatewayDomainName_tags_EmptyTag_OnCreate
=== PAUSE TestAccAPIGatewayDomainName_tags_EmptyTag_OnCreate
=== RUN   TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccAPIGatewayDomainName_tags_DefaultTags_providerOnly
=== PAUSE TestAccAPIGatewayDomainName_tags_DefaultTags_providerOnly
=== RUN   TestAccAPIGatewayDomainName_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccAPIGatewayDomainName_tags_DefaultTags_nonOverlapping
=== RUN   TestAccAPIGatewayDomainName_tags_DefaultTags_overlapping
=== PAUSE TestAccAPIGatewayDomainName_tags_DefaultTags_overlapping
=== RUN   TestAccAPIGatewayDomainName_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccAPIGatewayDomainName_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccAPIGatewayDomainName_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccAPIGatewayDomainName_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccAPIGatewayDomainName_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccAPIGatewayDomainName_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccAPIGatewayDomainName_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccAPIGatewayDomainName_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccAPIGatewayDomainName_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccAPIGatewayDomainName_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccAPIGatewayDomainName_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccAPIGatewayDomainName_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccAPIGatewayDomainName_tags_ComputedTag_OnCreate
=== PAUSE TestAccAPIGatewayDomainName_tags_ComputedTag_OnCreate
=== RUN   TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccAPIGatewayDomainName_certificateARN
    domain_name_test.go:29: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccAPIGatewayDomainName_certificateARN (0.00s)
=== RUN   TestAccAPIGatewayDomainName_certificateName
    domain_name_test.go:65: Environment variable AWS_API_GATEWAY_DOMAIN_NAME_CERTIFICATE_BODY is not set. This environment variable must be set to any non-empty value with a publicly trusted certificate body to enable the test.
--- SKIP: TestAccAPIGatewayDomainName_certificateName (0.00s)
=== RUN   TestAccAPIGatewayDomainName_regionalCertificateARN
=== PAUSE TestAccAPIGatewayDomainName_regionalCertificateARN
=== RUN   TestAccAPIGatewayDomainName_regionalCertificateName
    domain_name_test.go:162: Environment variable AWS_API_GATEWAY_DOMAIN_NAME_REGIONAL_CERTIFICATE_NAME_ENABLED is not set. This environment variable must be set to any non-empty value in a region where uploading REGIONAL certificates is allowed to enable the test.
--- SKIP: TestAccAPIGatewayDomainName_regionalCertificateName (0.00s)
=== RUN   TestAccAPIGatewayDomainName_securityPolicy
=== PAUSE TestAccAPIGatewayDomainName_securityPolicy
=== RUN   TestAccAPIGatewayDomainName_private
=== PAUSE TestAccAPIGatewayDomainName_private
=== RUN   TestAccAPIGatewayDomainName_privatePolicy
=== PAUSE TestAccAPIGatewayDomainName_privatePolicy
=== RUN   TestAccAPIGatewayDomainName_privatePolicy_added
=== PAUSE TestAccAPIGatewayDomainName_privatePolicy_added
=== RUN   TestAccAPIGatewayDomainName_disappears
=== PAUSE TestAccAPIGatewayDomainName_disappears
=== RUN   TestAccAPIGatewayDomainName_MutualTLSAuthentication_basic
    domain_name_test.go:360: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccAPIGatewayDomainName_MutualTLSAuthentication_basic (0.00s)
=== RUN   TestAccAPIGatewayDomainName_MutualTLSAuthentication_ownership
    domain_name_test.go:416: Environment variable ACM_CERTIFICATE_ROOT_DOMAIN is not set. For DNS validation requests, this domain must be publicly accessible and configurable via Route53 during the testing. For email validation requests, you must have access to one of the five standard email addresses used (admin|administrator|hostmaster|postmaster|webmaster)@domain or one of the WHOIS contact addresses.
--- SKIP: TestAccAPIGatewayDomainName_MutualTLSAuthentication_ownership (0.00s)
=== RUN   TestAccAPIGatewayDomainName_updateIDFormat
=== PAUSE TestAccAPIGatewayDomainName_updateIDFormat
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags
=== CONT  TestAccAPIGatewayDomainNameDataSource_basic
=== CONT  TestAccAPIGatewayDomainName_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccAPIGatewayDomainName_tags_DefaultTags_providerOnly
=== CONT  TestAccAPIGatewayDomainName_regionalCertificateARN
=== CONT  TestAccAPIGatewayDomainName_tags_AddOnUpdate
=== CONT  TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccAPIGatewayDomainName_tags_EmptyTag_OnCreate
=== CONT  TestAccAPIGatewayDomainName_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccAPIGatewayDomainNameDataSource_basic (48.78s)
=== CONT  TestAccAPIGatewayDomainName_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccAPIGatewayDomainName_regionalCertificateARN (58.67s)
=== CONT  TestAccAPIGatewayDomainName_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccAPIGatewayDomainName_tags_DefaultTags_emptyResourceTag (80.23s)
=== CONT  TestAccAPIGatewayDomainName_privatePolicy_added
--- PASS: TestAccAPIGatewayDomainName_tags_DefaultTags_emptyProviderOnlyTag (120.03s)
=== CONT  TestAccAPIGatewayDomainName_updateIDFormat
--- PASS: TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Add (220.35s)
=== CONT  TestAccAPIGatewayDomainName_disappears
--- PASS: TestAccAPIGatewayDomainName_privatePolicy_added (102.51s)
=== CONT  TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccAPIGatewayDomainName_updateIDFormat (95.98s)
=== CONT  TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags (352.06s)
=== CONT  TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_ResourceTag (101.01s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccAPIGatewayDomainName_disappears (188.26s)
=== CONT  TestAccAPIGatewayDomainNameDataSource_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Replace (180.41s)
=== CONT  TestAccAPIGatewayDomainNameDataSource_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccAPIGatewayDomainNameDataSource_tags_IgnoreTags_Overlap_ResourceTag (119.39s)
=== CONT  TestAccAPIGatewayDomainNameDataSource_tags_DefaultTags_nonOverlapping
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullNonOverlappingResourceTag (172.67s)
=== CONT  TestAccAPIGatewayDomainNameDataSource_tags_EmptyMap
--- PASS: TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_DefaultTag (189.43s)
=== CONT  TestAccAPIGatewayDomainNameDataSource_tags_NullMap
--- PASS: TestAccAPIGatewayDomainName_tags_DefaultTags_providerOnly (564.38s)
=== CONT  TestAccAPIGatewayDomainNameDataSource_tags
--- PASS: TestAccAPIGatewayDomainNameDataSource_tags_DefaultTags_nonOverlapping (53.53s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_disappears
--- PASS: TestAccAPIGatewayDomainNameDataSource_tags_IgnoreTags_Overlap_DefaultTag (184.94s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_basic
--- PASS: TestAccAPIGatewayDomainNameDataSource_tags_EmptyMap (87.51s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_disappears (157.97s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccAPIGatewayDomainName_tags_DefaultTags_nullOverlappingResourceTag (761.70s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccAPIGatewayDomainNameDataSource_tags_NullMap (221.02s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_basic (203.34s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnCreate
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_ResourceTag (213.69s)
=== CONT  TestAccAPIGatewayDomainName_private
--- PASS: TestAccAPIGatewayDomainName_tags_EmptyTag_OnCreate (854.76s)
=== CONT  TestAccAPIGatewayDomainName_privatePolicy
--- PASS: TestAccAPIGatewayDomainName_private (48.87s)
=== CONT  TestAccAPIGatewayDomainName_tags_ComputedTag_OnCreate
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Add (169.58s)
=== CONT  TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccAPIGatewayDomainName_tags_ComputedTag_OnCreate (84.42s)
=== CONT  TestAccAPIGatewayDomainName_securityPolicy
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Replace (211.27s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nonOverlapping
--- PASS: TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Add (67.44s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnCreate (215.54s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccAPIGatewayDomainName_securityPolicy (69.49s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_DefaultTag (328.59s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccAPIGatewayDomainName_tags_DefaultTags_updateToResourceOnly (1152.54s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullOverlappingResourceTag (163.85s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_overlapping
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nonOverlapping (235.39s)
=== CONT  TestAccAPIGatewayDomainName_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyResourceTag (194.10s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnCreate
--- PASS: TestAccAPIGatewayDomainName_tags_DefaultTags_nullNonOverlappingResourceTag (67.44s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_providerOnly
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToResourceOnly (209.31s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToProviderOnly (157.04s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccAPIGatewayDomainName_tags_AddOnUpdate (1319.36s)
=== CONT  TestAccAPIGatewayDomainName_tags_DefaultTags_overlapping
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_overlapping (214.78s)
=== CONT  TestAccAPIGatewayDomainName_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccAPIGatewayDomainNameDataSource_tags (851.27s)
=== CONT  TestAccAPIGatewayDomainName_tags_null
--- PASS: TestAccAPIGatewayDomainName_tags_DefaultTags_overlapping (113.21s)
=== CONT  TestAccAPIGatewayDomainName_tags_EmptyMap
--- PASS: TestAccAPIGatewayDomainName_tags_DefaultTags_updateToProviderOnly (86.61s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyMap
--- PASS: TestAccAPIGatewayDomainName_tags_null (57.92s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_AddOnUpdate
--- PASS: TestAccAPIGatewayDomainName_privatePolicy (629.36s)
=== CONT  TestAccAPIGatewayDomainName_tags
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_providerOnly (253.85s)
=== CONT  TestAccAPIGatewayDomainName_tags_DefaultTags_nonOverlapping
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyMap (121.22s)
=== CONT  TestAccAPIGatewayDomainNameAccessAssociation_tags_null
--- PASS: TestAccAPIGatewayDomainName_tags_DefaultTags_nonOverlapping (111.16s)
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_AddOnUpdate (172.84s)
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnCreate (445.64s)
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_null (164.94s)
--- PASS: TestAccAPIGatewayDomainName_tags (288.53s)
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Add (508.72s)
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Replace (548.56s)
--- PASS: TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyProviderOnlyTag (884.12s)
--- PASS: TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Replace (2010.72s)
--- PASS: TestAccAPIGatewayDomainName_tags_EmptyMap (768.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 2210.080s
```
