### PR TITLE
Fix resource aws_quicksight_data_set so tags of tag_column_operation gets populated

### DIFF
--- a/.changelog/39912.txt
+++ b/.changelog/39912.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_data_set: Fixes empty tags content when trying to add column_description text
+```

--- a/internal/service/quicksight/data_set_test.go
+++ b/internal/service/quicksight/data_set_test.go
@@ -118,6 +118,40 @@ func TestAccQuickSightDataSet_columnGroups(t *testing.T) {
 	})
 }
 
+func TestAccQuickSightDataSet_columnDescriptionText(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dataSet awstypes.DataSet
+	resourceName := "aws_quicksight_data_set.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSetConfigColumnDescriptionText(rId, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSetExists(ctx, resourceName, &dataSet),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.data_transforms.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.data_transforms.0.tag_column_operation.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.data_transforms.0.tag_column_operation.0.tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.data_transforms.0.tag_column_operation.0.tags.0.column_description.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "logical_table_map.0.data_transforms.0.tag_column_operation.0.tags.0.column_description.0.text", "Column1 Description"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccQuickSightDataSet_columnLevelPermissionRules(t *testing.T) {
 	ctx := acctest.Context(t)
 	var dataSet awstypes.DataSet
@@ -624,6 +658,49 @@ resource "aws_quicksight_data_set" "test" {
       columns      = ["Column1"]
       country_code = "US"
       name         = "test"
+    }
+  }
+}
+`, rId, rName))
+}
+
+func testAccDataSetConfigColumnDescriptionText(rId, rName string) string {
+	return acctest.ConfigCompose(
+		testAccDataSetConfig_base(rId, rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_data_set" "test" {
+  data_set_id = %[1]q
+  name        = %[2]q
+  import_mode = "SPICE"
+
+  physical_table_map {
+    physical_table_map_id = %[1]q
+    s3_source {
+      data_source_arn = aws_quicksight_data_source.test.arn
+      input_columns {
+        name = "Column1"
+        type = "STRING"
+      }
+      upload_settings {
+        format = "JSON"
+      }
+    }
+  }
+  logical_table_map {
+    logical_table_map_id = %[1]q
+    alias                = "Group1"
+    source {
+      physical_table_id = %[1]q
+    }
+    data_transforms {
+      tag_column_operation {
+        column_name = "Column1"
+        tags {
+          column_description {
+		        text = "Column1 Description"
+		      }
+        }
+      }
     }
   }
 }

--- a/internal/service/quicksight/schema/data_set.go
+++ b/internal/service/quicksight/schema/data_set.go
@@ -1119,7 +1119,7 @@ func expandColumnTag(tfMap map[string]interface{}) *awstypes.ColumnTag {
 
 	apiObject := &awstypes.ColumnTag{}
 
-	if v, ok := tfMap["column_description"].(map[string]interface{}); ok {
+	if v, ok := tfMap["column_description"].([]interface{}); ok {
 		apiObject.ColumnDescription = expandColumnDescription(v)
 	}
 	if v, ok := tfMap["column_geographic_role"].(string); ok {
@@ -1129,13 +1129,17 @@ func expandColumnTag(tfMap map[string]interface{}) *awstypes.ColumnTag {
 	return apiObject
 }
 
-func expandColumnDescription(tfMap map[string]interface{}) *awstypes.ColumnDescription {
-	if tfMap == nil {
+func expandColumnDescription(tfList []interface{}) *awstypes.ColumnDescription {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+
+	tfMap, ok := tfList[0].(map[string]interface{})
+	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ColumnDescription{}
-
 	if v, ok := tfMap["text"].(string); ok {
 		apiObject.Text = aws.String(v)
 	}


### PR DESCRIPTION
### Description
When trying to create or update aws_quicksight_data_set with column_descriptions an Invalid Parameter error was received because the request was sending an empty tags block.

column_description schema is a TypeList but in expandColumnDescription and the casting to pull out column_description was treating it like a map[string]interface{}.  This updates the schema code to treat column_description like an array and pull out the first element in expandColumnDescription to get the actual map.

### Relations

Closes #39912

### Output from Acceptance Testing
Ran the tests that applied to the changes I was making to avoid any potential aws costs I might get.

```console
> make testacc TESTS=TestAccQuickSightDataSet_columnDescriptionText PKG=quicksight

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDataSet_columnDescriptionText'  -timeout 360m
2024/12/27 18:27:17 Initializing Terraform AWS Provider...
=== RUN   TestAccQuickSightDataSet_columnDescriptionText
=== PAUSE TestAccQuickSightDataSet_columnDescriptionText
=== CONT  TestAccQuickSightDataSet_columnDescriptionText
--- PASS: TestAccQuickSightDataSet_columnDescriptionText (25.76s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 31.497s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  0.659s [no tests to run]

> make testacc TESTS=TestAccQuickSightDataSet_basic PKG=quicksight

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDataSet_basic'  -timeout 360m
2024/12/27 18:36:55 Initializing Terraform AWS Provider...
=== RUN   TestAccQuickSightDataSet_basic
=== PAUSE TestAccQuickSightDataSet_basic
=== CONT  TestAccQuickSightDataSet_basic
--- PASS: TestAccQuickSightDataSet_basic (24.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 30.224s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  0.465s [no tests to run]

> make testacc TESTS=TestAccQuickSightDataSet_logicalTableMap PKG=quicksight

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDataSet_logicalTableMap'  -timeout 360m
2024/12/27 18:40:50 Initializing Terraform AWS Provider...
=== RUN   TestAccQuickSightDataSet_logicalTableMap
=== PAUSE TestAccQuickSightDataSet_logicalTableMap
=== CONT  TestAccQuickSightDataSet_logicalTableMap
--- PASS: TestAccQuickSightDataSet_logicalTableMap (41.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 47.315s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  0.668s [no tests to run]
...
```
