### PR TITLE
Incorrect values for "vpc_config" block in AppStream image builder re…

### DIFF
--- a/internal/service/appstream/image_builder.go
+++ b/internal/service/appstream/image_builder.go
@@ -170,6 +170,7 @@ func ResourceImageBuilder() *schema.Resource {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Computed: true,
+							MaxItems: 1,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},


### PR DESCRIPTION
…source #33027


### Description
Was looking for a good first issue to get familiar with go.
Made the change mentioned by @justinretzolk in https://github.com/hashicorp/terraform-provider-aws/issues/33027 so that the MaxItems on the subnet_ids in the vpc_config is now handled in the plan phase.


### Relations
Closes #33027



### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccAppStreamImageBuilder_ PKG=appstream

...
```
