### PR TITLE
Remove ForceNew on AttrSecurityGroupIDs in domain_settings

### DIFF
--- a/internal/service/sagemaker/domain.go
+++ b/internal/service/sagemaker/domain.go
@@ -1386,7 +1386,6 @@ func resourceDomain() *schema.Resource {
 						names.AttrSecurityGroupIDs: {
 							Type:     schema.TypeSet,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 3,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},


### PR DESCRIPTION
Remove ForceNew on AttrSecurityGroupIDs in domain_settings

### Description
Updating the security group for a domain should not try and recreate the whole domain.
By removing the "ForceNew: true" on AttrSecurityGroupIDs in domain_settings we allow for the correct behavior.


### Relations

Closes #40600

### References
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sagemaker-domain-domainsettings.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
