### PR TITLE
docs: update resource name in  example code

### DIFF
--- a/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
+++ b/website/docs/r/ssoadmin_managed_policy_attachment.html.markdown
@@ -49,7 +49,7 @@ resource "aws_identitystore_group" "example" {
   description       = "Admin Group"
 }
 
-resource "aws_ssoadmin_account_assignment" "account_assignment" {
+resource "aws_ssoadmin_account_assignment" "example" {
   instance_arn       = tolist(data.aws_ssoadmin_instances.example.arns)[0]
   permission_set_arn = aws_ssoadmin_permission_set.example.arn
 


### PR DESCRIPTION
### Description

The documentation for the resource `aws_ssoadmin_managed_policy_attachment` contains an [example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment#with-account-assignment) that fails during the execution of  e.g. `terraform plan`.

The error is reported as below

```shell
│ Error: Reference to undeclared resource
│ 
│   on main.tf line 29, in resource "aws_ssoadmin_managed_policy_attachment" "example":
│   29:   depends_on = [aws_ssoadmin_account_assignment.example]
│ 
│ A managed resource "aws_ssoadmin_account_assignment" "example" has not been declared in the root module.
```

The pull request addresses this issue by renaming the existing `aws_ssoadmin_account_assignment` resource

- old name `account_assignment` 
- new name `example`

### Relations

Closes #40720 

### References

### Output from Acceptance Testing

Not applicable. Only documentation is updated.