### PR TITLE
cognito-idp/userpool - add email mfa configuration

### DIFF
--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -612,6 +612,8 @@ func TestAccCognitoIDPUserPool_MFA_emailConfigurationMFA(t *testing.T) {
 	replyTo := acctest.DefaultEmailAddress
 	sourceARN := acctest.SkipIfEnvVarNotSet(t, "TEST_AWS_SES_VERIFIED_EMAIL_ARN")
 	emailTo := sourceARN[strings.LastIndex(sourceARN, "/")+1:]
+	updatedSubject := sdkacctest.RandString(50)
+	updatedMessage := sdkacctest.RandomWithPrefix("{####}")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
@@ -626,6 +628,15 @@ func TestAccCognitoIDPUserPool_MFA_emailConfigurationMFA(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
 					resource.TestCheckResourceAttr(resourceName, "email_mfa_configuration.0.message", message),
 					resource.TestCheckResourceAttr(resourceName, "email_mfa_configuration.0.subject", subject),
+				),
+			},
+			{
+				Config: testAccUserPoolConfig_mfaEmailConfigurationConfigurationEnabled(rName, true, updatedMessage, updatedSubject, replyTo, sourceARN, emailTo, "DEVELOPER"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "email_mfa_configuration.0.message", updatedMessage),
+					resource.TestCheckResourceAttr(resourceName, "email_mfa_configuration.0.subject", updatedSubject),
 				),
 			},
 			{

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -602,6 +602,41 @@ func TestAccCognitoIDPUserPool_MFA_softwareTokenMFA(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPUserPool_MFA_emailConfigurationMFA(t *testing.T) {
+	ctx := acctest.Context(t)
+	var pool awstypes.UserPoolType
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cognito_user_pool.test"
+	subject := sdkacctest.RandString(50)
+	message := sdkacctest.RandomWithPrefix("{####}")
+	replyTo := acctest.DefaultEmailAddress
+	sourceARN := acctest.SkipIfEnvVarNotSet(t, "TEST_AWS_SES_VERIFIED_EMAIL_ARN")
+	emailTo := sourceARN[strings.LastIndex(sourceARN, "/")+1:]
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolConfig_mfaEmailConfigurationConfigurationEnabled(rName, true, message, subject, replyTo, sourceARN, emailTo, "DEVELOPER"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolExists(ctx, resourceName, &pool),
+					resource.TestCheckResourceAttr(resourceName, "mfa_configuration", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "email_mfa_configuration.0.message", message),
+					resource.TestCheckResourceAttr(resourceName, "email_mfa_configuration.0.subject", subject),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS(t *testing.T) {
 	ctx := acctest.Context(t)
 	var pool awstypes.UserPoolType
@@ -2179,6 +2214,48 @@ resource "aws_cognito_user_pool" "test" {
   }
 }
 `, rName, enabled)
+}
+
+func testAccUserPoolConfig_mfaEmailConfigurationConfigurationEnabled(rName string, enabled bool, message, subject, email, arn, from, account string) string {
+	return fmt.Sprintf(`
+
+resource "aws_ses_configuration_set" "test" {
+  name = %[1]q
+
+  delivery_options {
+    tls_policy = "Optional"
+  }
+}
+  
+resource "aws_cognito_user_pool" "test" {
+  mfa_configuration = "ON"
+  name              = %[1]q
+
+  email_configuration {
+    reply_to_email_address = %[5]q
+    source_arn             = %[6]q
+    from_email_address     = %[7]q
+    email_sending_account  = %[8]q
+    configuration_set      = aws_ses_configuration_set.test.name
+  }
+
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+    recovery_mechanism {
+      name     = "verified_phone_number"
+      priority = 2
+    }
+  }
+
+  email_mfa_configuration {
+	message = %[3]q
+	subject = %[4]q
+  }
+}
+`, rName, enabled, message, subject, email, arn, from, account)
 }
 
 func testAccUserPoolConfig_passwordHistorySize(rName string, passwordHistorySize int) string {


### PR DESCRIPTION
### Description
I've added the additional configuration to include email_mfa_configuration as suggested in https://github.com/hashicorp/terraform-provider-aws/issues/40561

The test include the creating, updating and the reading of identity pools.


Closes #40561


### Output from Acceptance Testing

Output below has an error due to missing feature about the new cognito pricing models.
It is however, unrelated to these changes

```console
 make testacc TESTS=TestAccCognitoIDPUserPool_ PKG=cognitoidp
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/cognitoidp/... -v -count 1 -parallel 5 -run='TestAccCognitoIDPUserPool_'  -timeout 360m
2024/12/30 21:48:57 Initializing Terraform AWS Provider...
=== RUN   TestAccCognitoIDPUserPool_tags
=== PAUSE TestAccCognitoIDPUserPool_tags
=== RUN   TestAccCognitoIDPUserPool_tags_null
=== PAUSE TestAccCognitoIDPUserPool_tags_null
=== RUN   TestAccCognitoIDPUserPool_tags_EmptyMap
=== PAUSE TestAccCognitoIDPUserPool_tags_EmptyMap
=== RUN   TestAccCognitoIDPUserPool_tags_AddOnUpdate
=== PAUSE TestAccCognitoIDPUserPool_tags_AddOnUpdate
=== RUN   TestAccCognitoIDPUserPool_tags_EmptyTag_OnCreate
=== PAUSE TestAccCognitoIDPUserPool_tags_EmptyTag_OnCreate
=== RUN   TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccCognitoIDPUserPool_tags_DefaultTags_providerOnly
=== PAUSE TestAccCognitoIDPUserPool_tags_DefaultTags_providerOnly
=== RUN   TestAccCognitoIDPUserPool_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccCognitoIDPUserPool_tags_DefaultTags_nonOverlapping
=== RUN   TestAccCognitoIDPUserPool_tags_DefaultTags_overlapping
=== PAUSE TestAccCognitoIDPUserPool_tags_DefaultTags_overlapping
=== RUN   TestAccCognitoIDPUserPool_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccCognitoIDPUserPool_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccCognitoIDPUserPool_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccCognitoIDPUserPool_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccCognitoIDPUserPool_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccCognitoIDPUserPool_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccCognitoIDPUserPool_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccCognitoIDPUserPool_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccCognitoIDPUserPool_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccCognitoIDPUserPool_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccCognitoIDPUserPool_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccCognitoIDPUserPool_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccCognitoIDPUserPool_tags_ComputedTag_OnCreate
=== PAUSE TestAccCognitoIDPUserPool_tags_ComputedTag_OnCreate
=== RUN   TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccCognitoIDPUserPool_basic
=== PAUSE TestAccCognitoIDPUserPool_basic
=== RUN   TestAccCognitoIDPUserPool_deletionProtection
=== PAUSE TestAccCognitoIDPUserPool_deletionProtection
=== RUN   TestAccCognitoIDPUserPool_recovery
=== PAUSE TestAccCognitoIDPUserPool_recovery
=== RUN   TestAccCognitoIDPUserPool_withAdminCreateUser
=== PAUSE TestAccCognitoIDPUserPool_withAdminCreateUser
=== RUN   TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== PAUSE TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== RUN   TestAccCognitoIDPUserPool_withAdvancedSecurityMode
=== PAUSE TestAccCognitoIDPUserPool_withAdvancedSecurityMode
=== RUN   TestAccCognitoIDPUserPool_withDevice
=== PAUSE TestAccCognitoIDPUserPool_withDevice
=== RUN   TestAccCognitoIDPUserPool_withEmailVerificationMessage
=== PAUSE TestAccCognitoIDPUserPool_withEmailVerificationMessage
=== RUN   TestAccCognitoIDPUserPool_passwordHistorySize
=== PAUSE TestAccCognitoIDPUserPool_passwordHistorySize
=== RUN   TestAccCognitoIDPUserPool_MFA_sms
=== PAUSE TestAccCognitoIDPUserPool_MFA_sms
=== RUN   TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_emailConfigurationMFA
=== PAUSE TestAccCognitoIDPUserPool_MFA_emailConfigurationMFA
=== RUN   TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
=== PAUSE TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
=== RUN   TestAccCognitoIDPUserPool_smsAuthenticationMessage
=== PAUSE TestAccCognitoIDPUserPool_smsAuthenticationMessage
=== RUN   TestAccCognitoIDPUserPool_sms
=== PAUSE TestAccCognitoIDPUserPool_sms
=== RUN   TestAccCognitoIDPUserPool_SMS_snsRegion
=== PAUSE TestAccCognitoIDPUserPool_SMS_snsRegion
=== RUN   TestAccCognitoIDPUserPool_SMS_externalID
=== PAUSE TestAccCognitoIDPUserPool_SMS_externalID
=== RUN   TestAccCognitoIDPUserPool_SMS_snsCallerARN
=== PAUSE TestAccCognitoIDPUserPool_SMS_snsCallerARN
=== RUN   TestAccCognitoIDPUserPool_smsVerificationMessage
=== PAUSE TestAccCognitoIDPUserPool_smsVerificationMessage
=== RUN   TestAccCognitoIDPUserPool_withEmail
=== PAUSE TestAccCognitoIDPUserPool_withEmail
=== RUN   TestAccCognitoIDPUserPool_withEmailSource
=== PAUSE TestAccCognitoIDPUserPool_withEmailSource
=== RUN   TestAccCognitoIDPUserPool_withAliasAttributes
=== PAUSE TestAccCognitoIDPUserPool_withAliasAttributes
=== RUN   TestAccCognitoIDPUserPool_withUsernameAttributes
=== PAUSE TestAccCognitoIDPUserPool_withUsernameAttributes
=== RUN   TestAccCognitoIDPUserPool_withPasswordPolicy
=== PAUSE TestAccCognitoIDPUserPool_withPasswordPolicy
=== RUN   TestAccCognitoIDPUserPool_withUsername
=== PAUSE TestAccCognitoIDPUserPool_withUsername
=== RUN   TestAccCognitoIDPUserPool_withLambda
=== PAUSE TestAccCognitoIDPUserPool_withLambda
=== RUN   TestAccCognitoIDPUserPool_WithLambda_email
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_email
=== RUN   TestAccCognitoIDPUserPool_WithLambda_sms
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_sms
=== RUN   TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig
=== PAUSE TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig
=== RUN   TestAccCognitoIDPUserPool_addLambda
=== PAUSE TestAccCognitoIDPUserPool_addLambda
=== RUN   TestAccCognitoIDPUserPool_schemaAttributes
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributes
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesRemoved
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesRemoved
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesModified
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesModified
=== RUN   TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints
=== PAUSE TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints
=== RUN   TestAccCognitoIDPUserPool_withVerificationMessageTemplate
=== PAUSE TestAccCognitoIDPUserPool_withVerificationMessageTemplate
=== RUN   TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8
=== PAUSE TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8
=== RUN   TestAccCognitoIDPUserPool_update
=== PAUSE TestAccCognitoIDPUserPool_update
=== RUN   TestAccCognitoIDPUserPool_disappears
=== PAUSE TestAccCognitoIDPUserPool_disappears
=== RUN   TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
=== PAUSE TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
=== CONT  TestAccCognitoIDPUserPool_tags
=== CONT  TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
=== CONT  TestAccCognitoIDPUserPool_withUsername
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesModified
=== CONT  TestAccCognitoIDPUserPool_WithLambda_sms
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesModified (28.90s)
=== CONT  TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig
--- PASS: TestAccCognitoIDPUserPool_withUsername (44.06s)
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesRemoved
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesRemoved (26.08s)
=== CONT  TestAccCognitoIDPUserPool_schemaAttributes
--- PASS: TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA (74.66s)
=== CONT  TestAccCognitoIDPUserPool_addLambda
--- PASS: TestAccCognitoIDPUserPool_tags (90.45s)
=== CONT  TestAccCognitoIDPUserPool_update
--- PASS: TestAccCognitoIDPUserPool_WithLambda_sms (94.09s)
=== CONT  TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings
=== CONT  TestAccCognitoIDPUserPool_disappears
--- PASS: TestAccCognitoIDPUserPool_schemaAttributes (39.37s)
--- PASS: TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig (88.78s)
=== CONT  TestAccCognitoIDPUserPool_SMS_externalID
--- PASS: TestAccCognitoIDPUserPool_disappears (20.90s)
=== CONT  TestAccCognitoIDPUserPool_withPasswordPolicy
--- PASS: TestAccCognitoIDPUserPool_addLambda (59.16s)
=== CONT  TestAccCognitoIDPUserPool_withUsernameAttributes
--- PASS: TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings (40.35s)
=== CONT  TestAccCognitoIDPUserPool_withAliasAttributes
--- PASS: TestAccCognitoIDPUserPool_update (69.67s)
=== CONT  TestAccCognitoIDPUserPool_withEmailSource
--- PASS: TestAccCognitoIDPUserPool_withPasswordPolicy (39.10s)
=== CONT  TestAccCognitoIDPUserPool_withEmail
--- PASS: TestAccCognitoIDPUserPool_withAliasAttributes (40.10s)
=== CONT  TestAccCognitoIDPUserPool_smsVerificationMessage
--- PASS: TestAccCognitoIDPUserPool_withUsernameAttributes (41.18s)
=== CONT  TestAccCognitoIDPUserPool_SMS_snsCallerARN
--- PASS: TestAccCognitoIDPUserPool_SMS_externalID (59.57s)
=== CONT  TestAccCognitoIDPUserPool_withVerificationMessageTemplate
--- PASS: TestAccCognitoIDPUserPool_withEmailSource (22.96s)
=== CONT  TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8
--- PASS: TestAccCognitoIDPUserPool_withEmail (25.02s)
=== CONT  TestAccCognitoIDPUserPool_tags_ComputedTag_OnCreate
--- PASS: TestAccCognitoIDPUserPool_smsVerificationMessage (38.93s)
=== CONT  TestAccCognitoIDPUserPool_MFA_sms
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplate (38.69s)
=== CONT  TestAccCognitoIDPUserPool_passwordHistorySize
--- PASS: TestAccCognitoIDPUserPool_tags_ComputedTag_OnCreate (27.89s)
=== CONT  TestAccCognitoIDPUserPool_withEmailVerificationMessage
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8 (39.53s)
=== CONT  TestAccCognitoIDPUserPool_withDevice
--- PASS: TestAccCognitoIDPUserPool_SMS_snsCallerARN (60.06s)
=== CONT  TestAccCognitoIDPUserPool_withAdvancedSecurityMode
--- PASS: TestAccCognitoIDPUserPool_passwordHistorySize (39.51s)
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
=== NAME  TestAccCognitoIDPUserPool_withAdvancedSecurityMode
    user_pool_test.go:264: Step 3/4 error: Error running apply: exit status 1
        
        Error: updating Cognito User Pool (us-west-2_kaKWe1Xna): operation error Cognito Identity Provider: UpdateUserPool, https response error StatusCode: 400, RequestID: 71214c1c-84f9-461f-8d47-7900b2cb6d68, FeatureUnavailableInTierException: The following features need to be disabled for the ESSENTIALS pricing tier configured: Threat Protection
        
          with aws_cognito_user_pool.test,
          on terraform_plugin_test.tf line 12, in resource "aws_cognito_user_pool" "test":
          12: resource "aws_cognito_user_pool" "test" {
        
--- PASS: TestAccCognitoIDPUserPool_withEmailVerificationMessage (40.18s)
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUser
--- PASS: TestAccCognitoIDPUserPool_withDevice (40.62s)
=== CONT  TestAccCognitoIDPUserPool_recovery
--- FAIL: TestAccCognitoIDPUserPool_withAdvancedSecurityMode (31.91s)
=== CONT  TestAccCognitoIDPUserPool_deletionProtection
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy (25.37s)
=== CONT  TestAccCognitoIDPUserPool_basic
--- PASS: TestAccCognitoIDPUserPool_MFA_sms (77.50s)
=== CONT  TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUser (39.41s)
=== CONT  TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccCognitoIDPUserPool_basic (25.41s)
=== CONT  TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccCognitoIDPUserPool_deletionProtection (39.39s)
=== CONT  TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccCognitoIDPUserPool_recovery (54.32s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_nonOverlapping
--- PASS: TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_ResourceTag (59.15s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Replace (44.71s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Add (44.96s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_DefaultTag (52.87s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_nullNonOverlappingResourceTag (27.44s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_nullOverlappingResourceTag (27.29s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_emptyProviderOnlyTag (27.09s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_overlapping
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_emptyResourceTag (26.67s)
=== CONT  TestAccCognitoIDPUserPool_tags_EmptyTag_OnCreate
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_nonOverlapping (67.58s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_providerOnly
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_updateToResourceOnly (40.49s)
=== CONT  TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_updateToProviderOnly (42.21s)
=== CONT  TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccCognitoIDPUserPool_tags_EmptyTag_OnCreate (46.68s)
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_overlapping (68.61s)
=== CONT  TestAccCognitoIDPUserPool_SMS_snsRegion
--- PASS: TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Replace (42.33s)
=== CONT  TestAccCognitoIDPUserPool_sms
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_providerOnly (87.58s)
=== CONT  TestAccCognitoIDPUserPool_smsAuthenticationMessage
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS (51.02s)
=== CONT  TestAccCognitoIDPUserPool_WithLambda_email
--- PASS: TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Add (61.73s)
=== CONT  TestAccCognitoIDPUserPool_withLambda
--- PASS: TestAccCognitoIDPUserPool_SMS_snsRegion (36.91s)
=== CONT  TestAccCognitoIDPUserPool_tags_EmptyMap
--- PASS: TestAccCognitoIDPUserPool_smsAuthenticationMessage (39.48s)
=== CONT  TestAccCognitoIDPUserPool_tags_AddOnUpdate
--- PASS: TestAccCognitoIDPUserPool_tags_EmptyMap (31.99s)
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
--- PASS: TestAccCognitoIDPUserPool_sms (65.52s)
=== CONT  TestAccCognitoIDPUserPool_MFA_emailConfigurationMFA
--- PASS: TestAccCognitoIDPUserPool_tags_AddOnUpdate (41.25s)
=== CONT  TestAccCognitoIDPUserPool_tags_null
--- PASS: TestAccCognitoIDPUserPool_WithLambda_email (85.60s)
=== CONT  TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
=== CONT  TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFA (52.90s)
--- PASS: TestAccCognitoIDPUserPool_MFA_emailConfigurationMFA (43.23s)
--- PASS: TestAccCognitoIDPUserPool_withLambda (87.88s)
--- PASS: TestAccCognitoIDPUserPool_tags_null (32.35s)
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints (25.31s)
--- PASS: TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA (47.61s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 612.578s
FAIL
make: *** [GNUmakefile:601: testacc] Error 1
...
```
