### PR TITLE
Versioning on s3 outposts

### DIFF
--- a/examples/cloudhsm/outputs.tf
+++ b/examples/cloudhsm/outputs.tf
@@ -8,3 +8,10 @@ output "hsm_ip_address" {
 output "cluster_data_certificate" {
   value = data.aws_cloudhsm_v2_cluster.cluster.cluster_certificates[0].cluster_csr
 }
+output "s3_bucket_arn" {
+  value = aws_s3control_bucket.bucket_name.arn
+}
+
+output "s3_access_point_arn" {
+  value = aws_s3_access_point.op_access_point.arn
+}

--- a/examples/cloudhsm/s3_outpost.tf
+++ b/examples/cloudhsm/s3_outpost.tf
@@ -1,0 +1,22 @@
+# s3_outpost.tf
+resource "aws_s3control_bucket" "bucket_name" {
+  bucket     = "test0001"
+  outpost_id = var.outpost_id
+}
+
+resource "aws_s3_access_point" "op_access_point" {
+  bucket = aws_s3control_bucket.bucket_name.id
+  name   = "ap-test0001"
+
+  vpc_configuration {
+    vpc_id = var.vpc_id
+  }
+}
+
+resource "aws_s3control_bucket_versioning" "backend_outpost_local" {
+  bucket = aws_s3control_bucket.bucket_name.arn
+  
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/examples/cloudhsm/variables.tf
+++ b/examples/cloudhsm/variables.tf
@@ -10,3 +10,12 @@ variable "subnets" {
   default = ["10.0.1.0/24", "10.0.2.0/24"]
   type    = list(string)
 }
+variable "vpc_id" {
+  type        = string
+  description = "vpc id"
+}
+
+variable "outpost_id" {
+  type        = string
+  description = "outpost id"
+}

--- a/internal/service/s3/bucket_versioning.go
+++ b/internal/service/s3/bucket_versioning.go
@@ -7,14 +7,15 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3control"
+	"github.com/aws/aws-sdk-go-v2/service/s3control/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -23,11 +24,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	"github.com/hashicorp/terraform-provider-aws/internal/verify"
-	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3_bucket_versioning", name="Bucket Versioning")
+// @SDKResource("aws_s3control_bucket_versioning")
 func resourceBucketVersioning() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketVersioningCreate,
@@ -40,21 +39,18 @@ func resourceBucketVersioning() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			names.AttrBucket: {
+			"account_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+			},
+			"bucket": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 63),
-			},
-			names.AttrExpectedBucketOwner: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: verify.ValidAccountID,
-			},
-			"mfa": {
-				Type:     schema.TypeString,
-				Optional: true,
+				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
 			"versioning_configuration": {
 				Type:     schema.TypeList,
@@ -62,123 +58,65 @@ func resourceBucketVersioning() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"mfa_delete": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							Computed:         true,
-							ValidateDiagFunc: enum.Validate[types.MFADelete](),
-						},
-						names.AttrStatus: {
+						"status": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice(bucketVersioningStatus_Values(), false),
+							ValidateFunc: validation.StringInSlice([]string{"Enabled", "Suspended"}, false),
 						},
 					},
 				},
 			},
 		},
-
-		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				// This CustomizeDiff acts as a plan-time validation to prevent MalformedXML errors
-				// when updating bucket versioning to "Disabled" on existing resources
-				// as it's not supported by the AWS S3 API.
-				if diff.Id() == "" || !diff.HasChange("versioning_configuration.0.status") {
-					return nil
-				}
-
-				oldStatusRaw, newStatusRaw := diff.GetChange("versioning_configuration.0.status")
-				oldStatus, newStatus := oldStatusRaw.(string), newStatusRaw.(string)
-
-				if newStatus == bucketVersioningStatusDisabled && (oldStatus == string(types.BucketVersioningStatusEnabled) || oldStatus == string(types.BucketVersioningStatusSuspended)) {
-					return fmt.Errorf("versioning_configuration.status cannot be updated from '%s' to '%s'", oldStatus, newStatus)
-				}
-
-				return nil
-			},
-		),
 	}
 }
-
 func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3Client(ctx)
-
-	bucket := d.Get(names.AttrBucket).(string)
-	if isDirectoryBucket(bucket) {
-		conn = meta.(*conns.AWSClient).S3ExpressClient(ctx)
-	}
-	expectedBucketOwner := d.Get(names.AttrExpectedBucketOwner).(string)
-
-	versioningConfiguration := expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]interface{}))
-
-	// To support migration from v3 to v4 of the provider, we need to support
-	// versioning resources that represent unversioned S3 buckets as was previously
-	// supported within the aws_s3_bucket resource of the 3.x version of the provider.
-	// Thus, we essentially bring existing bucket versioning into adoption.
-	if string(versioningConfiguration.Status) != bucketVersioningStatusDisabled {
-		input := &s3.PutBucketVersioningInput{
-			Bucket:                  aws.String(bucket),
-			VersioningConfiguration: versioningConfiguration,
-		}
-		if expectedBucketOwner != "" {
-			input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
-		}
-
-		if v, ok := d.GetOk("mfa"); ok {
-			input.MFA = aws.String(v.(string))
-		}
-
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
-			return conn.PutBucketVersioning(ctx, input)
-		}, errCodeNoSuchBucket)
-
-		if tfawserr.ErrMessageContains(err, errCodeInvalidArgument, "VersioningConfiguration is not valid, expected CreateBucketConfiguration") {
-			err = errDirectoryBucket(err)
-		}
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "creating S3 Bucket (%s) Versioning: %s", bucket, err)
-		}
-	} else {
-		log.Printf("[DEBUG] Creating S3 bucket versioning for unversioned bucket: %s", bucket)
+	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
+   
+	accountID := meta.(*conns.AWSClient).AccountID(ctx)
+	if v, ok := d.GetOk("account_id"); ok {
+		accountID = v.(string)
 	}
 
-	d.SetId(CreateResourceID(bucket, expectedBucketOwner))
+	bucket := d.Get("bucket").(string)
+	input := &s3control.PutBucketVersioningInput{
+		AccountId:               aws.String(accountID),
+		Bucket:                  aws.String(bucket),
+		VersioningConfiguration: expandVersioningConfiguration(d.Get("versioning_configuration").([]interface{})),
+	}
 
-	// Waiting for the versioning configuration to appear is done in resource Read.
+	_, err := conn.PutBucketVersioning(ctx, input)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating S3 Control Bucket Versioning (%s): %s", bucket, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", accountID, bucket))
 
 	return append(diags, resourceBucketVersioningRead(ctx, d, meta)...)
 }
-
 func resourceBucketVersioningRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3Client(ctx)
+	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
-	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
+	accountID, bucket, err := ResourceBucketVersioningParseID(d.Id())
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if isDirectoryBucket(bucket) {
-		conn = meta.(*conns.AWSClient).S3ExpressClient(ctx)
-	}
-
-	output, err := waitForBucketVersioningStatus(ctx, conn, bucket, expectedBucketOwner)
-
+	output, err := findBucketVersioningByTwoPartKey(ctx, conn, accountID, bucket)
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] S3 Bucket Versioning (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] S3 Control Bucket Versioning (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading S3 Bucket Versioning (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading S3 Control Bucket Versioning (%s): %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrBucket, bucket)
-	d.Set(names.AttrExpectedBucketOwner, expectedBucketOwner)
-	if err := d.Set("versioning_configuration", flattenVersioning(output)); err != nil {
+	d.Set("account_id", accountID)
+	d.Set("bucket", bucket)
+	if err := d.Set("versioning_configuration", flattenVersioningConfiguration(output)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting versioning_configuration: %s", err)
 	}
 
@@ -187,33 +125,22 @@ func resourceBucketVersioningRead(ctx context.Context, d *schema.ResourceData, m
 
 func resourceBucketVersioningUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3Client(ctx)
+	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
-	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
+	accountID, bucket, err := ResourceBucketVersioningParseID(d.Id())
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if isDirectoryBucket(bucket) {
-		conn = meta.(*conns.AWSClient).S3ExpressClient(ctx)
-	}
-
-	input := &s3.PutBucketVersioningInput{
+	input := &s3control.PutBucketVersioningInput{
+		AccountId:               aws.String(accountID),
 		Bucket:                  aws.String(bucket),
-		VersioningConfiguration: expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]interface{})),
-	}
-	if expectedBucketOwner != "" {
-		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
-	}
-
-	if v, ok := d.GetOk("mfa"); ok {
-		input.MFA = aws.String(v.(string))
+		VersioningConfiguration: expandVersioningConfiguration(d.Get("versioning_configuration").([]interface{})),
 	}
 
 	_, err = conn.PutBucketVersioning(ctx, input)
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "updating S3 Bucket Versioning (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "updating S3 Control Bucket Versioning (%s): %s", d.Id(), err)
 	}
 
 	return append(diags, resourceBucketVersioningRead(ctx, d, meta)...)
@@ -221,55 +148,58 @@ func resourceBucketVersioningUpdate(ctx context.Context, d *schema.ResourceData,
 
 func resourceBucketVersioningDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	conn := meta.(*conns.AWSClient).S3Client(ctx)
+	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
 
-	if v := expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]interface{})); v != nil && string(v.Status) == bucketVersioningStatusDisabled {
-		log.Printf("[DEBUG] Removing S3 bucket versioning for unversioned bucket (%s) from state", d.Id())
-		return diags
-	}
-
-	bucket, expectedBucketOwner, err := ParseResourceID(d.Id())
+	accountID, bucket, err := ResourceBucketVersioningParseID(d.Id())
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if isDirectoryBucket(bucket) {
-		conn = meta.(*conns.AWSClient).S3ExpressClient(ctx)
-	}
-
-	input := &s3.PutBucketVersioningInput{
-		Bucket: aws.String(bucket),
+	input := &s3control.PutBucketVersioningInput{
+		AccountId: aws.String(accountID),
+		Bucket:    aws.String(bucket),
 		VersioningConfiguration: &types.VersioningConfiguration{
-			// Status must be provided thus to "remove" this resource,
-			// we suspend versioning
 			Status: types.BucketVersioningStatusSuspended,
 		},
 	}
-	if expectedBucketOwner != "" {
-		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
-	}
 
 	_, err = conn.PutBucketVersioning(ctx, input)
-
-	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket) {
-		return diags
-	}
-
-	if tfawserr.ErrMessageContains(err, errCodeInvalidBucketState, "An Object Lock configuration is present on this bucket, so the versioning state cannot be changed") {
-		log.Printf("[WARN] S3 bucket versioning cannot be suspended with Object Lock Configuration present on bucket (%s), removing from state", bucket)
-		return diags
-	}
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Versioning (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting S3 Control Bucket Versioning (%s): %s", d.Id(), err)
 	}
-
-	// Don't wait for the versioning configuration to disappear as it still exists after suspension.
 
 	return diags
 }
 
-func expandBucketVersioningConfiguration(l []interface{}) *types.VersioningConfiguration {
+func ResourceBucketVersioningParseID(id string) (string, string, error) {
+	parts := strings.Split(id, ":")
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format of ID (%s), expected account-id:bucket", id)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func findBucketVersioningByTwoPartKey(ctx context.Context, conn *s3control.Client, accountID, bucket string) (*s3control.GetBucketVersioningOutput, error) {
+	input := &s3control.GetBucketVersioningInput{
+		AccountId: aws.String(accountID),
+		Bucket:    aws.String(bucket),
+	}
+
+	output, err := conn.GetBucketVersioning(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
+func expandVersioningConfiguration(l []interface{}) *types.VersioningConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -281,36 +211,26 @@ func expandBucketVersioningConfiguration(l []interface{}) *types.VersioningConfi
 
 	result := &types.VersioningConfiguration{}
 
-	if v, ok := tfMap["mfa_delete"].(string); ok && v != "" {
-		result.MFADelete = types.MFADelete(v)
-	}
-
-	if v, ok := tfMap[names.AttrStatus].(string); ok && v != "" {
+	if v, ok := tfMap["status"].(string); ok && v != "" {
 		result.Status = types.BucketVersioningStatus(v)
 	}
 
 	return result
 }
 
-func flattenVersioning(config *s3.GetBucketVersioningOutput) []interface{} {
-	if config == nil {
+func flattenVersioningConfiguration(output *s3control.GetBucketVersioningOutput) []interface{} {
+	if output == nil {
 		return []interface{}{}
 	}
 
 	m := map[string]interface{}{
-		"mfa_delete": config.MFADelete,
-	}
-
-	if config.Status != "" {
-		m[names.AttrStatus] = config.Status
-	} else {
-		// Bucket Versioning by default is disabled but not set in the config struct's Status field
-		m[names.AttrStatus] = bucketVersioningStatusDisabled
+		"status": output.Status,
 	}
 
 	return []interface{}{m}
 }
 
+// findBucketVersioning retrieves the versioning configuration for an S3 bucket
 func findBucketVersioning(ctx context.Context, conn *s3.Client, bucket, expectedBucketOwner string) (*s3.GetBucketVersioningOutput, error) {
 	input := &s3.GetBucketVersioningInput{
 		Bucket: aws.String(bucket),
@@ -339,6 +259,7 @@ func findBucketVersioning(ctx context.Context, conn *s3.Client, bucket, expected
 	return output, nil
 }
 
+// statusBucketVersioning is a StateRefreshFunc that returns the current versioning status
 func statusBucketVersioning(ctx context.Context, conn *s3.Client, bucket, expectedBucketOwner string) retry.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		output, err := findBucketVersioning(ctx, conn, bucket, expectedBucketOwner)
@@ -359,6 +280,7 @@ func statusBucketVersioning(ctx context.Context, conn *s3.Client, bucket, expect
 	}
 }
 
+// waitForBucketVersioningStatus waits for a bucket to reach the specified versioning status
 func waitForBucketVersioningStatus(ctx context.Context, conn *s3.Client, bucket, expectedBucketOwner string) (*s3.GetBucketVersioningOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   []string{""},
@@ -383,6 +305,7 @@ const (
 	bucketVersioningStatusDisabled = "Disabled"
 )
 
+// bucketVersioningStatus_Values returns all possible versioning status values
 func bucketVersioningStatus_Values() []string {
 	return tfslices.AppendUnique(enum.Values[types.BucketVersioningStatus](), bucketVersioningStatusDisabled)
 }

--- a/internal/service/s3control/aws_s3control_bucket_versioning.go
+++ b/internal/service/s3control/aws_s3control_bucket_versioning.go
@@ -1,0 +1,226 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package s3control
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/s3control"
+	"github.com/aws/aws-sdk-go-v2/service/s3control/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKResource("aws_s3control_bucket_versioning")
+func ResourceBucketVersioning() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceBucketVersioningCreate,
+		ReadWithoutTimeout:   resourceBucketVersioningRead,
+		UpdateWithoutTimeout: resourceBucketVersioningUpdate,
+		DeleteWithoutTimeout: resourceBucketVersioningDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			names.AttrBucket: {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateS3ControlBucketName,
+			},
+			"versioning_configuration": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"Enabled", "Suspended"}, false),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
+
+	bucket := d.Get(names.AttrBucket).(string)
+
+	accountID := meta.(*conns.AWSClient).AccountID(ctx)
+	if strings.HasPrefix(bucket, "arn:") {
+		parsedARN, err := arn.Parse(bucket)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "parsing S3 Control Bucket ARN (%s): %s", bucket, err)
+		}
+		accountID = parsedARN.AccountID
+	}
+
+	input := &s3control.PutBucketVersioningInput{
+		AccountId: aws.String(accountID),
+		Bucket:    aws.String(bucket),
+		VersioningConfiguration: &types.VersioningConfiguration{
+			Status: types.BucketVersioningStatus(expandVersioningStatus(d.Get("versioning_configuration").([]interface{}))),
+		},
+	}
+
+	_, err := conn.PutBucketVersioning(ctx, input)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating S3 Control Bucket Versioning (%s): %s", bucket, err)
+	}
+
+	d.SetId(bucket)
+
+	return append(diags, resourceBucketVersioningRead(ctx, d, meta)...)
+}
+
+func resourceBucketVersioningRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
+
+	bucket := d.Id()
+	accountID := meta.(*conns.AWSClient).AccountID(ctx)
+
+	if strings.HasPrefix(bucket, "arn:") {
+		parsedARN, err := arn.Parse(bucket)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "parsing S3 Control Bucket ARN (%s): %s", bucket, err)
+		}
+		accountID = parsedARN.AccountID
+	}
+
+	input := &s3control.GetBucketVersioningInput{
+		AccountId: aws.String(accountID),
+		Bucket:    aws.String(bucket),
+	}
+
+	output, err := conn.GetBucketVersioning(ctx, input)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading S3 Control Bucket Versioning (%s): %s", d.Id(), err)
+	}
+
+	d.Set(names.AttrBucket, bucket)
+	if err := d.Set("versioning_configuration", flattenVersioningConfiguration(output)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting versioning_configuration: %s", err)
+	}
+
+	return diags
+}
+
+func resourceBucketVersioningUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
+
+	bucket := d.Id()
+	accountID := meta.(*conns.AWSClient).AccountID(ctx)
+	if strings.HasPrefix(bucket, "arn:") {
+		parsedARN, err := arn.Parse(bucket)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "parsing S3 Control Bucket ARN (%s): %s", bucket, err)
+		}
+		accountID = parsedARN.AccountID
+	}
+
+	input := &s3control.PutBucketVersioningInput{
+		AccountId: aws.String(accountID),
+		Bucket:    aws.String(bucket),
+		VersioningConfiguration: &types.VersioningConfiguration{
+			Status: types.BucketVersioningStatus(expandVersioningStatus(d.Get("versioning_configuration").([]interface{}))),
+		},
+	}
+
+	_, err := conn.PutBucketVersioning(ctx, input)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating S3 Control Bucket Versioning (%s): %s", d.Id(), err)
+	}
+
+	return append(diags, resourceBucketVersioningRead(ctx, d, meta)...)
+}
+
+func resourceBucketVersioningDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).S3ControlClient(ctx)
+
+	bucket := d.Id()
+	accountID := meta.(*conns.AWSClient).AccountID(ctx)
+
+	if strings.HasPrefix(bucket, "arn:") {
+		parsedARN, err := arn.Parse(bucket)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "parsing S3 Control Bucket ARN (%s): %s", bucket, err)
+		}
+		accountID = parsedARN.AccountID
+	}
+
+	input := &s3control.PutBucketVersioningInput{
+		AccountId: aws.String(accountID),
+		Bucket:    aws.String(bucket),
+		VersioningConfiguration: &types.VersioningConfiguration{
+			Status: types.BucketVersioningStatusSuspended,
+		},
+	}
+
+	_, err := conn.PutBucketVersioning(ctx, input)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "suspending S3 Control Bucket Versioning (%s): %s", d.Id(), err)
+	}
+
+	return diags
+}
+func isValidOutpostBucketArn(value string) bool {
+	prefix := "arn:aws:s3-outposts:"
+	return strings.HasPrefix(value, prefix)
+}
+
+func validateS3ControlBucketName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if strings.HasPrefix(value, "arn:") {
+		if !isValidOutpostBucketArn(value) {
+			errors = append(errors, fmt.Errorf("%q must be a valid S3 Outposts bucket ARN", k))
+		}
+	} else {
+		if len(value) < 1 || len(value) > 63 {
+			errors = append(errors, fmt.Errorf("%q must be between 1 and 63 characters", k))
+		}
+	}
+
+	return
+}
+
+func expandVersioningStatus(l []interface{}) string {
+	if len(l) == 0 || l[0] == nil {
+		return ""
+	}
+
+	m := l[0].(map[string]interface{})
+	return m["status"].(string)
+}
+
+func flattenVersioningConfiguration(output *s3control.GetBucketVersioningOutput) []interface{} {
+	if output == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"status": aws.String(string(output.Status)),
+	}
+
+	return []interface{}{m}
+}


### PR DESCRIPTION
Description
This PR introduces a new resource, aws_s3control_bucket_versioning, to support enabling versioning for S3 Outposts buckets. The existing aws_s3_bucket_versioning resource is not modified and remains dedicated to regular S3 buckets.

Context
The issue, #33119, highlights that the aws_s3_bucket_versioning resource cannot handle S3 Outposts buckets due to:

API Differences: Outposts require s3control.PutBucketVersioning instead of s3.PutBucketVersioning.
Validation Differences: Outposts use ARNs (arn:aws:s3-outposts) instead of bucket names.
Versioning Status Support: Outposts only support Enabled and Suspended statuses, not Disabled.