### PR TITLE
r/aws_glue_catalog_database: fix crash expanding `create_table_default_permission`

### DIFF
--- a/.changelog/40761.txt
+++ b/.changelog/40761.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_database: Fix crash when expanding `create_table_default_permission` with a nil `principal` block
+```

--- a/internal/service/glue/catalog_database.go
+++ b/internal/service/glue/catalog_database.go
@@ -454,7 +454,7 @@ func expandDatabasePrincipalPermission(tfMap map[string]interface{}) awstypes.Pr
 		apiObject.Permissions = flex.ExpandStringyValueSet[awstypes.Permission](v)
 	}
 
-	if v, ok := tfMap[names.AttrPrincipal].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrPrincipal].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 		apiObject.Principal = expandDatabasePrincipal(v[0].(map[string]interface{}))
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Previously a nil nested `principal` block could trigger a panic:

```
panic: interface conversion: interface {} is nil, not map[string]interface {}
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40738

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=glue TESTS=TestAccGlueCatalogDatabase_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/glue/... -v -count 1 -parallel 20 -run='TestAccGlueCatalogDatabase_'  -timeout 360m
2025/01/03 10:35:25 Initializing Terraform AWS Provider...

--- PASS: TestAccGlueCatalogDatabase_disappears (14.67s)
--- PASS: TestAccGlueCatalogDatabase_targetDatabaseWithRegion (24.83s)
--- PASS: TestAccGlueCatalogDatabase_createTablePermission (26.68s)
--- PASS: TestAccGlueCatalogDatabase_targetDatabase (29.36s)
--- PASS: TestAccGlueCatalogDatabase_full (35.43s)
--- PASS: TestAccGlueCatalogDatabase_tags (35.46s)
--- PASS: TestAccGlueCatalogDatabase_federatedDatabase (320.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       325.906s
```
