### PR TITLE
fix(cloudformation): handle stackset updates with OU and multiple OU targets

### DIFF
--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -416,11 +416,19 @@ func resourceStackSetInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 
 		stackSetName, accountOrOrgID, region := parts[0], parts[1], parts[2]
 		input := &cloudformation.UpdateStackInstancesInput{
-			Accounts:           []string{accountOrOrgID},
 			OperationId:        aws.String(sdkid.UniqueId()),
 			ParameterOverrides: []awstypes.Parameter{},
 			Regions:            []string{region},
 			StackSetName:       aws.String(stackSetName),
+		}
+
+		if itypes.IsAWSAccountID(accountOrOrgID) {
+			input.Accounts = []string{accountOrOrgID}
+		} else {
+			orgIDs := strings.Split(accountOrOrgID, "/")
+			input.DeploymentTargets = &awstypes.DeploymentTargets{
+				OrganizationalUnitIds: orgIDs,
+			}
 		}
 
 		callAs := d.Get("call_as").(string)


### PR DESCRIPTION
Signed-off-by: Jon Leemon <4316746+nomeelnoj@users.noreply.github.com

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updates the cloudformation stack set code to properly handle updates when deployed to one or more OUs instead of accounts.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40675 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
