### PR TITLE
feat: Add association_id arg for aws_eip_association + improve docs

### DIFF
--- a/.changelog/40769.txt
+++ b/.changelog/40769.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eip_association: Adds validation to only allow one of `instance_id` or `network_interface_id`
+```

--- a/.changelog/40769.txt
+++ b/.changelog/40769.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eip_association: Add `association_id` attribute
+```

--- a/.changelog/40769.txt
+++ b/.changelog/40769.txt
@@ -1,3 +1,0 @@
-```release-note:enhancement
-resource/aws_eip_association: Add `association_id` attribute
-```

--- a/internal/service/ec2/ec2_eip_association.go
+++ b/internal/service/ec2/ec2_eip_association.go
@@ -43,6 +43,10 @@ func resourceEIPAssociation() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			names.AttrAssociationID: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrInstanceID: {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -107,7 +111,9 @@ func resourceEIPAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "creating EC2 EIP Association: %s", err)
 	}
 
-	d.SetId(aws.ToString(output.AssociationId))
+	association_id := aws.ToString(output.AssociationId)
+	d.Set(names.AttrAssociationID, association_id)
+	d.SetId(association_id)
 
 	_, err = tfresource.RetryWhen(ctx, ec2PropagationTimeout,
 		func() (interface{}, error) {
@@ -156,6 +162,7 @@ func resourceEIPAssociationRead(ctx context.Context, d *schema.ResourceData, met
 
 	d.Set("allocation_id", address.AllocationId)
 	d.Set(names.AttrInstanceID, address.InstanceId)
+	d.Set(names.AttrAssociationID, address.AssociationId)
 	d.Set(names.AttrNetworkInterfaceID, address.NetworkInterfaceId)
 	d.Set("private_ip_address", address.PrivateIpAddress)
 	d.Set("public_ip", address.PublicIp)

--- a/internal/service/ec2/ec2_eip_association.go
+++ b/internal/service/ec2/ec2_eip_association.go
@@ -48,12 +48,20 @@ func resourceEIPAssociation() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ExactlyOneOf: []string{
+					names.AttrInstanceID,
+					names.AttrNetworkInterfaceID,
+				},
 			},
 			names.AttrNetworkInterfaceID: {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ExactlyOneOf: []string{
+					names.AttrInstanceID,
+					names.AttrNetworkInterfaceID,
+				},
 			},
 			"private_ip_address": {
 				Type:     schema.TypeString,

--- a/internal/service/ec2/ec2_eip_association.go
+++ b/internal/service/ec2/ec2_eip_association.go
@@ -83,7 +83,7 @@ func resourceEIPAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	input := &ec2.AssociateAddressInput{}
+	input := ec2.AssociateAddressInput{}
 
 	if v, ok := d.GetOk("allocation_id"); ok {
 		input.AllocationId = aws.String(v.(string))
@@ -109,7 +109,7 @@ func resourceEIPAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 		input.PublicIp = aws.String(v.(string))
 	}
 
-	output, err := conn.AssociateAddress(ctx, input)
+	output, err := conn.AssociateAddress(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating EC2 EIP Association: %s", err)
@@ -179,12 +179,10 @@ func resourceEIPAssociationDelete(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, `with the retirement of EC2-Classic %s domain EC2 EIPs are no longer supported`, types.DomainTypeStandard)
 	}
 
-	input := &ec2.DisassociateAddressInput{
+	input := ec2.DisassociateAddressInput{
 		AssociationId: aws.String(d.Id()),
 	}
-
-	log.Printf("[DEBUG] Deleting EC2 EIP Association: %s", d.Id())
-	_, err := conn.DisassociateAddress(ctx, input)
+	_, err := conn.DisassociateAddress(ctx, &input)
 
 	if tfawserr.ErrCodeEquals(err, errCodeInvalidAssociationIDNotFound) {
 		return diags

--- a/internal/service/ec2/ec2_eip_association.go
+++ b/internal/service/ec2/ec2_eip_association.go
@@ -43,10 +43,6 @@ func resourceEIPAssociation() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			names.AttrAssociationID: {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			names.AttrInstanceID: {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -111,9 +107,7 @@ func resourceEIPAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 		return sdkdiag.AppendErrorf(diags, "creating EC2 EIP Association: %s", err)
 	}
 
-	association_id := aws.ToString(output.AssociationId)
-	d.Set(names.AttrAssociationID, association_id)
-	d.SetId(association_id)
+	d.SetId(aws.ToString(output.AssociationId))
 
 	_, err = tfresource.RetryWhen(ctx, ec2PropagationTimeout,
 		func() (interface{}, error) {
@@ -162,7 +156,6 @@ func resourceEIPAssociationRead(ctx context.Context, d *schema.ResourceData, met
 
 	d.Set("allocation_id", address.AllocationId)
 	d.Set(names.AttrInstanceID, address.InstanceId)
-	d.Set(names.AttrAssociationID, address.AssociationId)
 	d.Set(names.AttrNetworkInterfaceID, address.NetworkInterfaceId)
 	d.Set("private_ip_address", address.PrivateIpAddress)
 	d.Set("public_ip", address.PublicIp)

--- a/internal/service/ec2/ec2_eip_association_test.go
+++ b/internal/service/ec2/ec2_eip_association_test.go
@@ -35,6 +35,7 @@ func TestAccEC2EIPAssociation_basic(t *testing.T) {
 				Config: testAccEIPAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPAssociationExists(ctx, resourceName, &a),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrAssociationID, resourceName, names.AttrID),
 				),
 			},
 			{

--- a/internal/service/ec2/ec2_eip_association_test.go
+++ b/internal/service/ec2/ec2_eip_association_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -35,7 +36,7 @@ func TestAccEC2EIPAssociation_basic(t *testing.T) {
 				Config: testAccEIPAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEIPAssociationExists(ctx, resourceName, &a),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrAssociationID, resourceName, names.AttrID),
+					resource.TestMatchResourceAttr(resourceName, names.AttrID, regexache.MustCompile(`^eipassoc-\w+$`)),
 				),
 			},
 			{

--- a/internal/service/ec2/ec2_eip_association_test.go
+++ b/internal/service/ec2/ec2_eip_association_test.go
@@ -251,9 +251,9 @@ func testAccCheckEIPAssociationDestroy(ctx context.Context) resource.TestCheckFu
 
 func testAccEIPAssociationConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
-		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.ConfigLatestAmazonLinux2HVMEBSARM64AMI(),
 		acctest.ConfigVPCWithSubnets(rName, 1),
-		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t4g.micro", "t3a.micro"),
 		fmt.Sprintf(`
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
@@ -264,7 +264,7 @@ resource "aws_internet_gateway" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
   subnet_id     = aws_subnet.test[0].id
 
@@ -290,9 +290,9 @@ resource "aws_eip_association" "test" {
 
 func testAccEIPAssociationConfig_instance(rName string) string {
 	return acctest.ConfigCompose(
-		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.ConfigLatestAmazonLinux2HVMEBSARM64AMI(),
 		acctest.ConfigVPCWithSubnets(rName, 1),
-		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t4g.micro", "t3a.micro"),
 		fmt.Sprintf(`
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
@@ -303,7 +303,7 @@ resource "aws_internet_gateway" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
   subnet_id     = aws_subnet.test[0].id
 
@@ -329,9 +329,9 @@ resource "aws_eip_association" "test" {
 
 func testAccEIPAssociationConfig_instance_publicIP(rName string) string {
 	return acctest.ConfigCompose(
-		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.ConfigLatestAmazonLinux2HVMEBSARM64AMI(),
 		acctest.ConfigVPCWithSubnets(rName, 1),
-		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t4g.micro", "t3a.micro"),
 		fmt.Sprintf(`
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
@@ -342,7 +342,7 @@ resource "aws_internet_gateway" "test" {
 }
 
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = data.aws_ec2_instance_type_offering.available.instance_type
   subnet_id     = aws_subnet.test[0].id
 
@@ -401,9 +401,9 @@ resource "aws_eip_association" "test" {
 
 func testAccEIPAssociationConfig_spotInstance(rName, publicKey string) string {
 	return acctest.ConfigCompose(
-		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.ConfigLatestAmazonLinux2HVMEBSARM64AMI(),
 		acctest.ConfigVPCWithSubnets(rName, 1),
-		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t3.micro", "t2.micro"),
+		acctest.AvailableEC2InstanceTypeForAvailabilityZone("data.aws_availability_zones.available.names[0]", "t4g.micro", "t3a.micro"),
 		fmt.Sprintf(`
 resource "aws_internet_gateway" "test" {
   vpc_id = aws_vpc.test.id
@@ -423,7 +423,7 @@ resource "aws_key_pair" "test" {
 }
 
 resource "aws_spot_instance_request" "test" {
-  ami                  = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  ami                  = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type        = data.aws_ec2_instance_type_offering.available.instance_type
   key_name             = aws_key_pair.test.key_name
   spot_price           = "0.10"

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -5398,13 +5398,13 @@ func findEIPByAllocationID(ctx context.Context, conn *ec2.Client, id string) (*a
 }
 
 func findEIPByAssociationID(ctx context.Context, conn *ec2.Client, id string) (*awstypes.Address, error) {
-	input := &ec2.DescribeAddressesInput{
+	input := ec2.DescribeAddressesInput{
 		Filters: newAttributeFilterList(map[string]string{
 			"association-id": id,
 		}),
 	}
 
-	output, err := findEIP(ctx, conn, input)
+	output, err := findEIP(ctx, conn, &input)
 
 	if err != nil {
 		return nil, err

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -8,13 +8,11 @@ description: |-
 
 # Resource: aws_eip_association
 
-Provides an AWS EIP Association as a top level resource, to associate and
-disassociate Elastic IPs from AWS Instances and Network Interfaces.
+Provides an AWS EIP Association as a top level resource, to associate and disassociate Elastic IPs from AWS Instances and Network Interfaces.
 
 ~> **NOTE:** Do not use this resource to associate an EIP to `aws_lb` or `aws_nat_gateway` resources. Instead use the `allocation_id` available in those resources to allow AWS to manage the association, otherwise you will see `AuthFailure` errors.
 
-~> **NOTE:** `aws_eip_association` is useful in scenarios where EIPs are either
-pre-existing or distributed to customers or users and therefore cannot be changed.
+~> **NOTE:** `aws_eip_association` is useful in scenarios where EIPs are either pre-existing or distributed to customers or users and therefore cannot be changed.
 
 ## Example Usage
 
@@ -43,33 +41,19 @@ resource "aws_eip" "example" {
 
 This resource supports the following arguments:
 
-* `allocation_id` - (Optional) The allocation ID. This is required for EC2-VPC.
-* `allow_reassociation` - (Optional, Boolean) Whether to allow an Elastic IP to
-be re-associated. Defaults to `true` in VPC.
-* `instance_id` - (Optional) The ID of the instance. This is required for
-EC2-Classic. For EC2-VPC, you can specify either the instance ID or the
-network interface ID, but not both. The operation fails if you specify an
-instance ID unless exactly one network interface is attached.
-* `network_interface_id` - (Optional) The ID of the network interface. If the
-instance has more than one network interface, you must specify a network
-interface ID.
-* `private_ip_address` - (Optional) The primary or secondary private IP address
-to associate with the Elastic IP address. If no private IP address is
-specified, the Elastic IP address is associated with the primary private IP
-address.
-* `public_ip` - (Optional) The Elastic IP address. This is required for EC2-Classic.
+* `allocation_id` - (Optional, Forces new resource) Allocation ID. This argument is required despite being optional at the resource level due to legacy support for EC2-Classic networking.
+* `allow_reassociation` - (Optional, Forces new resource) Whether to allow an Elastic IP address to be re-associated. Defaults to `true`.
+* `instance_id` - (Optional, Forces new resource) ID of the instance. The instance must have exactly one attached network interface. You can specify either the instance ID or the network interface ID, but not both.
+* `network_interface_id` - (Optional, Forces new resource) ID of the network interface. If the instance has more than one network interface, you must specify a network interface ID. You can specify either the instance ID or the network interface ID, but not both.
+* `private_ip_address` - (Optional, Forces new resource) Primary or secondary private IP address to associate with the Elastic IP address. If no private IP address is specified, the Elastic IP address is associated with the primary private IP address.
+* `public_ip` - (Optional, Forces new resource, **Deprecated** since [EC2-Classic netwworking has retired](https://aws.amazon.com/blogs/aws/ec2-classic-is-retiring-heres-how-to-prepare/)) The Elastic IP address.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `association_id` - The ID that represents the association of the Elastic IP
-address with an instance.
-* `allocation_id` - As above
-* `instance_id` - As above
-* `network_interface_id` - As above
-* `private_ip_address` - As above
-* `public_ip` - As above
+* `association_id` - ID that represents the association of the Elastic IP address with an instance.
+* `id` - ID that represents the association of the Elastic IP address with an instance.
 
 ## Import
 

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -41,18 +41,24 @@ resource "aws_eip" "example" {
 
 This resource supports the following arguments:
 
-* `allocation_id` - (Optional, Forces new resource) Allocation ID. This argument is required despite being optional at the resource level due to legacy support for EC2-Classic networking.
-* `allow_reassociation` - (Optional, Forces new resource) Whether to allow an Elastic IP address to be re-associated. Defaults to `true`.
-* `instance_id` - (Optional, Forces new resource) ID of the instance. The instance must have exactly one attached network interface. You can specify either the instance ID or the network interface ID, but not both.
-* `network_interface_id` - (Optional, Forces new resource) ID of the network interface. If the instance has more than one network interface, you must specify a network interface ID. You can specify either the instance ID or the network interface ID, but not both.
-* `private_ip_address` - (Optional, Forces new resource) Primary or secondary private IP address to associate with the Elastic IP address. If no private IP address is specified, the Elastic IP address is associated with the primary private IP address.
-* `public_ip` - (Optional, Forces new resource, **Deprecated** since [EC2-Classic netwworking has retired](https://aws.amazon.com/blogs/aws/ec2-classic-is-retiring-heres-how-to-prepare/)) The Elastic IP address.
+* `allocation_id` - (Optional, Forces new resource) ID of the associated Elastic IP.
+  This argument is required despite being optional at the resource level due to legacy support for EC2-Classic networking.
+* `allow_reassociation` - (Optional, Forces new resource) Whether to allow an Elastic IP address to be re-associated.
+  Defaults to `true`.
+* `instance_id` - (Optional, Forces new resource) ID of the instance.
+  The instance must have exactly one attached network interface.
+  You can specify either the instance ID or the network interface ID, but not both.
+* `network_interface_id` - (Optional, Forces new resource) ID of the network interface.
+  If the instance has more than one network interface, you must specify a network interface ID.
+  You can specify either the instance ID or the network interface ID, but not both.
+* `private_ip_address` - (Optional, Forces new resource) Primary or secondary private IP address to associate with the Elastic IP address.
+  If no private IP address is specified, the Elastic IP address is associated with the primary private IP address.
+* `public_ip` - (Optional, Forces new resource, **Deprecated** since [EC2-Classic netwworking has retired](https://aws.amazon.com/blogs/aws/ec2-classic-is-retiring-heres-how-to-prepare/)) Address of the associated Elastic IP.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `association_id` - ID that represents the association of the Elastic IP address with an instance.
 * `id` - ID that represents the association of the Elastic IP address with an instance.
 
 ## Import


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `association_id` attribute to the `aws_eip_association` resource so that it is more aligned with typical convention with ID attributes. As per the original issue, the documentation has also been updated to include both `id` and `association_id`. Argument descriptions have also been updated to better reflect their specs.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40766

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [AssociateAddress](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateAddress.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccEC2EIPAssociation_ PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2EIPAssociation_'  -timeout 360m
2025/01/03 23:19:42 Initializing Terraform AWS Provider...
=== RUN   TestAccEC2EIPAssociation_basic
=== PAUSE TestAccEC2EIPAssociation_basic
=== RUN   TestAccEC2EIPAssociation_disappears
=== PAUSE TestAccEC2EIPAssociation_disappears
=== RUN   TestAccEC2EIPAssociation_instance
=== PAUSE TestAccEC2EIPAssociation_instance
=== RUN   TestAccEC2EIPAssociation_networkInterface
=== PAUSE TestAccEC2EIPAssociation_networkInterface
=== RUN   TestAccEC2EIPAssociation_spotInstance
=== PAUSE TestAccEC2EIPAssociation_spotInstance
=== CONT  TestAccEC2EIPAssociation_basic
=== CONT  TestAccEC2EIPAssociation_networkInterface
=== CONT  TestAccEC2EIPAssociation_spotInstance
=== CONT  TestAccEC2EIPAssociation_disappears
=== CONT  TestAccEC2EIPAssociation_instance
--- PASS: TestAccEC2EIPAssociation_networkInterface (29.52s)
--- PASS: TestAccEC2EIPAssociation_basic (136.30s)
--- PASS: TestAccEC2EIPAssociation_disappears (307.92s)
--- PASS: TestAccEC2EIPAssociation_spotInstance (326.89s)
--- PASS: TestAccEC2EIPAssociation_instance (327.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        327.435s

$
```
