### PR TITLE
feat: Add registry policy scope support for aws_ecr_account_setting

### DIFF
--- a/.changelog/40772.txt
+++ b/.changelog/40772.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_ecr_account_setting: Add valid values for registry policy scope to `name` and `value` arguments
+```

--- a/internal/service/ecr/account_setting.go
+++ b/internal/service/ecr/account_setting.go
@@ -46,7 +46,7 @@ func (r *accountSettingResource) Schema(ctx context.Context, request resource.Sc
 			names.AttrName: schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("BASIC_SCAN_TYPE_VERSION"),
+					stringvalidator.OneOf("BASIC_SCAN_TYPE_VERSION", "REGISTRY_POLICY_SCOPE"),
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -55,7 +55,7 @@ func (r *accountSettingResource) Schema(ctx context.Context, request resource.Sc
 			names.AttrValue: schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("AWS_NATIVE", "CLAIR"),
+					stringvalidator.OneOf("AWS_NATIVE", "CLAIR", "V1", "V2"),
 				},
 			},
 		},

--- a/internal/service/ecr/account_setting_test.go
+++ b/internal/service/ecr/account_setting_test.go
@@ -20,7 +20,8 @@ func TestAccECRAccountSetting_serial(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]func(t *testing.T){
-		acctest.CtBasic: testAccAccountSetting_basic,
+		acctest.CtBasic:       testAccAccountSetting_basic,
+		"registryPolicyScope": testAccAccountSetting_registryPolicyScope,
 	}
 
 	acctest.RunSerialTests1Level(t, testCases, 0)
@@ -57,6 +58,42 @@ func testAccAccountSetting_basic(t *testing.T) {
 					testAccCheckAccountSettingExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrValue, "CLAIR")),
+			},
+		},
+	})
+}
+
+func testAccAccountSetting_registryPolicyScope(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ecr_account_setting.test"
+	rName := "REGISTRY_POLICY_SCOPE"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountSettingConfig_basic(rName, "V1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountSettingExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrValue, "V1")),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportStateVerifyIdentifierAttribute: names.AttrName,
+				ImportStateId:                        rName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+			},
+			{
+				Config: testAccAccountSettingConfig_basic(rName, "V2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccountSettingExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrValue, "V2")),
 			},
 		},
 	})

--- a/website/docs/r/ecr_account_setting.html.markdown
+++ b/website/docs/r/ecr_account_setting.html.markdown
@@ -6,16 +6,27 @@ description: |-
   Provides a resource to manage AWS ECR Basic Scan Type
 ---
 
-# Resource: aws_ecr_account_settings
+# Resource: aws_ecr_account_setting
 
 Provides a resource to manage AWS ECR Basic Scan Type
 
 ## Example Usage
 
+### Configuring Basic Scanning
+
 ```terraform
-resource "aws_ecr_account_setting" "foo" {
+resource "aws_ecr_account_setting" "basic_scan_type_version" {
   name  = "BASIC_SCAN_TYPE_VERSION"
-  value = "CLAIR"
+  value = "AWS_NATIVE"
+}
+```
+
+### Configuring Registry Policy Scope
+
+```terraform
+resource "aws_ecr_account_setting" "registry_policy_scope" {
+  name  = "REGISTRY_POLICY_SCOPE"
+  value = "V2"
 }
 ```
 
@@ -23,16 +34,16 @@ resource "aws_ecr_account_setting" "foo" {
 
 This resource supports the following arguments:
 
-* `name` - (Required) The name of the ECR Scan Type. This should be `BASIC_SCAN_TYPE_VERSION`.
-* `value` - (Required) The value of the ECR Scan Type. This can be `AWS_NATIVE` or `CLAIR`.
+* `name` - (Required) Name of the account setting. One of: `BASIC_SCAN_TYPE_VERSION`, `REGISTRY_POLICY_SCOPE`.
+* `value` - (Required) Setting value that is specified. Valid values are:
+    * If `name` is specified as `BASIC_SCAN_TYPE_VERSION`, one of: `AWS_NATIVE`, `CLAIR`.
+    * If `name` is specified as `REGISTRY_POLICY_SCOPE`, one of: `V1`, `V2`.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The ID of the ECR Scan Type (Same as the `name`)
-* `name` - The Name of the ECR Scan Type
-* `value` - The Value of the ECR Scan Type
+* `id` - Name of the account setting.
 
 ## Import
 
@@ -45,7 +56,7 @@ import {
 }
 ```
 
-Using `terraform import`, import EMR Security Configurations using the `name`. For example:
+Using `terraform import`, import EMR Security Configurations using the account setting name. For example:
 
 ```console
 % terraform import aws_ecr_account_setting.foo BASIC_SCAN_TYPE_VERSION


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add support for setting registry policy scope via appropriate values for the `name` and `value` argument in the `aws_ecr_account_setting` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40705

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [PutAccountSetting](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_PutAccountSetting.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccECRAccountSetting_serial PKG=ecr
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRAccountSetting_serial'  -timeout 360m
2025/01/04 04:12:19 Initializing Terraform AWS Provider...
=== RUN   TestAccECRAccountSetting_serial
=== PAUSE TestAccECRAccountSetting_serial
=== CONT  TestAccECRAccountSetting_serial
=== RUN   TestAccECRAccountSetting_serial/basic
=== RUN   TestAccECRAccountSetting_serial/registryPolicyScope
--- PASS: TestAccECRAccountSetting_serial (50.72s)
    --- PASS: TestAccECRAccountSetting_serial/basic (25.99s)
    --- PASS: TestAccECRAccountSetting_serial/registryPolicyScope (24.73s)

$
```
