### PR TITLE
r/aws_service_discovery_service: Deprecates `health_check_custom_config.failure_threshold`

### DIFF
--- a/.changelog/40777.txt
+++ b/.changelog/40777.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_service_discovery_service: Deprecates `health_check_custom_config.failure_threshold`.
+```

--- a/.changelog/40777.txt
+++ b/.changelog/40777.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-resource/aws_service_discovery_service: Deprecates `health_check_custom_config.failure_threshold`.
+resource/aws_service_discovery_service: `health_check_custom_config.failure_threshold` is deprecated. The argument is no longer supported by AWS and always set to 1
 ```

--- a/.changelog/40777.txt
+++ b/.changelog/40777.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-resource/aws_service_discovery_service: `health_check_custom_config.failure_threshold` is deprecated. The argument is no longer supported by AWS and always set to 1
+resource/aws_service_discovery_service: `health_check_custom_config.failure_threshold` is deprecated. The argument is no longer supported by AWS and is always set to 1
 ```

--- a/internal/service/servicediscovery/service.go
+++ b/internal/service/servicediscovery/service.go
@@ -126,7 +126,7 @@ func resourceService() *schema.Resource {
 							Type:       schema.TypeInt,
 							Optional:   true,
 							ForceNew:   true,
-							Deprecated: `The attribute "failure_threshold" is now unsupported in the AWS API and is always set to 1. The attribute will be removed in a future major version.`,
+							Deprecated: `"failure_threshold" is deprecated and no longer supported by AWS. The attribute will be removed in a future major version.`,
 						},
 					},
 				},

--- a/internal/service/servicediscovery/service.go
+++ b/internal/service/servicediscovery/service.go
@@ -126,7 +126,7 @@ func resourceService() *schema.Resource {
 							Type:       schema.TypeInt,
 							Optional:   true,
 							ForceNew:   true,
-							Deprecated: `"failure_threshold" is deprecated and no longer supported by AWS. The attribute will be removed in a future major version.`,
+							Deprecated: "failure_threshold is deprecated and no longer supported by AWS. The attribute will be removed in a future major version.",
 						},
 					},
 				},

--- a/internal/service/servicediscovery/service.go
+++ b/internal/service/servicediscovery/service.go
@@ -123,10 +123,11 @@ func resourceService() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"failure_threshold": {
-							Type:       schema.TypeInt,
-							Optional:   true,
-							ForceNew:   true,
-							Deprecated: "failure_threshold is deprecated and no longer supported by AWS. The attribute will be removed in a future major version.",
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+							Deprecated: "failure_threshold is deprecated. The argument is no longer supported by AWS and the " +
+								"value is always set to 1. The attribute will be removed in a future major version.",
 						},
 					},
 				},

--- a/internal/service/servicediscovery/service.go
+++ b/internal/service/servicediscovery/service.go
@@ -123,9 +123,10 @@ func resourceService() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"failure_threshold": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
+							Type:       schema.TypeInt,
+							Optional:   true,
+							ForceNew:   true,
+							Deprecated: `The attribute "failure_threshold" is now unsupported in the AWS API and is always set to 1. The attribute will be removed in a future major version.`,
 						},
 					},
 				},

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -112,7 +112,7 @@ The `health_check_config` configuration block supports the following arguments:
 
 The `health_check_custom_config` configuration block supports the following arguments:
 
-* `failure_threshold` - (Optional, Forces new resource) The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance.  Maximum value of 10.
+* `failure_threshold` - (Optional, **Deprecated** Forces new resource) The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance.  Maximum value of 10.
 
 ## Attribute Reference
 

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -112,7 +112,7 @@ The `health_check_config` configuration block supports the following arguments:
 
 The `health_check_custom_config` configuration block supports the following arguments:
 
-* `failure_threshold` - (Optional, **Deprecated** Forces new resource) The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance.  Maximum value of 10.
+* `failure_threshold` - (Optional, **Deprecated** Forces new resource) The number of 30-second intervals that you want service discovery to wait before it changes the health status of a service instance.  Value is always set to 1.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR will try to resolve the issue with the `aws_service_discovery_service` resource where setting the `health_check_custom_config.failure_threshold` to a value other than `1` results into the following behaviors:

- During resource creation, the value is getting ignored as the AWS SDK overrides it to `1`
- After the initial resource creation, the resource always gets recreated as terraform detects that the value written in the terraform file is not on par with the setting in the AWS Cloudformation Stack. This causes uninteded `terraform apply` failures since terraform will try to destroy and then recreate the resource again even with tight depedencies that terraform won't simply allow.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37955 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

#35559 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
