### PR TITLE
fix(rds): cluster enabled_cloudwatch_logs_exports doesn't allow iam-db-auth-error

### DIFF
--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -1200,6 +1200,35 @@ func TestAccRDSCluster_EnabledCloudWatchLogsExports_postgresql(t *testing.T) {
 	})
 }
 
+func TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var dbCluster1 types.DBCluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_enabledCloudWatchLogsExportsAuroraPostgreSQL(rName, "postgresql", "iam-db-auth-error"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster1),
+					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "enabled_cloudwatch_logs_exports.*", "postgresql"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "enabled_cloudwatch_logs_exports.*", "iam-db-auth-error"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSCluster_updateIAMRoles(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBCluster
@@ -4021,6 +4050,30 @@ resource "aws_rds_cluster" "test" {
   engine_version                  = data.aws_rds_orderable_db_instance.test.engine_version
 }
 `, tfrds.ClusterEnginePostgres, mainInstanceClasses, rName, enabledCloudwatchLogExports1))
+}
+
+func testAccClusterConfig_enabledCloudWatchLogsExportsAuroraPostgreSQL(rName, enabledCloudwatchLogExports1, enabledCloudwatchLogExports2 string) string {
+	return acctest.ConfigCompose(
+		testAccConfig_ClusterSubnetGroup(rName),
+		fmt.Sprintf(`
+
+data "aws_rds_engine_version" "test" {
+  engine = "aurora-postgresql"
+	latest = true
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier              = %[1]q
+  enabled_cloudwatch_logs_exports = [%[2]q, %[3]q]
+  master_username                 = "tfacctest"
+  master_password                 = "avoid-plaintext-passwords"
+  skip_final_snapshot             = true
+  db_subnet_group_name            = aws_db_subnet_group.test.name
+  engine                          = "aurora-postgresql"
+  engine_mode                     = "provisioned"
+  engine_version                  = data.aws_rds_engine_version.test.version
+}
+`, rName, enabledCloudwatchLogExports1, enabledCloudwatchLogExports2))
 }
 
 func testAccClusterConfig_enabledCloudWatchLogsExportsPostgreSQL2(rName, enabledCloudwatchLogExports1, enabledCloudwatchLogExports2 string) string {

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -211,19 +211,20 @@ func engineLifecycleSupport_Values() []string {
 }
 
 const (
-	exportableLogTypeAgent      = "agent"
-	exportableLogTypeAlert      = "alert"
-	exportableLogTypeAudit      = "audit"
-	exportableLogTypeDiagLog    = "diag.log"
-	exportableLogTypeError      = "error"
-	exportableLogTypeGeneral    = "general"
-	exportableLogTypeListener   = "listener"
-	exportableLogTypeNotifyLog  = "notify.log"
-	exportableLogTypeOEMAgent   = "oemagent"
-	exportableLogTypePostgreSQL = "postgresql"
-	exportableLogTypeSlowQuery  = "slowquery"
-	exportableLogTypeTrace      = "trace"
-	exportableLogTypeUpgrade    = "upgrade"
+	exportableLogTypeAgent          = "agent"
+	exportableLogTypeAlert          = "alert"
+	exportableLogTypeAudit          = "audit"
+	exportableLogTypeDiagLog        = "diag.log"
+	exportableLogTypeError          = "error"
+	exportableLogTypeGeneral        = "general"
+	exportableLogTypeListener       = "listener"
+	exportableLogTypeNotifyLog      = "notify.log"
+	exportableLogTypeOEMAgent       = "oemagent"
+	exportableLogTypePostgreSQL     = "postgresql"
+	exportableLogTypeSlowQuery      = "slowquery"
+	exportableLogTypeTrace          = "trace"
+	exportableLogTypeUpgrade        = "upgrade"
+	exportableLogTypeIAMDbAuthError = "iam-db-auth-error"
 )
 
 func clusterExportableLogType_Values() []string {
@@ -234,6 +235,7 @@ func clusterExportableLogType_Values() []string {
 		exportableLogTypePostgreSQL,
 		exportableLogTypeSlowQuery,
 		exportableLogTypeUpgrade,
+		exportableLogTypeIAMDbAuthError,
 	}
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

There is a new value for aurora-postgresql that is accepted in the `enabled_cloudwatch_logs_exports` field. It looks like this is currently being rolled out and is only available in some regions (can be tested in `us-west-2`).


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

closes #40787

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```
% make testacc TESTS=TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql'  -timeout 360m
2025/01/06 10:04:01 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql
=== PAUSE TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql (115.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        119.716s
```

