### PR TITLE
feat(elasticache): Make engine name case insensitive for user and user_group

### DIFF
--- a/.changelog/40794.txt
+++ b/.changelog/40794.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_elasticache_user: engine attribute is now case insensitive
+```
+
+```release-note:enhancement
+resoruce/aws_elasticache_user_group: engine attribute is now case insensitive
+```

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -142,7 +142,7 @@ func resourceCluster() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ExactlyOneOf: []string{names.AttrEngine, "replication_group_id"},
-				ValidateFunc: validation.StringInSlice([]string{engineMemcached, engineRedis}, false),
+				ValidateFunc: validation.StringInSlice([]string{engineMemcached, engineRedis, engineValkey}, false),
 			},
 			names.AttrEngineVersion: {
 				Type:     schema.TypeString,

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -90,7 +90,7 @@ func resourceUser() *schema.Resource {
 			names.AttrEngine: {
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateFunc:     validation.StringInSlice([]string{"REDIS", "VALKEY"}, false),
+				ValidateFunc:     validation.StringInSlice([]string{engineRedis, engineValkey}, true),
 				DiffSuppressFunc: sdkv2.SuppressEquivalentStringCaseInsensitive,
 			},
 			"no_password_required": {

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -50,7 +50,7 @@ func resourceUserGroup() *schema.Resource {
 			names.AttrEngine: {
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateFunc:     validation.StringInSlice([]string{"REDIS", "VALKEY"}, false),
+				ValidateFunc:     validation.StringInSlice([]string{engineRedis, engineValkey}, true),
 				DiffSuppressFunc: sdkv2.SuppressEquivalentStringCaseInsensitive,
 			},
 			names.AttrTags:    tftags.TagsSchema(),

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -180,14 +180,14 @@ func TestAccElastiCacheUser_updateEngine(t *testing.T) {
 		CheckDestroy:             testAccCheckUserDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserConfigWithEngine(rName, "VALKEY"),
+				Config: testAccUserConfigWithEngine(rName, "valkey"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "valkey"),
 				),
 			},
 			{
-				Config: testAccUserConfigWithEngine(rName, "REDIS"),
+				Config: testAccUserConfigWithEngine(rName, "redis"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
@@ -453,7 +453,7 @@ resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
   user_name     = "username1"
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-  engine        = "REDIS"
+  engine        = "redis"
   passwords     = ["password123456789"]
 }
 `, rName)
@@ -465,7 +465,7 @@ resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
   user_name     = "username1"
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-  engine        = "REDIS"
+  engine        = "redis"
 
   authentication_mode {
     type      = "password"
@@ -481,7 +481,7 @@ resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
   user_name     = %[1]q
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-  engine        = "REDIS"
+  engine        = "redis"
 
   authentication_mode {
     type = "iam"
@@ -496,7 +496,7 @@ resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
   user_name     = "username1"
   access_string = "on ~* +@all"
-  engine        = "REDIS"
+  engine        = "redis"
   passwords     = ["password234567891", "password345678912"]
 }
 `, rName)
@@ -520,7 +520,7 @@ resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
   user_name     = "username1"
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-  engine        = "REDIS"
+  engine        = "redis"
 
   authentication_mode {
     type      = "password"
@@ -536,7 +536,7 @@ resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
   user_name     = "username1"
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-  engine        = "REDIS"
+  engine        = "redis"
 
   authentication_mode {
     type      = "password"
@@ -552,7 +552,7 @@ resource "aws_elasticache_user" "test" {
   user_id       = %[1]q
   user_name     = "username1"
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-  engine        = "REDIS"
+  engine        = "redis"
   passwords     = ["password123456789"]
 
   tags = {

--- a/website/docs/r/elasticache_user.html.markdown
+++ b/website/docs/r/elasticache_user.html.markdown
@@ -20,7 +20,7 @@ resource "aws_elasticache_user" "test" {
   user_id       = "testUserId"
   user_name     = "testUserName"
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-  engine        = "REDIS"
+  engine        = "redis"
   passwords     = ["password123456789"]
 }
 ```
@@ -30,7 +30,7 @@ resource "aws_elasticache_user" "test" {
   user_id       = "testUserId"
   user_name     = "testUserName"
   access_string = "on ~* +@all"
-  engine        = "REDIS"
+  engine        = "redis"
 
   authentication_mode {
     type = "iam"
@@ -43,7 +43,7 @@ resource "aws_elasticache_user" "test" {
   user_id       = "testUserId"
   user_name     = "testUserName"
   access_string = "on ~* +@all"
-  engine        = "REDIS"
+  engine        = "redis"
 
   authentication_mode {
     type      = "password"
@@ -57,7 +57,7 @@ resource "aws_elasticache_user" "test" {
 The following arguments are required:
 
 * `access_string` - (Required) Access permissions string used for this user. See [Specifying Permissions Using an Access String](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.RBAC.html#Access-string) for more details.
-* `engine` - (Required) The current supported values are `REDIS`, `VALKEY` (case insensitive).
+* `engine` - (Required) The current supported values are `redis`, `valkey` (case insensitive).
 * `user_id` - (Required) The ID of the user.
 * `user_name` - (Required) The username of the user.
 

--- a/website/docs/r/elasticache_user.html.markdown
+++ b/website/docs/r/elasticache_user.html.markdown
@@ -57,7 +57,7 @@ resource "aws_elasticache_user" "test" {
 The following arguments are required:
 
 * `access_string` - (Required) Access permissions string used for this user. See [Specifying Permissions Using an Access String](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Clusters.RBAC.html#Access-string) for more details.
-* `engine` - (Required) The current supported values are `REDIS`, `VALKEY`.
+* `engine` - (Required) The current supported values are `REDIS`, `VALKEY` (case insensitive).
 * `user_id` - (Required) The ID of the user.
 * `user_name` - (Required) The username of the user.
 

--- a/website/docs/r/elasticache_user_group.html.markdown
+++ b/website/docs/r/elasticache_user_group.html.markdown
@@ -17,12 +17,12 @@ resource "aws_elasticache_user" "test" {
   user_id       = "testUserId"
   user_name     = "default"
   access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
-  engine        = "REDIS"
+  engine        = "redis"
   passwords     = ["password123456789"]
 }
 
 resource "aws_elasticache_user_group" "test" {
-  engine        = "REDIS"
+  engine        = "redis"
   user_group_id = "userGroupId"
   user_ids      = [aws_elasticache_user.test.user_id]
 }
@@ -32,7 +32,7 @@ resource "aws_elasticache_user_group" "test" {
 
 The following arguments are required:
 
-* `engine` - (Required) The current supported value are `REDIS`, `VALKEY` (case insensitive).
+* `engine` - (Required) The current supported value are `redis`, `valkey` (case insensitive).
 * `user_group_id` - (Required) The ID of the user group.
 
 The following arguments are optional:

--- a/website/docs/r/elasticache_user_group.html.markdown
+++ b/website/docs/r/elasticache_user_group.html.markdown
@@ -32,7 +32,7 @@ resource "aws_elasticache_user_group" "test" {
 
 The following arguments are required:
 
-* `engine` - (Required) The current supported value are `REDIS`, `VALKEY`.
+* `engine` - (Required) The current supported value are `REDIS`, `VALKEY` (case insensitive).
 * `user_group_id` - (Required) The ID of the user group.
 
 The following arguments are optional:


### PR DESCRIPTION


From what I can tell, the name isn't case sensitive, and even if you set it with the uppercase version, AWS will return the lowercase version (and the diff was already case-insensitive).






