### PR TITLE
docs: reduce cost foot print of example code

### DIFF
--- a/website/docs/r/fsx_windows_file_system.html.markdown
+++ b/website/docs/r/fsx_windows_file_system.html.markdown
@@ -22,9 +22,9 @@ Additional information for using AWS Directory Service with Windows File Systems
 resource "aws_fsx_windows_file_system" "example" {
   active_directory_id = aws_directory_service_directory.example.id
   kms_key_id          = aws_kms_key.example.arn
-  storage_capacity    = 300
+  storage_capacity    = 32
   subnet_ids          = [aws_subnet.example.id]
-  throughput_capacity = 1024
+  throughput_capacity = 32
 }
 ```
 
@@ -35,9 +35,9 @@ Additional information for using AWS Directory Service with Windows File Systems
 ```terraform
 resource "aws_fsx_windows_file_system" "example" {
   kms_key_id          = aws_kms_key.example.arn
-  storage_capacity    = 300
+  storage_capacity    = 32
   subnet_ids          = [aws_subnet.example.id]
-  throughput_capacity = 1024
+  throughput_capacity = 32
 
   self_managed_active_directory {
     dns_ips     = ["10.0.0.111", "10.0.0.222"]


### PR DESCRIPTION
### Description

The examples provided for the resource [`aws_fsx_windows_file_system`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fsx_windows_file_system
) use a throughput capacity of 1024 MBps.

The AWS pricing calculator shows  cost of 1.10 USD per  MBps-month  (or more), so that each of the example creates  monthly cost of > 1k USD.

With this PR we update throughput capacity and storage, so that users can still run the example code but with significantly less cost.

### Relations

Closes #40817 

### References

- [FSx pricing](https://aws.amazon.com/fsx/windows/pricing/)
- [Announcement: Minimum storage size FSx Windows](https://aws.amazon.com/about-aws/whats-new/2019/11/amazon-fsx-for-windows-file-server-reduces-the-minimum-size-for-file-systems-from-300-gbs-to-32-gbs/)

### Output from Acceptance Testing

Not applicable, only documentation is updated.