### PR TITLE
testing: Reduce uses of `resource.TestCheckResourceAttrSet` with ARN attributes: `a` services

### DIFF
--- a/internal/service/amp/scraper_test.go
+++ b/internal/service/amp/scraper_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/amp"
 	"github.com/aws/aws-sdk-go-v2/service/amp/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -39,12 +40,17 @@ func TestAccAMPScraper_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccScraperConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckScraperExists(ctx, resourceName, &scraper),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrAlias),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					func(s *terraform.State) error {
+						return acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "aps", "scraper/"+aws.ToString(scraper.ScraperId))(s)
+					},
 					resource.TestCheckResourceAttr(resourceName, "destination.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "destination.0.amp.#", "1"),
+					func(s *terraform.State) error {
+						return resource.TestCheckResourceAttr(resourceName, names.AttrID, aws.ToString(scraper.ScraperId))(s)
+					},
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrRoleARN),
 					resource.TestCheckResourceAttrSet(resourceName, "scrape_configuration"),
 					resource.TestCheckResourceAttr(resourceName, "source.#", "1"),

--- a/internal/service/appautoscaling/target_test.go
+++ b/internal/service/appautoscaling/target_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -34,9 +35,9 @@ func TestAccAppAutoScalingTarget_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTargetConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTargetExists(ctx, resourceName, &target),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "application-autoscaling", regexache.MustCompile(`scalable-target/\w+$`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrMaxCapacity, "3"),
 					resource.TestCheckResourceAttr(resourceName, "min_capacity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "scalable_dimension", "ecs:service:DesiredCount"),

--- a/internal/service/appfabric/ingestion_destination_test.go
+++ b/internal/service/appfabric/ingestion_destination_test.go
@@ -43,8 +43,8 @@ func testAccIngestionDestination_basic(t *testing.T) {
 				Config: testAccIngestionDestinationConfig_basic(rName, tenantID, serviceAccountToken),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIngestionDestinationExists(ctx, resourceName, &ingestiondestination),
-					resource.TestCheckResourceAttrSet(resourceName, "app_bundle_arn"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, "app_bundle_arn", "aws_appfabric_app_bundle.test", names.AttrARN),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN), // nosemgrep:ci.semgrep.acctest.checks.arn-resourceattrset // TODO: need TFC Org for testing
 					resource.TestCheckResourceAttr(resourceName, "destination_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "destination_configuration.0.audit_log.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "destination_configuration.0.audit_log.0.destination.#", "1"),
@@ -52,7 +52,7 @@ func testAccIngestionDestination_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "destination_configuration.0.audit_log.0.destination.0.s3_bucket.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "destination_configuration.0.audit_log.0.destination.0.s3_bucket.0.bucket_name", rName),
 					resource.TestCheckNoResourceAttr(resourceName, "destination_configuration.0.audit_log.0.destination.0.s3_bucket.0.prefix"),
-					resource.TestCheckResourceAttrSet(resourceName, "ingestion_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "ingestion_arn", "aws_appfabric_ingestion.test", names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "processing_configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "processing_configuration.0.audit_log.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "processing_configuration.0.audit_log.0.format", names.AttrJSON),

--- a/internal/service/appfabric/ingestion_test.go
+++ b/internal/service/appfabric/ingestion_test.go
@@ -44,7 +44,7 @@ func testAccIngestion_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIngestionExists(ctx, resourceName, &ingestion),
 					resource.TestCheckResourceAttr(resourceName, "app", "TERRAFORMCLOUD"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN), // nosemgrep:ci.semgrep.acctest.checks.arn-resourceattrset // TODO: need TFC Org for testing
 					resource.TestCheckResourceAttr(resourceName, "ingestion_type", "auditLog"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),

--- a/internal/service/appintegrations/data_integration_test.go
+++ b/internal/service/appintegrations/data_integration_test.go
@@ -47,7 +47,7 @@ func TestAccAppIntegrationsDataIntegration_basic(t *testing.T) {
 				Config: testAccDataIntegrationConfig_basic(rName, description, sourceUri, firstExecutionFrom),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataIntegrationExists(ctx, resourceName, &dataIntegration),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN), // nosemgrep:ci.semgrep.acctest.checks.arn-resourceattrset // TODO: need TFC Org for testing
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrKMSKey, "aws_kms_key.test", names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),

--- a/internal/service/appintegrations/event_integration_test.go
+++ b/internal/service/appintegrations/event_integration_test.go
@@ -47,15 +47,14 @@ func TestAccAppIntegrationsEventIntegration_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEventIntegrationConfig_basic(rName, originalDescription, sourceName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEventIntegrationExists(ctx, resourceName, &eventIntegration),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "app-integrations", "event-integration/"+rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, originalDescription),
 					resource.TestCheckResourceAttr(resourceName, "eventbridge_bus", "default"),
 					resource.TestCheckResourceAttr(resourceName, "event_filter.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_filter.0.source", sourceName),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Event Integration"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),
 			},
 			{
@@ -65,95 +64,14 @@ func TestAccAppIntegrationsEventIntegration_basic(t *testing.T) {
 			},
 			{
 				Config: testAccEventIntegrationConfig_basic(rName, updatedDescription, sourceName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEventIntegrationExists(ctx, resourceName, &eventIntegration),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "app-integrations", "event-integration/"+rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, updatedDescription),
 					resource.TestCheckResourceAttr(resourceName, "eventbridge_bus", "default"),
 					resource.TestCheckResourceAttr(resourceName, "event_filter.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "event_filter.0.source", sourceName),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Event Integration"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAppIntegrationsEventIntegration_updateTags(t *testing.T) {
-	ctx := acctest.Context(t)
-	var eventIntegration appintegrations.GetEventIntegrationOutput
-
-	rName := sdkacctest.RandomWithPrefix("resource-test-terraform")
-	description := "example description"
-	resourceName := "aws_appintegrations_event_integration.test"
-
-	key := "EVENT_BRIDGE_PARTNER_EVENT_SOURCE_NAME"
-	var sourceName string
-	sourceName = os.Getenv(key)
-	if sourceName == "" {
-		sourceName = "aws.partner/examplepartner.com"
-	}
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, names.AppIntegrationsEndpointID)
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckEventIntegrationDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccEventIntegrationConfig_basic(rName, description, sourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEventIntegrationExists(ctx, resourceName, &eventIntegration),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
-					resource.TestCheckResourceAttr(resourceName, "eventbridge_bus", "default"),
-					resource.TestCheckResourceAttr(resourceName, "event_filter.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "event_filter.0.source", sourceName),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Event Integration"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccEventIntegrationConfig_tags(rName, description, sourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEventIntegrationExists(ctx, resourceName, &eventIntegration),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
-					resource.TestCheckResourceAttr(resourceName, "eventbridge_bus", "default"),
-					resource.TestCheckResourceAttr(resourceName, "event_filter.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "event_filter.0.source", sourceName),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Event Integration"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2a"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccEventIntegrationConfig_tagsUpdated(rName, description, sourceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEventIntegrationExists(ctx, resourceName, &eventIntegration),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
-					resource.TestCheckResourceAttr(resourceName, "eventbridge_bus", "default"),
-					resource.TestCheckResourceAttr(resourceName, "event_filter.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "event_filter.0.source", sourceName),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "3"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Name", "Test Event Integration"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key2", "Value2b"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Key3", "Value3"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),
 			},
 		},
@@ -253,49 +171,6 @@ resource "aws_appintegrations_event_integration" "test" {
 
   event_filter {
     source = %[3]q
-  }
-
-  tags = {
-    "Name" = "Test Event Integration"
-  }
-}
-`, rName, label, sourceName)
-}
-
-func testAccEventIntegrationConfig_tags(rName, label, sourceName string) string {
-	return fmt.Sprintf(`
-resource "aws_appintegrations_event_integration" "test" {
-  name            = %[1]q
-  description     = %[2]q
-  eventbridge_bus = "default"
-
-  event_filter {
-    source = %[3]q
-  }
-
-  tags = {
-    "Name" = "Test Event Integration"
-    "Key2" = "Value2a"
-  }
-}
-`, rName, label, sourceName)
-}
-
-func testAccEventIntegrationConfig_tagsUpdated(rName, label, sourceName string) string {
-	return fmt.Sprintf(`
-resource "aws_appintegrations_event_integration" "test" {
-  name            = %[1]q
-  description     = %[2]q
-  eventbridge_bus = "default"
-
-  event_filter {
-    source = %[3]q
-  }
-
-  tags = {
-    "Name" = "Test Event Integration"
-    "Key2" = "Value2b"
-    "Key3" = "Value3"
   }
 }
 `, rName, label, sourceName)

--- a/internal/service/appstream/image_data_source_test.go
+++ b/internal/service/appstream/image_data_source_test.go
@@ -6,6 +6,7 @@ package appstream_test
 import (
 	"testing"
 
+	awstypes "github.com/aws/aws-sdk-go-v2/service/appstream/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -32,16 +33,16 @@ func TestAccAppStreamImageDataSource_basic(t *testing.T) {
 
 					resource.TestCheckResourceAttrSet(dataSourceName, "applications.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "appstream_agent_version"),
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrARN),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrARN), // nosemgrep:ci.semgrep.acctest.checks.arn-resourceattrset
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrCreatedTime),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrDescription),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrDisplayName),
 					resource.TestCheckResourceAttrSet(dataSourceName, "image_builder_supported"),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrName),
-					resource.TestCheckResourceAttrSet(dataSourceName, "name_regex"),
+					resource.TestCheckResourceAttr(dataSourceName, "name_regex", "^AppStream-WinServer.*$"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "platform"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "public_base_image_released_date"),
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrType),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrType, string(awstypes.VisibilityTypePublic)),
 				),
 			},
 		},


### PR DESCRIPTION
### Description

Reduce uses of `resource.TestCheckResourceAttrSet` with ARN attributes in favour of explicit checks
