### PR TITLE
sweepers: fix opensearchserverless resource references

### DIFF
--- a/internal/service/opensearchserverless/sweep.go
+++ b/internal/service/opensearchserverless/sweep.go
@@ -164,7 +164,7 @@ func sweepSecurityConfigs(region string) error {
 			id := aws.ToString(sc.Id)
 
 			log.Printf("[INFO] Deleting OpenSearch Serverless Security Config: %s", id)
-			sweepResources = append(sweepResources, framework.NewSweepResource(newResourceCollection, client,
+			sweepResources = append(sweepResources, framework.NewSweepResource(newResourceSecurityConfig, client,
 				framework.NewAttribute(names.AttrID, id),
 			))
 		}
@@ -209,7 +209,7 @@ func sweepSecurityPolicies(region string) error {
 			name := aws.ToString(sp.Name)
 
 			log.Printf("[INFO] Deleting OpenSearch Serverless Security Policy: %s", name)
-			sweepResources = append(sweepResources, framework.NewSweepResource(newResourceCollection, client,
+			sweepResources = append(sweepResources, framework.NewSweepResource(newResourceSecurityPolicy, client,
 				framework.NewAttribute(names.AttrID, name),
 				framework.NewAttribute(names.AttrName, name),
 				framework.NewAttribute(names.AttrType, sp.Type),
@@ -236,7 +236,7 @@ func sweepSecurityPolicies(region string) error {
 			name := aws.ToString(sp.Name)
 
 			log.Printf("[INFO] Deleting OpenSearch Serverless Security Policy: %s", name)
-			sweepResources = append(sweepResources, framework.NewSweepResource(newResourceCollection, client,
+			sweepResources = append(sweepResources, framework.NewSweepResource(newResourceSecurityPolicy, client,
 				framework.NewAttribute(names.AttrID, name),
 				framework.NewAttribute(names.AttrName, name),
 				framework.NewAttribute(names.AttrType, sp.Type),
@@ -281,7 +281,7 @@ func sweepVPCEndpoints(region string) error {
 			id := aws.ToString(endpoint.Id)
 
 			log.Printf("[INFO] Deleting OpenSearch Serverless VPC Endpoint: %s", id)
-			sweepResources = append(sweepResources, framework.NewSweepResource(newResourceCollection, client,
+			sweepResources = append(sweepResources, framework.NewSweepResource(newVPCEndpointResource, client,
 				framework.NewAttribute(names.AttrID, id),
 			))
 		}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Multiple sweeper fixes

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sweep SWEEPARGS='-sweep-run=aws_opensearchserverless -sweep-allow-failures'

# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.23.3 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run=aws_opensearchserverless -sweep-allow-failures -timeout 360m
2025/01/08 11:16:38 [DEBUG] Running Sweepers for region (us-west-2):
2025/01/08 11:16:38 [DEBUG] Running Sweeper (aws_opensearchserverless_vpc_endpoint) in region (us-west-2)
2025/01/08 11:16:38 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2
2025-01-08T11:16:38.134-0600 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-2
2025-01-08T11:16:38.134-0600 [DEBUG] sweeper.aws-base: Using profile: sweeper_region=us-west-2 tf_aws.profile=default tf_aws.profile.source=envvar
2025-01-08T11:16:38.134-0600 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2
2025-01-08T11:16:38.136-0600 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-2
2025-01-08T11:16:38.136-0600 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-2 tf_aws.credentials_source="SharedConfigCredentials: /Users/adrianjohnson/.aws/credentials"
2025-01-08T11:16:38.136-0600 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2
2025/01/08 11:16:38 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-west-2
2025/01/08 11:16:38 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-2
2025-01-08T11:16:38.137-0600 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-2
2025-01-08T11:16:38.460-0600 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-2
2025/01/08 11:16:38 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2
2025/01/08 11:16:38 [DEBUG] Completed Sweeper (aws_opensearchserverless_vpc_endpoint) in region (us-west-2) in 670.893583ms
2025/01/08 11:16:38 [DEBUG] Running Sweeper (aws_opensearchserverless_security_policy) in region (us-west-2)
2025/01/08 11:16:39 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2
2025/01/08 11:16:39 [DEBUG] Completed Sweeper (aws_opensearchserverless_security_policy) in region (us-west-2) in 203.867208ms
2025/01/08 11:16:39 [DEBUG] Running Sweeper (aws_opensearchserverless_access_policy) in region (us-west-2)
2025/01/08 11:16:39 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2
2025/01/08 11:16:39 [DEBUG] Completed Sweeper (aws_opensearchserverless_access_policy) in region (us-west-2) in 107.581666ms
2025/01/08 11:16:39 [DEBUG] Running Sweeper (aws_opensearchserverless_security_config) in region (us-west-2)
2025/01/08 11:16:39 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2
2025/01/08 11:16:39 [DEBUG] Completed Sweeper (aws_opensearchserverless_security_config) in region (us-west-2) in 99.157208ms
2025/01/08 11:16:39 [DEBUG] Running Sweeper (aws_opensearchserverless_collection) in region (us-west-2)
2025/01/08 11:16:39 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2
2025/01/08 11:16:39 [DEBUG] Completed Sweeper (aws_opensearchserverless_collection) in region (us-west-2) in 100.103542ms
2025/01/08 11:16:39 Completed Sweepers for region (us-west-2) in 1.181964042s
2025/01/08 11:16:39 Sweeper Tests for region (us-west-2) ran successfully:
2025/01/08 11:16:39     - aws_opensearchserverless_vpc_endpoint
2025/01/08 11:16:39     - aws_opensearchserverless_security_policy
2025/01/08 11:16:39     - aws_opensearchserverless_access_policy
2025/01/08 11:16:39     - aws_opensearchserverless_security_config
2025/01/08 11:16:39     - aws_opensearchserverless_collection
2025/01/08 11:16:39 [DEBUG] Running Sweepers for region (us-east-1):
2025/01/08 11:16:39 [DEBUG] Running Sweeper (aws_opensearchserverless_security_policy) in region (us-east-1)
2025/01/08 11:16:39 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-1
2025-01-08T11:16:39.315-0600 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-1
2025-01-08T11:16:39.315-0600 [DEBUG] sweeper.aws-base: Using profile: sweeper_region=us-east-1 tf_aws.profile=default tf_aws.profile.source=envvar
2025-01-08T11:16:39.315-0600 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1
2025-01-08T11:16:39.317-0600 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-1
2025-01-08T11:16:39.317-0600 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-1 tf_aws.credentials_source="SharedConfigCredentials: /Users/adrianjohnson/.aws/credentials"
2025-01-08T11:16:39.317-0600 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1
2025/01/08 11:16:39 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-east-1
2025/01/08 11:16:39 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-1
2025-01-08T11:16:39.318-0600 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-1
2025-01-08T11:16:39.528-0600 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-1
2025/01/08 11:16:39 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1
2025/01/08 11:16:39 [DEBUG] Completed Sweeper (aws_opensearchserverless_security_policy) in region (us-east-1) in 640.271834ms
2025/01/08 11:16:39 [DEBUG] Running Sweeper (aws_opensearchserverless_access_policy) in region (us-east-1)
2025/01/08 11:16:40 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_access_policy) in region (us-east-1) in 81.494625ms
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_security_config) in region (us-east-1)
2025/01/08 11:16:40 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_security_config) in region (us-east-1) in 75.926375ms
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_collection) in region (us-east-1)
2025/01/08 11:16:40 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_collection) in region (us-east-1) in 73.926791ms
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_vpc_endpoint) in region (us-east-1)
2025/01/08 11:16:40 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_vpc_endpoint) in region (us-east-1) in 84.689583ms
2025/01/08 11:16:40 Completed Sweepers for region (us-east-1) in 956.4535ms
2025/01/08 11:16:40 Sweeper Tests for region (us-east-1) ran successfully:
2025/01/08 11:16:40     - aws_opensearchserverless_security_policy
2025/01/08 11:16:40     - aws_opensearchserverless_access_policy
2025/01/08 11:16:40     - aws_opensearchserverless_security_config
2025/01/08 11:16:40     - aws_opensearchserverless_collection
2025/01/08 11:16:40     - aws_opensearchserverless_vpc_endpoint
2025/01/08 11:16:40 [DEBUG] Running Sweepers for region (us-east-2):
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_vpc_endpoint) in region (us-east-2)
2025/01/08 11:16:40 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-2
2025-01-08T11:16:40.273-0600 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-2
2025-01-08T11:16:40.273-0600 [DEBUG] sweeper.aws-base: Using profile: tf_aws.profile.source=envvar sweeper_region=us-east-2 tf_aws.profile=default
2025-01-08T11:16:40.273-0600 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2
2025-01-08T11:16:40.274-0600 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-2
2025-01-08T11:16:40.274-0600 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-2 tf_aws.credentials_source="SharedConfigCredentials: /Users/adrianjohnson/.aws/credentials"
2025-01-08T11:16:40.274-0600 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2
2025/01/08 11:16:40 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-east-2
2025/01/08 11:16:40 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-2
2025-01-08T11:16:40.276-0600 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-2
2025-01-08T11:16:40.473-0600 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-2
2025/01/08 11:16:40 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_vpc_endpoint) in region (us-east-2) in 471.9955ms
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_security_policy) in region (us-east-2)
2025/01/08 11:16:40 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_security_policy) in region (us-east-2) in 106.86ms
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_access_policy) in region (us-east-2)
2025/01/08 11:16:40 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_access_policy) in region (us-east-2) in 49.106625ms
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_security_config) in region (us-east-2)
2025/01/08 11:16:40 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_security_config) in region (us-east-2) in 48.906041ms
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_collection) in region (us-east-2)
2025/01/08 11:16:40 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_collection) in region (us-east-2) in 49.180875ms
2025/01/08 11:16:40 Completed Sweepers for region (us-east-2) in 726.149875ms
2025/01/08 11:16:40 Sweeper Tests for region (us-east-2) ran successfully:
2025/01/08 11:16:40     - aws_opensearchserverless_collection
2025/01/08 11:16:40     - aws_opensearchserverless_vpc_endpoint
2025/01/08 11:16:40     - aws_opensearchserverless_security_policy
2025/01/08 11:16:40     - aws_opensearchserverless_access_policy
2025/01/08 11:16:40     - aws_opensearchserverless_security_config
2025/01/08 11:16:40 [DEBUG] Running Sweepers for region (us-west-1):
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_vpc_endpoint) in region (us-west-1)
2025/01/08 11:16:40 [WARN] Skipping OpenSearch Serverless Security Policy sweep for region: us-west-1
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_vpc_endpoint) in region (us-west-1) in 97.75µs
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_security_policy) in region (us-west-1)
2025/01/08 11:16:40 [WARN] Skipping OpenSearch Serverless Security Policy sweep for region: us-west-1
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_security_policy) in region (us-west-1) in 11.75µs
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_access_policy) in region (us-west-1)
2025/01/08 11:16:40 [WARN] Skipping OpenSearch Serverless Access Policy sweep for region: us-west-1
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_access_policy) in region (us-west-1) in 51.709µs
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_security_config) in region (us-west-1)
2025/01/08 11:16:40 [WARN] Skipping OpenSearch Serverless Security Config sweep for region: us-west-1
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_security_config) in region (us-west-1) in 14.333µs
2025/01/08 11:16:40 [DEBUG] Running Sweeper (aws_opensearchserverless_collection) in region (us-west-1)
2025/01/08 11:16:40 [WARN] Skipping OpenSearch Serverless Collection sweep for region: us-west-1
2025/01/08 11:16:40 [DEBUG] Completed Sweeper (aws_opensearchserverless_collection) in region (us-west-1) in 9.916µs
2025/01/08 11:16:40 Completed Sweepers for region (us-west-1) in 241.708µs
2025/01/08 11:16:40 Sweeper Tests for region (us-west-1) ran successfully:
2025/01/08 11:16:40     - aws_opensearchserverless_vpc_endpoint
2025/01/08 11:16:40     - aws_opensearchserverless_security_policy
2025/01/08 11:16:40     - aws_opensearchserverless_access_policy
2025/01/08 11:16:40     - aws_opensearchserverless_security_config
2025/01/08 11:16:40     - aws_opensearchserverless_collection
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      9.312s
```
