### PR TITLE
r/aws_apigatewayv2: additional `ConflictException` retry logic

### DIFF
--- a/.changelog/40840.txt
+++ b/.changelog/40840.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_apigatewayv2_route: Fix retry handling of `ConflictException` error responses
+```
+```release-note:note
+provider: The retry handling in the `apigatewayv2` client has been updated to more extensively match `ConflictException` error responses. This change should be transparent to users, but if any unexpected changes in behavior with `apigatewayv2` resources occur following an upgrade to this release, please open a bug report.
+```

--- a/internal/service/apigatewayv2/service_package.go
+++ b/internal/service/apigatewayv2/service_package.go
@@ -27,6 +27,13 @@ func (p *servicePackage) NewClient(ctx context.Context, config map[string]any) (
 				if errs.IsAErrorMessageContains[*awstypes.ConflictException](err, "try again later") {
 					return aws.TrueTernary
 				}
+				// In some instances, ConflictException error responses have been observed as
+				// a *smithy.OperationError type (not an *awstypes.ConflictException), which
+				// can't be handled via errs.IsAErrorMessageContains. Instead we fall back
+				// to a simple match on the message contents.
+				if errs.Contains(err, "Unable to complete operation due to concurrent modification. Please try again later.") {
+					return aws.TrueTernary
+				}
 				return aws.UnknownTernary // Delegate to configured Retryer.
 			}))
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change adds an additional step to the `apigatewayv2` service client retry logic to check for `ConflictException` error responses based solely on the message content. This is intended to address cases where the error is not serialized into the higher level `types.ConflictException` defined as the service package level (which the existing logic expects). Local testing of the configuration provided in the linked issue confirmed this additional logic prevents the intermittent failures observed during destruction of large numbers of routes in parallel.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40575

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- [`*smithy.OperationError`](https://github.com/aws/smithy-go/blob/v1.22.1/errors.go#L42-L48)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=apigatewayv2 TESTS=TestAccAPIGatewayV2Route_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2Route_'  -timeout 360m
2025/01/08 15:06:20 Initializing Terraform AWS Provider...

--- PASS: TestAccAPIGatewayV2Route_disappears (17.18s)
--- PASS: TestAccAPIGatewayV2Route_basic (18.81s)
--- PASS: TestAccAPIGatewayV2Route_target (19.62s)
--- PASS: TestAccAPIGatewayV2Route_model (19.76s)
--- PASS: TestAccAPIGatewayV2Route_updateRouteKey (27.79s)
--- PASS: TestAccAPIGatewayV2Route_requestParameters (36.06s)
--- PASS: TestAccAPIGatewayV2Route_simpleAttributes (36.27s)
--- PASS: TestAccAPIGatewayV2Route_authorizer (53.29s)
--- PASS: TestAccAPIGatewayV2Route_jwtAuthorization (53.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2       59.735s
```