### PR TITLE
r/aws_codebuild_project: Allow `file_system_locations` to be removed on Update

### DIFF
--- a/.changelog/40842.txt
+++ b/.changelog/40842.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_codebuild_project: Allow `file_system_locations` to be removed on Update
+```

--- a/internal/service/codebuild/project.go
+++ b/internal/service/codebuild/project.go
@@ -1020,6 +1020,8 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		if d.HasChange("file_system_locations") {
 			if v, ok := d.GetOk("file_system_locations"); ok && v.(*schema.Set).Len() > 0 {
 				input.FileSystemLocations = expandProjectFileSystemLocations(v.(*schema.Set).List())
+			} else {
+				input.FileSystemLocations = []types.ProjectFileSystemLocation{}
 			}
 		}
 


### PR DESCRIPTION
### Description
This PR fixes the `aws_codebuild_project` to allow the `file_system_locations` configuration to be removed on Update.

### Relations
Closes #38888.

### References
https://docs.aws.amazon.com/codebuild/latest/APIReference/API_UpdateProject.html

### Output from Acceptance Testing
```console
% make testacc PKG=codebuild ACCTEST_PARALLELISM=1 TESTARGS="-run=TestAccCodeBuildProject_fileSystemLocations"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/codebuild/... -v -count 1 -parallel 1  -run=TestAccCodeBuildProject_fileSystemLocations -timeout 360m
2025/01/08 16:48:54 Initializing Terraform AWS Provider...
=== RUN   TestAccCodeBuildProject_fileSystemLocations
=== PAUSE TestAccCodeBuildProject_fileSystemLocations
=== CONT  TestAccCodeBuildProject_fileSystemLocations
--- PASS: TestAccCodeBuildProject_fileSystemLocations (72.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  78.406s
```
