### PR TITLE
docs: Add deprecation notice of datasources arg for aws_guardduty_organization_configuration

### DIFF
--- a/website/docs/r/guardduty_organization_configuration.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration.html.markdown
@@ -53,7 +53,7 @@ This resource supports the following arguments:
 * `auto_enable` - (Optional) *Deprecated:* Use `auto_enable_organization_members` instead. When this setting is enabled, all new accounts that are created in, or added to, the organization are added as a member accounts of the organization’s GuardDuty delegated administrator and GuardDuty is enabled in that AWS Region.
 * `auto_enable_organization_members` - (Optional) Indicates the auto-enablement configuration of GuardDuty for the member accounts in the organization. Valid values are `ALL`, `NEW`, `NONE`.
 * `detector_id` - (Required) The detector ID of the GuardDuty account.
-* `datasources` - (Optional) Configuration for the collected datasources.
+* `datasources` - (Optional) Configuration for the collected datasources. [Deprecated](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty-feature-object-api-changes-march2023.html) in favor of [`aws_guardduty_organization_configuration_feature` resources](guardduty_organization_configuration_feature.html).
 
 `datasources` supports the following:
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add a deprecation notice for the `datasources` argument for the `aws_guardduty_organization_configuration` resource, similar to that of the `aws_guardduty_detector` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37809

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the [`aws_guardduty_detector` resource doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector) for wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

n/a