### PR TITLE
testing: Reduce uses of `resource.TestCheckResourceAttrSet` with ARN attributes: `b` and `c` services

### DIFF
--- a/.ci/semgrep/acctest/checks/arn.go
+++ b/.ci/semgrep/acctest/checks/arn.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func test1(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	const resourceName = "aws_prometheus_scraper.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckScraperDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScraperConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// ruleid: arn-resourceattrset
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					// ok: arn-resourceattrset
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "aps", regexache.MustCompile(`scraper/\w+$`)),
+					// todoruleid: arn-resourceattrset
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrRoleARN),
+					// todoruleid: arn-resourceattrset
+					resource.TestCheckResourceAttrSet(resourceName, "some_other_arn"),
+				),
+			},
+		},
+	})
+
+}

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -4,7 +4,6 @@ rules:
     message: Use one of the `acctest` ARN value checks or TestCheckResourceAttrPair
     paths:
       exclude:
-        - "internal/service/configservice"
         - "internal/service/connect"
         - "internal/service/controltower"
         - "internal/service/datazone"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -4,7 +4,6 @@ rules:
     message: Use one of the `acctest` ARN value checks or TestCheckResourceAttrPair
     paths:
       exclude:
-        - "internal/service/cloudfront"
         - "internal/service/cloudtrail"
         - "internal/service/codeguruprofiler"
         - "internal/service/configservice"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -4,7 +4,6 @@ rules:
     message: Use one of the `acctest` ARN value checks or TestCheckResourceAttrPair
     paths:
       exclude:
-        - "internal/service/cloudtrail"
         - "internal/service/codeguruprofiler"
         - "internal/service/configservice"
         - "internal/service/connect"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -4,7 +4,6 @@ rules:
     message: Use one of the `acctest` ARN value checks or TestCheckResourceAttrPair
     paths:
       exclude:
-        - "internal/service/codeguruprofiler"
         - "internal/service/configservice"
         - "internal/service/connect"
         - "internal/service/controltower"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -4,7 +4,6 @@ rules:
     message: Use one of the `acctest` ARN value checks or TestCheckResourceAttrPair
     paths:
       exclude:
-        - "internal/service/chimesdkvoice"
         - "internal/service/cloudfront"
         - "internal/service/cloudtrail"
         - "internal/service/codeguruprofiler"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -1,0 +1,65 @@
+rules:
+  - id: arn-resourceattrset
+    languages: [go]
+    message: Use one of the `acctest` ARN value checks or TestCheckResourceAttrPair
+    paths:
+      exclude:
+        - "internal/service/chimesdkvoice"
+        - "internal/service/cloudfront"
+        - "internal/service/cloudtrail"
+        - "internal/service/codeguruprofiler"
+        - "internal/service/configservice"
+        - "internal/service/connect"
+        - "internal/service/controltower"
+        - "internal/service/datazone"
+        - "internal/service/deploy"
+        - "internal/service/directconnect"
+        - "internal/service/dms"
+        - "internal/service/docdb"
+        - "internal/service/docdbelastic"
+        - "internal/service/drs"
+        - "internal/service/ec2"
+        - "internal/service/elasticache"
+        - "internal/service/elasticbeanstalk"
+        - "internal/service/elb"
+        - "internal/service/elbv2"
+        - "internal/service/events"
+        - "internal/service/firehose"
+        - "internal/service/globalaccelerator"
+        - "internal/service/guardduty"
+        - "internal/service/iam"
+        - "internal/service/iot"
+        - "internal/service/kafka"
+        - "internal/service/kafkaconnect"
+        - "internal/service/kendra"
+        - "internal/service/kinesis"
+        - "internal/service/kinesisvideo"
+        - "internal/service/lexmodels"
+        - "internal/service/lightsail"
+        - "internal/service/medialive"
+        - "internal/service/memorydb"
+        - "internal/service/networkmanager"
+        - "internal/service/networkmonitor"
+        - "internal/service/oam"
+        - "internal/service/organizations"
+        - "internal/service/pinpoint"
+        - "internal/service/redshift"
+        - "internal/service/rekognition"
+        - "internal/service/resourcegroups"
+        - "internal/service/route53resolver"
+        - "internal/service/s3"
+        - "internal/service/servicediscovery"
+        - "internal/service/ses"
+        - "internal/service/signer"
+        - "internal/service/transcribe"
+        - "internal/service/transfer"
+    patterns:
+      - pattern: |
+          resource.TestCheckResourceAttrSet($NAME, $ATTR)
+      - metavariable-pattern:
+          metavariable: $ATTR
+          patterns:
+            - pattern-either:
+                - pattern: names.AttrARN
+                # - pattern-regex: arn
+    severity: ERROR

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -382,14 +382,14 @@ sane: prereq-go ## Run sane check
 	@echo "make: NOTE: NOT an exhaustive set of tests! Finds big problems only."
 	@TF_ACC=1 $(GO_VER) test \
 		./internal/service/iam/... \
-		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccIAMRole_basic|TestAccIAMRole_namePrefix|TestAccIAMRole_disappears|TestAccIAMRole_InlinePolicy_basic|TestAccIAMPolicyDocumentDataSource_basic|TestAccIAMPolicyDocumentDataSource_sourceConflicting|TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON|TestAccIAMRolePolicyAttachment_basic|TestAccIAMRolePolicyAttachment_disappears|TestAccIAMRolePolicyAttachment_Disappears_role|TestAccIAMPolicy_basic|TestAccIAMPolicy_policy|TestAccIAMPolicy_tags|TestAccIAMRolePolicy_basic|TestAccIAMRolePolicy_unknownsInPolicy|TestAccIAMInstanceProfile_basic|TestAccIAMInstanceProfile_tags' -timeout $(ACCTEST_TIMEOUT)
+		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccIAMRole_basic|TestAccIAMRole_namePrefix|TestAccIAMRole_disappears|TestAccIAMRole_InlinePolicy_basic|TestAccIAMPolicyDocumentDataSource_basic|TestAccIAMPolicyDocumentDataSource_sourceConflicting|TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON|TestAccIAMRolePolicyAttachment_basic|TestAccIAMRolePolicyAttachment_disappears|TestAccIAMRolePolicyAttachment_Disappears_role|TestAccIAMPolicy_basic|TestAccIAMPolicy_policy|TestAccIAMPolicy_tags|TestAccIAMRolePolicy_basic|TestAccIAMRolePolicy_unknownsInPolicy|TestAccIAMInstanceProfile_basic|TestAccIAMInstanceProfile_tags' -timeout $(ACCTEST_TIMEOUT) -vet=off
 	@TF_ACC=1 $(GO_VER) test \
 		./internal/service/logs/... \
 		./internal/service/ec2/... \
 		./internal/service/ecs/... \
 		./internal/service/elbv2/... \
 		./internal/service/kms/... \
-		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccVPCSecurityGroup_basic|TestAccVPCSecurityGroup_egressMode|TestAccVPCSecurityGroup_vpcAllEgress|TestAccVPCSecurityGroupRule_race|TestAccVPCSecurityGroupRule_protocolChange|TestAccVPCDataSource_basic|TestAccVPCSubnet_basic|TestAccVPC_tenancy|TestAccVPCRouteTableAssociation_Subnet_basic|TestAccVPCRouteTable_basic|TestAccLogsGroup_basic|TestAccLogsGroup_multiple|TestAccKMSKey_basic|TestAccELBV2TargetGroup_basic|TestAccECSTaskDefinition_basic|TestAccECSService_basic' -timeout $(ACCTEST_TIMEOUT)
+		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccVPCSecurityGroup_basic|TestAccVPCSecurityGroup_egressMode|TestAccVPCSecurityGroup_vpcAllEgress|TestAccVPCSecurityGroupRule_race|TestAccVPCSecurityGroupRule_protocolChange|TestAccVPCDataSource_basic|TestAccVPCSubnet_basic|TestAccVPC_tenancy|TestAccVPCRouteTableAssociation_Subnet_basic|TestAccVPCRouteTable_basic|TestAccLogsGroup_basic|TestAccLogsGroup_multiple|TestAccKMSKey_basic|TestAccELBV2TargetGroup_basic|TestAccECSTaskDefinition_basic|TestAccECSService_basic' -timeout $(ACCTEST_TIMEOUT) -vet=off
 	@TF_ACC=1 $(GO_VER) test \
 		./internal/service/lambda/... \
 		./internal/service/meta/... \
@@ -397,7 +397,7 @@ sane: prereq-go ## Run sane check
 		./internal/service/s3/... \
 		./internal/service/secretsmanager/... \
 		./internal/service/sts/... \
-		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccSTSCallerIdentityDataSource_basic|TestAccMetaRegionDataSource_basic|TestAccMetaRegionDataSource_endpoint|TestAccMetaPartitionDataSource_basic|TestAccS3Bucket_Basic_basic|TestAccS3Bucket_Security_corsUpdate|TestAccS3BucketPublicAccessBlock_basic|TestAccS3BucketPolicy_basic|TestAccS3BucketACL_updateACL|TestAccRoute53Record_basic|TestAccRoute53Record_Latency_basic|TestAccRoute53ZoneDataSource_name|TestAccLambdaFunction_basic|TestAccLambdaPermission_basic|TestAccSecretsManagerSecret_basic' -timeout $(ACCTEST_TIMEOUT)
+		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccSTSCallerIdentityDataSource_basic|TestAccMetaRegionDataSource_basic|TestAccMetaRegionDataSource_endpoint|TestAccMetaPartitionDataSource_basic|TestAccS3Bucket_Basic_basic|TestAccS3Bucket_Security_corsUpdate|TestAccS3BucketPublicAccessBlock_basic|TestAccS3BucketPolicy_basic|TestAccS3BucketACL_updateACL|TestAccRoute53Record_basic|TestAccRoute53Record_Latency_basic|TestAccRoute53ZoneDataSource_name|TestAccLambdaFunction_basic|TestAccLambdaPermission_basic|TestAccSecretsManagerSecret_basic' -timeout $(ACCTEST_TIMEOUT) -vet=off
 
 sanity: prereq-go ## Run sanity check (failures allowed)
 	@echo "make: Sanity Check (48 tests of Top 30 resources)"
@@ -405,7 +405,7 @@ sanity: prereq-go ## Run sanity check (failures allowed)
 	@echo "make: NOTE: NOT an exhaustive set of tests! Finds big problems only."
 	@iam=`TF_ACC=1 $(GO_VER) test \
 		./internal/service/iam/... \
-		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccIAMRole_basic|TestAccIAMRole_namePrefix|TestAccIAMRole_disappears|TestAccIAMRole_InlinePolicy_basic|TestAccIAMPolicyDocumentDataSource_basic|TestAccIAMPolicyDocumentDataSource_sourceConflicting|TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON|TestAccIAMRolePolicyAttachment_basic|TestAccIAMRolePolicyAttachment_disappears|TestAccIAMRolePolicyAttachment_Disappears_role|TestAccIAMPolicy_basic|TestAccIAMPolicy_policy|TestAccIAMPolicy_tags|TestAccIAMRolePolicy_basic|TestAccIAMRolePolicy_unknownsInPolicy|TestAccIAMInstanceProfile_basic|TestAccIAMInstanceProfile_tags' -timeout $(ACCTEST_TIMEOUT) || true` ; \
+		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccIAMRole_basic|TestAccIAMRole_namePrefix|TestAccIAMRole_disappears|TestAccIAMRole_InlinePolicy_basic|TestAccIAMPolicyDocumentDataSource_basic|TestAccIAMPolicyDocumentDataSource_sourceConflicting|TestAccIAMPolicyDocumentDataSource_sourceJSONValidJSON|TestAccIAMRolePolicyAttachment_basic|TestAccIAMRolePolicyAttachment_disappears|TestAccIAMRolePolicyAttachment_Disappears_role|TestAccIAMPolicy_basic|TestAccIAMPolicy_policy|TestAccIAMPolicy_tags|TestAccIAMRolePolicy_basic|TestAccIAMRolePolicy_unknownsInPolicy|TestAccIAMInstanceProfile_basic|TestAccIAMInstanceProfile_tags' -timeout $(ACCTEST_TIMEOUT) -vet=off || true` ; \
 	fails1=`echo -n $$iam | grep -Fo FAIL: | wc -l | xargs` ; \
 	passes=$$(( 17-$$fails1 )) ; \
 	echo "17 of 48 complete: $$passes passed, $$fails1 failed" ; \
@@ -415,7 +415,7 @@ sanity: prereq-go ## Run sanity check (failures allowed)
 		./internal/service/ecs/... \
 		./internal/service/elbv2/... \
 		./internal/service/kms/... \
-		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccVPCSecurityGroup_basic|TestAccVPCSecurityGroup_egressMode|TestAccVPCSecurityGroup_vpcAllEgress|TestAccVPCSecurityGroupRule_race|TestAccVPCSecurityGroupRule_protocolChange|TestAccVPCDataSource_basic|TestAccVPCSubnet_basic|TestAccVPC_tenancy|TestAccVPCRouteTableAssociation_Subnet_basic|TestAccVPCRouteTable_basic|TestAccLogsGroup_basic|TestAccLogsGroup_multiple|TestAccKMSKey_basic|TestAccELBV2TargetGroup_basic|TestAccECSTaskDefinition_basic|TestAccECSService_basic' -timeout $(ACCTEST_TIMEOUT) || true` ; \
+		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccVPCSecurityGroup_basic|TestAccVPCSecurityGroup_egressMode|TestAccVPCSecurityGroup_vpcAllEgress|TestAccVPCSecurityGroupRule_race|TestAccVPCSecurityGroupRule_protocolChange|TestAccVPCDataSource_basic|TestAccVPCSubnet_basic|TestAccVPC_tenancy|TestAccVPCRouteTableAssociation_Subnet_basic|TestAccVPCRouteTable_basic|TestAccLogsGroup_basic|TestAccLogsGroup_multiple|TestAccKMSKey_basic|TestAccELBV2TargetGroup_basic|TestAccECSTaskDefinition_basic|TestAccECSService_basic' -timeout $(ACCTEST_TIMEOUT) -vet=off || true` ; \
 	fails2=`echo -n $$logs | grep -Fo FAIL: | wc -l | xargs` ; \
 	tot_fails=$$(( $$fails1+$$fails2 )) ; \
 	passes=$$(( 33-$$tot_fails )) ; \
@@ -427,7 +427,7 @@ sanity: prereq-go ## Run sanity check (failures allowed)
 		./internal/service/s3/... \
 		./internal/service/secretsmanager/... \
 		./internal/service/sts/... \
-		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccSTSCallerIdentityDataSource_basic|TestAccMetaRegionDataSource_basic|TestAccMetaRegionDataSource_endpoint|TestAccMetaPartitionDataSource_basic|TestAccS3Bucket_Basic_basic|TestAccS3Bucket_Security_corsUpdate|TestAccS3BucketPublicAccessBlock_basic|TestAccS3BucketPolicy_basic|TestAccS3BucketACL_updateACL|TestAccRoute53Record_basic|TestAccRoute53Record_Latency_basic|TestAccRoute53ZoneDataSource_name|TestAccLambdaFunction_basic|TestAccLambdaPermission_basic|TestAccSecretsManagerSecret_basic' -timeout $(ACCTEST_TIMEOUT) || true` ; \
+		-v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) -run='TestAccSTSCallerIdentityDataSource_basic|TestAccMetaRegionDataSource_basic|TestAccMetaRegionDataSource_endpoint|TestAccMetaPartitionDataSource_basic|TestAccS3Bucket_Basic_basic|TestAccS3Bucket_Security_corsUpdate|TestAccS3BucketPublicAccessBlock_basic|TestAccS3BucketPolicy_basic|TestAccS3BucketACL_updateACL|TestAccRoute53Record_basic|TestAccRoute53Record_Latency_basic|TestAccRoute53ZoneDataSource_name|TestAccLambdaFunction_basic|TestAccLambdaPermission_basic|TestAccSecretsManagerSecret_basic' -timeout $(ACCTEST_TIMEOUT) -vet=off || true` ; \
 	fails3=`echo -n $$lambda | grep -Fo FAIL: | wc -l | xargs` ; \
 	tot_fails=$$(( $$fails1+$$fails2+$$fails3 )) ; \
 	passes=$$(( 48-$$tot_fails )) ; \
@@ -567,11 +567,11 @@ sweep: prereq-go ## Run sweepers
 	# make sweep SWEEPARGS=-sweep-run=aws_example_thing
 	# set SWEEPARGS=-sweep-allow-failures to continue after first failure
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
-	$(GO_VER) test $(SWEEP_DIR) -v -sweep=$(SWEEP) $(SWEEPARGS) -timeout $(SWEEP_TIMEOUT)
+	$(GO_VER) test $(SWEEP_DIR) -v -sweep=$(SWEEP) $(SWEEPARGS) -timeout $(SWEEP_TIMEOUT) -vet=off
 
 sweeper: prereq-go ## Run sweepers with failures allowed
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
-	$(GO_VER) test $(SWEEP_DIR) -v -sweep=$(SWEEP) -sweep-allow-failures -timeout $(SWEEP_TIMEOUT)
+	$(GO_VER) test $(SWEEP_DIR) -v -sweep=$(SWEEP) -sweep-allow-failures -timeout $(SWEEP_TIMEOUT) -vet=off
 
 sweeper-check: sweeper-linked sweeper-unlinked ## [CI] Provider Checks / Sweeper Linked, Unlinked
 
@@ -594,11 +594,11 @@ sweeper-unlinked: go-build ## [CI] Provider Checks / Sweeper Functions Not Linke
 		(echo "Expected `strings` to detect no sweeper function names in provider binary."; exit 1)
 
 t: prereq-go fmt-check ## Run acceptance tests (similar to testacc)
-	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
+	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -vet=off
 
 test: prereq-go fmt-check ## Run unit tests
 	@echo "make: Running unit tests..."
-	$(GO_VER) test -count $(TEST_COUNT) $(TEST) $(TESTARGS) -timeout=15m
+	$(GO_VER) test -count $(TEST_COUNT) $(TEST) $(TESTARGS) -timeout=15m -vet=off
 
 test-compile: prereq-go ## Test package compilation
 	@if [ "$(TEST)" = "./..." ]; then \
@@ -606,7 +606,7 @@ test-compile: prereq-go ## Test package compilation
 		echo "  make test-compile TEST=./$(PKG_NAME)"; \
 		exit 1; \
 	fi
-	$(GO_VER) test -c $(TEST) $(TESTARGS)
+	$(GO_VER) test -c $(TEST) $(TESTARGS) -vet=off
 
 testacc: prereq-go fmt-check ## Run acceptance tests
 	@if [ "$(TESTARGS)" = "-run=TestAccXXX" ]; then \
@@ -619,7 +619,7 @@ testacc: prereq-go fmt-check ## Run acceptance tests
 		echo "See the contributing guide for more information: https://hashicorp.github.io/terraform-provider-aws/running-and-writing-acceptance-tests"; \
 		exit 1; \
 	fi
-	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
+	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -vet=off
 
 testacc-lint: ## [CI] Acceptance Test Linting / terrafmt
 	@echo "make: Acceptance Test Linting / terrafmt..."
@@ -635,7 +635,7 @@ testacc-lint-fix: ## Fix acceptance test linter findings
 
 testacc-short: prereq-go fmt-check ## Run acceptace tests with the -short flag
 	@echo "Running acceptance tests with -short flag"
-	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -short -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
+	TF_ACC=1 $(GO_VER) test ./$(PKG_NAME)/... -v -short -count $(TEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(RUNARGS) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT) -vet=off
 
 testacc-tflint: testacc-tflint-dir testacc-tflint-embedded ## [CI] Acceptance Test Linting / tflint
 

--- a/internal/acctest/arn.go
+++ b/internal/acctest/arn.go
@@ -14,36 +14,55 @@ import (
 
 func CheckResourceAttrGlobalARNFormat(ctx context.Context, resourceName, attributeName, arnService, arnFormat string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		is, err := PrimaryInstanceState(s, resourceName)
+		resource, err := populateARNFormat(s, resourceName, arnFormat)
 		if err != nil {
 			return err
 		}
 
-		var foo strings.Builder
-		str := arnFormat
-		for str != "" {
-			var (
-				stuff string
-				found bool
-			)
-			stuff, str, found = strings.Cut(str, "{")
-			foo.WriteString(stuff)
-			if found {
-				var param string
-				param, str, found = strings.Cut(str, "}")
-				if !found {
-					return fmt.Errorf("missing closing '}' in ARN format %q", arnFormat)
-				}
-
-				attr, ok := is.Attributes[param]
-				if !ok {
-					return fmt.Errorf("attribute %q not found in resource %q, referenced in ARN format %q", param, resourceName, arnFormat)
-				}
-				foo.WriteString(attr)
-			}
-		}
-		resource := foo.String()
-
 		return CheckResourceAttrGlobalARN(ctx, resourceName, attributeName, arnService, resource)(s)
 	}
+}
+
+func CheckResourceAttrRegionalARNFormat(ctx context.Context, resourceName, attributeName, arnService, arnFormat string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resource, err := populateARNFormat(s, resourceName, arnFormat)
+		if err != nil {
+			return err
+		}
+
+		return CheckResourceAttrRegionalARN(ctx, resourceName, attributeName, arnService, resource)(s)
+	}
+}
+
+func populateARNFormat(s *terraform.State, resourceName, arnFormat string) (string, error) {
+	is, err := PrimaryInstanceState(s, resourceName)
+	if err != nil {
+		return "", err
+	}
+
+	var buf strings.Builder
+	str := arnFormat
+	for str != "" {
+		var (
+			stuff string
+			found bool
+		)
+		stuff, str, found = strings.Cut(str, "{")
+		buf.WriteString(stuff)
+		if found {
+			var param string
+			param, str, found = strings.Cut(str, "}")
+			if !found {
+				return "", fmt.Errorf("missing closing '}' in ARN format %q", arnFormat)
+			}
+
+			attr, ok := is.Attributes[param]
+			if !ok {
+				return "", fmt.Errorf("attribute %q not found in resource %q, referenced in ARN format %q", param, resourceName, arnFormat)
+			}
+			buf.WriteString(attr)
+		}
+	}
+
+	return buf.String(), nil
 }

--- a/internal/acctest/arn.go
+++ b/internal/acctest/arn.go
@@ -1,0 +1,49 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package acctest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func CheckResourceAttrGlobalARNFormat(ctx context.Context, resourceName, attributeName, arnService, arnFormat string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		is, err := PrimaryInstanceState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		var foo strings.Builder
+		str := arnFormat
+		for str != "" {
+			var (
+				stuff string
+				found bool
+			)
+			stuff, str, found = strings.Cut(str, "{")
+			foo.WriteString(stuff)
+			if found {
+				var param string
+				param, str, found = strings.Cut(str, "}")
+				if !found {
+					return fmt.Errorf("missing closing '}' in ARN format %q", arnFormat)
+				}
+
+				attr, ok := is.Attributes[param]
+				if !ok {
+					return fmt.Errorf("attribute %q not found in resource %q, referenced in ARN format %q", param, resourceName, arnFormat)
+				}
+				foo.WriteString(attr)
+			}
+		}
+		resource := foo.String()
+
+		return CheckResourceAttrGlobalARN(ctx, resourceName, attributeName, arnService, resource)(s)
+	}
+}

--- a/internal/service/amp/scraper_test.go
+++ b/internal/service/amp/scraper_test.go
@@ -43,9 +43,7 @@ func TestAccAMPScraper_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckScraperExists(ctx, resourceName, &scraper),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrAlias),
-					func(s *terraform.State) error {
-						return acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "aps", "scraper/"+aws.ToString(scraper.ScraperId))(s)
-					},
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "aps", "scraper/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "destination.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "destination.0.amp.#", "1"),
 					func(s *terraform.State) error {

--- a/internal/service/amp/workspace_test.go
+++ b/internal/service/amp/workspace_test.go
@@ -39,9 +39,7 @@ func TestAccAMPWorkspace_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckWorkspaceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAlias, ""),
-					func(s *terraform.State) error {
-						return acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "aps", "workspace/"+aws.ToString(v.WorkspaceId))(s)
-					},
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "aps", "workspace/{id}"),
 					func(s *terraform.State) error {
 						return resource.TestCheckResourceAttr(resourceName, names.AttrID, aws.ToString(v.WorkspaceId))(s)
 					},

--- a/internal/service/appintegrations/event_integration_test.go
+++ b/internal/service/appintegrations/event_integration_test.go
@@ -49,7 +49,7 @@ func TestAccAppIntegrationsEventIntegration_basic(t *testing.T) {
 				Config: testAccEventIntegrationConfig_basic(rName, originalDescription, sourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEventIntegrationExists(ctx, resourceName, &eventIntegration),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "app-integrations", "event-integration/"+rName),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "app-integrations", "event-integration/{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, originalDescription),
 					resource.TestCheckResourceAttr(resourceName, "eventbridge_bus", "default"),
 					resource.TestCheckResourceAttr(resourceName, "event_filter.#", "1"),
@@ -66,7 +66,7 @@ func TestAccAppIntegrationsEventIntegration_basic(t *testing.T) {
 				Config: testAccEventIntegrationConfig_basic(rName, updatedDescription, sourceName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEventIntegrationExists(ctx, resourceName, &eventIntegration),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "app-integrations", "event-integration/"+rName),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "app-integrations", "event-integration/{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, updatedDescription),
 					resource.TestCheckResourceAttr(resourceName, "eventbridge_bus", "default"),
 					resource.TestCheckResourceAttr(resourceName, "event_filter.#", "1"),

--- a/internal/service/backup/framework_test.go
+++ b/internal/service/backup/framework_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/backup"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfbackup "github.com/hashicorp/terraform-provider-aws/internal/service/backup"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -57,7 +59,7 @@ func testAccFramework_basic(t *testing.T) {
 				Config: testAccFrameworkConfig_basic(rName, originalDescription),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("framework:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
@@ -80,7 +82,7 @@ func testAccFramework_basic(t *testing.T) {
 				Config: testAccFrameworkConfig_basic(rName, updatedDescription),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("framework:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
@@ -117,7 +119,7 @@ func testAccFramework_updateControlScope(t *testing.T) {
 				Config: testAccFrameworkConfig_basic(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("framework:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
@@ -140,7 +142,7 @@ func testAccFramework_updateControlScope(t *testing.T) {
 				Config: testAccFrameworkConfig_controlScopeComplianceResourceID(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("framework:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
@@ -166,7 +168,7 @@ func testAccFramework_updateControlScope(t *testing.T) {
 				Config: testAccFrameworkConfig_controlScopeTag(rName, description, originalControlScopeTagValue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("framework:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
@@ -190,7 +192,7 @@ func testAccFramework_updateControlScope(t *testing.T) {
 				Config: testAccFrameworkConfig_controlScopeTag(rName, description, updatedControlScopeTagValue),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("framework:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
@@ -228,7 +230,7 @@ func testAccFramework_updateControlInputParameters(t *testing.T) {
 				Config: testAccFrameworkConfig_controlInputParameter(rName, description, originalRequiredRetentionDays),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("framework:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_PLAN_MIN_FREQUENCY_AND_MIN_RETENTION_CHECK"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.input_parameter.#", "3"),
@@ -262,7 +264,7 @@ func testAccFramework_updateControlInputParameters(t *testing.T) {
 				Config: testAccFrameworkConfig_controlInputParameter(rName, description, updatedRequiredRetentionDays),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("framework:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_PLAN_MIN_FREQUENCY_AND_MIN_RETENTION_CHECK"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.input_parameter.#", "3"),
@@ -308,7 +310,7 @@ func testAccFramework_updateControls(t *testing.T) {
 				Config: testAccFrameworkConfig_basic(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("framework:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, "control.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.name", "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"),
 					resource.TestCheckResourceAttr(resourceName, "control.0.scope.#", "1"),
@@ -331,7 +333,7 @@ func testAccFramework_updateControls(t *testing.T) {
 				Config: testAccFrameworkConfig_controls(rName, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFrameworkExists(ctx, resourceName, &framework),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("framework:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, "control.#", "5"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "control.*", map[string]string{
 						names.AttrName:            "BACKUP_RECOVERY_POINT_MINIMUM_RETENTION_CHECK",

--- a/internal/service/backup/report_plan_test.go
+++ b/internal/service/backup/report_plan_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/backup"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/backup/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfbackup "github.com/hashicorp/terraform-provider-aws/internal/service/backup"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -39,7 +41,7 @@ func TestAccBackupReportPlan_basic(t *testing.T) {
 				Config: testAccReportPlanConfig_basic(rName, rName2, originalDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(ctx, resourceName, &reportPlan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("report-plan:"+rName2+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
 					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, originalDescription),
@@ -62,7 +64,7 @@ func TestAccBackupReportPlan_basic(t *testing.T) {
 				Config: testAccReportPlanConfig_basic(rName, rName2, updatedDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(ctx, resourceName, &reportPlan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("report-plan:"+rName2+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
 					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, updatedDescription),
@@ -98,7 +100,7 @@ func TestAccBackupReportPlan_updateReportDeliveryChannel(t *testing.T) {
 				Config: testAccReportPlanConfig_basic(rName, rName2, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(ctx, resourceName, &reportPlan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("report-plan:"+rName2+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
 					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
@@ -121,7 +123,7 @@ func TestAccBackupReportPlan_updateReportDeliveryChannel(t *testing.T) {
 				Config: testAccReportPlanConfig_deliveryChannel(rName, rName2, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(ctx, resourceName, &reportPlan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("report-plan:"+rName2+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
 					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
@@ -158,7 +160,7 @@ func TestAccBackupReportPlan_updateReportSettings(t *testing.T) {
 				Config: testAccReportPlanConfig_basic(rName, rName2, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(ctx, resourceName, &reportPlan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("report-plan:"+rName2+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
 					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
@@ -183,7 +185,7 @@ func TestAccBackupReportPlan_updateReportSettings(t *testing.T) {
 				Config: testAccReportPlanConfig_reportSettings(rName, rName2, description),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReportPlanExists(ctx, resourceName, &reportPlan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("report-plan:"+rName2+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
 					resource.TestCheckResourceAttrSet(resourceName, "deployment_status"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),

--- a/internal/service/backup/restore_testing_plan_test.go
+++ b/internal/service/backup/restore_testing_plan_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/backup/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfbackup "github.com/hashicorp/terraform-provider-aws/internal/service/backup"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -39,7 +41,7 @@ func TestAccBackupRestoreTestingPlan_basic(t *testing.T) {
 				Config: testAccRestoreTestingPlanConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRestoreTestingPlanExists(ctx, resourceName, &restoretestingplan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("restore-testing-plan:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.algorithm", "LATEST_WITHIN_WINDOW"),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.include_vaults.#", "1"),
@@ -154,7 +156,7 @@ func TestAccBackupRestoreTestingPlan_includeVaults(t *testing.T) {
 				Config: testAccRestoreTestingPlanConfig_includeVaults(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRestoreTestingPlanExists(ctx, resourceName, &restoretestingplan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("restore-testing-plan:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.algorithm", "LATEST_WITHIN_WINDOW"),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.include_vaults.#", "1"),
@@ -192,7 +194,7 @@ func TestAccBackupRestoreTestingPlan_excludeVaults(t *testing.T) {
 				Config: testAccRestoreTestingPlanConfig_excludeVaults(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRestoreTestingPlanExists(ctx, resourceName, &restoretestingplan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("restore-testing-plan:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.algorithm", "LATEST_WITHIN_WINDOW"),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.exclude_vaults.#", "1"),
@@ -230,7 +232,7 @@ func TestAccBackupRestoreTestingPlan_additionals(t *testing.T) {
 				Config: testAccRestoreTestingPlanConfig_additionals("365", "cron(0 12 ? * * *)", rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRestoreTestingPlanExists(ctx, resourceName, &restoretestingplan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("restore-testing-plan:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.algorithm", "LATEST_WITHIN_WINDOW"),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.include_vaults.#", "1"),
@@ -270,7 +272,7 @@ func TestAccBackupRestoreTestingPlan_additionalsWithUpdate(t *testing.T) {
 				Config: testAccRestoreTestingPlanConfig_additionals("365", "cron(0 1 ? * * *)", rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRestoreTestingPlanExists(ctx, resourceName, &restoretestingplan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("restore-testing-plan:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.algorithm", "LATEST_WITHIN_WINDOW"),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.include_vaults.#", "1"),
@@ -292,7 +294,7 @@ func TestAccBackupRestoreTestingPlan_additionalsWithUpdate(t *testing.T) {
 				Config: testAccRestoreTestingPlanConfig_additionals("1", "cron(0 12 ? * * *)", rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRestoreTestingPlanExists(ctx, resourceName, &restoretestingplan),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "backup", regexache.MustCompile("restore-testing-plan:"+rName+"-"+verify.UUIDRegexPattern+"$")),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.algorithm", "LATEST_WITHIN_WINDOW"),
 					resource.TestCheckResourceAttr(resourceName, "recovery_point_selection.0.include_vaults.#", "1"),

--- a/internal/service/batch/scheduling_policy_test.go
+++ b/internal/service/batch/scheduling_policy_test.go
@@ -35,7 +35,7 @@ func TestAccBatchSchedulingPolicy_basic(t *testing.T) {
 				Config: testAccSchedulingPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchedulingPolicyExists(ctx, resourceName, &schedulingPolicy1),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "batch", "scheduling-policy/"+rName),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "batch", "scheduling-policy/{name}"),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.0.compute_reservation", "1"),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.0.share_decay_seconds", "3600"),
@@ -54,7 +54,7 @@ func TestAccBatchSchedulingPolicy_basic(t *testing.T) {
 				Config: testAccSchedulingPolicyConfig_basic2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchedulingPolicyExists(ctx, resourceName, &schedulingPolicy1),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "batch", "scheduling-policy/"+rName),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "batch", "scheduling-policy/{name}"),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.0.compute_reservation", "1"),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.0.share_decay_seconds", "3600"),

--- a/internal/service/batch/scheduling_policy_test.go
+++ b/internal/service/batch/scheduling_policy_test.go
@@ -35,7 +35,7 @@ func TestAccBatchSchedulingPolicy_basic(t *testing.T) {
 				Config: testAccSchedulingPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchedulingPolicyExists(ctx, resourceName, &schedulingPolicy1),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "batch", "scheduling-policy/"+rName),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.0.compute_reservation", "1"),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.0.share_decay_seconds", "3600"),
@@ -54,7 +54,7 @@ func TestAccBatchSchedulingPolicy_basic(t *testing.T) {
 				Config: testAccSchedulingPolicyConfig_basic2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSchedulingPolicyExists(ctx, resourceName, &schedulingPolicy1),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "batch", "scheduling-policy/"+rName),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.0.compute_reservation", "1"),
 					resource.TestCheckResourceAttr(resourceName, "fair_share_policy.0.share_decay_seconds", "3600"),

--- a/internal/service/chimesdkvoice/sip_media_application_test.go
+++ b/internal/service/chimesdkvoice/sip_media_application_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/chimesdkvoice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -21,7 +22,7 @@ import (
 
 func TestAccChimeSDKVoiceSipMediaApplication_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var chimeSipMediaApplication *awstypes.SipMediaApplication
+	var chimeSipMediaApplication awstypes.SipMediaApplication
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_sip_media_application.test"
@@ -38,9 +39,14 @@ func TestAccChimeSDKVoiceSipMediaApplication_basic(t *testing.T) {
 			{
 				Config: testAccSipMediaApplicationConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSipMediaApplicationExists(ctx, resourceName, chimeSipMediaApplication),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					testAccCheckSipMediaApplicationExists(ctx, resourceName, &chimeSipMediaApplication),
+					func(s *terraform.State) error {
+						return acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "chime", "sma/"+aws.ToString(chimeSipMediaApplication.SipMediaApplicationId))(s)
+					},
 					resource.TestCheckResourceAttrSet(resourceName, "aws_region"),
+					func(s *terraform.State) error {
+						return resource.TestCheckResourceAttr(resourceName, names.AttrID, aws.ToString(chimeSipMediaApplication.SipMediaApplicationId))(s)
+					},
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoints.0.lambda_arn", lambdaFunctionResourceName, names.AttrARN),
 				),
@@ -56,7 +62,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_basic(t *testing.T) {
 
 func TestAccChimeSDKVoiceSipMediaApplication_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var chimeSipMediaApplication *awstypes.SipMediaApplication
+	var chimeSipMediaApplication awstypes.SipMediaApplication
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_sip_media_application.test"
@@ -72,7 +78,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_disappears(t *testing.T) {
 			{
 				Config: testAccSipMediaApplicationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSipMediaApplicationExists(ctx, resourceName, chimeSipMediaApplication),
+					testAccCheckSipMediaApplicationExists(ctx, resourceName, &chimeSipMediaApplication),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfchimesdkvoice.ResourceSipMediaApplication(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -83,7 +89,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_disappears(t *testing.T) {
 
 func TestAccChimeSDKVoiceSipMediaApplication_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	var chimeSipMediaApplication *awstypes.SipMediaApplication
+	var chimeSipMediaApplication awstypes.SipMediaApplication
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rNameUpdated := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -101,8 +107,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_update(t *testing.T) {
 			{
 				Config: testAccSipMediaApplicationConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSipMediaApplicationExists(ctx, resourceName, chimeSipMediaApplication),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					testAccCheckSipMediaApplicationExists(ctx, resourceName, &chimeSipMediaApplication),
 					resource.TestCheckResourceAttrSet(resourceName, "aws_region"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoints.0.lambda_arn", lambdaFunctionResourceName, names.AttrARN),
@@ -111,8 +116,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_update(t *testing.T) {
 			{
 				Config: testAccSipMediaApplicationConfig_basic(rNameUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSipMediaApplicationExists(ctx, resourceName, chimeSipMediaApplication),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					testAccCheckSipMediaApplicationExists(ctx, resourceName, &chimeSipMediaApplication),
 					resource.TestCheckResourceAttrSet(resourceName, "aws_region"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rNameUpdated),
 					resource.TestCheckResourceAttrPair(resourceName, "endpoints.0.lambda_arn", lambdaFunctionResourceName, names.AttrARN),
@@ -129,7 +133,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_update(t *testing.T) {
 
 func TestAccChimeSDKVoiceSipMediaApplication_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	var sipMediaApplication *awstypes.SipMediaApplication
+	var sipMediaApplication awstypes.SipMediaApplication
 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_chimesdkvoice_sip_media_application.test"
@@ -145,7 +149,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_tags(t *testing.T) {
 			{
 				Config: testAccSipMediaApplicationConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSipMediaApplicationExists(ctx, resourceName, sipMediaApplication),
+					testAccCheckSipMediaApplicationExists(ctx, resourceName, &sipMediaApplication),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
@@ -159,7 +163,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_tags(t *testing.T) {
 			{
 				Config: testAccSipMediaApplicationConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSipMediaApplicationExists(ctx, resourceName, sipMediaApplication),
+					testAccCheckSipMediaApplicationExists(ctx, resourceName, &sipMediaApplication),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
@@ -169,7 +173,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_tags(t *testing.T) {
 			{
 				Config: testAccSipMediaApplicationConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSipMediaApplicationExists(ctx, resourceName, sipMediaApplication),
+					testAccCheckSipMediaApplicationExists(ctx, resourceName, &sipMediaApplication),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -200,7 +204,7 @@ func testAccCheckSipMediaApplicationExists(ctx context.Context, name string, vc 
 			return err
 		}
 
-		vc = resp
+		*vc = *resp
 
 		return nil
 	}

--- a/internal/service/chimesdkvoice/sip_media_application_test.go
+++ b/internal/service/chimesdkvoice/sip_media_application_test.go
@@ -40,9 +40,7 @@ func TestAccChimeSDKVoiceSipMediaApplication_basic(t *testing.T) {
 				Config: testAccSipMediaApplicationConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSipMediaApplicationExists(ctx, resourceName, &chimeSipMediaApplication),
-					func(s *terraform.State) error {
-						return acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "chime", "sma/"+aws.ToString(chimeSipMediaApplication.SipMediaApplicationId))(s)
-					},
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "chime", "sma/{id}"),
 					resource.TestCheckResourceAttrSet(resourceName, "aws_region"),
 					func(s *terraform.State) error {
 						return resource.TestCheckResourceAttr(resourceName, names.AttrID, aws.ToString(chimeSipMediaApplication.SipMediaApplicationId))(s)

--- a/internal/service/cloudfront/key_value_store_test.go
+++ b/internal/service/cloudfront/key_value_store_test.go
@@ -8,7 +8,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -21,7 +22,7 @@ import (
 
 func TestAccCloudFrontKeyValueStore_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	var keyvaluestore cloudfront.DescribeKeyValueStoreOutput
+	var keyvaluestore awstypes.KeyValueStore
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudfront_key_value_store.test"
 
@@ -38,9 +39,12 @@ func TestAccCloudFrontKeyValueStore_basic(t *testing.T) {
 				Config: testAccKeyValueStoreConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyValueStoreExists(ctx, resourceName, &keyvaluestore),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					func(s *terraform.State) error {
+						return acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "cloudfront", "key-value-store/"+aws.ToString(keyvaluestore.Id))(s)
+					},
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrComment),
 					resource.TestCheckResourceAttrSet(resourceName, "etag"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
 					resource.TestCheckResourceAttrSet(resourceName, "last_modified_time"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 				),
@@ -56,7 +60,7 @@ func TestAccCloudFrontKeyValueStore_basic(t *testing.T) {
 
 func TestAccCloudFrontKeyValueStore_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	var keyvaluestore cloudfront.DescribeKeyValueStoreOutput
+	var keyvaluestore awstypes.KeyValueStore
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudfront_key_value_store.test"
 
@@ -83,7 +87,7 @@ func TestAccCloudFrontKeyValueStore_disappears(t *testing.T) {
 
 func TestAccCloudFrontKeyValueStore_comment(t *testing.T) {
 	ctx := acctest.Context(t)
-	var keyvaluestore cloudfront.DescribeKeyValueStoreOutput
+	var keyvaluestore awstypes.KeyValueStore
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudfront_key_value_store.test"
 	comment1 := "comment1"
@@ -144,7 +148,7 @@ func testAccCheckKeyValueStoreDestroy(ctx context.Context) resource.TestCheckFun
 	}
 }
 
-func testAccCheckKeyValueStoreExists(ctx context.Context, n string, v *cloudfront.DescribeKeyValueStoreOutput) resource.TestCheckFunc {
+func testAccCheckKeyValueStoreExists(ctx context.Context, n string, v *awstypes.KeyValueStore) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -159,7 +163,7 @@ func testAccCheckKeyValueStoreExists(ctx context.Context, n string, v *cloudfron
 			return err
 		}
 
-		*v = *output
+		*v = *output.KeyValueStore
 
 		return nil
 	}

--- a/internal/service/cloudfront/vpc_origin_test.go
+++ b/internal/service/cloudfront/vpc_origin_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -35,8 +36,11 @@ func TestAccCloudFrontVPCOrigin_basic(t *testing.T) {
 				Config: testAccVPCOriginConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVPCOriginExists(ctx, resourceName, &vpcOrigin),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "cloudfront", "vpcorigin/{id}"),
 					resource.TestCheckResourceAttrSet(resourceName, "etag"),
+					func(s *terraform.State) error {
+						return resource.TestCheckResourceAttr(resourceName, names.AttrID, aws.ToString(vpcOrigin.Id))(s)
+					},
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_origin_endpoint_config.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_origin_endpoint_config.0.arn"),
@@ -99,7 +103,7 @@ func TestAccCloudFrontVPCOrigin_update(t *testing.T) {
 				Config: testAccVPCOriginConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVPCOriginExists(ctx, resourceName, &vpcOrigin),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "cloudfront", "vpcorigin/{id}"),
 					resource.TestCheckResourceAttrSet(resourceName, "etag"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_origin_endpoint_config.#", "1"),
@@ -117,7 +121,7 @@ func TestAccCloudFrontVPCOrigin_update(t *testing.T) {
 				Config: testAccVPCOriginConfig_httpsOnly(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVPCOriginExists(ctx, resourceName, &vpcOrigin),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "cloudfront", "vpcorigin/{id}"),
 					resource.TestCheckResourceAttrSet(resourceName, "etag"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_origin_endpoint_config.#", "1"),

--- a/internal/service/cloudtrail/organization_delegated_admin_account_test.go
+++ b/internal/service/cloudtrail/organization_delegated_admin_account_test.go
@@ -38,7 +38,7 @@ func testAccOrganizationDelegatedAdminAccount_basic(t *testing.T) {
 				Config: testAccOrganizationDelegatedAdminAccountConfig_basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckOrganizationDelegatedAdminAccountExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN), // nosemgrep:ci.semgrep.acctest.checks.arn-resourceattrset // TODO: need environment where this test can run
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrEmail),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "service_principal", tfcloudtrail.ServicePrincipal),

--- a/internal/service/codeguruprofiler/profiling_group_test.go
+++ b/internal/service/codeguruprofiler/profiling_group_test.go
@@ -43,12 +43,13 @@ func TestAccCodeGuruProfilerProfilingGroup_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProfilingGroupConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckProfilingGroupExists(ctx, resourceName, &profilinggroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "codeguru-profiler", "profilingGroup/{name}"),
 					resource.TestCheckResourceAttr(resourceName, "compute_platform", "Default"),
 					resource.TestCheckResourceAttr(resourceName, "agent_orchestration_config.0.profiling_enabled", acctest.CtTrue),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
 				),
 			},
 			{
@@ -115,7 +116,7 @@ func TestAccCodeGuruProfilerProfilingGroup_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfilingGroupExists(ctx, resourceName, &profilinggroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "codeguru-profiler", "profilingGroup/{name}"),
 					resource.TestCheckResourceAttr(resourceName, "compute_platform", "Default"),
 					resource.TestCheckResourceAttr(resourceName, "agent_orchestration_config.0.profiling_enabled", acctest.CtTrue),
 				),
@@ -125,7 +126,7 @@ func TestAccCodeGuruProfilerProfilingGroup_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfilingGroupExists(ctx, resourceName, &profilinggroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "codeguru-profiler", "profilingGroup/{name}"),
 					resource.TestCheckResourceAttr(resourceName, "compute_platform", "Default"),
 					resource.TestCheckResourceAttr(resourceName, "agent_orchestration_config.0.profiling_enabled", acctest.CtFalse),
 				),

--- a/internal/service/configservice/aggregate_authorization_test.go
+++ b/internal/service/configservice/aggregate_authorization_test.go
@@ -35,7 +35,7 @@ func TestAccConfigServiceAggregateAuthorization_basic(t *testing.T) {
 				Config: testAccAggregateAuthorizationConfig_basic(accountID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAggregateAuthorizationExists(ctx, resourceName, &aa),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "config", "aggregation-authorization/{account_id}/{region}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAccountID, accountID),
 					resource.TestCheckResourceAttr(resourceName, names.AttrRegion, acctest.Region()),
 				),


### PR DESCRIPTION
### Description

Reduce uses of `resource.TestCheckResourceAttrSet` on ARN attributes in favour of explicit checks

Addresses `b` and most of the `c` services