### PR TITLE
fix(typo): fixes typo in "awiting for Lambda Function" message

### DIFF
--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -597,7 +597,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "awaiting for Lambda Function (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Lambda Function (%s) create: %s", d.Id(), err)
 	}
 
 	if _, err := waitFunctionCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -601,7 +601,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if _, err := waitFunctionCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "awaiting for Lambda Function (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for Lambda Function (%s) create: %s", d.Id(), err)
 	}
 
 	if v, ok := d.Get("reserved_concurrent_executions").(int); ok && v >= 0 {

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -597,11 +597,11 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "awiting for Lambda Function (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "awaiting for Lambda Function (%s) create: %s", d.Id(), err)
 	}
 
 	if _, err := waitFunctionCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "awiting for Lambda Function (%s) create: %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "awaiting for Lambda Function (%s) create: %s", d.Id(), err)
 	}
 
 	if v, ok := d.Get("reserved_concurrent_executions").(int); ok && v >= 0 {


### PR DESCRIPTION
### Description

This fixes a small typo in error messages (missing the second `a` of `awaiting`):

```
╷
│ Error: awiting for Lambda Function (******) create: unexpected state 'Failed', wanted target 'Active'. last error: InternalError: Error while creating lambda: 
│ 
│   with module.******.aws_lambda_function.this,
│   on main.tf line 66, in resource "aws_lambda_function" "this":
│   66: resource "aws_lambda_function" "this" {
│ 
╵
```

Edit: switched to `waiting` for sake of consistency