### PR TITLE
r/aws_ses_receipt_rule: Retry IAM eventual consistency errors

### DIFF
--- a/.changelog/40873.txt
+++ b/.changelog/40873.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ses_receipt_rul: Retry IAM eventual consistency errors
+resource/aws_ses_receipt_rule: Retry errors caused by IAM eventual consistency
 ```

--- a/.changelog/40873.txt
+++ b/.changelog/40873.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ses_receipt_rul: Retry IAM eventual consistency errors
+```

--- a/internal/service/ses/errors.go
+++ b/internal/service/ses/errors.go
@@ -4,5 +4,7 @@
 package ses
 
 const (
-	errCodeInvalidParameterValue = "InvalidParameterValue"
+	errCodeInvalidLambdaConfiguration = "InvalidLambdaConfiguration"
+	errCodeInvalidParameterValue      = "InvalidParameterValue"
+	errCodeInvalidS3Configuration     = "InvalidS3Configuration"
 )

--- a/internal/service/ses/receipt_rule.go
+++ b/internal/service/ses/receipt_rule.go
@@ -300,8 +300,10 @@ func resourceReceiptRuleCreate(ctx context.Context, d *schema.ResourceData, meta
 			return conn.CreateReceiptRule(ctx, input)
 		},
 		func(err error) (bool, error) {
-			if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Could not assume the provided IAM Role") ||
-				tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Unable to write to S3 bucket") {
+			if tfawserr.ErrMessageContains(err, errCodeInvalidLambdaConfiguration, "Could not invoke Lambda function") ||
+				tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Could not assume the provided IAM Role") ||
+				tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Unable to write to S3 bucket") ||
+				tfawserr.ErrMessageContains(err, errCodeInvalidS3Configuration, "Could not write to bucket") {
 				return true, err
 			}
 
@@ -500,8 +502,10 @@ func resourceReceiptRuleUpdate(ctx context.Context, d *schema.ResourceData, meta
 			return conn.UpdateReceiptRule(ctx, input)
 		},
 		func(err error) (bool, error) {
-			if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Could not assume the provided IAM Role") ||
-				tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Unable to write to S3 bucket") {
+			if tfawserr.ErrMessageContains(err, errCodeInvalidLambdaConfiguration, "Could not invoke Lambda function") ||
+				tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Could not assume the provided IAM Role") ||
+				tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Unable to write to S3 bucket") ||
+				tfawserr.ErrMessageContains(err, errCodeInvalidS3Configuration, "Could not write to bucket") {
 				return true, err
 			}
 


### PR DESCRIPTION
### Description
This PR adds retries for IAM eventual consistency errors when creating or updating the `aws_ses_receipt_rule` resource.

### Relations
Closes #7917
Closes #34259 

### References
https://docs.aws.amazon.com/ses/latest/APIReference/API_CreateReceiptRule.html
https://docs.aws.amazon.com/ses/latest/APIReference/API_UpdateReceiptRule.html

### Output from Acceptance Testing
```console
% make testacc PKG=ses ACCTEST_PARALLELISM=1 TESTARGS="-run=TestAccSESReceiptRule_"  
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ses/... -v -count 1 -parallel 1  -run=TestAccSESReceiptRule_ -timeout 360m
2025/01/10 19:09:47 Initializing Terraform AWS Provider...
=== RUN   TestAccSESReceiptRule_basic
=== PAUSE TestAccSESReceiptRule_basic
=== RUN   TestAccSESReceiptRule_s3Action
=== PAUSE TestAccSESReceiptRule_s3Action
=== RUN   TestAccSESReceiptRule_s3Action_iamRoleARN
=== PAUSE TestAccSESReceiptRule_s3Action_iamRoleARN
=== RUN   TestAccSESReceiptRule_snsAction
=== PAUSE TestAccSESReceiptRule_snsAction
=== RUN   TestAccSESReceiptRule_snsActionEncoding
=== PAUSE TestAccSESReceiptRule_snsActionEncoding
=== RUN   TestAccSESReceiptRule_lambdaAction
=== PAUSE TestAccSESReceiptRule_lambdaAction
=== RUN   TestAccSESReceiptRule_stopAction
=== PAUSE TestAccSESReceiptRule_stopAction
=== RUN   TestAccSESReceiptRule_order
=== PAUSE TestAccSESReceiptRule_order
=== RUN   TestAccSESReceiptRule_actions
=== PAUSE TestAccSESReceiptRule_actions
=== RUN   TestAccSESReceiptRule_disappears
=== PAUSE TestAccSESReceiptRule_disappears
=== RUN   TestAccSESReceiptRule_Disappears_receiptRuleSet
=== PAUSE TestAccSESReceiptRule_Disappears_receiptRuleSet
=== CONT  TestAccSESReceiptRule_basic
--- PASS: TestAccSESReceiptRule_basic (20.09s)
=== CONT  TestAccSESReceiptRule_stopAction
--- PASS: TestAccSESReceiptRule_stopAction (21.80s)
=== CONT  TestAccSESReceiptRule_Disappears_receiptRuleSet
--- PASS: TestAccSESReceiptRule_Disappears_receiptRuleSet (16.13s)
=== CONT  TestAccSESReceiptRule_disappears
--- PASS: TestAccSESReceiptRule_disappears (16.08s)
=== CONT  TestAccSESReceiptRule_actions
--- PASS: TestAccSESReceiptRule_actions (19.43s)
=== CONT  TestAccSESReceiptRule_order
--- PASS: TestAccSESReceiptRule_order (19.70s)
=== CONT  TestAccSESReceiptRule_snsAction
--- PASS: TestAccSESReceiptRule_snsAction (21.11s)
=== CONT  TestAccSESReceiptRule_lambdaAction
--- PASS: TestAccSESReceiptRule_lambdaAction (39.75s)
=== CONT  TestAccSESReceiptRule_snsActionEncoding
--- PASS: TestAccSESReceiptRule_snsActionEncoding (21.13s)
=== CONT  TestAccSESReceiptRule_s3Action_iamRoleARN
--- PASS: TestAccSESReceiptRule_s3Action_iamRoleARN (31.36s)
=== CONT  TestAccSESReceiptRule_s3Action
--- PASS: TestAccSESReceiptRule_s3Action (30.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ses        263.170s
```
