### PR TITLE
fix: update year in ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ Each weekly release will include necessary tasks that lead to the completion of 
 
 This roadmap does not describe all the work that will be included within this timeframe, but it does describe our focus. We will include other work as events occur.
 
-In the period spanning Nov to Jan 2024 the AWS Provider added support for the following (among many others):
+In the period spanning Nov to Jan 2025 the AWS Provider added support for the following (among many others):
 
 - AWS Chatbot
 - Amazon Bedrock
@@ -16,7 +16,7 @@ In the period spanning Nov to Jan 2024 the AWS Provider added support for the fo
 - Amazon Bedrock Agents
 - Completed the migration to Amazon GO SDK v2
 
-From Nov - Jan 2024, we will be prioritizing the following areas of work:
+From Nov - Jan 2025, we will be prioritizing the following areas of work:
 
 ## New Services
 


### PR DESCRIPTION
### Description

Pull request 40877 fixed an issue with the wrong year in the roadmap, but not all references were updated. Only a heading changed.

This pull requests updates two locations in the roadmap that also references the year 2024 instead of 2025.

### Relations

### References

[PR 40877](https://github.com/hashicorp/terraform-provider-aws/pull/40877)

### Output from Acceptance Testing

Not applicable