### PR TITLE
r/sagemaker_endpoint_configuration - allow scaling endpoints to zero

### DIFF
--- a/.changelog/40882.txt
+++ b/.changelog/40882.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sagemaker_endpoint_configuration: allow setting `production_variants.managed_instance_scaling` and `shadow_production_variants.managed_instance_scaling` to zero
+```

--- a/.changelog/40882.txt
+++ b/.changelog/40882.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_sagemaker_endpoint_configuration: allow setting `production_variants.managed_instance_scaling` and `shadow_production_variants.managed_instance_scaling` to zero
+resource/aws_sagemaker_endpoint_configuration: Support setting `production_variants.managed_instance_scaling` and `shadow_production_variants.managed_instance_scaling` to `0`
 ```

--- a/internal/service/sagemaker/endpoint_configuration.go
+++ b/internal/service/sagemaker/endpoint_configuration.go
@@ -394,7 +394,7 @@ func resourceEndpointConfiguration() *schema.Resource {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										ForceNew:     true,
-										ValidateFunc: validation.IntAtLeast(1),
+										ValidateFunc: validation.IntAtLeast(0),
 									},
 									names.AttrStatus: {
 										Type:             schema.TypeString,
@@ -566,7 +566,7 @@ func resourceEndpointConfiguration() *schema.Resource {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										ForceNew:     true,
-										ValidateFunc: validation.IntAtLeast(1),
+										ValidateFunc: validation.IntAtLeast(0),
 									},
 									names.AttrStatus: {
 										Type:             schema.TypeString,
@@ -1133,7 +1133,7 @@ func expandManagedInstanceScaling(configured []interface{}) *awstypes.Production
 		c.Status = awstypes.ManagedInstanceScalingStatus(v)
 	}
 
-	if v, ok := m["min_instance_count"].(int); ok && v > 0 {
+	if v, ok := m["min_instance_count"].(int); ok {
 		c.MinInstanceCount = aws.Int32(int32(v))
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40606

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccSageMakerEndpointConfiguration_productionVariantsManagedInstanceScaling PKG=sagemaker

--- PASS: TestAccSageMakerEndpointConfiguration_productionVariantsManagedInstanceScalingZero (26.61s)
--- PASS: TestAccSageMakerEndpointConfiguration_productionVariantsManagedInstanceScaling (30.29s)
```
