### PR TITLE
docs: update import instructions for aws_dataexchange_data_set

### DIFF
--- a/website/docs/r/dataexchange_data_set.html.markdown
+++ b/website/docs/r/dataexchange_data_set.html.markdown
@@ -46,7 +46,7 @@ import {
 }
 ```
 
-Using `terraform import`, import DataExchange DataSets using their ARN. For example:
+Using `terraform import`, import DataExchange DataSets using their `id`. For example:
 
 ```console
 % terraform import aws_dataexchange_data_set.example 4fa784c7-ccb4-4dbf-ba4f-02198320daa1

--- a/website/docs/r/dataexchange_data_set.html.markdown
+++ b/website/docs/r/dataexchange_data_set.html.markdown
@@ -37,17 +37,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DataExchange DataSets using their ARN. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DataExchange DataSets using their `id`. For example:
 
 ```terraform
 import {
   to = aws_dataexchange_data_set.example
-  id = "arn:aws:dataexchange:us-west-2:123456789012:data-sets/4fa784c7-ccb4-4dbf-ba4f-02198320daa1"
+  id = "4fa784c7-ccb4-4dbf-ba4f-02198320daa1"
 }
 ```
 
 Using `terraform import`, import DataExchange DataSets using their ARN. For example:
 
 ```console
-% terraform import aws_dataexchange_data_set.example arn:aws:dataexchange:us-west-2:123456789012:data-sets/4fa784c7-ccb4-4dbf-ba4f-02198320daa1
+% terraform import aws_dataexchange_data_set.example 4fa784c7-ccb4-4dbf-ba4f-02198320daa1
 ```


### PR DESCRIPTION
### Description

In #40871 an issue related to the resource `aws_dataexchange_data_set` is described. The user followed the import instructions available in the [official documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dataexchange_data_set#import) and ran into an issue.

The pull requests updates the import instructions, so that imports can be executed successfully.

#### Detailed information

In the documentation it is stated that the resource ARN should be used when importing, e.g.

```shell
terraform import aws_dataexchange_data_set.datashare arn:aws:dataexchange:eu-west-1:123456789012:data-sets/3e2a5bd133cf6247a3198410370444f6
```

This leads to a failed import and also validation error messages (likely from the AWS Go SDK). 



I tried similar import with debug logs enabled:

```plain
2025-01-11T21:52:08.176+0100 [INFO]  provider.terraform-provider-aws_v5.82.2_x5: Retrieved caller identity from STS: tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=f6a97c26-1f4c-3e6f-9d07-b7440b792e53 tf_rpc=ConfigureProvider tf_provider_addr=registry.terraform.io/hashicorp/aws @caller=github.com/hashicorp/aws-sdk-go-base/v2@v2.0.0-beta.59/logging/tf_logger.go:39 @module=aws.aws-base timestamp="2025-01-11T21:52:08.176+0100"
2025-01-11T21:52:08.178+0100 [DEBUG] ReferenceTransformer: "aws_dataexchange_data_set.datashare (import id \"arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e\")" references: []
aws_dataexchange_data_set.datashare: Importing from ID "arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e"...
aws_dataexchange_data_set.datashare: Import prepared!
  Prepared aws_dataexchange_data_set for import
aws_dataexchange_data_set.datashare: Refreshing state... [id=arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e]
2025-01-11T21:52:08.193+0100 [DEBUG] provider.terraform-provider-aws_v5.82.2_x5: HTTP Request Sent: http.method=GET http.request.header.amz_sdk_invocation_id=c48591a0-a728-4e83-92a1-3ba58afaf182 http.request.header.amz_sdk_request="attempt=1; max=25" rpc.method=GetDataSet tf_aws.sdk=aws-sdk-go-v2 tf_mux_provider="*schema.GRPCProviderServer" tf_provider_addr=registry.terraform.io/hashicorp/aws tf_req_id=4f651358-fcf5-e203-6649-df68b190cc50 @caller=github.com/hashicorp/aws-sdk-go-base/v2@v2.0.0-beta.59/logging/tf_logger.go:45 http.request.header.authorization="AWS4-HMAC-SHA256 Credential=AKIA************RU6X/20250111/us-east-1/dataexchange/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;host;x-amz-date, Signature=*****" http.user_agent="APN/1.0 HashiCorp/1.0 Terraform/1.10.2 (+https://www.terraform.io) terraform-provider-aws/5.82.2 (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go-v2/1.32.6 ua/2.1 os/linux lang/go#1.23.3 md/GOOS#linux md/GOARCH#amd64 api/dataexchange#1.33.5" net.peer.name=dataexchange.us-east-1.amazonaws.com rpc.system=aws-api tf_resource_type=aws_dataexchange_data_set http.request.body="" http.url="https://dataexchange.us-east-1.amazonaws.com/v1/data-sets/arn%3Aaws%3Adataexchange%3Aus-east-1%3A<redacted>%3Adata-sets%2F72a09faa2ec3c7a223899058d4374e9e" rpc.service=DataExchange tf_rpc=ReadResource @module=aws aws.region=us-east-1 http.request.header.x_amz_date=20250111T205208Z tf_aws.signing_region="" timestamp="2025-01-11T21:52:08.193+0100"
2025-01-11T21:52:08.687+0100 [DEBUG] provider.terraform-provider-aws_v5.82.2_x5: HTTP Response Received: tf_aws.sdk=aws-sdk-go-v2 tf_req_id=4f651358-fcf5-e203-6649-df68b190cc50 @caller=github.com/hashicorp/aws-sdk-go-base/v2@v2.0.0-beta.59/logging/tf_logger.go:45 aws.region=us-east-1 http.response.header.x_amz_cf_pop=FRA56-C1 http.response.header.access_control_allow_origin="*" http.response.header.x_cache="Error from cloudfront" http.response.header.access_control_expose_headers="x-amzn-errortype,x-amzn-requestid,x-amzn-errormessage,x-amzn-trace-id,x-amz-apigw-id,date" tf_aws.signing_region="" tf_rpc=ReadResource @module=aws http.response.header.x_amzn_errortype=ValidationException http.response.header.access_control_allow_headers="*,Authorization,Date,X-Amz-Date,X-Amz-Security-Token,X-Amz-Target,content-type,x-amz-content-sha256,x-amz-user-agent,x-amzn-platform-id,x-amzn-trace-id" rpc.method=GetDataSet http.response.header.date="Sat, 11 Jan 2025 20:52:08 GMT" http.response.header.via="1.1 35a6ad9a7597ea2f4dacbdb5dc66a66c.cloudfront.net (CloudFront)" http.response.header.x_amz_apigw_id=EPb-4F7woAMEg7g= http.response.header.x_amz_cf_id=KfPumn72H3E4NLHIXKXdKvt1vLLMsk6em5zllUlyU1XOSUCfxlSM2g== http.response_content_length=190 tf_provider_addr=registry.terraform.io/hashicorp/aws
  http.response.body=
  | {
  |   "Message" : "The following parameter(s) are not valid: \"DataSetId\" must only contain alpha-numeric characters, \"DataSetId\" length must be less than or equal to 40 characters long."
  | }
   tf_resource_type=aws_dataexchange_data_set http.response.header.x_amzn_trace_id=Root=1-6782d9f8-398b0f4462adcb2f3e42ee6f http.status_code=400 tf_mux_provider="*schema.GRPCProviderServer" http.response.header.access_control_max_age=86400 http.response.header.x_amzn_requestid=4a6f4299-c7af-46f9-9ed7-059b9a96d197 http.response.header.content_type=application/json rpc.service=DataExchange rpc.system=aws-api http.duration=493 http.response.header.access_control_allow_methods="*" timestamp="2025-01-11T21:52:08.687+0100"
2025-01-11T21:52:08.687+0100 [DEBUG] provider.terraform-provider-aws_v5.82.2_x5: request failed with unretryable error https response error StatusCode: 400, RequestID: 4a6f4299-c7af-46f9-9ed7-059b9a96d197, ValidationException: The following parameter(s) are not valid: "DataSetId" must only contain alpha-numeric characters, "DataSetId" length must be less than or equal to 40 characters long.: @module=aws rpc.method=GetDataSet rpc.system=aws-api aws.region=us-east-1 tf_aws.sdk=aws-sdk-go-v2 tf_provider_addr=registry.terraform.io/hashicorp/aws tf_rpc=ReadResource @caller=github.com/hashicorp/aws-sdk-go-base/v2@v2.0.0-beta.59/logging/tf_logger.go:45 rpc.service=DataExchange tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=4f651358-fcf5-e203-6649-df68b190cc50 tf_resource_type=aws_dataexchange_data_set timestamp="2025-01-11T21:52:08.687+0100"
2025-01-11T21:52:08.687+0100 [ERROR] provider.terraform-provider-aws_v5.82.2_x5: Response contains error diagnostic: tf_rpc=ReadResource @caller=github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov5/internal/diag/diagnostics.go:58 @module=sdk.proto tf_req_id=4f651358-fcf5-e203-6649-df68b190cc50 tf_resource_type=aws_dataexchange_data_set diagnostic_detail="" diagnostic_severity=ERROR diagnostic_summary="reading DataExchange DataSet (arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e): operation error DataExchange: GetDataSet, https response error StatusCode: 400, RequestID: 4a6f4299-c7af-46f9-9ed7-059b9a96d197, ValidationException: The following parameter(s) are not valid: \"DataSetId\" must only contain alpha-numeric characters, \"DataSetId\" length must be less than or equal to 40 characters long." tf_proto_version=5.7 tf_provider_addr=registry.terraform.io/hashicorp/aws timestamp="2025-01-11T21:52:08.687+0100"
2025-01-11T21:52:08.688+0100 [ERROR] vertex "import aws_dataexchange_data_set.datashare result" error: reading DataExchange DataSet (arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e): operation error DataExchange: GetDataSet, https response error StatusCode: 400, RequestID: 4a6f4299-c7af-46f9-9ed7-059b9a96d197, ValidationException: The following parameter(s) are not valid: "DataSetId" must only contain alpha-numeric characters, "DataSetId" length must be less than or equal to 40 characters long.
2025-01-11T21:52:08.688+0100 [ERROR] vertex "aws_dataexchange_data_set.datashare (import id \"arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e\")" error: reading DataExchange DataSet (arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e): operation error DataExchange: GetDataSet, https response error StatusCode: 400, RequestID: 4a6f4299-c7af-46f9-9ed7-059b9a96d197, ValidationException: The following parameter(s) are not valid: "DataSetId" must only contain alpha-numeric characters, "DataSetId" length must be less than or equal to 40 characters long.
2025-01-11T21:52:08.688+0100 [ERROR] vertex "aws_dataexchange_data_set.datashare (expand)" error: reading DataExchange DataSet (arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e): operation error DataExchange: GetDataSet, https response error StatusCode: 400, RequestID: 4a6f4299-c7af-46f9-9ed7-059b9a96d197, ValidationException: The following parameter(s) are not valid: "DataSetId" must only contain alpha-numeric characters, "DataSetId" length must be less than or equal to 40 characters long.
╷
│ Error: reading DataExchange DataSet (arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e): operation error DataExchange: GetDataSet, https response error StatusCode: 400, RequestID: 4a6f4299-c7af-46f9-9ed7-059b9a96d197, ValidationException: The following parameter(s) are not valid: "DataSetId" must only contain alpha-numeric characters, "DataSetId" length must be less than or equal to 40 characters long.
│ 
│ 
╵

2025-01-11T21:52:08.689+0100 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2025-01-11T21:52:08.710+0100 [INFO]  provider: plugin process exited: plugin=.terraform/providers/registry.terraform.io/hashicorp/aws/5.82.2/linux_amd64/terraform-provider-aws_v5.82.2_x5 id=27133
2025-01-11T21:52:08.710+0100 [DEBUG] provider: plugin exited
```

The relevant information contained in above output is 

>   http.url="https://dataexchange.us-east-1.amazonaws.com/v1/data-sets/arn%3Aaws%3Adataexchange%3Aus-east-1%3A<redacted>%3Adata-sets%2F72a09faa2ec3c7a223899058d4374e9e"

The provider seems to expect not the ARN, but the dataset identifier when importing, so something like

```shell
terraform import aws_dataexchange_data_set.datashare 72a09faa2ec3c7a223899058d4374e9e
```

The debug log for this command is

```plain
2025-01-11T21:52:34.896+0100 [DEBUG] ReferenceTransformer: "aws_dataexchange_data_set.datashare (import id \"72a09faa2ec3c7a223899058d4374e9e\")" references: []
aws_dataexchange_data_set.datashare: Importing from ID "72a09faa2ec3c7a223899058d4374e9e"...
aws_dataexchange_data_set.datashare: Import prepared!
  Prepared aws_dataexchange_data_set for import
aws_dataexchange_data_set.datashare: Refreshing state... [id=72a09faa2ec3c7a223899058d4374e9e]
2025-01-11T21:52:34.913+0100 [DEBUG] provider.terraform-provider-aws_v5.82.2_x5: HTTP Request Sent: @caller=github.com/hashicorp/aws-sdk-go-base/v2@v2.0.0-beta.59/logging/tf_logger.go:45 net.peer.name=dataexchange.us-east-1.amazonaws.com rpc.system=aws-api tf_aws.sdk=aws-sdk-go-v2 tf_resource_type=aws_dataexchange_data_set tf_rpc=ReadResource rpc.service=DataExchange tf_aws.signing_region="" tf_mux_provider="*schema.GRPCProviderServer" http.url=https://dataexchange.us-east-1.amazonaws.com/v1/data-sets/72a09faa2ec3c7a223899058d4374e9e @module=aws aws.region=us-east-1 http.request.header.amz_sdk_invocation_id=900e68f6-e4e1-48bb-a244-9776ce9fff4b http.request.header.amz_sdk_request="attempt=1; max=25" http.request.header.authorization="AWS4-HMAC-SHA256 Credential=AKIA************RU6X/20250111/us-east-1/dataexchange/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;host;x-amz-date, Signature=*****" http.request.header.x_amz_date=20250111T205234Z http.user_agent="APN/1.0 HashiCorp/1.0 Terraform/1.10.2 (+https://www.terraform.io) terraform-provider-aws/5.82.2 (+https://registry.terraform.io/providers/hashicorp/aws) aws-sdk-go-v2/1.32.6 ua/2.1 os/linux lang/go#1.23.3 md/GOOS#linux md/GOARCH#amd64 api/dataexchange#1.33.5" rpc.method=GetDataSet http.method=GET http.request.body="" tf_provider_addr=registry.terraform.io/hashicorp/aws tf_req_id=fdb5b5cb-ee1c-aacb-7592-05ccefb0b242 timestamp="2025-01-11T21:52:34.913+0100"
2025-01-11T21:52:35.370+0100 [DEBUG] provider.terraform-provider-aws_v5.82.2_x5: HTTP Response Received: http.duration=456 http.response.header.content_type=application/json tf_aws.signing_region="" @caller=github.com/hashicorp/aws-sdk-go-base/v2@v2.0.0-beta.59/logging/tf_logger.go:45 http.response.header.access_control_allow_headers="*,Authorization,Date,X-Amz-Date,X-Amz-Security-Token,X-Amz-Target,content-type,x-amz-content-sha256,x-amz-user-agent,x-amzn-platform-id,x-amzn-trace-id" http.status_code=200 tf_aws.sdk=aws-sdk-go-v2 tf_resource_type=aws_dataexchange_data_set aws.region=us-east-1 http.response.header.x_amz_cf_pop=FRA56-C1 http.response.header.x_amzn_requestid=3d651725-342c-4444-b055-c64847a9c95f tf_req_id=fdb5b5cb-ee1c-aacb-7592-05ccefb0b242 http.response.header.access_control_allow_methods="*" http.response.header.x_amz_cf_id=bVUt8a1CChuOVTqAVI7-SE5h9zqdl0OCUgyFS6Y7bhYK10gxAxAKHQ== rpc.service=DataExchange http.response.header.x_amzn_trace_id=Root=1-6782da13-58f074081f5059ba53a69c99 tf_rpc=ReadResource @module=aws http.response.header.date="Sat, 11 Jan 2025 20:52:35 GMT" http.response_content_length=355 rpc.method=GetDataSet rpc.system=aws-api http.response.header.access_control_max_age=86400 http.response.header.access_control_allow_origin="*" http.response.header.access_control_expose_headers="x-amzn-errortype,x-amzn-requestid,x-amzn-errormessage,x-amzn-trace-id,x-amz-apigw-id,date" http.response.header.via="1.1 1c5b98f7bd5001d6fe1040daa237afc6.cloudfront.net (CloudFront)" http.response.header.x_amz_apigw_id=EPcDEE_WIAMEFgw= http.response.header.x_cache="Miss from cloudfront" tf_mux_provider="*schema.GRPCProviderServer" tf_provider_addr=registry.terraform.io/hashicorp/aws
  http.response.body=
  | {
  |   "Id" : "72a09faa2ec3c7a223899058d4374e9e",
  |   "Arn" : "arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e",
  |   "Name" : "Test123",
  |   "Description" : "Test123",
  |   "AssetType" : "S3_SNAPSHOT",
  |   "CreatedAt" : "2025-01-11T20:48:50.276Z",
  |   "UpdatedAt" : "2025-01-11T20:49:19.911Z",
  |   "Origin" : "OWNED",
  |   "Tags" : { }
  | }
   timestamp="2025-01-11T21:52:35.370+0100"
2025-01-11T21:52:35.372+0100 [WARN]  Provider "registry.terraform.io/hashicorp/aws" produced an unexpected new value for aws_dataexchange_data_set.datashare during refresh.
      - .asset_type: was null, but now cty.StringVal("S3_SNAPSHOT")
      - .description: was null, but now cty.StringVal("Test123")
      - .name: was null, but now cty.StringVal("Test123")
      - .tags: was null, but now cty.MapValEmpty(cty.String)
      - .tags_all: was null, but now cty.MapValEmpty(cty.String)
      - .arn: was null, but now cty.StringVal("arn:aws:dataexchange:us-east-1:<redacted>:data-sets/72a09faa2ec3c7a223899058d4374e9e")
2025-01-11T21:52:35.373+0100 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2025-01-11T21:52:35.392+0100 [INFO]  provider: plugin process exited: plugin=.terraform/providers/registry.terraform.io/hashicorp/aws/5.82.2/linux_amd64/terraform-provider-aws_v5.82.2_x5 id=27368
2025-01-11T21:52:35.393+0100 [DEBUG] provider: plugin exited
2025-01-11T21:52:35.393+0100 [INFO]  Writing state output to:

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

The resource import was succesful.

### Relations

Relates #40871 

### References

- [Importer definition in source code](https://github.com/hashicorp/terraform-provider-aws/blob/15776d9903414a249bde1450e96e20e72266df3f/internal/service/dataexchange/data_set.go#L34)

### Output from Acceptance Testing

Not applicable, only documentation is updated.