### PR TITLE
Tech debt: Require `name=` value for `@SDKResource` annotation

### DIFF
--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -287,6 +287,10 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 				} else {
 					v.sdkResources[typeName] = d
 				}
+
+				if d.Name == "" {
+					v.g.Errorf("%s missing name: %s/%s", annotationName, v.packageName, typeName)
+				}
 			case "Tags":
 				// Handled above.
 			case "Testing":

--- a/internal/service/accessanalyzer/archive_rule.go
+++ b/internal/service/accessanalyzer/archive_rule.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_accessanalyzer_archive_rule")
+// @SDKResource("aws_accessanalyzer_archive_rule", name="Archive Rule")
 func resourceArchiveRule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceArchiveRuleCreate,

--- a/internal/service/accessanalyzer/service_package_gen.go
+++ b/internal/service/accessanalyzer/service_package_gen.go
@@ -39,6 +39,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceArchiveRule,
 			TypeName: "aws_accessanalyzer_archive_rule",
+			Name:     "Archive Rule",
 		},
 	}
 }

--- a/internal/service/account/alternate_contact.go
+++ b/internal/service/account/alternate_contact.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_account_alternate_contact")
+// @SDKResource("aws_account_alternate_contact", name="Alternate Contact")
 func resourceAlternateContact() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAlternateContactCreate,

--- a/internal/service/account/primary_contact.go
+++ b/internal/service/account/primary_contact.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_account_primary_contact")
+// @SDKResource("aws_account_primary_contact", name="Primary Contact")
 func resourcePrimaryContact() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePrimaryContactPut,

--- a/internal/service/account/service_package_gen.go
+++ b/internal/service/account/service_package_gen.go
@@ -31,10 +31,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceAlternateContact,
 			TypeName: "aws_account_alternate_contact",
+			Name:     "Alternate Contact",
 		},
 		{
 			Factory:  resourcePrimaryContact,
 			TypeName: "aws_account_primary_contact",
+			Name:     "Primary Contact",
 		},
 		{
 			Factory:  resourceRegion,

--- a/internal/service/acm/certificate_validation.go
+++ b/internal/service/acm/certificate_validation.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_acm_certificate_validation")
+// @SDKResource("aws_acm_certificate_validation", name="Certificate Validation")
 func resourceCertificateValidation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCertificateValidationCreate,

--- a/internal/service/acm/service_package_gen.go
+++ b/internal/service/acm/service_package_gen.go
@@ -48,6 +48,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceCertificateValidation,
 			TypeName: "aws_acm_certificate_validation",
+			Name:     "Certificate Validation",
 		},
 	}
 }

--- a/internal/service/appautoscaling/scheduled_action.go
+++ b/internal/service/appautoscaling/scheduled_action.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_appautoscaling_scheduled_action", namae="Scheduled Action")
+// @SDKResource("aws_appautoscaling_scheduled_action", name="Scheduled Action")
 func resourceScheduledAction() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceScheduledActionPut,

--- a/internal/service/appautoscaling/service_package_gen.go
+++ b/internal/service/appautoscaling/service_package_gen.go
@@ -36,6 +36,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceScheduledAction,
 			TypeName: "aws_appautoscaling_scheduled_action",
+			Name:     "Scheduled Action",
 		},
 		{
 			Factory:  resourceTarget,

--- a/internal/service/appconfig/extension_association.go
+++ b/internal/service/appconfig/extension_association.go
@@ -25,7 +25,7 @@ const (
 	ResExtensionAssociation = "ExtensionAssociation"
 )
 
-// @SDKResource("aws_appconfig_extension_association")
+// @SDKResource("aws_appconfig_extension_association", name="Extension Association")
 func ResourceExtensionAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceExtensionAssociationCreate,

--- a/internal/service/appconfig/hosted_configuration_version.go
+++ b/internal/service/appconfig/hosted_configuration_version.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_appconfig_hosted_configuration_version")
+// @SDKResource("aws_appconfig_hosted_configuration_version", name="Hosted Configuration Version")
 func ResourceHostedConfigurationVersion() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceHostedConfigurationVersionCreate,

--- a/internal/service/appconfig/service_package_gen.go
+++ b/internal/service/appconfig/service_package_gen.go
@@ -106,10 +106,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceExtensionAssociation,
 			TypeName: "aws_appconfig_extension_association",
+			Name:     "Extension Association",
 		},
 		{
 			Factory:  ResourceHostedConfigurationVersion,
 			TypeName: "aws_appconfig_hosted_configuration_version",
+			Name:     "Hosted Configuration Version",
 		},
 	}
 }

--- a/internal/service/appstream/directory_config.go
+++ b/internal/service/appstream/directory_config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_appstream_directory_config")
+// @SDKResource("aws_appstream_directory_config", name="Directory Config")
 func ResourceDirectoryConfig() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDirectoryConfigCreate,

--- a/internal/service/appstream/fleet_stack_association.go
+++ b/internal/service/appstream/fleet_stack_association.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// @SDKResource("aws_appstream_fleet_stack_association")
+// @SDKResource("aws_appstream_fleet_stack_association", name="Fleet Stack Association")
 func ResourceFleetStackAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceFleetStackAssociationCreate,

--- a/internal/service/appstream/service_package_gen.go
+++ b/internal/service/appstream/service_package_gen.go
@@ -36,6 +36,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDirectoryConfig,
 			TypeName: "aws_appstream_directory_config",
+			Name:     "Directory Config",
 		},
 		{
 			Factory:  ResourceFleet,
@@ -48,6 +49,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceFleetStackAssociation,
 			TypeName: "aws_appstream_fleet_stack_association",
+			Name:     "Fleet Stack Association",
 		},
 		{
 			Factory:  ResourceImageBuilder,
@@ -68,10 +70,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceUser,
 			TypeName: "aws_appstream_user",
+			Name:     "User",
 		},
 		{
 			Factory:  ResourceUserStackAssociation,
 			TypeName: "aws_appstream_user_stack_association",
+			Name:     "User Stack Association",
 		},
 	}
 }

--- a/internal/service/appstream/user.go
+++ b/internal/service/appstream/user.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_appstream_user")
+// @SDKResource("aws_appstream_user", name="User")
 func ResourceUser() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUserCreate,

--- a/internal/service/appstream/user_stack_association.go
+++ b/internal/service/appstream/user_stack_association.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_appstream_user_stack_association")
+// @SDKResource("aws_appstream_user_stack_association", name="User Stack Association")
 func ResourceUserStackAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUserStackAssociationCreate,

--- a/internal/service/athena/database.go
+++ b/internal/service/athena/database.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_athena_database")
+// @SDKResource("aws_athena_database", name="Database")
 func resourceDatabase() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDatabaseCreate,

--- a/internal/service/athena/named_query.go
+++ b/internal/service/athena/named_query.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_athena_named_query")
+// @SDKResource("aws_athena_named_query", name="Named Query")
 func resourceNamedQuery() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceNamedQueryCreate,

--- a/internal/service/athena/service_package_gen.go
+++ b/internal/service/athena/service_package_gen.go
@@ -44,10 +44,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceDatabase,
 			TypeName: "aws_athena_database",
+			Name:     "Database",
 		},
 		{
 			Factory:  resourceNamedQuery,
 			TypeName: "aws_athena_named_query",
+			Name:     "Named Query",
 		},
 		{
 			Factory:  resourcePreparedStatement,

--- a/internal/service/autoscalingplans/scaling_plan.go
+++ b/internal/service/autoscalingplans/scaling_plan.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_autoscalingplans_scaling_plan")
+// @SDKResource("aws_autoscalingplans_scaling_plan", name="Scaling Plan")
 func ResourceScalingPlan() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceScalingPlanCreate,

--- a/internal/service/autoscalingplans/service_package_gen.go
+++ b/internal/service/autoscalingplans/service_package_gen.go
@@ -31,6 +31,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceScalingPlan,
 			TypeName: "aws_autoscalingplans_scaling_plan",
+			Name:     "Scaling Plan",
 		},
 	}
 }

--- a/internal/service/budgets/budget_action.go
+++ b/internal/service/budgets/budget_action.go
@@ -30,7 +30,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_budgets_budget_action")
+// @SDKResource("aws_budgets_budget_action", name="Budget Action")
 // @Tags(identifierAttribute="arn")
 // @Testing(tagsTest=false)
 func ResourceBudgetAction() *schema.Resource {

--- a/internal/service/budgets/service_package_gen.go
+++ b/internal/service/budgets/service_package_gen.go
@@ -48,6 +48,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceBudgetAction,
 			TypeName: "aws_budgets_budget_action",
+			Name:     "Budget Action",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			},

--- a/internal/service/chime/service_package_gen.go
+++ b/internal/service/chime/service_package_gen.go
@@ -39,26 +39,32 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceVoiceConnectorGroup,
 			TypeName: "aws_chime_voice_connector_group",
+			Name:     "Voice Connector Group",
 		},
 		{
 			Factory:  ResourceVoiceConnectorLogging,
 			TypeName: "aws_chime_voice_connector_logging",
+			Name:     "Voice Connector Logging",
 		},
 		{
 			Factory:  ResourceVoiceConnectorOrigination,
 			TypeName: "aws_chime_voice_connector_origination",
+			Name:     "Voice Connector Origination",
 		},
 		{
 			Factory:  ResourceVoiceConnectorStreaming,
 			TypeName: "aws_chime_voice_connector_streaming",
+			Name:     "Voice Connector Streaming",
 		},
 		{
 			Factory:  ResourceVoiceConnectorTermination,
 			TypeName: "aws_chime_voice_connector_termination",
+			Name:     "Voice Connector Termination",
 		},
 		{
 			Factory:  ResourceVoiceConnectorTerminationCredentials,
 			TypeName: "aws_chime_voice_connector_termination_credentials",
+			Name:     "Voice Connector Termination Credentials",
 		},
 	}
 }

--- a/internal/service/chime/voice_connector_group.go
+++ b/internal/service/chime/voice_connector_group.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_chime_voice_connector_group")
+// @SDKResource("aws_chime_voice_connector_group", name="Voice Connector Group")
 func ResourceVoiceConnectorGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVoiceConnectorGroupCreate,

--- a/internal/service/chime/voice_connector_logging.go
+++ b/internal/service/chime/voice_connector_logging.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// @SDKResource("aws_chime_voice_connector_logging")
+// @SDKResource("aws_chime_voice_connector_logging", name="Voice Connector Logging")
 func ResourceVoiceConnectorLogging() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVoiceConnectorLoggingCreate,

--- a/internal/service/chime/voice_connector_origination.go
+++ b/internal/service/chime/voice_connector_origination.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_chime_voice_connector_origination")
+// @SDKResource("aws_chime_voice_connector_origination", name="Voice Connector Origination")
 func ResourceVoiceConnectorOrigination() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVoiceConnectorOriginationCreate,

--- a/internal/service/chime/voice_connector_streaming.go
+++ b/internal/service/chime/voice_connector_streaming.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_chime_voice_connector_streaming")
+// @SDKResource("aws_chime_voice_connector_streaming", name="Voice Connector Streaming")
 func ResourceVoiceConnectorStreaming() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVoiceConnectorStreamingCreate,

--- a/internal/service/chime/voice_connector_termination.go
+++ b/internal/service/chime/voice_connector_termination.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
-// @SDKResource("aws_chime_voice_connector_termination")
+// @SDKResource("aws_chime_voice_connector_termination", name="Voice Connector Termination")
 func ResourceVoiceConnectorTermination() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVoiceConnectorTerminationCreate,

--- a/internal/service/chime/voice_connector_termination_credentials.go
+++ b/internal/service/chime/voice_connector_termination_credentials.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_chime_voice_connector_termination_credentials")
+// @SDKResource("aws_chime_voice_connector_termination_credentials", name="Voice Connector Termination Credentials")
 func ResourceVoiceConnectorTerminationCredentials() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVoiceConnectorTerminationCredentialsCreate,

--- a/internal/service/chimesdkvoice/global_settings.go
+++ b/internal/service/chimesdkvoice/global_settings.go
@@ -26,7 +26,7 @@ const (
 	globalSettingsPropagationTimeout = 20 * time.Second
 )
 
-// @SDKResource("aws_chimesdkvoice_global_settings")
+// @SDKResource("aws_chimesdkvoice_global_settings", name="Global Settings")
 func ResourceGlobalSettings() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceGlobalSettingsUpdate,

--- a/internal/service/chimesdkvoice/service_package_gen.go
+++ b/internal/service/chimesdkvoice/service_package_gen.go
@@ -31,6 +31,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceGlobalSettings,
 			TypeName: "aws_chimesdkvoice_global_settings",
+			Name:     "Global Settings",
 		},
 		{
 			Factory:  ResourceSipMediaApplication,

--- a/internal/service/cleanrooms/collaboration.go
+++ b/internal/service/cleanrooms/collaboration.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_cleanrooms_collaboration")
+// @SDKResource("aws_cleanrooms_collaboration", name="Collaboration")
 // @Tags(identifierAttribute="arn")
 // @Testing(tagsTest=false)
 func ResourceCollaboration() *schema.Resource {

--- a/internal/service/cleanrooms/configured_table.go
+++ b/internal/service/cleanrooms/configured_table.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_cleanrooms_configured_table")
+// @SDKResource("aws_cleanrooms_configured_table", name="Configured Table")
 // @Tags(identifierAttribute="arn")
 // @Testing(tagsTest=false)
 func ResourceConfiguredTable() *schema.Resource {

--- a/internal/service/cleanrooms/service_package_gen.go
+++ b/internal/service/cleanrooms/service_package_gen.go
@@ -39,6 +39,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCollaboration,
 			TypeName: "aws_cleanrooms_collaboration",
+			Name:     "Collaboration",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			},
@@ -46,6 +47,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceConfiguredTable,
 			TypeName: "aws_cleanrooms_configured_table",
+			Name:     "Configured Table",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			},

--- a/internal/service/customerprofiles/domain.go
+++ b/internal/service/customerprofiles/domain.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_customerprofiles_domain")
+// @SDKResource("aws_customerprofiles_domain", name="Domain")
 // @Tags(identifierAttribute="arn")
 func ResourceDomain() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/customerprofiles/profile.go
+++ b/internal/service/customerprofiles/profile.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_customerprofiles_profile")
+// @SDKResource("aws_customerprofiles_profile", name="Profile")
 func ResourceProfile() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceProfileCreate,

--- a/internal/service/customerprofiles/service_package_gen.go
+++ b/internal/service/customerprofiles/service_package_gen.go
@@ -31,6 +31,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDomain,
 			TypeName: "aws_customerprofiles_domain",
+			Name:     "Domain",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			},
@@ -38,6 +39,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceProfile,
 			TypeName: "aws_customerprofiles_profile",
+			Name:     "Profile",
 		},
 	}
 }

--- a/internal/service/datapipeline/pipeline_definition.go
+++ b/internal/service/datapipeline/pipeline_definition.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_datapipeline_pipeline_definition")
+// @SDKResource("aws_datapipeline_pipeline_definition", name="Pipeline Definition")
 func ResourcePipelineDefinition() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePipelineDefinitionPut,

--- a/internal/service/datapipeline/service_package_gen.go
+++ b/internal/service/datapipeline/service_package_gen.go
@@ -50,6 +50,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePipelineDefinition,
 			TypeName: "aws_datapipeline_pipeline_definition",
+			Name:     "Pipeline Definition",
 		},
 	}
 }

--- a/internal/service/dax/parameter_group.go
+++ b/internal/service/dax/parameter_group.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_dax_parameter_group")
+// @SDKResource("aws_dax_parameter_group", name="Parameter Group")
 func ResourceParameterGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceParameterGroupCreate,

--- a/internal/service/dax/service_package_gen.go
+++ b/internal/service/dax/service_package_gen.go
@@ -39,10 +39,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceParameterGroup,
 			TypeName: "aws_dax_parameter_group",
+			Name:     "Parameter Group",
 		},
 		{
 			Factory:  ResourceSubnetGroup,
 			TypeName: "aws_dax_subnet_group",
+			Name:     "Subnet Group",
 		},
 	}
 }

--- a/internal/service/dax/subnet_group.go
+++ b/internal/service/dax/subnet_group.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_dax_subnet_group")
+// @SDKResource("aws_dax_subnet_group", name="Subnet Group")
 func ResourceSubnetGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSubnetGroupCreate,

--- a/internal/service/detective/invitation_accepter.go
+++ b/internal/service/detective/invitation_accepter.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_detective_invitation_accepter")
+// @SDKResource("aws_detective_invitation_accepter", name="Invitation Accepter")
 func ResourceInvitationAccepter() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceInvitationAccepterCreate,

--- a/internal/service/detective/member.go
+++ b/internal/service/detective/member.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_detective_member")
+// @SDKResource("aws_detective_member", name="Member")
 func ResourceMember() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceMemberCreate,

--- a/internal/service/detective/organization_admin_account.go
+++ b/internal/service/detective/organization_admin_account.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_detective_organization_admin_account")
+// @SDKResource("aws_detective_organization_admin_account", name="Organization Admin Account")
 func ResourceOrganizationAdminAccount() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceOrganizationAdminAccountCreate,

--- a/internal/service/detective/organization_configuration.go
+++ b/internal/service/detective/organization_configuration.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_detective_organization_configuration")
+// @SDKResource("aws_detective_organization_configuration", name="Organization Configuration")
 func ResourceOrganizationConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceOrganizationConfigurationUpdate,

--- a/internal/service/detective/service_package_gen.go
+++ b/internal/service/detective/service_package_gen.go
@@ -39,18 +39,22 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceInvitationAccepter,
 			TypeName: "aws_detective_invitation_accepter",
+			Name:     "Invitation Accepter",
 		},
 		{
 			Factory:  ResourceMember,
 			TypeName: "aws_detective_member",
+			Name:     "Member",
 		},
 		{
 			Factory:  ResourceOrganizationAdminAccount,
 			TypeName: "aws_detective_organization_admin_account",
+			Name:     "Organization Admin Account",
 		},
 		{
 			Factory:  ResourceOrganizationConfiguration,
 			TypeName: "aws_detective_organization_configuration",
+			Name:     "Organization Configuration",
 		},
 	}
 }

--- a/internal/service/docdb/cluster_snapshot.go
+++ b/internal/service/docdb/cluster_snapshot.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_docdb_cluster_snapshot")
+// @SDKResource("aws_docdb_cluster_snapshot", name="Cluster Snapshot")
 func ResourceClusterSnapshot() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterSnapshotCreate,

--- a/internal/service/docdb/global_cluster.go
+++ b/internal/service/docdb/global_cluster.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_docdb_global_cluster")
+// @SDKResource("aws_docdb_global_cluster", name="Global Cluster")
 func resourceGlobalCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceGlobalClusterCreate,

--- a/internal/service/docdb/service_package_gen.go
+++ b/internal/service/docdb/service_package_gen.go
@@ -64,6 +64,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceClusterSnapshot,
 			TypeName: "aws_docdb_cluster_snapshot",
+			Name:     "Cluster Snapshot",
 		},
 		{
 			Factory:  resourceEventSubscription,
@@ -76,6 +77,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceGlobalCluster,
 			TypeName: "aws_docdb_global_cluster",
+			Name:     "Global Cluster",
 		},
 		{
 			Factory:  resourceSubnetGroup,

--- a/internal/service/ec2/outposts_local_gateway_route.go
+++ b/internal/service/ec2/outposts_local_gateway_route.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_ec2_local_gateway_route")
+// @SDKResource("aws_ec2_local_gateway_route", name="Local Gateway Route")
 func resourceLocalGatewayRoute() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLocalGatewayRouteCreate,

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -765,6 +765,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceLocalGatewayRoute,
 			TypeName: "aws_ec2_local_gateway_route",
+			Name:     "Local Gateway Route",
 		},
 		{
 			Factory:  resourceLocalGatewayRouteTableVPCAssociation,
@@ -1244,6 +1245,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceVPCEndpointPolicy,
 			TypeName: "aws_vpc_endpoint_policy",
+			Name:     "VPC Endpoint Policy",
 		},
 		{
 			Factory:  resourceVPCEndpointRouteTableAssociation,

--- a/internal/service/ec2/vpc_endpoint_policy.go
+++ b/internal/service/ec2/vpc_endpoint_policy.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_vpc_endpoint_policy", "VPC Endpoint Policy")
+// @SDKResource("aws_vpc_endpoint_policy", name="VPC Endpoint Policy")
 func resourceVPCEndpointPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVPCEndpointPolicyPut,

--- a/internal/service/ecrpublic/repository_policy.go
+++ b/internal/service/ecrpublic/repository_policy.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ecrpublic_repository_policy")
+// @SDKResource("aws_ecrpublic_repository_policy", name="Repository Policy")
 func ResourceRepositoryPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRepositoryPolicyPut,

--- a/internal/service/ecrpublic/service_package_gen.go
+++ b/internal/service/ecrpublic/service_package_gen.go
@@ -44,6 +44,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceRepositoryPolicy,
 			TypeName: "aws_ecrpublic_repository_policy",
+			Name:     "Repository Policy",
 		},
 	}
 }

--- a/internal/service/elastictranscoder/pipeline.go
+++ b/internal/service/elastictranscoder/pipeline.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_elastictranscoder_pipeline")
+// @SDKResource("aws_elastictranscoder_pipeline", name="Pipeline")
 func ResourcePipeline() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePipelineCreate,

--- a/internal/service/elastictranscoder/preset.go
+++ b/internal/service/elastictranscoder/preset.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_elastictranscoder_preset")
+// @SDKResource("aws_elastictranscoder_preset", name="Preset")
 func ResourcePreset() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePresetCreate,

--- a/internal/service/elastictranscoder/service_package_gen.go
+++ b/internal/service/elastictranscoder/service_package_gen.go
@@ -31,10 +31,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePipeline,
 			TypeName: "aws_elastictranscoder_pipeline",
+			Name:     "Pipeline",
 		},
 		{
 			Factory:  ResourcePreset,
 			TypeName: "aws_elastictranscoder_preset",
+			Name:     "Preset",
 		},
 	}
 }

--- a/internal/service/glacier/service_package_gen.go
+++ b/internal/service/glacier/service_package_gen.go
@@ -39,6 +39,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceVaultLock,
 			TypeName: "aws_glacier_vault_lock",
+			Name:     "Vault Lock",
 		},
 	}
 }

--- a/internal/service/glacier/vault_lock.go
+++ b/internal/service/glacier/vault_lock.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_glacier_vault_lock")
+// @SDKResource("aws_glacier_vault_lock", name="Vault Lock")
 func resourceVaultLock() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceVaultLockCreate,

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_glue_catalog_table")
+// @SDKResource("aws_glue_catalog_table", name="Catalog Table")
 func ResourceCatalogTable() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCatalogTableCreate,

--- a/internal/service/glue/classifier.go
+++ b/internal/service/glue/classifier.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_glue_classifier")
+// @SDKResource("aws_glue_classifier", name="Classifier")
 func ResourceClassifier() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClassifierCreate,

--- a/internal/service/glue/data_catalog_encryption_settings.go
+++ b/internal/service/glue/data_catalog_encryption_settings.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_glue_data_catalog_encryption_settings")
+// @SDKResource("aws_glue_data_catalog_encryption_settings", name="Data Catalog Encryption Settings")
 func ResourceDataCatalogEncryptionSettings() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDataCatalogEncryptionSettingsPut,

--- a/internal/service/glue/data_catalog_encryption_settings_data_source.go
+++ b/internal/service/glue/data_catalog_encryption_settings_data_source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_glue_data_catalog_encryption_settings")
+// @SDKDataSource("aws_glue_data_catalog_encryption_settings", name="Data Catalog Encryption Settings")
 func DataSourceDataCatalogEncryptionSettings() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceDataCatalogEncryptionSettingsRead,

--- a/internal/service/glue/partition.go
+++ b/internal/service/glue/partition.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_glue_partition")
+// @SDKResource("aws_glue_partition", name="Partition")
 func ResourcePartition() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePartitionCreate,

--- a/internal/service/glue/partition_index.go
+++ b/internal/service/glue/partition_index.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_glue_partition_index")
+// @SDKResource("aws_glue_partition_index", name="Partition Index")
 func ResourcePartitionIndex() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePartitionIndexCreate,

--- a/internal/service/glue/resource_policy.go
+++ b/internal/service/glue/resource_policy.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_glue_resource_policy")
+// @SDKResource("aws_glue_resource_policy", name="Resource Policy")
 func ResourceResourcePolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceResourcePolicyPut(awstypes.ExistConditionNotExist),

--- a/internal/service/glue/security_configuration.go
+++ b/internal/service/glue/security_configuration.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_glue_security_configuration")
+// @SDKResource("aws_glue_security_configuration", name="Security Configuration")
 func ResourceSecurityConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSecurityConfigurationCreate,

--- a/internal/service/glue/service_package_gen.go
+++ b/internal/service/glue/service_package_gen.go
@@ -45,6 +45,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceDataCatalogEncryptionSettings,
 			TypeName: "aws_glue_data_catalog_encryption_settings",
+			Name:     "Data Catalog Encryption Settings",
 		},
 		{
 			Factory:  DataSourceScript,
@@ -66,10 +67,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceCatalogTable,
 			TypeName: "aws_glue_catalog_table",
+			Name:     "Catalog Table",
 		},
 		{
 			Factory:  ResourceClassifier,
 			TypeName: "aws_glue_classifier",
+			Name:     "Classifier",
 		},
 		{
 			Factory:  ResourceConnection,
@@ -90,6 +93,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDataCatalogEncryptionSettings,
 			TypeName: "aws_glue_data_catalog_encryption_settings",
+			Name:     "Data Catalog Encryption Settings",
 		},
 		{
 			Factory:  ResourceDataQualityRuleset,
@@ -126,10 +130,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePartition,
 			TypeName: "aws_glue_partition",
+			Name:     "Partition",
 		},
 		{
 			Factory:  ResourcePartitionIndex,
 			TypeName: "aws_glue_partition_index",
+			Name:     "Partition Index",
 		},
 		{
 			Factory:  ResourceRegistry,
@@ -142,6 +148,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceResourcePolicy,
 			TypeName: "aws_glue_resource_policy",
+			Name:     "Resource Policy",
 		},
 		{
 			Factory:  ResourceSchema,
@@ -154,6 +161,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSecurityConfiguration,
 			TypeName: "aws_glue_security_configuration",
+			Name:     "Security Configuration",
 		},
 		{
 			Factory:  ResourceTrigger,
@@ -166,6 +174,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceUserDefinedFunction,
 			TypeName: "aws_glue_user_defined_function",
+			Name:     "User Defined Function",
 		},
 		{
 			Factory:  ResourceWorkflow,

--- a/internal/service/glue/user_defined_function.go
+++ b/internal/service/glue/user_defined_function.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_glue_user_defined_function")
+// @SDKResource("aws_glue_user_defined_function", name="User Defined Function")
 func ResourceUserDefinedFunction() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceUserDefinedFunctionCreate,

--- a/internal/service/guardduty/member.go
+++ b/internal/service/guardduty/member.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_guardduty_member")
+// @SDKResource("aws_guardduty_member", name="Member")
 func ResourceMember() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceMemberCreate,

--- a/internal/service/guardduty/organization_admin_account.go
+++ b/internal/service/guardduty/organization_admin_account.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_guardduty_organization_admin_account")
+// @SDKResource("aws_guardduty_organization_admin_account", name="Organization Admin Account")
 func ResourceOrganizationAdminAccount() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceOrganizationAdminAccountCreate,

--- a/internal/service/guardduty/publishing_destination.go
+++ b/internal/service/guardduty/publishing_destination.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_guardduty_publishing_destination")
+// @SDKResource("aws_guardduty_publishing_destination", name="Publishing Destination")
 func ResourcePublishingDestination() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePublishingDestinationCreate,

--- a/internal/service/guardduty/service_package_gen.go
+++ b/internal/service/guardduty/service_package_gen.go
@@ -83,10 +83,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceMember,
 			TypeName: "aws_guardduty_member",
+			Name:     "Member",
 		},
 		{
 			Factory:  ResourceOrganizationAdminAccount,
 			TypeName: "aws_guardduty_organization_admin_account",
+			Name:     "Organization Admin Account",
 		},
 		{
 			Factory:  ResourceOrganizationConfiguration,
@@ -101,6 +103,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePublishingDestination,
 			TypeName: "aws_guardduty_publishing_destination",
+			Name:     "Publishing Destination",
 		},
 		{
 			Factory:  ResourceThreatIntelSet,

--- a/internal/service/inspector/assessment_target.go
+++ b/internal/service/inspector/assessment_target.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_inspector_assessment_target")
+// @SDKResource("aws_inspector_assessment_target", name="Assessment Target")
 func ResourceAssessmentTarget() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAssessmentTargetCreate,

--- a/internal/service/inspector/resource_group.go
+++ b/internal/service/inspector/resource_group.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_inspector_resource_group")
+// @SDKResource("aws_inspector_resource_group", name="Resource Group")
 func ResourceResourceGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceResourceGroupCreate,

--- a/internal/service/inspector/service_package_gen.go
+++ b/internal/service/inspector/service_package_gen.go
@@ -36,6 +36,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAssessmentTarget,
 			TypeName: "aws_inspector_assessment_target",
+			Name:     "Assessment Target",
 		},
 		{
 			Factory:  ResourceAssessmentTemplate,
@@ -48,6 +49,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceResourceGroup,
 			TypeName: "aws_inspector_resource_group",
+			Name:     "Resource Group",
 		},
 	}
 }

--- a/internal/service/inspector2/enabler.go
+++ b/internal/service/inspector2/enabler.go
@@ -34,7 +34,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// @SDKResource("aws_inspector2_enabler")
+// @SDKResource("aws_inspector2_enabler", name="Enabler")
 func ResourceEnabler() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEnablerCreate,

--- a/internal/service/inspector2/service_package_gen.go
+++ b/internal/service/inspector2/service_package_gen.go
@@ -36,6 +36,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceEnabler,
 			TypeName: "aws_inspector2_enabler",
+			Name:     "Enabler",
 		},
 		{
 			Factory:  resourceMemberAssociation,

--- a/internal/service/iot/policy_attachment.go
+++ b/internal/service/iot/policy_attachment.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_iot_policy_attachment", nmw="Policy Attachment")
+// @SDKResource("aws_iot_policy_attachment", name="Policy Attachment")
 func resourcePolicyAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePolicyAttachmentCreate,

--- a/internal/service/iot/service_package_gen.go
+++ b/internal/service/iot/service_package_gen.go
@@ -102,6 +102,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourcePolicyAttachment,
 			TypeName: "aws_iot_policy_attachment",
+			Name:     "Policy Attachment",
 		},
 		{
 			Factory:  resourceProvisioningTemplate,

--- a/internal/service/kendra/experience.go
+++ b/internal/service/kendra/experience.go
@@ -29,7 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_kendra_experience")
+// @SDKResource("aws_kendra_experience", name="Experience")
 func ResourceExperience() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceExperienceCreate,

--- a/internal/service/kendra/service_package_gen.go
+++ b/internal/service/kendra/service_package_gen.go
@@ -60,6 +60,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceExperience,
 			TypeName: "aws_kendra_experience",
+			Name:     "Experience",
 		},
 		{
 			Factory:  ResourceFaq,

--- a/internal/service/lakeformation/data_lake_settings.go
+++ b/internal/service/lakeformation/data_lake_settings.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lakeformation_data_lake_settings")
+// @SDKResource("aws_lakeformation_data_lake_settings", name="Data Lake Settings")
 func ResourceDataLakeSettings() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDataLakeSettingsCreate,

--- a/internal/service/lakeformation/lf_tag.go
+++ b/internal/service/lakeformation/lf_tag.go
@@ -27,7 +27,7 @@ import (
 // This value is defined by AWS API
 const lfTagsValuesMaxBatchSize = 50
 
-// @SDKResource("aws_lakeformation_lf_tag")
+// @SDKResource("aws_lakeformation_lf_tag", name="LF Tag")
 func ResourceLFTag() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLFTagCreate,

--- a/internal/service/lakeformation/permissions.go
+++ b/internal/service/lakeformation/permissions.go
@@ -29,7 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lakeformation_permissions")
+// @SDKResource("aws_lakeformation_permissions", name="Permissions")
 func ResourcePermissions() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePermissionsCreate,

--- a/internal/service/lakeformation/resource_lf_tags.go
+++ b/internal/service/lakeformation/resource_lf_tags.go
@@ -30,7 +30,7 @@ const (
 	ResNameLFTags = "Resource LF Tags"
 )
 
-// @SDKResource("aws_lakeformation_resource_lf_tags")
+// @SDKResource("aws_lakeformation_resource_lf_tags", name="Resource LF Tags")
 func ResourceResourceLFTags() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceResourceLFTagsCreate,

--- a/internal/service/lakeformation/service_package_gen.go
+++ b/internal/service/lakeformation/service_package_gen.go
@@ -53,14 +53,17 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDataLakeSettings,
 			TypeName: "aws_lakeformation_data_lake_settings",
+			Name:     "Data Lake Settings",
 		},
 		{
 			Factory:  ResourceLFTag,
 			TypeName: "aws_lakeformation_lf_tag",
+			Name:     "LF Tag",
 		},
 		{
 			Factory:  ResourcePermissions,
 			TypeName: "aws_lakeformation_permissions",
+			Name:     "Permissions",
 		},
 		{
 			Factory:  ResourceResource,
@@ -70,6 +73,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceResourceLFTags,
 			TypeName: "aws_lakeformation_resource_lf_tags",
+			Name:     "Resource LF Tags",
 		},
 	}
 }

--- a/internal/service/lexmodels/bot.go
+++ b/internal/service/lexmodels/bot.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lex_bot")
+// @SDKResource("aws_lex_bot", name="Bot")
 func resourceBot() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBotCreate,

--- a/internal/service/lexmodels/service_package_gen.go
+++ b/internal/service/lexmodels/service_package_gen.go
@@ -52,6 +52,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceBot,
 			TypeName: "aws_lex_bot",
+			Name:     "Bot",
 		},
 		{
 			Factory:  resourceBotAlias,

--- a/internal/service/lightsail/bucket_access_key.go
+++ b/internal/service/lightsail/bucket_access_key.go
@@ -27,7 +27,7 @@ const (
 	BucketAccessKeyIdPartsCount = 2
 )
 
-// @SDKResource("aws_lightsail_bucket_access_key")
+// @SDKResource("aws_lightsail_bucket_access_key", name="Bucket Access Key")
 func ResourceBucketAccessKey() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketAccessKeyCreate,

--- a/internal/service/lightsail/bucket_resource_access.go
+++ b/internal/service/lightsail/bucket_resource_access.go
@@ -26,7 +26,7 @@ const (
 	BucketResourceAccessIdPartsCount = 2
 )
 
-// @SDKResource("aws_lightsail_bucket_resource_access")
+// @SDKResource("aws_lightsail_bucket_resource_access", name="Bucket Resource Access")
 func ResourceBucketResourceAccess() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketResourceAccessCreate,

--- a/internal/service/lightsail/container_service_deployment_version.go
+++ b/internal/service/lightsail/container_service_deployment_version.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_container_service_deployment_version")
+// @SDKResource("aws_lightsail_container_service_deployment_version", name=Container Service Deployment Version")
 func ResourceContainerServiceDeploymentVersion() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceContainerServiceDeploymentVersionCreate,

--- a/internal/service/lightsail/disk_attachment.go
+++ b/internal/service/lightsail/disk_attachment.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_disk_attachment")
+// @SDKResource("aws_lightsail_disk_attachment", name="Disk Attachment")
 func ResourceDiskAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDiskAttachmentCreate,

--- a/internal/service/lightsail/domain.go
+++ b/internal/service/lightsail/domain.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_domain")
+// @SDKResource("aws_lightsail_domain", name="Domain")
 func ResourceDomain() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainCreate,

--- a/internal/service/lightsail/domain_entry.go
+++ b/internal/service/lightsail/domain_entry.go
@@ -28,7 +28,7 @@ const (
 	ResNameDomainEntry      = "DomainEntry"
 )
 
-// @SDKResource("aws_lightsail_domain_entry")
+// @SDKResource("aws_lightsail_domain_entry", name="Domain Entry")
 func ResourceDomainEntry() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDomainEntryCreate,

--- a/internal/service/lightsail/instance_public_ports.go
+++ b/internal/service/lightsail/instance_public_ports.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_instance_public_ports")
+// @SDKResource("aws_lightsail_instance_public_ports", name="Instance Public Ports")
 func ResourceInstancePublicPorts() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceInstancePublicPortsCreate,

--- a/internal/service/lightsail/lb_attachment.go
+++ b/internal/service/lightsail/lb_attachment.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_lb_attachment")
+// @SDKResource("aws_lightsail_lb_attachment", name="Load Balancer Attachment")
 func ResourceLoadBalancerAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLoadBalancerAttachmentCreate,

--- a/internal/service/lightsail/lb_certificate.go
+++ b/internal/service/lightsail/lb_certificate.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_lb_certificate")
+// @SDKResource("aws_lightsail_lb_certificate", name="Load Balancer Certificate")
 func ResourceLoadBalancerCertificate() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLoadBalancerCertificateCreate,

--- a/internal/service/lightsail/lb_certificate_attachment.go
+++ b/internal/service/lightsail/lb_certificate_attachment.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_lb_certificate_attachment")
+// @SDKResource("aws_lightsail_lb_certificate_attachment", name="Load Balancer Certificate Attachment")
 func ResourceLoadBalancerCertificateAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLoadBalancerCertificateAttachmentCreate,

--- a/internal/service/lightsail/lb_https_redirection_policy.go
+++ b/internal/service/lightsail/lb_https_redirection_policy.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_lb_https_redirection_policy")
+// @SDKResource("aws_lightsail_lb_https_redirection_policy", name="Load Balancer HTTPS Redirection Policy")
 func ResourceLoadBalancerHTTPSRedirectionPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLoadBalancerHTTPSRedirectionPolicyCreate,

--- a/internal/service/lightsail/lb_stickiness_policy.go
+++ b/internal/service/lightsail/lb_stickiness_policy.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_lb_stickiness_policy")
+// @SDKResource("aws_lightsail_lb_stickiness_policy", name="Load Balancer Stickiness Policy")
 func ResourceLoadBalancerStickinessPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceLoadBalancerStickinessPolicyCreate,

--- a/internal/service/lightsail/service_package_gen.go
+++ b/internal/service/lightsail/service_package_gen.go
@@ -38,10 +38,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceBucketAccessKey,
 			TypeName: "aws_lightsail_bucket_access_key",
+			Name:     "Bucket Access Key",
 		},
 		{
 			Factory:  ResourceBucketResourceAccess,
 			TypeName: "aws_lightsail_bucket_resource_access",
+			Name:     "Bucket Resource Access",
 		},
 		{
 			Factory:  ResourceCertificate,
@@ -64,6 +66,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceContainerServiceDeploymentVersion,
 			TypeName: "aws_lightsail_container_service_deployment_version",
+			Name:     "Container Service Deployment Version",
 		},
 		{
 			Factory:  ResourceDatabase,
@@ -86,6 +89,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDiskAttachment,
 			TypeName: "aws_lightsail_disk_attachment",
+			Name:     "Disk Attachment",
 		},
 		{
 			Factory:  ResourceDistribution,
@@ -99,10 +103,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceDomain,
 			TypeName: "aws_lightsail_domain",
+			Name:     "Domain",
 		},
 		{
 			Factory:  ResourceDomainEntry,
 			TypeName: "aws_lightsail_domain_entry",
+			Name:     "Domain Entry",
 		},
 		{
 			Factory:  ResourceInstance,
@@ -116,6 +122,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceInstancePublicPorts,
 			TypeName: "aws_lightsail_instance_public_ports",
+			Name:     "Instance Public Ports",
 		},
 		{
 			Factory:  ResourceKeyPair,
@@ -138,30 +145,37 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceLoadBalancerAttachment,
 			TypeName: "aws_lightsail_lb_attachment",
+			Name:     "Load Balancer Attachment",
 		},
 		{
 			Factory:  ResourceLoadBalancerCertificate,
 			TypeName: "aws_lightsail_lb_certificate",
+			Name:     "Load Balancer Certificate",
 		},
 		{
 			Factory:  ResourceLoadBalancerCertificateAttachment,
 			TypeName: "aws_lightsail_lb_certificate_attachment",
+			Name:     "Load Balancer Certificate Attachment",
 		},
 		{
 			Factory:  ResourceLoadBalancerHTTPSRedirectionPolicy,
 			TypeName: "aws_lightsail_lb_https_redirection_policy",
+			Name:     "Load Balancer HTTPS Redirection Policy",
 		},
 		{
 			Factory:  ResourceLoadBalancerStickinessPolicy,
 			TypeName: "aws_lightsail_lb_stickiness_policy",
+			Name:     "Load Balancer Stickiness Policy",
 		},
 		{
 			Factory:  ResourceStaticIP,
 			TypeName: "aws_lightsail_static_ip",
+			Name:     "Static IP",
 		},
 		{
 			Factory:  ResourceStaticIPAttachment,
 			TypeName: "aws_lightsail_static_ip_attachment",
+			Name:     "Static IP Attachment",
 		},
 	}
 }

--- a/internal/service/lightsail/static_ip.go
+++ b/internal/service/lightsail/static_ip.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_static_ip")
+// @SDKResource("aws_lightsail_static_ip", name="Static IP")
 func ResourceStaticIP() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStaticIPCreate,

--- a/internal/service/lightsail/static_ip_attachment.go
+++ b/internal/service/lightsail/static_ip_attachment.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_lightsail_static_ip_attachment")
+// @SDKResource("aws_lightsail_static_ip_attachment", name="Static IP Attachment")
 func ResourceStaticIPAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStaticIPAttachmentCreate,

--- a/internal/service/location/service_package_gen.go
+++ b/internal/service/location/service_package_gen.go
@@ -100,6 +100,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceTrackerAssociation,
 			TypeName: "aws_location_tracker_association",
+			Name:     "Tracker Association",
 		},
 	}
 }

--- a/internal/service/location/tracker_association.go
+++ b/internal/service/location/tracker_association.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_location_tracker_association")
+// @SDKResource("aws_location_tracker_association", name="Tracker Association")
 func ResourceTrackerAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTrackerAssociationCreate,

--- a/internal/service/mediastore/container_policy.go
+++ b/internal/service/mediastore/container_policy.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_media_store_container_policy")
+// @SDKResource("aws_media_store_container_policy", name="Container Policy")
 func ResourceContainerPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceContainerPolicyPut,

--- a/internal/service/mediastore/service_package_gen.go
+++ b/internal/service/mediastore/service_package_gen.go
@@ -39,6 +39,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceContainerPolicy,
 			TypeName: "aws_media_store_container_policy",
+			Name:     "Container Policy",
 		},
 	}
 }

--- a/internal/service/oam/service_package_gen.go
+++ b/internal/service/oam/service_package_gen.go
@@ -64,6 +64,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSinkPolicy,
 			TypeName: "aws_oam_sink_policy",
+			Name:     "Sink Policy",
 		},
 	}
 }

--- a/internal/service/oam/sink_policy.go
+++ b/internal/service/oam/sink_policy.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_oam_sink_policy")
+// @SDKResource("aws_oam_sink_policy", name="Sink Policy")
 func ResourceSinkPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSinkPolicyPut,

--- a/internal/service/redshiftdata/service_package_gen.go
+++ b/internal/service/redshiftdata/service_package_gen.go
@@ -31,6 +31,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceStatement,
 			TypeName: "aws_redshiftdata_statement",
+			Name:     "Statement",
 		},
 	}
 }

--- a/internal/service/redshiftdata/statement.go
+++ b/internal/service/redshiftdata/statement.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_redshiftdata_statement")
+// @SDKResource("aws_redshiftdata_statement", name="Statement")
 func resourceStatement() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceStatementCreate,

--- a/internal/service/s3control/access_point.go
+++ b/internal/service/s3control/access_point.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3_access_point")
+// @SDKResource("aws_s3_access_point, name="Access Point")
 func resourceAccessPoint() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAccessPointCreate,

--- a/internal/service/s3control/access_point_policy.go
+++ b/internal/service/s3control/access_point_policy.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3control_access_point_policy")
+// @SDKResource("aws_s3control_access_point_policy", name="Access Point Policy")
 func resourceAccessPointPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAccessPointPolicyCreate,

--- a/internal/service/s3control/bucket_lifecycle_configuration.go
+++ b/internal/service/s3control/bucket_lifecycle_configuration.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3control_bucket_lifecycle_configuration")
+// @SDKResource("aws_s3control_bucket_lifecycle_configuration", name="Bucket Lifecycle Configuration")
 func resourceBucketLifecycleConfiguration() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketLifecycleConfigurationCreate,

--- a/internal/service/s3control/bucket_policy.go
+++ b/internal/service/s3control/bucket_policy.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3control_bucket_policy")
+// @SDKResource("aws_s3control_bucket_policy", name="Bucket Policy")
 func resourceBucketPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceBucketPolicyCreate,

--- a/internal/service/s3control/multi_region_access_point.go
+++ b/internal/service/s3control/multi_region_access_point.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3control_multi_region_access_point")
+// @SDKResource("aws_s3control_multi_region_access_point", name="Multi-Region Access Point")
 func resourceMultiRegionAccessPoint() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceMultiRegionAccessPointCreate,

--- a/internal/service/s3control/multi_region_access_point_policy.go
+++ b/internal/service/s3control/multi_region_access_point_policy.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3control_multi_region_access_point_policy")
+// @SDKResource("aws_s3control_multi_region_access_point_policy", name="Multi-Region Access Point Policy")
 func resourceMultiRegionAccessPointPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceMultiRegionAccessPointPolicyCreate,

--- a/internal/service/s3control/object_lambda_access_point.go
+++ b/internal/service/s3control/object_lambda_access_point.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3control_object_lambda_access_point")
+// @SDKResource("aws_s3control_object_lambda_access_point", name="Object Lambda Access Point")
 func resourceObjectLambdaAccessPoint() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceObjectLambdaAccessPointCreate,

--- a/internal/service/s3control/object_lambda_access_point_policy.go
+++ b/internal/service/s3control/object_lambda_access_point_policy.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_s3control_object_lambda_access_point_policy")
+// @SDKResource("aws_s3control_object_lambda_access_point_policy", name="Object Lambda Access Point Policy")
 func resourceObjectLambdaAccessPointPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceObjectLambdaAccessPointPolicyCreate,

--- a/internal/service/s3control/service_package_gen.go
+++ b/internal/service/s3control/service_package_gen.go
@@ -61,6 +61,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceAccessPoint,
 			TypeName: "aws_s3_access_point",
+			Name:     "Access Point",
 		},
 		{
 			Factory:  resourceAccountPublicAccessBlock,
@@ -70,6 +71,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceAccessPointPolicy,
 			TypeName: "aws_s3control_access_point_policy",
+			Name:     "Access Point Policy",
 		},
 		{
 			Factory:  resourceBucket,
@@ -80,26 +82,32 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceBucketLifecycleConfiguration,
 			TypeName: "aws_s3control_bucket_lifecycle_configuration",
+			Name:     "Bucket Lifecycle Configuration",
 		},
 		{
 			Factory:  resourceBucketPolicy,
 			TypeName: "aws_s3control_bucket_policy",
+			Name:     "Bucket Policy",
 		},
 		{
 			Factory:  resourceMultiRegionAccessPoint,
 			TypeName: "aws_s3control_multi_region_access_point",
+			Name:     "Multi-Region Access Point",
 		},
 		{
 			Factory:  resourceMultiRegionAccessPointPolicy,
 			TypeName: "aws_s3control_multi_region_access_point_policy",
+			Name:     "Multi-Region Access Point Policy",
 		},
 		{
 			Factory:  resourceObjectLambdaAccessPoint,
 			TypeName: "aws_s3control_object_lambda_access_point",
+			Name:     "Object Lambda Access Point",
 		},
 		{
 			Factory:  resourceObjectLambdaAccessPointPolicy,
 			TypeName: "aws_s3control_object_lambda_access_point_policy",
+			Name:     "Object Lambda Access Point Policy",
 		},
 		{
 			Factory:  resourceStorageLensConfiguration,

--- a/internal/service/scheduler/schedule.go
+++ b/internal/service/scheduler/schedule.go
@@ -32,7 +32,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_scheduler_schedule")
+// @SDKResource("aws_scheduler_schedule", name="Schedule")
 func resourceSchedule() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceScheduleCreate,

--- a/internal/service/scheduler/service_package_gen.go
+++ b/internal/service/scheduler/service_package_gen.go
@@ -31,6 +31,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceSchedule,
 			TypeName: "aws_scheduler_schedule",
+			Name:     "Schedule",
 		},
 		{
 			Factory:  ResourceScheduleGroup,

--- a/internal/service/servicequotas/service_package_gen.go
+++ b/internal/service/servicequotas/service_package_gen.go
@@ -54,6 +54,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceServiceQuota,
 			TypeName: "aws_servicequotas_service_quota",
+			Name:     "Service Quota",
 		},
 	}
 }

--- a/internal/service/servicequotas/service_quota.go
+++ b/internal/service/servicequotas/service_quota.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_servicequotas_service_quota")
+// @SDKResource("aws_servicequotas_service_quota", name="Service Quota")
 func ResourceServiceQuota() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceServiceQuotaCreate,

--- a/internal/service/shield/protection_health_check_association.go
+++ b/internal/service/shield/protection_health_check_association.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
-// @SDKResource("aws_shield_protection_health_check_association")
+// @SDKResource("aws_shield_protection_health_check_association", name="Protection Health Check Association")
 func ResourceProtectionHealthCheckAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: ResourceProtectionHealthCheckAssociationCreate,

--- a/internal/service/shield/service_package_gen.go
+++ b/internal/service/shield/service_package_gen.go
@@ -71,6 +71,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceProtectionHealthCheckAssociation,
 			TypeName: "aws_shield_protection_health_check_association",
+			Name:     "Protection Health Check Association",
 		},
 	}
 }

--- a/internal/service/signer/service_package_gen.go
+++ b/internal/service/signer/service_package_gen.go
@@ -40,6 +40,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSigningJob,
 			TypeName: "aws_signer_signing_job",
+			Name:     "Signing Job",
 		},
 		{
 			Factory:  ResourceSigningProfile,
@@ -52,6 +53,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceSigningProfilePermission,
 			TypeName: "aws_signer_signing_profile_permission",
+			Name:     "Signing Profile Permission",
 		},
 	}
 }

--- a/internal/service/signer/signing_job.go
+++ b/internal/service/signer/signing_job.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_signer_signing_job")
+// @SDKResource("aws_signer_signing_job", name="Signing Job")
 func ResourceSigningJob() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSigningJobCreate,

--- a/internal/service/signer/signing_profile_permission.go
+++ b/internal/service/signer/signing_profile_permission.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_signer_signing_profile_permission")
+// @SDKResource("aws_signer_signing_profile_permission", name="Signing Profile Permission")
 func ResourceSigningProfilePermission() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSigningProfilePermissionCreate,

--- a/internal/service/sns/platform_application.go
+++ b/internal/service/sns/platform_application.go
@@ -105,7 +105,7 @@ var (
 	}, platformApplicationSchema).WithSkipUpdate("apple_platform_bundle_id").WithSkipUpdate("apple_platform_team_id").WithSkipUpdate("platform_credential").WithSkipUpdate("platform_principal")
 )
 
-// @SDKResource("aws_sns_platform_application")
+// @SDKResource("aws_sns_platform_application", name="Platform Application")
 func resourcePlatformApplication() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePlatformApplicationCreate,

--- a/internal/service/sns/service_package_gen.go
+++ b/internal/service/sns/service_package_gen.go
@@ -39,10 +39,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourcePlatformApplication,
 			TypeName: "aws_sns_platform_application",
+			Name:     "Platform Application",
 		},
 		{
 			Factory:  resourceSMSPreferences,
 			TypeName: "aws_sns_sms_preferences",
+			Name:     "SMS Preferences",
 		},
 		{
 			Factory:  resourceTopic,
@@ -55,14 +57,17 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceTopicDataProtectionPolicy,
 			TypeName: "aws_sns_topic_data_protection_policy",
+			Name:     "Topic Data Protection Policy",
 		},
 		{
 			Factory:  resourceTopicPolicy,
 			TypeName: "aws_sns_topic_policy",
+			Name:     "Topic Policy",
 		},
 		{
 			Factory:  resourceTopicSubscription,
 			TypeName: "aws_sns_topic_subscription",
+			Name:     "Topic Subscription",
 		},
 	}
 }

--- a/internal/service/sns/sms_preferences.go
+++ b/internal/service/sns/sms_preferences.go
@@ -123,7 +123,7 @@ var (
 	}, smsPreferencesSchema).WithMissingSetToNil("*")
 )
 
-// @SDKResource("aws_sns_sms_preferences")
+// @SDKResource("aws_sns_sms_preferences", name="SMS Preferences")
 func resourceSMSPreferences() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSMSPreferencesSet,

--- a/internal/service/sns/topic_data_protection_policy.go
+++ b/internal/service/sns/topic_data_protection_policy.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sns_topic_data_protection_policy")
+// @SDKResource("aws_sns_topic_data_protection_policy", name="Topic Data Protection Policy")
 func resourceTopicDataProtectionPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTopicDataProtectionPolicyUpsert,

--- a/internal/service/sns/topic_policy.go
+++ b/internal/service/sns/topic_policy.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sns_topic_policy")
+// @SDKResource("aws_sns_topic_policy", name="Topic Policy")
 func resourceTopicPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTopicPolicyUpsert,

--- a/internal/service/sns/topic_subscription.go
+++ b/internal/service/sns/topic_subscription.go
@@ -156,7 +156,7 @@ var (
 	}, subscriptionSchema).WithMissingSetToNil("*")
 )
 
-// @SDKResource("aws_sns_topic_subscription")
+// @SDKResource("aws_sns_topic_subscription", name="Topic Subscription")
 func resourceTopicSubscription() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceTopicSubscriptionCreate,

--- a/internal/service/sqs/queue_policy.go
+++ b/internal/service/sqs/queue_policy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sqs_queue_policy")
+// @SDKResource("aws_sqs_queue_policy", name="Queue Policy")
 func resourceQueuePolicy() *schema.Resource {
 	h := &queueAttributeHandler{
 		AttributeName: types.QueueAttributeNamePolicy,

--- a/internal/service/sqs/queue_redrive_allow_policy.go
+++ b/internal/service/sqs/queue_redrive_allow_policy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_sqs_queue_redrive_allow_policy")
+// @SDKResource("aws_sqs_queue_redrive_allow_policy", name="Queue Redrive Allow Policy")
 func resourceQueueRedriveAllowPolicy() *schema.Resource {
 	h := &queueAttributeHandler{
 		AttributeName: types.QueueAttributeNameRedriveAllowPolicy,

--- a/internal/service/sqs/queue_redrive_policy.go
+++ b/internal/service/sqs/queue_redrive_policy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_sqs_queue_redrive_policy")
+// @SDKResource("aws_sqs_queue_redrive_policy", name="Queue Redrive Policy")
 func resourceQueueRedrivePolicy() *schema.Resource {
 	h := &queueAttributeHandler{
 		AttributeName: types.QueueAttributeNameRedrivePolicy,

--- a/internal/service/sqs/service_package_gen.go
+++ b/internal/service/sqs/service_package_gen.go
@@ -51,14 +51,17 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceQueuePolicy,
 			TypeName: "aws_sqs_queue_policy",
+			Name:     "Queue Policy",
 		},
 		{
 			Factory:  resourceQueueRedriveAllowPolicy,
 			TypeName: "aws_sqs_queue_redrive_allow_policy",
+			Name:     "Queue Redrive Allow Policy",
 		},
 		{
 			Factory:  resourceQueueRedrivePolicy,
 			TypeName: "aws_sqs_queue_redrive_policy",
+			Name:     "Queue Redrive Policy",
 		},
 	}
 }

--- a/internal/service/ssoadmin/account_assignment.go
+++ b/internal/service/ssoadmin/account_assignment.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_ssoadmin_account_assignment")
+// @SDKResource("aws_ssoadmin_account_assignment", name="Account Assignment")
 func ResourceAccountAssignment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAccountAssignmentCreate,

--- a/internal/service/ssoadmin/customer_managed_policy_attachment.go
+++ b/internal/service/ssoadmin/customer_managed_policy_attachment.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ssoadmin_customer_managed_policy_attachment")
+// @SDKResource("aws_ssoadmin_customer_managed_policy_attachment", name="Customer Managed Policy Attachment")
 func ResourceCustomerManagedPolicyAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceCustomerManagedPolicyAttachmentCreate,

--- a/internal/service/ssoadmin/instance_access_control_attributes.go
+++ b/internal/service/ssoadmin/instance_access_control_attributes.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ssoadmin_instance_access_control_attributes")
+// @SDKResource("aws_ssoadmin_instance_access_control_attributes", name="Instance Access Control Attributes")
 func ResourceAccessControlAttributes() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAccessControlAttributesCreate,

--- a/internal/service/ssoadmin/managed_policy_attachment.go
+++ b/internal/service/ssoadmin/managed_policy_attachment.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_ssoadmin_managed_policy_attachment")
+// @SDKResource("aws_ssoadmin_managed_policy_attachment", name="Managed Policy Attachment")
 func ResourceManagedPolicyAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceManagedPolicyAttachmentCreate,

--- a/internal/service/ssoadmin/permission_set_inline_policy.go
+++ b/internal/service/ssoadmin/permission_set_inline_policy.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 )
 
-// @SDKResource("aws_ssoadmin_permission_set_inline_policy")
+// @SDKResource("aws_ssoadmin_permission_set_inline_policy", name="Permission Set Inline Policy")
 func ResourcePermissionSetInlinePolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePermissionSetInlinePolicyPut,

--- a/internal/service/ssoadmin/permissions_boundary_attachment.go
+++ b/internal/service/ssoadmin/permissions_boundary_attachment.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_ssoadmin_permissions_boundary_attachment")
+// @SDKResource("aws_ssoadmin_permissions_boundary_attachment", name="Permissions Boundary Attachment")
 func ResourcePermissionsBoundaryAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourcePermissionsBoundaryAttachmentCreate,

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -82,18 +82,22 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAccountAssignment,
 			TypeName: "aws_ssoadmin_account_assignment",
+			Name:     "Account Assignment",
 		},
 		{
 			Factory:  ResourceCustomerManagedPolicyAttachment,
 			TypeName: "aws_ssoadmin_customer_managed_policy_attachment",
+			Name:     "Customer Managed Policy Attachment",
 		},
 		{
 			Factory:  ResourceAccessControlAttributes,
 			TypeName: "aws_ssoadmin_instance_access_control_attributes",
+			Name:     "Instance Access Control Attributes",
 		},
 		{
 			Factory:  ResourceManagedPolicyAttachment,
 			TypeName: "aws_ssoadmin_managed_policy_attachment",
+			Name:     "Managed Policy Attachment",
 		},
 		{
 			Factory:  ResourcePermissionSet,
@@ -104,10 +108,12 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourcePermissionSetInlinePolicy,
 			TypeName: "aws_ssoadmin_permission_set_inline_policy",
+			Name:     "Permission Set Inline Policy",
 		},
 		{
 			Factory:  ResourcePermissionsBoundaryAttachment,
 			TypeName: "aws_ssoadmin_permissions_boundary_attachment",
+			Name:     "Permissions Boundary Attachment",
 		},
 	}
 }

--- a/internal/service/vpclattice/auth_policy.go
+++ b/internal/service/vpclattice/auth_policy.go
@@ -24,8 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
-// @SDKResource("aws_vpclattice_auth_policy")
+// @SDKResource("aws_vpclattice_auth_policy", name="Auth Policy")
 func ResourceAuthPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAuthPolicyPut,

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -73,6 +73,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  ResourceAuthPolicy,
 			TypeName: "aws_vpclattice_auth_policy",
+			Name:     "Auth Policy",
 		},
 		{
 			Factory:  resourceListener,

--- a/internal/service/xray/encryption_config.go
+++ b/internal/service/xray/encryption_config.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_xray_encryption_config")
+// @SDKResource("aws_xray_encryption_config", name="Encryption Config")
 func resourceEncryptionConfig() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceEncryptionPutConfig,

--- a/internal/service/xray/service_package_gen.go
+++ b/internal/service/xray/service_package_gen.go
@@ -31,6 +31,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 		{
 			Factory:  resourceEncryptionConfig,
 			TypeName: "aws_xray_encryption_config",
+			Name:     "Encryption Config",
 		},
 		{
 			Factory:  resourceGroup,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Enforce setting a friendly name for every resource declared with the `@SDKResource` annotation.
Backfill those resource that were missing such a value.