### PR TITLE
Tech debt: Require `name=` value for `@SDKDataSource` annotation

### DIFF
--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -274,6 +274,10 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 				} else {
 					v.sdkDataSources[typeName] = d
 				}
+
+				if d.Name == "" {
+					v.g.Errorf("%s missing name: %s/%s", annotationName, v.packageName, typeName)
+				}
 			case "SDKResource":
 				if len(args.Positional) == 0 {
 					v.errs = append(v.errs, fmt.Errorf("no type name: %s", fmt.Sprintf("%s.%s", v.packageName, v.functionName)))

--- a/internal/service/athena/named_query_data_source.go
+++ b/internal/service/athena/named_query_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_athena_named_query")
+// @SDKDataSource("aws_athena_named_query", name="Named Query")
 func dataSourceNamedQuery() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceNamedQueryRead,

--- a/internal/service/athena/service_package_gen.go
+++ b/internal/service/athena/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceNamedQuery,
 			TypeName: "aws_athena_named_query",
+			Name:     "Named Query",
 		},
 	}
 }

--- a/internal/service/codestarconnections/connection_data_source.go
+++ b/internal/service/codestarconnections/connection_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_codestarconnections_connection")
+// @SDKDataSource("aws_codestarconnections_connection", name="Connection")
 func dataSourceConnection() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceConnectionRead,

--- a/internal/service/codestarconnections/service_package_gen.go
+++ b/internal/service/codestarconnections/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceConnection,
 			TypeName: "aws_codestarconnections_connection",
+			Name:     "Connection",
 		},
 	}
 }

--- a/internal/service/connect/lambda_function_association_data_source.go
+++ b/internal/service/connect/lambda_function_association_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_connect_lambda_function_association")
+// @SDKDataSource("aws_connect_lambda_function_association", name="Lambda Function Association")
 func dataSourceLambdaFunctionAssociation() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceLambdaFunctionAssociationRead,

--- a/internal/service/connect/service_package_gen.go
+++ b/internal/service/connect/service_package_gen.go
@@ -61,6 +61,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceLambdaFunctionAssociation,
 			TypeName: "aws_connect_lambda_function_association",
+			Name:     "Lambda Function Association",
 		},
 		{
 			Factory:  dataSourcePrompt,

--- a/internal/service/datapipeline/pipeline_data_source.go
+++ b/internal/service/datapipeline/pipeline_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_datapipeline_pipeline")
+// @SDKDataSource("aws_datapipeline_pipeline", name="Pipeline")
 // @Tags
 // @Testing(tagsIdentifierAttribute="id", tagsResourceType="Pipeline")
 func dataSourcePipeline() *schema.Resource {

--- a/internal/service/datapipeline/pipeline_definition_data_source.go
+++ b/internal/service/datapipeline/pipeline_definition_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_datapipeline_pipeline_definition")
+// @SDKDataSource("aws_datapipeline_pipeline_definition", name="Pipeline Definition")
 func DataSourcePipelineDefinition() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourcePipelineDefinitionRead,

--- a/internal/service/datapipeline/service_package_gen.go
+++ b/internal/service/datapipeline/service_package_gen.go
@@ -27,11 +27,13 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourcePipeline,
 			TypeName: "aws_datapipeline_pipeline",
+			Name:     "Pipeline",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  DataSourcePipelineDefinition,
 			TypeName: "aws_datapipeline_pipeline_definition",
+			Name:     "Pipeline Definition",
 		},
 	}
 }

--- a/internal/service/docdb/engine_version_data_source.go
+++ b/internal/service/docdb/engine_version_data_source.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_docdb_engine_version")
+// @SDKDataSource("aws_docdb_engine_version", name="Engine Version")
 func dataSourceEngineVersion() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceEngineVersionRead,

--- a/internal/service/docdb/orderable_db_instance_data_source.go
+++ b/internal/service/docdb/orderable_db_instance_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_docdb_orderable_db_instance")
+// @SDKDataSource("aws_docdb_orderable_db_instance", name="Orderable DB Instance")
 func dataSourceOrderableDBInstance() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceOrderableDBInstanceRead,

--- a/internal/service/docdb/service_package_gen.go
+++ b/internal/service/docdb/service_package_gen.go
@@ -27,10 +27,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceEngineVersion,
 			TypeName: "aws_docdb_engine_version",
+			Name:     "Engine Version",
 		},
 		{
 			Factory:  dataSourceOrderableDBInstance,
 			TypeName: "aws_docdb_orderable_db_instance",
+			Name:     "Orderable DB Instance",
 		},
 	}
 }

--- a/internal/service/ec2/service_package_gen.go
+++ b/internal/service/ec2/service_package_gen.go
@@ -477,6 +477,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceSecurityGroup,
 			TypeName: "aws_security_group",
+			Name:     "Security Group",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
@@ -487,11 +488,13 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceSubnet,
 			TypeName: "aws_subnet",
+			Name:     "Subnet",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  dataSourceSubnets,
 			TypeName: "aws_subnets",
+			Name:     "Subnets",
 		},
 		{
 			Factory:  dataSourceVPC,
@@ -502,6 +505,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceVPCDHCPOptions,
 			TypeName: "aws_vpc_dhcp_options",
+			Name:     "DHCP Options",
 		},
 		{
 			Factory:  dataSourceVPCEndpoint,

--- a/internal/service/ec2/vpc_dhcp_options_data_source.go
+++ b/internal/service/ec2/vpc_dhcp_options_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_vpc_dhcp_options")
+// @SDKDataSource("aws_vpc_dhcp_options", name="DHCP Options")
 func dataSourceVPCDHCPOptions() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceVPCDHCPOptionsRead,

--- a/internal/service/ec2/vpc_security_group_data_source.go
+++ b/internal/service/ec2/vpc_security_group_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_security_group")
+// @SDKDataSource("aws_security_group", name="Security Group")
 // @Tags
 // @Testing(tagsIdentifierAttribute="id")
 func dataSourceSecurityGroup() *schema.Resource {

--- a/internal/service/ec2/vpc_subnet_data_source.go
+++ b/internal/service/ec2/vpc_subnet_data_source.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_subnet")
+// @SDKDataSource("aws_subnet", name="Subnet")
 // @Tags
 // @Testing(tagsIdentifierAttribute="id", generator=false)
 func dataSourceSubnet() *schema.Resource {

--- a/internal/service/ec2/vpc_subnets_data_source.go
+++ b/internal/service/ec2/vpc_subnets_data_source.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_subnets", name "Subnets")
+// @SDKDataSource("aws_subnets", name="Subnets")
 func dataSourceSubnets() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSubnetsRead,

--- a/internal/service/ecrpublic/authorization_token_data_source.go
+++ b/internal/service/ecrpublic/authorization_token_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_ecrpublic_authorization_token")
+// @SDKDataSource("aws_ecrpublic_authorization_token", name="Authorization Token")
 func DataSourceAuthorizationToken() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAuthorizationTokenRead,

--- a/internal/service/ecrpublic/service_package_gen.go
+++ b/internal/service/ecrpublic/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceAuthorizationToken,
 			TypeName: "aws_ecrpublic_authorization_token",
+			Name:     "Authorization Token",
 		},
 	}
 }

--- a/internal/service/eks/addon_data_source.go
+++ b/internal/service/eks/addon_data_source.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_eks_addon")
+// @SDKDataSource("aws_eks_addon", name="Add-On")
 func dataSourceAddon() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAddonRead,

--- a/internal/service/eks/addon_version_data_source.go
+++ b/internal/service/eks/addon_version_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_eks_addon_version")
+// @SDKDataSource("aws_eks_addon_version", name="Add-On Version")
 func dataSourceAddonVersion() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAddonVersionRead,

--- a/internal/service/eks/cluster_auth_data_source.go
+++ b/internal/service/eks/cluster_auth_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_eks_cluster_auth")
+// @SDKDataSource("aws_eks_cluster_auth", name="Cluster Authentication Token")
 func dataSourceClusterAuth() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceClusterAuthRead,

--- a/internal/service/eks/cluster_data_source.go
+++ b/internal/service/eks/cluster_data_source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_eks_cluster")
+// @SDKDataSource("aws_eks_cluster", name="Cluster")
 func dataSourceCluster() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceClusterRead,

--- a/internal/service/eks/clusters_data_source.go
+++ b/internal/service/eks/clusters_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_eks_clusters")
+// @SDKDataSource("aws_eks_clusters", name="Clusters")
 func dataSourceClusters() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceClustersRead,

--- a/internal/service/eks/node_group_data_source.go
+++ b/internal/service/eks/node_group_data_source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_eks_node_group")
+// @SDKDataSource("aws_eks_node_group", name="Node Group")
 func dataSourceNodeGroup() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceNodeGroupRead,

--- a/internal/service/eks/node_groups_data_source.go
+++ b/internal/service/eks/node_groups_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_eks_node_groups")
+// @SDKDataSource("aws_eks_node_groups", name="Node Groups")
 func dataSourceNodeGroups() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceNodeGroupsRead,

--- a/internal/service/eks/service_package_gen.go
+++ b/internal/service/eks/service_package_gen.go
@@ -40,30 +40,37 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceAddon,
 			TypeName: "aws_eks_addon",
+			Name:     "Add-On",
 		},
 		{
 			Factory:  dataSourceAddonVersion,
 			TypeName: "aws_eks_addon_version",
+			Name:     "Add-On Version",
 		},
 		{
 			Factory:  dataSourceCluster,
 			TypeName: "aws_eks_cluster",
+			Name:     "Cluster",
 		},
 		{
 			Factory:  dataSourceClusterAuth,
 			TypeName: "aws_eks_cluster_auth",
+			Name:     "Cluster Authentication Token",
 		},
 		{
 			Factory:  dataSourceClusters,
 			TypeName: "aws_eks_clusters",
+			Name:     "Clusters",
 		},
 		{
 			Factory:  dataSourceNodeGroup,
 			TypeName: "aws_eks_node_group",
+			Name:     "Node Group",
 		},
 		{
 			Factory:  dataSourceNodeGroups,
 			TypeName: "aws_eks_node_groups",
+			Name:     "Node Groups",
 		},
 	}
 }

--- a/internal/service/elasticbeanstalk/hosted_zone_data_source.go
+++ b/internal/service/elasticbeanstalk/hosted_zone_data_source.go
@@ -45,7 +45,7 @@ var hostedZoneIDs = map[string]string{
 	endpoints.UsGovWest1RegionID: "Z4KAURWC4UUUG",
 }
 
-// @SDKDataSource("aws_elastic_beanstalk_hosted_zone")
+// @SDKDataSource("aws_elastic_beanstalk_hosted_zone", name="Hosted Zone")
 func dataSourceHostedZone() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceHostedZoneRead,

--- a/internal/service/elasticbeanstalk/service_package_gen.go
+++ b/internal/service/elasticbeanstalk/service_package_gen.go
@@ -32,6 +32,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceHostedZone,
 			TypeName: "aws_elastic_beanstalk_hosted_zone",
+			Name:     "Hosted Zone",
 		},
 		{
 			Factory:  dataSourceSolutionStack,

--- a/internal/service/firehose/delivery_stream_data_source.go
+++ b/internal/service/firehose/delivery_stream_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_kinesis_firehose_delivery_stream")
+// @SDKDataSource("aws_kinesis_firehose_delivery_stream", name="Delivery Stream")
 func dataSourceDeliveryStream() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceDeliveryStreamRead,

--- a/internal/service/firehose/service_package_gen.go
+++ b/internal/service/firehose/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceDeliveryStream,
 			TypeName: "aws_kinesis_firehose_delivery_stream",
+			Name:     "Delivery Stream",
 		},
 	}
 }

--- a/internal/service/glue/catalog_table_data_source.go
+++ b/internal/service/glue/catalog_table_data_source.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_glue_catalog_table")
+// @SDKDataSource("aws_glue_catalog_table", name="Catalog Table")
 func DataSourceCatalogTable() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceCatalogTableRead,

--- a/internal/service/glue/connection_data_source.go
+++ b/internal/service/glue/connection_data_source.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_glue_connection")
+// @SDKDataSource("aws_glue_connection", name="Connection")
 func DataSourceConnection() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceConnectionRead,

--- a/internal/service/glue/script_data_source.go
+++ b/internal/service/glue/script_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_glue_script")
+// @SDKDataSource("aws_glue_script", name="Script")
 func DataSourceScript() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceScriptRead,

--- a/internal/service/glue/service_package_gen.go
+++ b/internal/service/glue/service_package_gen.go
@@ -37,10 +37,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceCatalogTable,
 			TypeName: "aws_glue_catalog_table",
+			Name:     "Catalog Table",
 		},
 		{
 			Factory:  DataSourceConnection,
 			TypeName: "aws_glue_connection",
+			Name:     "Connection",
 		},
 		{
 			Factory:  DataSourceDataCatalogEncryptionSettings,
@@ -50,6 +52,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceScript,
 			TypeName: "aws_glue_script",
+			Name:     "Script",
 		},
 	}
 }

--- a/internal/service/guardduty/detector_data_source.go
+++ b/internal/service/guardduty/detector_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_guardduty_detector")
+// @SDKDataSource("aws_guardduty_detector", name="Detector")
 func DataSourceDetector() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceDetectorRead,

--- a/internal/service/guardduty/service_package_gen.go
+++ b/internal/service/guardduty/service_package_gen.go
@@ -40,6 +40,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceDetector,
 			TypeName: "aws_guardduty_detector",
+			Name:     "Detector",
 		},
 	}
 }

--- a/internal/service/inspector/rules_packages_data_source.go
+++ b/internal/service/inspector/rules_packages_data_source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_inspector_rules_packages")
+// @SDKDataSource("aws_inspector_rules_packages", name="Rules Packages")
 func DataSourceRulesPackages() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceRulesPackagesRead,

--- a/internal/service/inspector/service_package_gen.go
+++ b/internal/service/inspector/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceRulesPackages,
 			TypeName: "aws_inspector_rules_packages",
+			Name:     "Rules Packages",
 		},
 	}
 }

--- a/internal/service/ivs/service_package_gen.go
+++ b/internal/service/ivs/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceStreamKey,
 			TypeName: "aws_ivs_stream_key",
+			Name:     "Stream Key",
 		},
 	}
 }

--- a/internal/service/ivs/stream_key_data_source.go
+++ b/internal/service/ivs/stream_key_data_source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_ivs_stream_key")
+// @SDKDataSource("aws_ivs_stream_key", name="Stream Key")
 func DataSourceStreamKey() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceStreamKeyRead,

--- a/internal/service/kendra/experience_data_source.go
+++ b/internal/service/kendra/experience_data_source.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_kendra_experience")
+// @SDKDataSource("aws_kendra_experience", name="Experience")
 func DataSourceExperience() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceExperienceRead,

--- a/internal/service/kendra/faq_data_source.go
+++ b/internal/service/kendra/faq_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_kendra_faq")
+// @SDKDataSource("aws_kendra_faq", name="FAQ")
 func DataSourceFaq() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceFaqRead,

--- a/internal/service/kendra/index_data_source.go
+++ b/internal/service/kendra/index_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_kendra_index")
+// @SDKDataSource("aws_kendra_index", name="Index")
 func DataSourceIndex() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceIndexRead,

--- a/internal/service/kendra/query_suggestions_block_list_data_source.go
+++ b/internal/service/kendra/query_suggestions_block_list_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_kendra_query_suggestions_block_list")
+// @SDKDataSource("aws_kendra_query_suggestions_block_list", name="Query Suggestions Block List")
 func DataSourceQuerySuggestionsBlockList() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceQuerySuggestionsBlockListRead,

--- a/internal/service/kendra/service_package_gen.go
+++ b/internal/service/kendra/service_package_gen.go
@@ -27,22 +27,27 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceExperience,
 			TypeName: "aws_kendra_experience",
+			Name:     "Experience",
 		},
 		{
 			Factory:  DataSourceFaq,
 			TypeName: "aws_kendra_faq",
+			Name:     "FAQ",
 		},
 		{
 			Factory:  DataSourceIndex,
 			TypeName: "aws_kendra_index",
+			Name:     "Index",
 		},
 		{
 			Factory:  DataSourceQuerySuggestionsBlockList,
 			TypeName: "aws_kendra_query_suggestions_block_list",
+			Name:     "Query Suggestions Block List",
 		},
 		{
 			Factory:  DataSourceThesaurus,
 			TypeName: "aws_kendra_thesaurus",
+			Name:     "Thesaurus",
 		},
 	}
 }

--- a/internal/service/kendra/thesaurus_data_source.go
+++ b/internal/service/kendra/thesaurus_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_kendra_thesaurus")
+// @SDKDataSource("aws_kendra_thesaurus", name="Thesaurus")
 func DataSourceThesaurus() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceThesaurusRead,

--- a/internal/service/kinesis/service_package_gen.go
+++ b/internal/service/kinesis/service_package_gen.go
@@ -30,6 +30,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceStream,
 			TypeName: "aws_kinesis_stream",
+			Name:     "Stream",
 		},
 		{
 			Factory:  dataSourceStreamConsumer,

--- a/internal/service/kinesis/stream_data_source.go
+++ b/internal/service/kinesis/stream_data_source.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_kinesis_stream")
+// @SDKDataSource("aws_kinesis_stream", name="Stream")
 func DataSourceStream() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceStreamRead,

--- a/internal/service/lakeformation/data_lake_settings_data_source.go
+++ b/internal/service/lakeformation/data_lake_settings_data_source.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_lakeformation_data_lake_settings")
+// @SDKDataSource("aws_lakeformation_data_lake_settings", name="Data Lake Settings")
 func DataSourceDataLakeSettings() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceDataLakeSettingsRead,

--- a/internal/service/lakeformation/permissions_data_source.go
+++ b/internal/service/lakeformation/permissions_data_source.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_lakeformation_permissions")
+// @SDKDataSource("aws_lakeformation_permissions", name="Permissions")
 func DataSourcePermissions() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourcePermissionsRead,

--- a/internal/service/lakeformation/resource_data_source.go
+++ b/internal/service/lakeformation/resource_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_lakeformation_resource")
+// @SDKDataSource("aws_lakeformation_resource", name="Resource")
 func DataSourceResource() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceResourceRead,

--- a/internal/service/lakeformation/service_package_gen.go
+++ b/internal/service/lakeformation/service_package_gen.go
@@ -36,14 +36,17 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceDataLakeSettings,
 			TypeName: "aws_lakeformation_data_lake_settings",
+			Name:     "Data Lake Settings",
 		},
 		{
 			Factory:  DataSourcePermissions,
 			TypeName: "aws_lakeformation_permissions",
+			Name:     "Permissions",
 		},
 		{
 			Factory:  DataSourceResource,
 			TypeName: "aws_lakeformation_resource",
+			Name:     "Resource",
 		},
 	}
 }

--- a/internal/service/lambda/alias_data_source.go
+++ b/internal/service/lambda/alias_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_lambda_alias", Name="Alias")
+// @SDKDataSource("aws_lambda_alias", name="Alias")
 func dataSourceAlias() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceAliasRead,

--- a/internal/service/lambda/service_package_gen.go
+++ b/internal/service/lambda/service_package_gen.go
@@ -45,6 +45,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceAlias,
 			TypeName: "aws_lambda_alias",
+			Name:     "Alias",
 		},
 		{
 			Factory:  dataSourceCodeSigningConfig,

--- a/internal/service/location/geofence_collection_data_source.go
+++ b/internal/service/location/geofence_collection_data_source.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_location_geofence_collection")
+// @SDKDataSource("aws_location_geofence_collection", name="Geofence Collection")
 func DataSourceGeofenceCollection() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceGeofenceCollectionRead,

--- a/internal/service/location/map_data_source.go
+++ b/internal/service/location/map_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_location_map")
+// @SDKDataSource("aws_location_map", name="Map")
 func DataSourceMap() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceMapRead,

--- a/internal/service/location/place_index_data_source.go
+++ b/internal/service/location/place_index_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_location_place_index")
+// @SDKDataSource("aws_location_place_index", name="Place Index")
 func DataSourcePlaceIndex() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourcePlaceIndexRead,

--- a/internal/service/location/route_calculator_data_source.go
+++ b/internal/service/location/route_calculator_data_source.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_location_route_calculator")
+// @SDKDataSource("aws_location_route_calculator", name="Route Calculator")
 func DataSourceRouteCalculator() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceRouteCalculatorRead,

--- a/internal/service/location/service_package_gen.go
+++ b/internal/service/location/service_package_gen.go
@@ -27,30 +27,37 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceGeofenceCollection,
 			TypeName: "aws_location_geofence_collection",
+			Name:     "Geofence Collection",
 		},
 		{
 			Factory:  DataSourceMap,
 			TypeName: "aws_location_map",
+			Name:     "Map",
 		},
 		{
 			Factory:  DataSourcePlaceIndex,
 			TypeName: "aws_location_place_index",
+			Name:     "Place Index",
 		},
 		{
 			Factory:  DataSourceRouteCalculator,
 			TypeName: "aws_location_route_calculator",
+			Name:     "Route Calculator",
 		},
 		{
 			Factory:  DataSourceTracker,
 			TypeName: "aws_location_tracker",
+			Name:     "Tracker",
 		},
 		{
 			Factory:  DataSourceTrackerAssociation,
 			TypeName: "aws_location_tracker_association",
+			Name:     "Tracker Association",
 		},
 		{
 			Factory:  DataSourceTrackerAssociations,
 			TypeName: "aws_location_tracker_associations",
+			Name:     "Tracker Associations",
 		},
 	}
 }

--- a/internal/service/location/tracker_association_data_source.go
+++ b/internal/service/location/tracker_association_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_location_tracker_association")
+// @SDKDataSource("aws_location_tracker_association", name="Tracker Association")
 func DataSourceTrackerAssociation() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceTrackerAssociationRead,

--- a/internal/service/location/tracker_associations_data_source.go
+++ b/internal/service/location/tracker_associations_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_location_tracker_associations")
+// @SDKDataSource("aws_location_tracker_associations", name="Tracker Associations")
 func DataSourceTrackerAssociations() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceTrackerAssociationsRead,

--- a/internal/service/location/tracker_data_source.go
+++ b/internal/service/location/tracker_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_location_tracker")
+// @SDKDataSource("aws_location_tracker", name="Tracker")
 func DataSourceTracker() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceTrackerRead,

--- a/internal/service/logs/data_protection_policy_document_data_source.go
+++ b/internal/service/logs/data_protection_policy_document_data_source.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_cloudwatch_log_data_protection_policy_document")
+// @SDKDataSource("aws_cloudwatch_log_data_protection_policy_document", name="Data Protection Policy Document")
 func dataSourceDataProtectionPolicyDocument() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceDataProtectionPolicyDocumentRead,

--- a/internal/service/logs/service_package_gen.go
+++ b/internal/service/logs/service_package_gen.go
@@ -64,6 +64,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceDataProtectionPolicyDocument,
 			TypeName: "aws_cloudwatch_log_data_protection_policy_document",
+			Name:     "Data Protection Policy Document",
 		},
 		{
 			Factory:  dataSourceGroup,

--- a/internal/service/oam/link_data_source.go
+++ b/internal/service/oam/link_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_oam_link")
+// @SDKDataSource("aws_oam_link", name="Link")
 func DataSourceLink() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceLinkRead,

--- a/internal/service/oam/links_data_source.go
+++ b/internal/service/oam/links_data_source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_oam_links")
+// @SDKDataSource("aws_oam_links", name="Links")
 func DataSourceLinks() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceLinksRead,

--- a/internal/service/oam/service_package_gen.go
+++ b/internal/service/oam/service_package_gen.go
@@ -27,18 +27,22 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceLink,
 			TypeName: "aws_oam_link",
+			Name:     "Link",
 		},
 		{
 			Factory:  DataSourceLinks,
 			TypeName: "aws_oam_links",
+			Name:     "Links",
 		},
 		{
 			Factory:  DataSourceSink,
 			TypeName: "aws_oam_sink",
+			Name:     "Sink",
 		},
 		{
 			Factory:  DataSourceSinks,
 			TypeName: "aws_oam_sinks",
+			Name:     "Sinks",
 		},
 	}
 }

--- a/internal/service/oam/sink_data_source.go
+++ b/internal/service/oam/sink_data_source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_oam_sink")
+// @SDKDataSource("aws_oam_sink", name="Sink")
 func DataSourceSink() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSinkRead,

--- a/internal/service/oam/sinks_data_source.go
+++ b/internal/service/oam/sinks_data_source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_oam_sinks")
+// @SDKDataSource("aws_oam_sinks", name="Sinks")
 func DataSourceSinks() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSinksRead,

--- a/internal/service/pricing/product_data_source.go
+++ b/internal/service/pricing/product_data_source.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_pricing_product")
+// @SDKDataSource("aws_pricing_product", name="Product")
 func dataSourceProduct() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceProductRead,

--- a/internal/service/pricing/service_package_gen.go
+++ b/internal/service/pricing/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceProduct,
 			TypeName: "aws_pricing_product",
+			Name:     "Product",
 		},
 	}
 }

--- a/internal/service/qldb/ledger_data_source.go
+++ b/internal/service/qldb/ledger_data_source.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_qldb_ledger")
+// @SDKDataSource("aws_qldb_ledger", name="Ledger")
 func dataSourceLedger() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceLedgerRead,

--- a/internal/service/qldb/service_package_gen.go
+++ b/internal/service/qldb/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceLedger,
 			TypeName: "aws_qldb_ledger",
+			Name:     "Ledger",
 		},
 	}
 }

--- a/internal/service/resourcegroupstaggingapi/resources_data_source.go
+++ b/internal/service/resourcegroupstaggingapi/resources_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_resourcegroupstaggingapi_resources")
+// @SDKDataSource("aws_resourcegroupstaggingapi_resources", name="Resources")
 func dataSourceResources() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceResourcesRead,

--- a/internal/service/resourcegroupstaggingapi/service_package_gen.go
+++ b/internal/service/resourcegroupstaggingapi/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceResources,
 			TypeName: "aws_resourcegroupstaggingapi_resources",
+			Name:     "Resources",
 		},
 	}
 }

--- a/internal/service/s3control/multi_region_access_point_data_source.go
+++ b/internal/service/s3control/multi_region_access_point_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_s3control_multi_region_access_point")
+// @SDKDataSource("aws_s3control_multi_region_access_point", name="Multi-Region Access Point")
 func dataSourceMultiRegionAccessPoint() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceMultiRegionAccessPointBlockRead,

--- a/internal/service/s3control/service_package_gen.go
+++ b/internal/service/s3control/service_package_gen.go
@@ -52,6 +52,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceMultiRegionAccessPoint,
 			TypeName: "aws_s3control_multi_region_access_point",
+			Name:     "Multi-Region Access Point",
 		},
 	}
 }

--- a/internal/service/serverlessrepo/application_data_source.go
+++ b/internal/service/serverlessrepo/application_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_serverlessapplicationrepository_application")
+// @SDKDataSource("aws_serverlessapplicationrepository_application", name="Application")
 func DataSourceApplication() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceApplicationRead,

--- a/internal/service/serverlessrepo/service_package_gen.go
+++ b/internal/service/serverlessrepo/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceApplication,
 			TypeName: "aws_serverlessapplicationrepository_application",
+			Name:     "Application",
 		},
 	}
 }

--- a/internal/service/servicequotas/service_data_source.go
+++ b/internal/service/servicequotas/service_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_servicequotas_service")
+// @SDKDataSource("aws_servicequotas_service", name="Service)
 func DataSourceService() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceServiceRead,

--- a/internal/service/servicequotas/service_package_gen.go
+++ b/internal/service/servicequotas/service_package_gen.go
@@ -41,10 +41,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceService,
 			TypeName: "aws_servicequotas_service",
+			Name:     "Service",
 		},
 		{
 			Factory:  DataSourceServiceQuota,
 			TypeName: "aws_servicequotas_service_quota",
+			Name:     "Service Quota",
 		},
 	}
 }

--- a/internal/service/servicequotas/service_quota_data_source.go
+++ b/internal/service/servicequotas/service_quota_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_servicequotas_service_quota")
+// @SDKDataSource("aws_servicequotas_service_quota", name="Service Quota")
 func DataSourceServiceQuota() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceServiceQuotaRead,

--- a/internal/service/signer/service_package_gen.go
+++ b/internal/service/signer/service_package_gen.go
@@ -27,10 +27,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceSigningJob,
 			TypeName: "aws_signer_signing_job",
+			Name:     "Signing Job",
 		},
 		{
 			Factory:  DataSourceSigningProfile,
 			TypeName: "aws_signer_signing_profile",
+			Name:     "Signing Profile",
 		},
 	}
 }

--- a/internal/service/signer/signing_job_data_source.go
+++ b/internal/service/signer/signing_job_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_signer_signing_job")
+// @SDKDataSource("aws_signer_signing_job", name="Signing Job")
 func DataSourceSigningJob() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSigningJobRead,

--- a/internal/service/signer/signing_profile_data_source.go
+++ b/internal/service/signer/signing_profile_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_signer_signing_profile")
+// @SDKDataSource("aws_signer_signing_profile", name="Signing Profile")
 func DataSourceSigningProfile() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceSigningProfileRead,

--- a/internal/service/sns/service_package_gen.go
+++ b/internal/service/sns/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceTopic,
 			TypeName: "aws_sns_topic",
+			Name:     "Topic",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			},

--- a/internal/service/sns/topic_data_source.go
+++ b/internal/service/sns/topic_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_sns_topic")
+// @SDKDataSource("aws_sns_topic", name="Topic")
 // @Testing(tagsTest=true)
 // @Tags(identifierAttribute="arn")
 func dataSourceTopic() *schema.Resource {

--- a/internal/service/sqs/queue_data_source.go
+++ b/internal/service/sqs/queue_data_source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_sqs_queue")
+// @SDKDataSource("aws_sqs_queue", name="Queue")
 // @Tags(identifierAttribute="url")
 func dataSourceQueue() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/sqs/queues_data_source.go
+++ b/internal/service/sqs/queues_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
-// @SDKDataSource("aws_sqs_queues")
+// @SDKDataSource("aws_sqs_queues", name="Queues")
 func dataSourceQueues() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceQueuesRead,

--- a/internal/service/sqs/service_package_gen.go
+++ b/internal/service/sqs/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceQueue,
 			TypeName: "aws_sqs_queue",
+			Name:     "Queue",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrURL,
 			},
@@ -34,6 +35,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceQueues,
 			TypeName: "aws_sqs_queues",
+			Name:     "Queues",
 		},
 	}
 }

--- a/internal/service/ssmcontacts/contact_channel_data_source.go
+++ b/internal/service/ssmcontacts/contact_channel_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_ssmcontacts_contact_channel")
+// @SDKDataSource("aws_ssmcontacts_contact_channel", name="Contact Channel")
 func DataSourceContactChannel() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceContactChannelRead,

--- a/internal/service/ssmcontacts/contact_data_source.go
+++ b/internal/service/ssmcontacts/contact_data_source.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_ssmcontacts_contact")
+// @SDKDataSource("aws_ssmcontacts_contact", name="Contact")
 // @Tags(identifierAttribute="arn")
 // @Testing(serialize=true)
 func DataSourceContact() *schema.Resource {

--- a/internal/service/ssmcontacts/plan_data_source.go
+++ b/internal/service/ssmcontacts/plan_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_ssmcontacts_plan")
+// @SDKDataSource("aws_ssmcontacts_plan", name="Plan")
 func DataSourcePlan() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourcePlanRead,

--- a/internal/service/ssmcontacts/service_package_gen.go
+++ b/internal/service/ssmcontacts/service_package_gen.go
@@ -43,6 +43,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceContact,
 			TypeName: "aws_ssmcontacts_contact",
+			Name:     "Contact",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			},
@@ -50,10 +51,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceContactChannel,
 			TypeName: "aws_ssmcontacts_contact_channel",
+			Name:     "Contact Channel",
 		},
 		{
 			Factory:  DataSourcePlan,
 			TypeName: "aws_ssmcontacts_plan",
+			Name:     "Plan",
 		},
 	}
 }

--- a/internal/service/ssmincidents/replication_set_data_source.go
+++ b/internal/service/ssmincidents/replication_set_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_ssmincidents_replication_set")
+// @SDKDataSource("aws_ssmincidents_replication_set", name="Replication Set")
 func DataSourceReplicationSet() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceReplicationSetRead,

--- a/internal/service/ssmincidents/response_plan_data_source.go
+++ b/internal/service/ssmincidents/response_plan_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_ssmincidents_response_plan")
+// @SDKDataSource("aws_ssmincidents_response_plan", name="Response Plan")
 func DataSourceResponsePlan() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceResponsePlanRead,

--- a/internal/service/ssmincidents/service_package_gen.go
+++ b/internal/service/ssmincidents/service_package_gen.go
@@ -27,10 +27,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceReplicationSet,
 			TypeName: "aws_ssmincidents_replication_set",
+			Name:     "Replication Set",
 		},
 		{
 			Factory:  DataSourceResponsePlan,
 			TypeName: "aws_ssmincidents_response_plan",
+			Name:     "Response Plan",
 		},
 	}
 }

--- a/internal/service/ssoadmin/instances_data_source.go
+++ b/internal/service/ssoadmin/instances_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_ssoadmin_instances")
+// @SDKDataSource("aws_ssoadmin_instances", name="Instances")
 func DataSourceInstances() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceInstancesRead,

--- a/internal/service/ssoadmin/permission_set_data_source.go
+++ b/internal/service/ssoadmin/permission_set_data_source.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_ssoadmin_permission_set")
+// @SDKDataSource("aws_ssoadmin_permission_set", name="Permission Set")
 func DataSourcePermissionSet() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourcePermissionSetRead,

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -69,10 +69,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  DataSourceInstances,
 			TypeName: "aws_ssoadmin_instances",
+			Name:     "Instances",
 		},
 		{
 			Factory:  DataSourcePermissionSet,
 			TypeName: "aws_ssoadmin_permission_set",
+			Name:     "Permission Set",
 		},
 	}
 }

--- a/internal/service/vpclattice/service_data_source.go
+++ b/internal/service/vpclattice/service_data_source.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_vpclattice_service")
+// @SDKDataSource("aws_vpclattice_service", name="Service")
 // @Tags
 func dataSourceService() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/vpclattice/service_network_data_source.go
+++ b/internal/service/vpclattice/service_network_data_source.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKDataSource("aws_vpclattice_service_network")
+// @SDKDataSource("aws_vpclattice_service_network", name="Service Network")
 // @Tags
 func dataSourceServiceNetwork() *schema.Resource {
 	return &schema.Resource{

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -50,11 +50,13 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 		{
 			Factory:  dataSourceService,
 			TypeName: "aws_vpclattice_service",
+			Name:     "Service",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  dataSourceServiceNetwork,
 			TypeName: "aws_vpclattice_service_network",
+			Name:     "Service Network",
 			Tags:     &types.ServicePackageResourceTags{},
 		},
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Enforce setting a friendly name for every data source declared with the `@SDKDataSource` annotation.
Backfill those data sources that were missing such a value.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/40913.