### PR TITLE
r/aws_route53_health_check: add `triggers` argument

### DIFF
--- a/.changelog/40918.txt
+++ b/.changelog/40918.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_route53_health_check: Add `triggers` argument to support synchronization with upstream CloudWatch alarm changes
+```

--- a/internal/service/route53/health_check_test.go
+++ b/internal/service/route53/health_check_test.go
@@ -288,6 +288,46 @@ func TestAccRoute53HealthCheck_cloudWatchAlarmCheck(t *testing.T) {
 	})
 }
 
+func TestAccRoute53HealthCheck_triggers(t *testing.T) {
+	ctx := acctest.Context(t)
+	var check awstypes.HealthCheck
+	resourceName := "aws_route53_health_check.test"
+	alarmResourceName := "aws_cloudwatch_metric_alarm.test"
+	threshold := "80"
+	thresholdUpdated := "90"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckHealthCheckDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHealthCheckConfig_triggers(threshold),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHealthCheckExists(ctx, resourceName, &check),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_alarm_name", alarmResourceName, "alarm_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "triggers.threshold", alarmResourceName, "threshold"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{names.AttrTriggers},
+			},
+			{
+				Config: testAccHealthCheckConfig_triggers(thresholdUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHealthCheckExists(ctx, resourceName, &check),
+					resource.TestCheckResourceAttrPair(resourceName, "cloudwatch_alarm_name", alarmResourceName, "alarm_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "triggers.threshold", alarmResourceName, "threshold"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRoute53HealthCheck_withSNI(t *testing.T) {
 	ctx := acctest.Context(t)
 	var check awstypes.HealthCheck
@@ -604,6 +644,35 @@ resource "aws_route53_health_check" "test" {
   insufficient_data_health_status = "Healthy"
 }
 `
+
+func testAccHealthCheckConfig_triggers(threshold string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudwatch_metric_alarm" "test" {
+  alarm_name          = "cloudwatch-healthcheck-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = %[1]q
+  alarm_description   = "This metric monitors ec2 cpu utilization"
+}
+
+data "aws_region" "current" {}
+
+resource "aws_route53_health_check" "test" {
+  type                            = "CLOUDWATCH_METRIC"
+  cloudwatch_alarm_name           = aws_cloudwatch_metric_alarm.test.alarm_name
+  cloudwatch_alarm_region         = data.aws_region.current.name
+  insufficient_data_health_status = "Healthy"
+
+  triggers = {
+    threshold = aws_cloudwatch_metric_alarm.test.threshold
+  }
+}
+`, threshold)
+}
 
 func testAccHealthCheckConfig_searchString(search string, invert bool) string {
 	return fmt.Sprintf(`

--- a/website/docs/r/route53_health_check.html.markdown
+++ b/website/docs/r/route53_health_check.html.markdown
@@ -79,6 +79,36 @@ resource "aws_route53_health_check" "foo" {
 }
 ```
 
+### CloudWatch Alarm Check With Triggers
+
+The `triggers` argument allows the Route53 health check to be synchronized when a change to the upstream CloudWatch alarm is made.
+In the configuration below, the health check will be synchronized any time the `threshold` of the alarm is changed.
+
+```terraform
+resource "aws_cloudwatch_metric_alarm" "example" {
+  alarm_name          = "example"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "80"
+  alarm_description   = "This metric monitors ec2 cpu utilization"
+}
+
+resource "aws_route53_health_check" "example" {
+  type                            = "CLOUDWATCH_METRIC"
+  cloudwatch_alarm_name           = aws_cloudwatch_metric_alarm.example.alarm_name
+  cloudwatch_alarm_region         = "us-west-2"
+  insufficient_data_health_status = "Healthy"
+
+  triggers = {
+    threshold = aws_cloudwatch_metric_alarm.example.threshold
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -98,7 +128,7 @@ This resource supports the following arguments:
 * `measure_latency` - (Optional) A Boolean value that indicates whether you want Route 53 to measure the latency between health checkers in multiple AWS regions and your endpoint and to display CloudWatch latency graphs in the Route 53 console.
 * `invert_healthcheck` - (Optional) A boolean value that indicates whether the status of health check should be inverted. For example, if a health check is healthy but Inverted is True , then Route 53 considers the health check to be unhealthy.
 * `disabled` - (Optional) A boolean value that stops Route 53 from performing health checks. When set to true, Route 53 will do the following depending on the type of health check:
-    * For health checks that check the health of endpoints, Route5 53 stops submitting requests to your application, server, or other resource.
+    * For health checks that check the health of endpoints, Route53 stops submitting requests to your application, server, or other resource.
     * For calculated health checks, Route 53 stops aggregating the status of the referenced health checks.
     * For health checks that monitor CloudWatch alarms, Route 53 stops monitoring the corresponding CloudWatch metrics.
 
@@ -107,11 +137,12 @@ This resource supports the following arguments:
 * `child_healthchecks` - (Optional) For a specified parent health check, a list of HealthCheckId values for the associated child health checks.
 * `child_health_threshold` - (Optional) The minimum number of child health checks that must be healthy for Route 53 to consider the parent health check to be healthy. Valid values are integers between 0 and 256, inclusive
 * `cloudwatch_alarm_name` - (Optional) The name of the CloudWatch alarm.
-* `cloudwatch_alarm_region` - (Optional) The CloudWatchRegion that the CloudWatch alarm was created in.
+* `cloudwatch_alarm_region` - (Optional) The region that the CloudWatch alarm was created in.
 * `insufficient_data_health_status` - (Optional) The status of the health check when CloudWatch has insufficient data about the state of associated alarm. Valid values are `Healthy` , `Unhealthy` and `LastKnownStatus`.
 * `regions` - (Optional) A list of AWS regions that you want Amazon Route 53 health checkers to check the specified endpoint from.
 * `routing_control_arn` - (Optional) The Amazon Resource Name (ARN) for the Route 53 Application Recovery Controller routing control. This is used when health check type is `RECOVERY_CONTROL`
 * `tags` - (Optional) A map of tags to assign to the health check. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger an in-place update of the CloudWatch alarm arguments. Use this argument to synchronize the health check when an alarm is changed. See example above.
 
 ## Attribute Reference
 


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This argument will allow for the health check to be synchronized with the upstream CloudWatch alarm when changes are made.

```console
% make testacc PKG=route53 TESTS=TestAccRoute53HealthCheck_triggers
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53HealthCheck_triggers'  -timeout 360m -vet=off
2025/01/14 10:39:47 Initializing Terraform AWS Provider...

--- PASS: TestAccRoute53HealthCheck_triggers (23.64s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    28.800s
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29251

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/health-checks-updating-cloudwatch-alarm-settings.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=route53 TESTS=TestAccRoute53HealthCheck_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/route53/... -v -count 1 -parallel 20 -run='TestAccRoute53HealthCheck_'  -timeout 360m -vet=off
2025/01/14 10:46:44 Initializing Terraform AWS Provider...

--- PASS: TestAccRoute53HealthCheck_disappears (20.63s)
--- PASS: TestAccRoute53HealthCheck_withChildHealthChecks (25.44s)
--- PASS: TestAccRoute53HealthCheck_withHealthCheckRegions (28.06s)
--- PASS: TestAccRoute53HealthCheck_ipv6 (30.28s)
--- PASS: TestAccRoute53HealthCheck_cloudWatchAlarmCheck (30.57s)
--- PASS: TestAccRoute53HealthCheck_basic (36.66s)
--- PASS: TestAccRoute53HealthCheck_ip (39.52s)
--- PASS: TestAccRoute53HealthCheck_withSearchString (39.53s)
--- PASS: TestAccRoute53HealthCheck_disabled (42.84s)
--- PASS: TestAccRoute53HealthCheck_triggers (42.87s)
--- PASS: TestAccRoute53HealthCheck_withSNI (42.88s)
--- PASS: TestAccRoute53HealthCheck_tags (45.26s)
--- PASS: TestAccRoute53HealthCheck_withRoutingControlARN (95.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53    100.263s
```
