### PR TITLE
Tech debt: Require `name=` value for `@EphemeralResource` and `@FrameworkResource` annotations

### DIFF
--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -249,6 +249,10 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 				} else {
 					v.ephemeralResources = append(v.ephemeralResources, d)
 				}
+
+				if d.Name == "" {
+					v.g.Errorf("%s missing name: %s.%s", annotationName, v.packageName, v.functionName)
+				}
 			case "FrameworkDataSource":
 				if slices.ContainsFunc(v.frameworkDataSources, func(d ResourceDatum) bool { return d.FactoryName == v.functionName }) {
 					v.errs = append(v.errs, fmt.Errorf("duplicate Framework Data Source: %s", fmt.Sprintf("%s.%s", v.packageName, v.functionName)))
@@ -260,6 +264,10 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 					v.errs = append(v.errs, fmt.Errorf("duplicate Framework Resource: %s", fmt.Sprintf("%s.%s", v.packageName, v.functionName)))
 				} else {
 					v.frameworkResources = append(v.frameworkResources, d)
+				}
+
+				if d.Name == "" {
+					v.g.Errorf("%s missing name: %s.%s", annotationName, v.packageName, v.functionName)
 				}
 			case "SDKDataSource":
 				if len(args.Positional) == 0 {

--- a/internal/service/apigateway/account.go
+++ b/internal/service/apigateway/account.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkResource("aws_api_gateway_account")
+// @FrameworkResource("aws_api_gateway_account", name="Account")
 func newResourceAccount(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceAccount{}
 

--- a/internal/service/apigateway/service_package_gen.go
+++ b/internal/service/apigateway/service_package_gen.go
@@ -27,6 +27,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 		},
 		{
 			Factory: newResourceAccount,
+			Name:    "Account",
 		},
 	}
 }

--- a/internal/service/auditmanager/account_registration.go
+++ b/internal/service/auditmanager/account_registration.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkResource
+// @FrameworkResource("aws_auditmanager_account_registration", name="Account Registration")
 func newResourceAccountRegistration(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &resourceAccountRegistration{}, nil
 }

--- a/internal/service/auditmanager/assessment_delegation.go
+++ b/internal/service/auditmanager/assessment_delegation.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkResource
+// @FrameworkResource("aws_auditmanager_assessment_delegation", name="Assessment Delegation")
 func newResourceAssessmentDelegation(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &resourceAssessmentDelegation{}, nil
 }

--- a/internal/service/auditmanager/assessment_report.go
+++ b/internal/service/auditmanager/assessment_report.go
@@ -28,7 +28,7 @@ import (
 
 const reportCompletionTimeout = 5 * time.Minute
 
-// @FrameworkResource
+// @FrameworkResource("aws_auditmanager_assessment_report", name="Assessment Report")
 func newResourceAssessmentReport(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &resourceAssessmentReport{}, nil
 }

--- a/internal/service/auditmanager/framework_share.go
+++ b/internal/service/auditmanager/framework_share.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkResource
+// @FrameworkResource("aws_auditmanager_framework_share", name="Framework Share")
 func newResourceFrameworkShare(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &resourceFrameworkShare{}, nil
 }

--- a/internal/service/auditmanager/organization_admin_account_registration.go
+++ b/internal/service/auditmanager/organization_admin_account_registration.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkResource
+// @FrameworkResource("aws_auditmanager_organization_admin_account_registration", name="Organization Admin Account Registration")
 func newResourceOrganizationAdminAccountRegistration(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &resourceOrganizationAdminAccountRegistration{}, nil
 }

--- a/internal/service/auditmanager/service_package_gen.go
+++ b/internal/service/auditmanager/service_package_gen.go
@@ -29,6 +29,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 	return []*types.ServicePackageFrameworkResource{
 		{
 			Factory: newResourceAccountRegistration,
+			Name:    "Account Registration",
 		},
 		{
 			Factory: newResourceAssessment,
@@ -39,9 +40,11 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 		},
 		{
 			Factory: newResourceAssessmentDelegation,
+			Name:    "Assessment Delegation",
 		},
 		{
 			Factory: newResourceAssessmentReport,
+			Name:    "Assessment Report",
 		},
 		{
 			Factory: newResourceControl,
@@ -59,9 +62,11 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 		},
 		{
 			Factory: newResourceFrameworkShare,
+			Name:    "Framework Share",
 		},
 		{
 			Factory: newResourceOrganizationAdminAccountRegistration,
+			Name:    "Organization Admin Account Registration",
 		},
 	}
 }

--- a/internal/service/elasticache/reserved_cache_node.go
+++ b/internal/service/elasticache/reserved_cache_node.go
@@ -31,7 +31,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkResource("aws_elasticache_reserved_cache_node")
+// @FrameworkResource("aws_elasticache_reserved_cache_node", name="Reserved Cache Node")
 // @Tags(identifierAttribute="arn")
 // @Testing(tagsTests=false)
 func newResourceReservedCacheNode(context.Context) (resource.ResourceWithConfigure, error) {

--- a/internal/service/elasticache/service_package_gen.go
+++ b/internal/service/elasticache/service_package_gen.go
@@ -30,6 +30,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 	return []*types.ServicePackageFrameworkResource{
 		{
 			Factory: newResourceReservedCacheNode,
+			Name:    "Reserved Cache Node",
 			Tags: &types.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			},

--- a/internal/service/medialive/multiplex_program.go
+++ b/internal/service/medialive/multiplex_program.go
@@ -33,7 +33,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkResource("aws_medialive_multiplex_program")
+// @FrameworkResource("aws_medialive_multiplex_program", name="Multiplex Program")
 func newResourceMultiplexProgram(_ context.Context) (resource.ResourceWithConfigure, error) {
 	return &multiplexProgram{}, nil
 }

--- a/internal/service/medialive/service_package_gen.go
+++ b/internal/service/medialive/service_package_gen.go
@@ -28,6 +28,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 	return []*types.ServicePackageFrameworkResource{
 		{
 			Factory: newResourceMultiplexProgram,
+			Name:    "Multiplex Program",
 		},
 	}
 }

--- a/internal/service/rds/export_task.go
+++ b/internal/service/rds/export_task.go
@@ -29,7 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkResource("aws_rds_export_task")
+// @FrameworkResource("aws_rds_export_task", name="Export Task")
 func newResourceExportTask(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceExportTask{}
 	r.SetDefaultCreateTimeout(60 * time.Minute)

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -41,6 +41,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 		},
 		{
 			Factory: newResourceExportTask,
+			Name:    "Export Task",
 		},
 		{
 			Factory: newResourceInstanceState,

--- a/internal/service/simpledb/domain.go
+++ b/internal/service/simpledb/domain.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @FrameworkResource
+// @FrameworkResource("aws_simpledb_domain", name="Domain")
 func newDomainResource(context.Context) (resource.ResourceWithConfigure, error) {
 	r := &domainResource{}
 

--- a/internal/service/simpledb/service_package_gen.go
+++ b/internal/service/simpledb/service_package_gen.go
@@ -20,6 +20,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 	return []*types.ServicePackageFrameworkResource{
 		{
 			Factory: newDomainResource,
+			Name:    "Domain",
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Enforce setting a friendly name for every ephemeral resource declared with the `@EphemeralResource` annotation and resource declared with the `@FrameworkResource` annotation.
Backfill those resources that were missing such a value.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/40917.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/40913.