### PR TITLE
rds_global_cluster: Ensure replication_source_identifier changes ignored on secondary

### DIFF
--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -54,6 +54,12 @@ resource "aws_rds_cluster" "secondary" {
   global_cluster_identifier = aws_rds_global_cluster.example.id
   db_subnet_group_name      = "default"
 
+  lifecycle {
+    ignore_changes = [
+      replication_source_identifier
+    ]
+  }
+  
   depends_on = [
     aws_rds_cluster_instance.primary
   ]
@@ -120,6 +126,12 @@ resource "aws_rds_cluster" "secondary" {
   global_cluster_identifier = aws_rds_global_cluster.example.id
   skip_final_snapshot       = true
   db_subnet_group_name      = "default"
+
+  lifecycle {
+    ignore_changes = [
+      replication_source_identifier
+    ]
+  }
 
   depends_on = [
     aws_rds_cluster_instance.primary

--- a/website/docs/r/rds_global_cluster.html.markdown
+++ b/website/docs/r/rds_global_cluster.html.markdown
@@ -59,7 +59,6 @@ resource "aws_rds_cluster" "secondary" {
       replication_source_identifier
     ]
   }
-  
   depends_on = [
     aws_rds_cluster_instance.primary
   ]


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modify the  `rds_global_cluster` examples to include an ignore of  `replication_source_identifier`.

The `aws_rds_cluster` docs note that this must be ignored for the secondary cluster. 

Without this any additional run after the initial one will promote the secondary instance to a standalone instance. 

>[replication_source_identifier](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#replication_source_identifier-3) - (Optional) ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica. Note: Removing this attribute after creation will promote the read replica to a standalone cluster. If DB Cluster is part of a Global Cluster, use the [lifecycle configuration block ignore_changes argument](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html#ignore_changes) to prevent Terraform from showing differences for this argument instead of configuring this value. 


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
