### PR TITLE
[Bug]: AWS Apprunner Vpc Ingress Connection recreate upon service arn modification

### DIFF
--- a/.changelog/40927.txt
+++ b/.changelog/40927.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_apprunner_vpc_ingress_connection: Mark `service_arn` as `ForceNew`
+```

--- a/.changelog/40927.txt
+++ b/.changelog/40927.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_apprunner_vpc_ingress_connection: Mark `service_arn` as `ForceNew`
+resource/aws_apprunner_vpc_ingress_connection: Change `service_arn` to [ForceNew](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew)
 ```

--- a/.changelog/40927.txt
+++ b/.changelog/40927.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_apprunner_vpc_ingress_connection: Change `service_arn` to [ForceNew](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew)
+resource/aws_apprunner_vpc_ingress_connection: Change `ingress_vpc_configuration`, `name`, and `service_arn` to [ForceNew](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew)
 ```

--- a/internal/service/apprunner/vpc_ingress_connection.go
+++ b/internal/service/apprunner/vpc_ingress_connection.go
@@ -49,16 +49,19 @@ func resourceVPCIngressConnection() *schema.Resource {
 			"ingress_vpc_configuration": {
 				Type:     schema.TypeList,
 				Required: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrVPCEndpointID: {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						names.AttrVPCID: {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},
@@ -66,6 +69,7 @@ func resourceVPCIngressConnection() *schema.Resource {
 			names.AttrName: {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"service_arn": {
 				Type:         schema.TypeString,

--- a/internal/service/apprunner/vpc_ingress_connection.go
+++ b/internal/service/apprunner/vpc_ingress_connection.go
@@ -70,6 +70,7 @@ func resourceVPCIngressConnection() *schema.Resource {
 			"service_arn": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
 			names.AttrStatus: {

--- a/internal/service/apprunner/vpc_ingress_connection_test.go
+++ b/internal/service/apprunner/vpc_ingress_connection_test.go
@@ -79,33 +79,6 @@ func TestAccAppRunnerVPCIngressConnection_disappears(t *testing.T) {
 	})
 }
 
-func TestAccAppRunnerVPCIngressConnection_serviceARNChange(t *testing.T) {
-	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckVPCIngressConnectionDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccVPCIngressConnectionConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVPCIngressConnectionExists(ctx, resourceName),
-				),
-			},
-			{
-				Config: testAccVPCIngressConnectionConfig_serviceARNChange(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVPCIngressConnectionExists(ctx, resourceName),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckVPCIngressConnectionDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -195,41 +168,6 @@ func testAccVPCIngressConnectionConfig_basic(rName string) string {
 resource "aws_apprunner_vpc_ingress_connection" "test" {
   name        = %[1]q
   service_arn = aws_apprunner_service.test.arn
-
-  ingress_vpc_configuration {
-    vpc_id          = aws_vpc.test.id
-    vpc_endpoint_id = aws_vpc_endpoint.test.id
-  }
-}
-`, rName))
-}
-
-func testAccVPCIngressConnectionConfig_serviceARNChange(rName string) string {
-	return acctest.ConfigCompose(testAccVPCIngressConnectionConfig_base(rName), fmt.Sprintf(`
-resource "aws_apprunner_service" "test2" {
-  service_name = "%[1]s-changed"
-
-  source_configuration {
-    image_repository {
-      image_configuration {
-        port = "8000"
-      }
-      image_identifier      = "public.ecr.aws/aws-containers/hello-app-runner:latest"
-      image_repository_type = "ECR_PUBLIC"
-    }
-    auto_deployments_enabled = false
-  }
-
-  network_configuration {
-    ingress_configuration {
-      is_publicly_accessible = false
-    }
-  }
-}
-
-resource "aws_apprunner_vpc_ingress_connection" "test" {
-  name        = %[1]q
-  service_arn = aws_apprunner_service.test2.arn
 
   ingress_vpc_configuration {
     vpc_id          = aws_vpc.test.id


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This pull request addresses the mentioned issue by ensuring that changes to the service_arn attribute of the `aws_apprunner_vpc_ingress_connection` resource trigger a recreation of the resource. This is achieved by setting `ForceNew: true` on the `service_arn` schema definition.

Additionally, a new acceptance test `TestAccAppRunnerVPCIngressConnection_serviceARNChange` has been added to verify that the resource is recreated when the `service_arn` changes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40896 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc P=3 TESTS=TestAccAppRunnerVPCIngressConnection_ PKG=apprunner

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/apprunner/... -v -count 1 -parallel 3 -run='TestAccAppRunnerVPCIngressConnection_'  -timeout 360m -vet=off
2025/01/14 21:38:34 Initializing Terraform AWS Provider...
=== RUN   TestAccAppRunnerVPCIngressConnection_tags
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_null
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_null
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_EmptyMap
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_EmptyMap
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_AddOnUpdate
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_AddOnUpdate
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnCreate
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnCreate
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_providerOnly
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_providerOnly
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nonOverlapping
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_overlapping
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_overlapping
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnCreate
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnCreate
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccAppRunnerVPCIngressConnection_basic
=== PAUSE TestAccAppRunnerVPCIngressConnection_basic
=== RUN   TestAccAppRunnerVPCIngressConnection_disappears
=== PAUSE TestAccAppRunnerVPCIngressConnection_disappears
=== RUN   TestAccAppRunnerVPCIngressConnection_serviceARNChange
=== PAUSE TestAccAppRunnerVPCIngressConnection_serviceARNChange
=== CONT  TestAccAppRunnerVPCIngressConnection_tags
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Replace (337.82s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_overlapping
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyResourceTag (356.96s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccAppRunnerVPCIngressConnection_tags (433.56s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToResourceOnly (400.88s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nonOverlapping
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_overlapping (434.76s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_providerOnly
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToProviderOnly (377.18s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_AddOnUpdate
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nonOverlapping (432.52s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_AddOnUpdate (400.09s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnCreate
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_providerOnly (525.36s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnCreate (384.79s)
=== CONT  TestAccAppRunnerVPCIngressConnection_serviceARNChange
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Add (408.87s)
=== CONT  TestAccAppRunnerVPCIngressConnection_disappears
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Replace (426.39s)
=== CONT  TestAccAppRunnerVPCIngressConnection_basic
--- PASS: TestAccAppRunnerVPCIngressConnection_disappears (374.91s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccAppRunnerVPCIngressConnection_basic (366.05s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccAppRunnerVPCIngressConnection_serviceARNChange (638.21s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_null
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_ResourceTag (378.15s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_DefaultTag (358.92s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_EmptyMap
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_null (376.52s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullNonOverlappingResourceTag (387.21s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnCreate
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_EmptyMap (340.77s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Add (380.51s)
=== CONT  TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnCreate (409.54s)
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullOverlappingResourceTag (449.15s)
--- PASS: TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyProviderOnlyTag (367.82s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apprunner  3363.755s
...
```
