### PR TITLE
feat: add on_failure parameter with retry configuration handling for codepipeline

### DIFF
--- a/.changelog/40936.txt
+++ b/.changelog/40936.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codepipeline: Add `on_failure` parameter to specify stage failure behavior and optional retry logic
+```

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -2763,7 +2763,7 @@ resource "aws_codepipeline" "test" {
     on_failure {
       result = %[2]q
       retry_configuration {
-      retry_mode = %[3]q
+        retry_mode = %[3]q
       }
     }
   }
@@ -2787,7 +2787,7 @@ resource "aws_codepipeline" "test" {
     on_failure {
       result = %[2]q
       retry_configuration {
-       retry_mode = %[3]q
+        retry_mode = %[3]q
       }
     }
   }

--- a/website/docs/r/codepipeline.html.markdown
+++ b/website/docs/r/codepipeline.html.markdown
@@ -201,6 +201,7 @@ A `stage` block supports the following arguments:
 
 * `name` - (Required) The name of the stage.
 * `action` - (Required) The action(s) to include in the stage. Defined as an `action` block below
+* `on_failure` - (Optional) Specifies how CodePipeline should behave if this stage fails. An `on_failure` block is documented below.
 
 An `action` block supports the following arguments:
 
@@ -216,6 +217,13 @@ An `action` block supports the following arguments:
 * `run_order` - (Optional) The order in which actions are run.
 * `region` - (Optional) The region in which to run the action.
 * `namespace` - (Optional) The namespace all output variables will be accessed from.
+
+
+A `on_failure` block supports the following arguments:
+
+* `result` - (Required) The stage’s failure outcome. Possible values are `RETRY`
+* `retry_configuration` - (Optional) Nested block specifying retry details for the failed stage. A `retry_configuration` block supports the following arguments:
+* `retry_mode` - (Required) Defines which actions in the stage are retried upon failure. Possible values are `ALL_ACTIONS`, `FAILED_ACTIONS`
 
 A `trigger` block supports the following arguments:
 

--- a/website/docs/r/codepipeline.html.markdown
+++ b/website/docs/r/codepipeline.html.markdown
@@ -218,7 +218,6 @@ An `action` block supports the following arguments:
 * `region` - (Optional) The region in which to run the action.
 * `namespace` - (Optional) The namespace all output variables will be accessed from.
 
-
 A `on_failure` block supports the following arguments:
 
 * `result` - (Required) The stage’s failure outcome. Possible values are `RETRY`


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modify the CodePipeline resource to add a new `on_failure` parameter. This parameter is defined as a map containing a required retry field and an optional `retry_configuration` block, which itself includes a `retry_mode` field. Internally, this change introduces two new expand functions (`expandFailureConditions`, `expandRetryConfiguration`) and their corresponding flatten functions (`flattenFailureConditions`, `flattenRetryConfiguration`) to handle reading and writing these values.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39966

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- API Reference: https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_StageDeclaration.html#CodePipeline-Type-StageDeclaration-onFailure
- Docs: https://docs.aws.amazon.com/codepipeline/latest/userguide/stage-retry.html
- What's new: https://aws.amazon.com/about-aws/whats-new/2024/10/aws-codepipeline-automatic-retry-stage-failure/?nc1=h_ls

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
kimjihun@gimjihun-ui-MacBookPro terraform-provider-aws % make testacc TESTS=TestAccCodePipeline_onFailure PKG=codepipeline
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/codepipeline/... -v -count 1 -parallel 20 -run='TestAccCodePipeline_onFailure'  -timeout 360m
2025/01/12 20:37:23 Initializing Terraform AWS Provider...
=== RUN   TestAccCodePipeline_onFailure
=== PAUSE TestAccCodePipeline_onFailure
=== CONT  TestAccCodePipeline_onFailure
--- PASS: TestAccCodePipeline_onFailure (63.68s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline       68.599s
...
```
