### PR TITLE
r/ssm_parameter: add `value_wo' write-only attribute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -288,7 +288,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
-	github.com/hashicorp/terraform-plugin-go v0.25.0
+	github.com/hashicorp/terraform-plugin-go v0.25.1-0.20241217173851-dcf8f64dbfaa
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-mux v0.17.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
@@ -380,3 +380,8 @@ require (
 )
 
 replace github.com/hashicorp/terraform-plugin-log => github.com/gdavison/terraform-plugin-log v0.0.0-20230928191232-6c653d8ef8fb
+
+replace (
+	github.com/hashicorp/terraform-plugin-go => github.com/hashicorp/terraform-plugin-go v0.25.1-0.20241217173851-dcf8f64dbfaa
+	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.1-0.20250103201413-5f29273ad6f0
+)

--- a/go.sum
+++ b/go.sum
@@ -664,12 +664,12 @@ github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0 h1:v3DapR8gsp3E
 github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0/go.mod h1:c3PnGE9pHBDfdEVG9t1S1C9ia5LW+gkFR0CygXlM8ak=
 github.com/hashicorp/terraform-plugin-framework-validators v0.16.0 h1:O9QqGoYDzQT7lwTXUsZEtgabeWW96zUBh47Smn2lkFA=
 github.com/hashicorp/terraform-plugin-framework-validators v0.16.0/go.mod h1:Bh89/hNmqsEWug4/XWKYBwtnw3tbz5BAy1L1OgvbIaY=
-github.com/hashicorp/terraform-plugin-go v0.25.0 h1:oi13cx7xXA6QciMcpcFi/rwA974rdTxjqEhXJjbAyks=
-github.com/hashicorp/terraform-plugin-go v0.25.0/go.mod h1:+SYagMYadJP86Kvn+TGeV+ofr/R3g4/If0O5sO96MVw=
+github.com/hashicorp/terraform-plugin-go v0.25.1-0.20241217173851-dcf8f64dbfaa h1:GOXZVYZrfDrWxZMHdSNqZKDwayH8WBBtyOLx25ekwv8=
+github.com/hashicorp/terraform-plugin-go v0.25.1-0.20241217173851-dcf8f64dbfaa/go.mod h1:OKJU8uauqiLVRWjlFB0KIgK++baq26qfvOU1IVycx9k=
 github.com/hashicorp/terraform-plugin-mux v0.17.0 h1:/J3vv3Ps2ISkbLPiZOLspFcIZ0v5ycUXCEQScudGCCw=
 github.com/hashicorp/terraform-plugin-mux v0.17.0/go.mod h1:yWuM9U1Jg8DryNfvCp+lH70WcYv6D8aooQxxxIzFDsE=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0 h1:wyKCCtn6pBBL46c1uIIBNUOWlNfYXfXpVo16iDyLp8Y=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0/go.mod h1:B0Al8NyYVr8Mp/KLwssKXG1RqnTk7FySqSn4fRuLNgw=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.1-0.20250103201413-5f29273ad6f0 h1:wBngDRqcqKObWtg/2e/FPcMaL9SLtkBePd5adYjCcMo=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.1-0.20250103201413-5f29273ad6f0/go.mod h1:wsPZ9W0E/8tID4aejTrYrNPlJS8YhkEepeMeZlUaB8M=
 github.com/hashicorp/terraform-plugin-testing v1.11.0 h1:MeDT5W3YHbONJt2aPQyaBsgQeAIckwPX41EUHXEn29A=
 github.com/hashicorp/terraform-plugin-testing v1.11.0/go.mod h1:WNAHQ3DcgV/0J+B15WTE6hDvxcUdkPPpnB1FR3M910U=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -368,7 +368,7 @@ func resourceParameterUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		if !valueWO.IsNull() && valueWO.AsString() != "" {
 			value = valueWO.AsString()
 		}
-		
+
 		input := &ssm.PutParameterInput{
 			AllowedPattern: aws.String(d.Get("allowed_pattern").(string)),
 			Name:           aws.String(d.Id()),

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -158,7 +158,16 @@ func resourceParameter() *schema.Resource {
 			func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 				conn := meta.(*conns.AWSClient).SSMClient(ctx)
 
-				output, err := findParameterByName(ctx, conn, diff.Id(), true)
+				if diff.Id() == "" {
+					return nil
+				}
+
+				output, err := findParameterByName(ctx, conn, diff.Get(names.AttrName).(string), true)
+
+				if tfresource.NotFound(err) {
+					return nil
+				}
+
 				if err != nil {
 					return err
 				}

--- a/internal/service/ssm/parameter_tags_gen_test.go
+++ b/internal/service/ssm/parameter_tags_gen_test.go
@@ -71,6 +71,9 @@ func TestAccSSMParameter_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/tags/"),
@@ -120,6 +123,9 @@ func TestAccSSMParameter_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/tags/"),
@@ -163,6 +169,9 @@ func TestAccSSMParameter_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/tags/"),
@@ -194,6 +203,9 @@ func TestAccSSMParameter_tags(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -246,6 +258,9 @@ func TestAccSSMParameter_tags_null(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/tags/"),
@@ -303,6 +318,9 @@ func TestAccSSMParameter_tags_EmptyMap(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/tags/"),
@@ -393,6 +411,9 @@ func TestAccSSMParameter_tags_AddOnUpdate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -451,6 +472,9 @@ func TestAccSSMParameter_tags_EmptyTag_OnCreate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/tags/"),
@@ -482,6 +506,9 @@ func TestAccSSMParameter_tags_EmptyTag_OnCreate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -576,6 +603,9 @@ func TestAccSSMParameter_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ConfigDirectory: config.StaticDirectory("testdata/Parameter/tags/"),
@@ -619,6 +649,9 @@ func TestAccSSMParameter_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -708,6 +741,9 @@ func TestAccSSMParameter_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -766,6 +802,9 @@ func TestAccSSMParameter_tags_DefaultTags_providerOnly(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -813,6 +852,9 @@ func TestAccSSMParameter_tags_DefaultTags_providerOnly(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -856,6 +898,9 @@ func TestAccSSMParameter_tags_DefaultTags_providerOnly(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -889,6 +934,9 @@ func TestAccSSMParameter_tags_DefaultTags_providerOnly(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -957,6 +1005,9 @@ func TestAccSSMParameter_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1016,6 +1067,9 @@ func TestAccSSMParameter_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1049,6 +1103,9 @@ func TestAccSSMParameter_tags_DefaultTags_nonOverlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -1115,6 +1172,9 @@ func TestAccSSMParameter_tags_DefaultTags_overlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1174,6 +1234,9 @@ func TestAccSSMParameter_tags_DefaultTags_overlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1225,6 +1288,9 @@ func TestAccSSMParameter_tags_DefaultTags_overlapping(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -1315,6 +1381,9 @@ func TestAccSSMParameter_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -1404,6 +1473,9 @@ func TestAccSSMParameter_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -1469,6 +1541,9 @@ func TestAccSSMParameter_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -1526,6 +1601,9 @@ func TestAccSSMParameter_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -1588,6 +1666,9 @@ func TestAccSSMParameter_tags_DefaultTags_nullOverlappingResourceTag(t *testing.
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -1650,6 +1731,9 @@ func TestAccSSMParameter_tags_DefaultTags_nullNonOverlappingResourceTag(t *testi
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -1705,6 +1789,9 @@ func TestAccSSMParameter_tags_ComputedTag_OnCreate(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -1802,6 +1889,9 @@ func TestAccSSMParameter_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})
@@ -1889,6 +1979,9 @@ func TestAccSSMParameter_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"has_value_wo",
+				},
 			},
 		},
 	})

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -55,9 +55,10 @@ func TestAccSSMParameter_basic(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			// Test import with version.
 			// https://github.com/hashicorp/terraform-provider-aws/issues/37812.
@@ -67,7 +68,7 @@ func TestAccSSMParameter_basic(t *testing.T) {
 				ImportStateId:                        name + ":1",
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: names.AttrName,
-				ImportStateVerifyIgnore:              []string{names.AttrID, "overwrite"},
+				ImportStateVerifyIgnore:              []string{names.AttrID, "overwrite", "has_value_wo"},
 			},
 		},
 	})
@@ -125,9 +126,10 @@ func TestAccSSMParameter_updateValue(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_basic(name, "String", "test2"),
@@ -139,9 +141,10 @@ func TestAccSSMParameter_updateValue(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 		},
 	})
@@ -170,9 +173,10 @@ func TestAccSSMParameter_updateDescription(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_description(name, "updated description", "String", "test"),
@@ -185,9 +189,10 @@ func TestAccSSMParameter_updateDescription(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 		},
 	})
@@ -213,9 +218,10 @@ func TestAccSSMParameter_tier(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_tier(rName, string(awstypes.ParameterTierStandard)),
@@ -255,9 +261,10 @@ func TestAccSSMParameter_Tier_intelligentTieringToStandard(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_tier(rName, string(awstypes.ParameterTierStandard)),
@@ -274,9 +281,10 @@ func TestAccSSMParameter_Tier_intelligentTieringToStandard(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 		},
 	})
@@ -302,9 +310,10 @@ func TestAccSSMParameter_Tier_intelligentTieringToAdvanced(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_tier(rName, string(awstypes.ParameterTierAdvanced)),
@@ -322,9 +331,10 @@ func TestAccSSMParameter_Tier_intelligentTieringToAdvanced(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 		},
 	})
@@ -352,9 +362,10 @@ func TestAccSSMParameter_Tier_intelligentTieringOnCreation(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 		},
 	})
@@ -462,7 +473,7 @@ func TestAccSSMParameter_Overwrite_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"overwrite"},
+				ImportStateVerifyIgnore: []string{"overwrite", "has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_basicOverwrite(name, "String", "test3"),
@@ -532,7 +543,7 @@ func TestAccSSMParameter_Overwrite_tags(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"overwrite"},
+				ImportStateVerifyIgnore: []string{"overwrite", "has_value_wo"},
 			},
 		},
 	})
@@ -566,7 +577,7 @@ func TestAccSSMParameter_Overwrite_noOverwriteTags(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"overwrite"},
+				ImportStateVerifyIgnore: []string{"overwrite", "has_value_wo"},
 			},
 		},
 	})
@@ -597,9 +608,10 @@ func TestAccSSMParameter_Overwrite_updateToTags(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_overwriteTags1(rName, true, acctest.CtKey1, acctest.CtValue2),
@@ -667,9 +679,10 @@ func TestAccSSMParameter_updateType(t *testing.T) {
 				Config: testAccParameterConfig_basic(name, "SecureString", "test2"),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_basic(name, "String", "test2"),
@@ -701,7 +714,7 @@ func TestAccSSMParameter_Overwrite_updateDescription(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"overwrite"},
+				ImportStateVerifyIgnore: []string{"overwrite", "has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_basicOverwriteNoDescription(name, "String", "test2"),
@@ -734,9 +747,10 @@ func TestAccSSMParameter_changeNameForcesNew(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_basic(after, "String", "test2"),
@@ -771,9 +785,10 @@ func TestAccSSMParameter_fullPath(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 		},
 	})
@@ -801,9 +816,10 @@ func TestAccSSMParameter_Secure_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 		},
 	})
@@ -910,9 +926,10 @@ func TestAccSSMParameter_DataType_ec2Image(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 		},
 	})
@@ -939,9 +956,10 @@ func TestAccSSMParameter_DataType_ssmIntegration(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 		},
 	})
@@ -967,9 +985,10 @@ func TestAccSSMParameter_DataType_update(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_dataTypeUpdate(rName, "aws:ec2:image"),
@@ -1005,9 +1024,10 @@ func TestAccSSMParameter_Secure_key(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 		},
 	})
@@ -1036,9 +1056,10 @@ func TestAccSSMParameter_Secure_keyUpdate(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"has_value_wo"},
 			},
 			{
 				Config: testAccParameterConfig_secureKey(name, "secret", randString),
@@ -1082,7 +1103,7 @@ func TestAccSSMParameter_importByARN(t *testing.T) {
 				},
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: names.AttrName,
-				ImportStateVerifyIgnore:              []string{names.AttrID, "overwrite"},
+				ImportStateVerifyIgnore:              []string{names.AttrID, "overwrite", "has_value_wo"},
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

adding new write-only attribute `value_wo`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccSSMParameter_' PKG=ssm

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ssm/... -v -count 1 -parallel 20  -run=TestAccSSMParameter_ -timeout 360m -vet=off
2025/01/15 13:05:59 Initializing Terraform AWS Provider...
--- PASS: TestAccSSMParameter_DataType_ssmIntegration (44.26s)
--- PASS: TestAccSSMParameter_importByARN (44.40s)
--- PASS: TestAccSSMParameter_DataType_ec2Image (44.61s)
--- PASS: TestAccSSMParameter_Secure_key (44.78s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_emptyResourceTag (48.25s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_emptyProviderOnlyTag (48.44s)
--- PASS: TestAccSSMParameter_tags_EmptyMap (62.49s)
--- PASS: TestAccSSMParameter_Overwrite_updateDescription (66.48s)
--- PASS: TestAccSSMParameter_updateType (66.51s)
--- PASS: TestAccSSMParameter_Secure_keyUpdate (72.41s)
--- PASS: TestAccSSMParameter_Overwrite_updateToTags (76.75s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_updateToResourceOnly (76.94s)
--- PASS: TestAccSSMParameter_DataType_update (77.41s)
--- PASS: TestAccSSMParameter_tags_AddOnUpdate (81.40s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_updateToProviderOnly (85.06s)
--- PASS: TestAccSSMParameter_Secure_basic (43.94s)
--- PASS: TestAccSSMParameter_tags_EmptyTag_OnCreate (90.99s)
--- PASS: TestAccSSMParameter_Secure_insecureChangeSecure (91.79s)
--- PASS: TestAccSSMParameter_Overwrite_noOverwriteTags (49.78s)
--- PASS: TestAccSSMParameter_fullPath (46.57s)
--- PASS: TestAccSSMParameter_tier (99.94s)
--- PASS: TestAccSSMParameter_Overwrite_removeAttribute (67.70s)
--- PASS: TestAccSSMParameter_multiple (37.10s)
--- PASS: TestAccSSMParameter_changeNameForcesNew (74.18s)
--- PASS: TestAccSSMParameter_disappears (35.36s)
--- PASS: TestAccSSMParameter_Secure_insecure (91.03s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnUpdate (60.79s)
--- PASS: TestAccSSMParameter_basic (52.80s)
--- PASS: TestAccSSMParameter_tags_ComputedTag_OnCreate (51.45s)
--- PASS: TestAccSSMParameter_tags_EmptyTag_OnUpdate_Replace (87.23s)
--- PASS: TestAccSSMParameter_Overwrite_tags (50.16s)
--- PASS: TestAccSSMParameter_updateDescription (82.43s)
--- PASS: TestAccSSMParameter_updateValue (79.80s)
--- PASS: TestAccSSMParameter_tags_null (62.52s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnCreation (42.55s)
--- PASS: TestAccSSMParameter_tags (168.17s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_nullNonOverlappingResourceTag (45.86s)
--- PASS: TestAccSSMParameter_tags_IgnoreTags_Overlap_DefaultTag (104.85s)
--- PASS: TestAccSSMParameter_tags_ComputedTag_OnUpdate_Replace (77.50s)
--- PASS: TestAccSSMParameter_Overwrite_basic (92.11s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_providerOnly (173.60s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_nullOverlappingResourceTag (39.56s)
--- PASS: TestAccSSMParameter_tags_EmptyTag_OnUpdate_Add (112.50s)
--- PASS: TestAccSSMParameter_tags_ComputedTag_OnUpdate_Add (68.84s)
--- PASS: TestAccSSMParameter_tags_IgnoreTags_Overlap_ResourceTag (96.02s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToAdvanced (75.37s)
--- PASS: TestAccSSMParameter_Overwrite_cascade (42.05s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToStandard (57.66s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_nonOverlapping (68.69s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_overlapping (66.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	216.056s
```
