### PR TITLE
fix: update comparison

### DIFF
--- a/.changelog/40953.txt
+++ b/.changelog/40953.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_workspaces_workspace: Fixes value conversion error.
+resource/aws_workspaces_workspace: Properly update `workspace_properties.running_mode_auto_stop_timeout_in_minutes` when modified
 ```

--- a/.changelog/40953.txt
+++ b/.changelog/40953.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_workspaces_workspace: Fixes value conversion error.
+```

--- a/internal/service/workspaces/workspace.go
+++ b/internal/service/workspaces/workspace.go
@@ -314,7 +314,7 @@ func workspacePropertyUpdate(ctx context.Context, conn *workspaces.Client, d *sc
 			RunningMode: types.RunningMode(d.Get(key).(string)),
 		}
 	case "workspace_properties.0.running_mode_auto_stop_timeout_in_minutes":
-		if d.Get("workspace_properties.0.running_mode") != types.RunningModeAutoStop {
+		if d.Get("workspace_properties.0.running_mode") != string(types.RunningModeAutoStop) {
 			log.Printf("[DEBUG] Property running_mode_auto_stop_timeout_in_minutes makes sense only for AUTO_STOP running mode")
 			return nil
 		}

--- a/internal/service/workspaces/workspace_test.go
+++ b/internal/service/workspaces/workspace_test.go
@@ -194,6 +194,54 @@ func testAccWorkspace_workspaceProperties(t *testing.T) {
 	})
 }
 
+func testAccWorkspace_workspaceProperties_runningModeAutoStopTimeoutInMinutes(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1 types.Workspace
+	rName := sdkacctest.RandString(8)
+	domain := acctest.RandomDomainName()
+
+	resourceName := "aws_workspaces_workspace.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckDirectory(ctx, t)
+			acctest.PreCheckDirectoryServiceSimpleDirectory(ctx, t)
+			acctest.PreCheckHasIAMRole(ctx, t, "workspaces_DefaultRole")
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, strings.ToLower(workspaces.ServiceID)),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Destroy: false,
+				Config:  testAccWorkspaceConfig_propertiesAutoStopTimeoutInMinutes(rName, domain, 120),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkspaceExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.compute_type_name", string(types.ComputeValue)),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.root_volume_size_gib", "80"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode", string(types.RunningModeAutoStop)),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode_auto_stop_timeout_in_minutes", "120"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.user_volume_size_gib", "10"),
+				),
+			},
+			{
+				Config: testAccWorkspaceConfig_propertiesAutoStopTimeoutInMinutes(rName, domain, 180),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkspaceExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.compute_type_name", string(types.ComputeValue)),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.root_volume_size_gib", "80"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode", string(types.RunningModeAutoStop)),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.running_mode_auto_stop_timeout_in_minutes", "180"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_properties.0.user_volume_size_gib", "10"),
+				),
+			},
+		},
+	})
+}
+
 // testAccWorkspace_workspaceProperties_runningModeAlwaysOn
 // validates workspace resource creation/import when workspace_properties.running_mode is set to ALWAYS_ON
 // Reference: https://github.com/hashicorp/terraform-provider-aws/issues/13558
@@ -552,6 +600,31 @@ resource "aws_workspaces_workspace" "test" {
   }
 }
 `, rName))
+}
+
+func testAccWorkspaceConfig_propertiesAutoStopTimeoutInMinutes(rName, domain string, autoStoptimeoutInMinutes int) string {
+	return acctest.ConfigCompose(
+		testAccWorkspaceConfig_Prerequisites(rName, domain),
+		fmt.Sprintf(`
+resource "aws_workspaces_workspace" "test" {
+  bundle_id    = data.aws_workspaces_bundle.test.id
+  directory_id = aws_workspaces_directory.test.id
+
+  # NOTE: WorkSpaces API doesn't allow creating users in the directory.
+  # However, "Administrator"" user is always present in a bare directory.
+  user_name = "Administrator"
+
+  workspace_properties {
+    # NOTE: Compute type and volume size update not allowed within 6 hours after creation.
+    running_mode                              = "AUTO_STOP"
+    running_mode_auto_stop_timeout_in_minutes = %[2]d
+  }
+
+  tags = {
+    Name = "tf-testacc-workspaces-workspace-%[1]s"
+  }
+}
+`, rName, autoStoptimeoutInMinutes))
 }
 
 func testAccWorkspaceConfig_validateRootVolumeSize(rName, domain string) string {

--- a/internal/service/workspaces/workspaces_test.go
+++ b/internal/service/workspaces/workspaces_test.go
@@ -39,7 +39,8 @@ func TestAccWorkSpaces_serial(t *testing.T) {
 			"validateRootVolumeSize": testAccWorkspace_validateRootVolumeSize,
 			"validateUserVolumeSize": testAccWorkspace_validateUserVolumeSize,
 			"workspaceProperties":    testAccWorkspace_workspaceProperties,
-			"workspaceProperties_runningModeAlwaysOn": testAccWorkspace_workspaceProperties_runningModeAlwaysOn,
+			"workspaceProperties_runningModeAlwaysOn":                 testAccWorkspace_workspaceProperties_runningModeAlwaysOn,
+			"workspaceProperties_runningModeAutoStopTimeoutInMinutes": testAccWorkspace_workspaceProperties_runningModeAutoStopTimeoutInMinutes,
 		},
 	}
 


### PR DESCRIPTION
### Description

As described in #40580 updates to the value of `running_mode_auto_stop_timeout_in_minutes` in the resource `aws_workspaces_workspace` are not forwarded to the AWS Go SDK v2.


Example configuration of the resource:

```hcl
resource "aws_workspaces_workspace" "workspace" {
  directory_id = "d-2783a367e8"
  bundle_id    = "wsb-8ry31mu7v"
  user_name    = "john.johnson"

  root_volume_encryption_enabled = true
  user_volume_encryption_enabled = true
  volume_encryption_key          = "arn:aws:kms:us-east-1:012345678912:key/05e668b8-debd-9829-8e18-ad62a787863f"

  workspace_prooperties {
    compute_type_name                 = STANDARD
    root_volume_size_gib              = 80
    user_volume_size_gib              = 10
    running_mode                      = "AUTO_STOP"
    running_mode_auto_stop_in_minutes = 120
  }
}
```

`running_mode` is set to `"AUTO_STOP"`, so that the provider should allow updated to `running_mode_auto_stop_in_minutes`.

In the debug logs of a `terraform apply` one can actually find below line

```plain
2025-01-02T19:35:22.800+0100 [DEBUG] provider.terraform-provider-aws_v5.81.0_x5: [DEBUG] Property running_mode_auto_stop_timeout_in_minutes makes sense only for AUTO_STOP running mode
```

originating from [this](https://github.com/hashicorp/terraform-provider-aws/blob/94283e5383e7d60cfc77e78f37f7fc98e29ed5b0/internal/service/workspaces/workspace.go#L318) source code.


It seems to be the case that a type conversion to `string` is missing in [this](https://github.com/hashicorp/terraform-provider-aws/blob/94283e5383e7d60cfc77e78f37f7fc98e29ed5b0/internal/service/workspaces/workspace.go#L317) code snippet

```
if d.Get("workspace_properties.0.running_mode") != types.RunningModeAutoStop {
	log.Printf("[DEBUG] Property running_mode_auto_stop_timeout_in_minutes makes sense only for AUTO_STOP running mode")
	return nil
}
```

`types.RunningModeAutoStop` should read `string(types.RunningModeAutoStop)`

### Relations

Closes #40580 
Relates #32346 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

I am not 100% sure what to add here. I think it should be something like below for running all tests related to workspaces

```console
% make testacc TESTS=TestAccWorkSpaces_serial PKG=workspaces
```

On my end I executed the test `testAccWorkspace_workspaceProperties_runningModeAutoStopTimeoutInMinutes`, but not other  tests/ the whole "suite"  because of costs.
Please let me know if that`s fine from your end.