### PR TITLE
Add Missing id Attribute to aws_vpc_endpoint Data Source

### DIFF
--- a/website/docs/d/vpc_endpoint.html.markdown
+++ b/website/docs/d/vpc_endpoint.html.markdown
@@ -51,6 +51,7 @@ which take the following arguments:
 
 In addition to all arguments above except `filter`, the following attributes are exported:
 
+* `id` - ID of the VPC endpoint.
 * `arn` - ARN of the VPC endpoint.
 * `cidr_blocks` - List of CIDR blocks for the exposed AWS service. Applicable for endpoints of type `Gateway`.
 * `dns_entry` - DNS entries for the VPC Endpoint. Applicable for endpoints of type `Interface`. [DNS entry blocks are documented below](#dns_entry-block).


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This Pull Request addresses the issue of the missing id attribute in the aws_vpc_endpoint data source documentation. The id attribute is crucial for users to retrieve the ID of the VPC endpoint. 


### Relations

Closes: #40959
