### PR TITLE
r/elasticache_serverless_cache: fix modify error using autoflex

### DIFF
--- a/.changelog/40969.txt
+++ b/.changelog/40969.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_serverless_cache: Fix `InvalidParameterCombination` error during update
+```

--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -604,12 +604,3 @@ type endpointModel struct {
 	Address types.String `tfsdk:"address"`
 	Port    types.Int64  `tfsdk:"port"`
 }
-
-func serverlessCacheHasChanges(_ context.Context, plan, state serverlessCacheResourceModel) bool {
-	return !plan.CacheUsageLimits.Equal(state.CacheUsageLimits) ||
-		!plan.DailySnapshotTime.Equal(state.DailySnapshotTime) ||
-		!plan.Description.Equal(state.Description) ||
-		!plan.UserGroupID.Equal(state.UserGroupID) ||
-		!plan.SecurityGroupIDs.Equal(state.SecurityGroupIDs) ||
-		!plan.SnapshotRetentionLimit.Equal(state.SnapshotRetentionLimit)
-}

--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -340,9 +340,20 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 
 	conn := r.Meta().ElastiCacheClient(ctx)
 
-	if serverlessCacheHasChanges(ctx, new, old) {
-		input := &elasticache.ModifyServerlessCacheInput{}
-		response.Diagnostics.Append(fwflex.Expand(ctx, new, input)...)
+	diff, d := fwflex.Calculate(ctx, new, old)
+	response.Diagnostics.Append(d...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	if diff.HasChanges() {
+		input := elasticache.ModifyServerlessCacheInput{
+			ServerlessCacheName: new.ServerlessCacheName.ValueStringPointer(),
+		}
+		response.Diagnostics.Append(fwflex.Expand(ctx, new, &input, diff.IgnoredFieldNamesOpts()...)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
 		// Unset engine related stuff to prevent the following error:
 		// This API supports only cross-engine upgrades to Valkey engine currently.
 		if new.Engine.Equal(old.Engine) {
@@ -351,11 +362,8 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 		if new.MajorEngineVersion.Equal(old.MajorEngineVersion) {
 			input.MajorEngineVersion = nil
 		}
-		if response.Diagnostics.HasError() {
-			return
-		}
 
-		_, err := conn.ModifyServerlessCache(ctx, input)
+		_, err := conn.ModifyServerlessCache(ctx, &input)
 
 		if err != nil {
 			response.Diagnostics.AddError(fmt.Sprintf("updating ElastiCache Serverless Cache (%s)", new.ID.ValueString()), err.Error())


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When modifying and `aws_elasticache_serverless_cache` the resource can sometimes throw the following error due all parameters being passed to the update:

```console
% make testacc TESTARGS='-run=TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup' PKG=elasticache

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/elasticache/... -v -count 1 -parallel 20  -run=TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup -timeout 360m -vet=off
2025/01/16 09:43:53 Initializing Terraform AWS Provider...
=== RUN   TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
=== PAUSE TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
=== CONT  TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
    serverless_cache_test.go:214: Step 2/2 error: Error running apply: exit status 1

        Error: updating ElastiCache Serverless Cache (tf-acc-test-7713555080296793790)

          with aws_elasticache_serverless_cache.test,
          on terraform_plugin_test.tf line 56, in resource "aws_elasticache_serverless_cache" "test":
          56: resource "aws_elasticache_serverless_cache" "test" {

        operation error ElastiCache: ModifyServerlessCache, https response error
        StatusCode: 400, RequestID: fa52f39a-9a6f-4267-b141-dd7372806b81,
        InvalidParameterCombination: Serverless Cache modifications only support
        modifying one field per request.
--- FAIL: TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup (619.41s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	625.897s
FAIL
make: *** [testacc] Error 1
```



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #37499
Closes #40461

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup' PKG=elasticache

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/elasticache/... -v -count 1 -parallel 20  -run=TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup -timeout 360m -vet=off
2025/01/16 09:59:31 Initializing Terraform AWS Provider...
=== RUN   TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
=== PAUSE TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
=== CONT  TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
--- PASS: TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup (532.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	539.266s
```

```console
% make testacc TESTARGS='-run=TestAccElastiCacheServerlessCache_' PKG=elasticache

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/elasticache/... -v -count 1 -parallel 20  -run=TestAccElastiCacheServerlessCache_ -timeout 360m -vet=off
2025/01/16 10:12:47 Initializing Terraform AWS Provider...
--- PASS: TestAccElastiCacheServerlessCache_disappears (416.33s)
--- PASS: TestAccElastiCacheServerlessCache_update (458.97s)
--- PASS: TestAccElastiCacheServerlessCache_tags (463.96s)
--- PASS: TestAccElastiCacheServerlessCache_basicValkey (471.00s)
--- PASS: TestAccElastiCacheServerlessCache_basicRedis (482.76s)
--- PASS: TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup (524.66s)
--- PASS: TestAccElastiCacheServerlessCache_fullValkey (572.70s)
--- PASS: TestAccElastiCacheServerlessCache_fullRedis (624.83s)
--- PASS: TestAccElastiCacheServerlessCache_full (655.87s)
--- PASS: TestAccElastiCacheServerlessCache_updatesc (682.26s)
--- PASS: TestAccElastiCacheServerlessCache_update_RedisToValkey (777.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	783.887s
```
