### PR TITLE
fix(doc): update valid values for action property of wafv2 logging configuration

### DIFF
--- a/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
+++ b/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
@@ -153,7 +153,7 @@ The `condition` block supports the following arguments:
 
 The `action_condition` block supports the following argument:
 
-* `action` - (Required) Action setting that a log record must contain in order to meet the condition. Valid values for `action` are `ALLOW`, `BLOCK`, and `COUNT`.
+* `action` - (Required) Action setting that a log record must contain in order to meet the condition. Valid values for `action` are `ALLOW`, `BLOCK`, `COUNT`, `CAPTCHA`, `CHALLENGE` and `EXCLUDED_AS_COUNT`.
 
 ### Label Name Condition
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Update valid values of `action` property of WAFv2 logging configuration. Added missing values from [aws-sdk-go-v2](https://github.com/aws/aws-sdk-go-v2/blob/7ea97e576564775a287646a2b992f7b31a48b785/service/wafv2/types/enums.go#L8-L15): CAPTCHA, CHALLENGE, and EXCLUDED_AS_COUNT.

### Relations
Closes #40978

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/waf/latest/APIReference/API_ActionCondition.html
- https://github.com/aws/aws-sdk-go-v2/blob/7ea97e576564775a287646a2b992f7b31a48b785/service/wafv2/types/enums.go#L8-L15


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccXXX'  -timeout 360m -vet=off
2025/01/17 14:43:25 Initializing Terraform AWS Provider...
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      4.723s [no tests to run]
...
```
No test needed.
