### PR TITLE
testing: Reduce uses of `resource.TestCheckResourceAttrSet` with ARN attributes: `k` to `m` services

### DIFF
--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -6,7 +6,6 @@ rules:
       exclude:
         - "internal/service/controltower"
         - "internal/service/kafka"
-        - "internal/service/kendra"
         - "internal/service/kinesis"
         - "internal/service/kinesisvideo"
         - "internal/service/lexmodels"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -6,7 +6,6 @@ rules:
       exclude:
         - "internal/service/controltower"
         - "internal/service/kafka"
-        - "internal/service/kinesis"
         - "internal/service/kinesisvideo"
         - "internal/service/lexmodels"
         - "internal/service/lightsail"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -5,7 +5,6 @@ rules:
     paths:
       exclude:
         - "internal/service/controltower"
-        - "internal/service/kafka"
         - "internal/service/lexmodels"
         - "internal/service/lightsail"
         - "internal/service/medialive"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -6,7 +6,6 @@ rules:
       exclude:
         - "internal/service/controltower"
         - "internal/service/lightsail"
-        - "internal/service/memorydb"
         - "internal/service/networkmanager"
         - "internal/service/networkmonitor"
         - "internal/service/oam"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -5,7 +5,6 @@ rules:
     paths:
       exclude:
         - "internal/service/controltower"
-        - "internal/service/lightsail"
         - "internal/service/networkmanager"
         - "internal/service/networkmonitor"
         - "internal/service/oam"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -6,7 +6,6 @@ rules:
       exclude:
         - "internal/service/controltower"
         - "internal/service/kafka"
-        - "internal/service/kafkaconnect"
         - "internal/service/kendra"
         - "internal/service/kinesis"
         - "internal/service/kinesisvideo"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -6,7 +6,6 @@ rules:
       exclude:
         - "internal/service/controltower"
         - "internal/service/lightsail"
-        - "internal/service/medialive"
         - "internal/service/memorydb"
         - "internal/service/networkmanager"
         - "internal/service/networkmonitor"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -6,7 +6,6 @@ rules:
       exclude:
         - "internal/service/controltower"
         - "internal/service/kafka"
-        - "internal/service/kinesisvideo"
         - "internal/service/lexmodels"
         - "internal/service/lightsail"
         - "internal/service/medialive"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -5,7 +5,6 @@ rules:
     paths:
       exclude:
         - "internal/service/controltower"
-        - "internal/service/lexmodels"
         - "internal/service/lightsail"
         - "internal/service/medialive"
         - "internal/service/memorydb"

--- a/internal/service/kafka/replicator_test.go
+++ b/internal/service/kafka/replicator_test.go
@@ -24,7 +24,7 @@ import (
 const (
 	// The ARN format documentation (https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonmanagedstreamingforapachekafka.html#amazonmanagedstreamingforapachekafka-resources-for-iam-policies)
 	// shows ARNs having a UUID component, but in testing there is an additional component.
-	kafkaUUIDRegexPattern = verify.UUIDRegexPattern + `-\w+`
+	kafkaUUIDRegexPattern = verify.UUIDRegexPattern + `-\w+` // nosemgrep:ci.kafka-in-const-name,ci.kafka-in-var-name
 )
 
 func TestAccKafkaReplicator_basic(t *testing.T) {

--- a/internal/service/kafka/replicator_test.go
+++ b/internal/service/kafka/replicator_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -16,7 +17,14 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfkafka "github.com/hashicorp/terraform-provider-aws/internal/service/kafka"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	// The ARN format documentation (https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonmanagedstreamingforapachekafka.html#amazonmanagedstreamingforapachekafka-resources-for-iam-policies)
+	// shows ARNs having a UUID component, but in testing there is an additional component.
+	kafkaUUIDRegexPattern = verify.UUIDRegexPattern + `-\w+`
 )
 
 func TestAccKafkaReplicator_basic(t *testing.T) {
@@ -45,9 +53,10 @@ func TestAccKafkaReplicator_basic(t *testing.T) {
 				Config: testAccReplicatorConfig_basic(rName, sourceCluster, targetCluster),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicatorExists(ctx, resourceName, &replicator),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafka", regexache.MustCompile(`replicator/`+rName+`/`+kafkaUUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttr(resourceName, "replicator_name", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test-description"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "kafka_cluster.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "kafka_cluster.0.vpc_config.0.subnet_ids.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "kafka_cluster.0.vpc_config.0.security_groups_ids.#", "1"),
@@ -95,7 +104,7 @@ func TestAccKafkaReplicator_update(t *testing.T) {
 				Config: testAccReplicatorConfig_basic(rName, sourceCluster, targetCluster),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicatorExists(ctx, resourceName, &replicator),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafka", regexache.MustCompile(`replicator/`+rName+`/`+kafkaUUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttr(resourceName, "replicator_name", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test-description"),
 					resource.TestCheckResourceAttr(resourceName, "kafka_cluster.#", "2"),
@@ -119,7 +128,7 @@ func TestAccKafkaReplicator_update(t *testing.T) {
 				Config: testAccReplicatorConfig_update(rName, sourceCluster, targetCluster),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckReplicatorExists(ctx, resourceName, &replicator),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafka", regexache.MustCompile(`replicator/`+rName+`/`+kafkaUUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttr(resourceName, "replicator_name", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test-description"),
 					resource.TestCheckResourceAttr(resourceName, "kafka_cluster.#", "2"),

--- a/internal/service/kafka/vpc_connection_test.go
+++ b/internal/service/kafka/vpc_connection_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -35,9 +36,10 @@ func TestAccKafkaVPCConnection_basic(t *testing.T) {
 				Config: testAccVPCConnectionConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVPCConnectionExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafka", regexache.MustCompile(`vpc-connection/\d{12}/`+rName+`/`+kafkaUUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttr(resourceName, "authentication", "SASL_IAM"),
 					resource.TestCheckResourceAttr(resourceName, "client_subnets.#", "3"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "security_groups.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),

--- a/internal/service/kafkaconnect/connector_test.go
+++ b/internal/service/kafkaconnect/connector_test.go
@@ -23,7 +23,7 @@ import (
 const (
 	// The ARN format documentation (https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonmanagedstreamingforkafkaconnect.html#amazonmanagedstreamingforkafkaconnect-resources-for-iam-policies)
 	// shows ARNs having a UUID component, but in testing there is an additional component.
-	kafkaConnectUUIDRegexPattern = verify.UUIDRegexPattern + `-\w+`
+	kafkaConnectUUIDRegexPattern = verify.UUIDRegexPattern + `-\w+` // nosemgrep:ci.kafkaconnect-in-const-name,ci.kafkaconnect-in-var-name
 )
 
 func TestAccKafkaConnectConnector_basic(t *testing.T) {

--- a/internal/service/kafkaconnect/connector_test.go
+++ b/internal/service/kafkaconnect/connector_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -15,7 +16,14 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfkafkaconnect "github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+const (
+	// The ARN format documentation (https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonmanagedstreamingforkafkaconnect.html#amazonmanagedstreamingforkafkaconnect-resources-for-iam-policies)
+	// shows ARNs having a UUID component, but in testing there is an additional component.
+	kafkaConnectUUIDRegexPattern = verify.UUIDRegexPattern + `-\w+`
 )
 
 func TestAccKafkaConnectConnector_basic(t *testing.T) {
@@ -33,7 +41,7 @@ func TestAccKafkaConnectConnector_basic(t *testing.T) {
 				Config: testAccConnectorConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectorExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafkaconnect", regexache.MustCompile(`connector/`+rName+`/`+kafkaConnectUUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttr(resourceName, "capacity.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "capacity.0.autoscaling.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "capacity.0.autoscaling.0.max_worker_count", "2"),
@@ -49,6 +57,7 @@ func TestAccKafkaConnectConnector_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "connector_configuration.tasks.max", "1"),
 					resource.TestCheckResourceAttr(resourceName, "connector_configuration.topics", "t1"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "kafka_cluster.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "kafka_cluster.0.apache_kafka_cluster.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "kafka_cluster.0.apache_kafka_cluster.0.bootstrap_servers"),
@@ -120,7 +129,7 @@ func TestAccKafkaConnectConnector_update(t *testing.T) {
 				Config: testAccConnectorConfig_allAttributes(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectorExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafkaconnect", regexache.MustCompile(`connector/`+rName+`/`+kafkaConnectUUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttr(resourceName, "capacity.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "capacity.0.autoscaling.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "capacity.0.autoscaling.0.max_worker_count", "6"),
@@ -180,7 +189,7 @@ func TestAccKafkaConnectConnector_update(t *testing.T) {
 				Config: testAccConnectorConfig_allAttributesCapacityUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectorExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafkaconnect", regexache.MustCompile(`connector/`+rName+`/`+kafkaConnectUUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttr(resourceName, "capacity.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "capacity.0.autoscaling.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "capacity.0.provisioned_capacity.#", "1"),

--- a/internal/service/kafkaconnect/custom_plugin_test.go
+++ b/internal/service/kafkaconnect/custom_plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -33,9 +34,10 @@ func TestAccKafkaConnectCustomPlugin_basic(t *testing.T) {
 				Config: testAccCustomPluginConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCustomPluginExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafkaconnect", regexache.MustCompile(`custom-plugin/`+rName+`/`+kafkaConnectUUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrContentType, "ZIP"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrSet(resourceName, "latest_revision"),
 					resource.TestCheckResourceAttr(resourceName, "location.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "location.0.s3.#", "1"),

--- a/internal/service/kafkaconnect/worker_configuration_test.go
+++ b/internal/service/kafkaconnect/worker_configuration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -33,7 +34,8 @@ func TestAccKafkaConnectWorkerConfiguration_basic(t *testing.T) {
 				Config: testAccWorkerConfigurationConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckWorkerConfigurationExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafkaconnect", regexache.MustCompile(`worker-configuration/`+rName+`/`+kafkaConnectUUIDRegexPattern+`$`)),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrSet(resourceName, "latest_revision"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "properties_file_content", "key.converter=org.apache.kafka.connect.storage.StringConverter\nvalue.converter=org.apache.kafka.connect.storage.StringConverter\n"),

--- a/internal/service/kendra/index_test.go
+++ b/internal/service/kendra/index_test.go
@@ -58,7 +58,7 @@ func TestAccKendraIndex_basic(t *testing.T) {
 				Config: testAccIndexConfig_basic(rName, rName2, rName3, acctest.CtBasic),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIndexExists(ctx, resourceName, &index),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "kendra", "index/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "capacity_units.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "capacity_units.0.query_capacity_units", "0"),
 					resource.TestCheckResourceAttr(resourceName, "capacity_units.0.storage_capacity_units", "0"),

--- a/internal/service/kinesis/stream_data_source_test.go
+++ b/internal/service/kinesis/stream_data_source_test.go
@@ -22,6 +22,7 @@ func TestAccKinesisStreamDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_kinesis_stream.test"
+	resourceName := "aws_kinesis_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -31,24 +32,27 @@ func TestAccKinesisStreamDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamDataSourceConfig_basic(rName, 2),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrARN),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					// resource.TestCheckResourceAttrPair(dataSourceName, "creation_timestamp", resourceName, "creation_timestamp"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "creation_timestamp"),
-					resource.TestCheckResourceAttr(dataSourceName, "closed_shards.#", "0"),
-					resource.TestCheckResourceAttr(dataSourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(dataSourceName, "open_shards.#", "2"),
-					resource.TestCheckResourceAttr(dataSourceName, names.AttrRetentionPeriod, "72"),
-					resource.TestCheckResourceAttr(dataSourceName, "shard_level_metrics.#", "2"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "closed_shards.#", resourceName, "closed_shards.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "encryption_type", resourceName, "encryption_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrKMSKeyID, resourceName, names.AttrKMSKeyID),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "open_shards.#", resourceName, "shard_count"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrRetentionPeriod, resourceName, names.AttrRetentionPeriod),
+					resource.TestCheckResourceAttrPair(dataSourceName, "shard_level_metrics.#", resourceName, "shard_level_metrics.#"),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrStatus, "ACTIVE"),
-					resource.TestCheckResourceAttr(dataSourceName, "stream_mode_details.0.stream_mode", "PROVISIONED"),
-					resource.TestCheckResourceAttr(dataSourceName, "tags.Name", rName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "stream_mode_details.0.stream_mode", resourceName, "stream_mode_details.0.stream_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tags.Name", resourceName, "tags.Name"),
 				),
 			},
 			{
 				Config: testAccStreamDataSourceConfig_basic(rName, 3),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "closed_shards.#", "4"),
-					resource.TestCheckResourceAttr(dataSourceName, "open_shards.#", "3"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "open_shards.#", resourceName, "shard_count"),
 				),
 			},
 		},
@@ -59,6 +63,7 @@ func TestAccKinesisStreamDataSource_encryption(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_kinesis_stream.test"
+	resourceName := "aws_kinesis_stream.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -68,16 +73,17 @@ func TestAccKinesisStreamDataSource_encryption(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamDataSourceConfig_encryption(rName, 2),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrARN),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					// resource.TestCheckResourceAttrPair(dataSourceName, "creation_timestamp", resourceName, "creation_timestamp"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "creation_timestamp"),
 					resource.TestCheckResourceAttr(dataSourceName, "closed_shards.#", "0"),
-					resource.TestCheckResourceAttr(dataSourceName, "encryption_type", "KMS"),
-					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrKMSKeyID, "aws_kms_key.test", names.AttrID),
-					resource.TestCheckResourceAttr(dataSourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(dataSourceName, "open_shards.#", "2"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "encryption_type", resourceName, "encryption_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrKMSKeyID, resourceName, names.AttrKMSKeyID),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "open_shards.#", resourceName, "shard_count"),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrStatus, "ACTIVE"),
-					resource.TestCheckResourceAttr(dataSourceName, "stream_mode_details.0.stream_mode", "PROVISIONED"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "stream_mode_details.0.stream_mode", resourceName, "stream_mode_details.0.stream_mode"),
 				),
 			},
 		},

--- a/internal/service/kinesis/stream_test.go
+++ b/internal/service/kinesis/stream_test.go
@@ -36,11 +36,12 @@ func TestAccKinesisStream_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamExists(ctx, resourceName, &stream),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kinesis", fmt.Sprintf("stream/%s", rName)),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "kinesis", "stream/{name}"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_type", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "enforce_consumer_deletion", acctest.CtFalse),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrKMSKeyID, ""),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrRetentionPeriod, "24"),

--- a/internal/service/lexmodels/bot_alias_test.go
+++ b/internal/service/lexmodels/bot_alias_test.go
@@ -27,7 +27,8 @@ func TestAccLexModelsBotAlias_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	resourceName := "aws_lex_bot_alias.test"
-	testBotAliasID := "test_bot_alias" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotAliasName := "test_bot_alias" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -36,25 +37,25 @@ func TestAccLexModelsBotAlias_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LexModelsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotAliasID, testBotAliasID),
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotAliasName, testBotAliasName),
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotAliasID),
-					testAccBotConfig_basic(testBotAliasID),
-					testAccBotAliasConfig_basic(testBotAliasID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
+					testAccBotAliasConfig_basic(testBotAliasName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, resourceName, &v),
 
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "lex", "bot:{bot_name}:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "checksum"),
 					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrCreatedDate),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Testing lex bot alias create."),
 					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrLastUpdatedDate),
-					resource.TestCheckResourceAttr(resourceName, "bot_name", testBotAliasID),
+					resource.TestCheckResourceAttr(resourceName, "bot_name", testBotName),
 					resource.TestCheckResourceAttr(resourceName, "bot_version", tflexmodels.BotVersionLatest),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, testBotAliasID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, testBotAliasName),
 					resource.TestCheckResourceAttr(resourceName, "conversation_logs.#", "0"),
 				),
 			},
@@ -71,7 +72,8 @@ func testAccBotAlias_botVersion(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	resourceName := "aws_lex_bot_alias.test"
-	testBotAliasID := "test_bot_alias" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotAliasName := "test_bot_alias" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	// If this test runs in parallel with other Lex Bot tests, it loses its description
 	resource.Test(t, resource.TestCase{
@@ -81,13 +83,13 @@ func testAccBotAlias_botVersion(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LexModelsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotAliasID, testBotAliasID),
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotAliasName, testBotAliasName),
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotAliasID),
-					testAccBotConfig_basic(testBotAliasID),
-					testAccBotAliasConfig_basic(testBotAliasID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
+					testAccBotAliasConfig_basic(testBotAliasName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, resourceName, &v),
@@ -102,9 +104,9 @@ func testAccBotAlias_botVersion(t *testing.T) {
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotAliasID),
-					testAccBotConfig_createVersion(testBotAliasID),
-					testAccBotAliasConfig_botVersionUpdate(testBotAliasID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_createVersion(testBotAliasName),
+					testAccBotAliasConfig_botVersionUpdate(testBotAliasName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, resourceName, &v),
@@ -125,7 +127,7 @@ func TestAccLexModelsBotAlias_conversationLogsText(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
-	testBotAliasID := "test_bot_alias" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotAliasName := "test_bot_alias" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resourceName := "aws_lex_bot_alias.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -138,13 +140,13 @@ func TestAccLexModelsBotAlias_conversationLogsText(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LexModelsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotID, testBotAliasID),
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotID, testBotAliasName),
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
 					testAccBotConfig_intent(testBotID),
 					testAccBotConfig_basic(testBotID),
-					testAccBotAliasConfig_conversationLogsText(testBotAliasID),
+					testAccBotAliasConfig_conversationLogsText(testBotAliasName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, resourceName, &v),
@@ -158,7 +160,7 @@ func TestAccLexModelsBotAlias_conversationLogsText(t *testing.T) {
 					}),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", cloudwatchLogGroupResourceName, names.AttrARN),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]*regexp.Regexp{
-						"resource_prefix": regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf(`aws/lex/%s/%s/%s/`, testBotID, testBotAliasID, tflexmodels.BotVersionLatest))),
+						"resource_prefix": regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf(`aws/lex/%s/%s/%s/`, testBotID, testBotAliasName, tflexmodels.BotVersionLatest))),
 					}),
 				),
 			},
@@ -175,7 +177,7 @@ func TestAccLexModelsBotAlias_conversationLogsAudio(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
-	testBotAliasID := sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotAliasName := sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resourceName := "aws_lex_bot_alias.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -189,13 +191,13 @@ func TestAccLexModelsBotAlias_conversationLogsAudio(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LexModelsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotID, testBotAliasID),
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotID, testBotAliasName),
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
 					testAccBotConfig_intent(testBotID),
 					testAccBotConfig_basic(testBotID),
-					testAccBotAliasConfig_conversationLogsAudio(testBotAliasID),
+					testAccBotAliasConfig_conversationLogsAudio(testBotAliasName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, resourceName, &v),
@@ -209,7 +211,7 @@ func TestAccLexModelsBotAlias_conversationLogsAudio(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.resource_arn", s3BucketResourceName, names.AttrARN),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "conversation_logs.0.log_settings.*.kms_key_arn", kmsKeyResourceName, names.AttrARN),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "conversation_logs.0.log_settings.*", map[string]*regexp.Regexp{
-						"resource_prefix": regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf(`aws/lex/%s/%s/%s/`, testBotID, testBotAliasID, tflexmodels.BotVersionLatest))),
+						"resource_prefix": regexache.MustCompile(regexp.QuoteMeta(fmt.Sprintf(`aws/lex/%s/%s/%s/`, testBotID, testBotAliasName, tflexmodels.BotVersionLatest))),
 					}),
 				),
 			},
@@ -226,7 +228,7 @@ func TestAccLexModelsBotAlias_conversationLogsBoth(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
-	testBotAliasID := sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotAliasName := sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resourceName := "aws_lex_bot_alias.test"
 	iamRoleResourceName := "aws_iam_role.test"
@@ -241,13 +243,13 @@ func TestAccLexModelsBotAlias_conversationLogsBoth(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LexModelsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotID, testBotAliasID),
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotID, testBotAliasName),
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
 					testAccBotConfig_intent(testBotID),
 					testAccBotConfig_basic(testBotID),
-					testAccBotAliasConfig_conversationLogsBoth(testBotAliasID),
+					testAccBotAliasConfig_conversationLogsBoth(testBotAliasName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, resourceName, &v),
@@ -283,7 +285,8 @@ func TestAccLexModelsBotAlias_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	resourceName := "aws_lex_bot_alias.test"
-	testBotAliasID := "test_bot_alias" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotAliasName := "test_bot_alias" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -292,13 +295,13 @@ func TestAccLexModelsBotAlias_description(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LexModelsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotAliasID, testBotAliasID),
+		CheckDestroy:             testAccCheckBotAliasDestroy(ctx, testBotAliasName, testBotAliasName),
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotAliasID),
-					testAccBotConfig_basic(testBotAliasID),
-					testAccBotAliasConfig_basic(testBotAliasID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
+					testAccBotAliasConfig_basic(testBotAliasName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, resourceName, &v),
@@ -311,9 +314,9 @@ func TestAccLexModelsBotAlias_description(t *testing.T) {
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotAliasID),
-					testAccBotConfig_basic(testBotAliasID),
-					testAccBotAliasConfig_descriptionUpdate(testBotAliasID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
+					testAccBotAliasConfig_descriptionUpdate(testBotAliasName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, resourceName, &v),
@@ -333,7 +336,8 @@ func TestAccLexModelsBotAlias_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotAliasOutput
 	resourceName := "aws_lex_bot_alias.test"
-	testBotAliasID := "test_bot_alias" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotAliasName := "test_bot_alias" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -346,9 +350,9 @@ func TestAccLexModelsBotAlias_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotAliasID),
-					testAccBotConfig_basic(testBotAliasID),
-					testAccBotAliasConfig_basic(testBotAliasID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
+					testAccBotAliasConfig_basic(testBotAliasName),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBotAliasExists(ctx, resourceName, &v),

--- a/internal/service/lexmodels/bot_test.go
+++ b/internal/service/lexmodels/bot_test.go
@@ -33,8 +33,8 @@ func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 func TestAccLexModelsBot_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -47,38 +47,39 @@ func TestAccLexModelsBot_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					testAccCheckBotNotExists(ctx, testBotID, "1"),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					testAccCheckBotNotExists(ctx, testBotName, "1"),
 
-					resource.TestCheckResourceAttr(rName, "abort_statement.#", "1"),
-					resource.TestCheckResourceAttrSet(rName, names.AttrARN),
-					resource.TestCheckResourceAttrSet(rName, "checksum"),
-					resource.TestCheckResourceAttr(rName, "child_directed", acctest.CtFalse),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.#", "0"),
-					resource.TestCheckResourceAttr(rName, "create_version", acctest.CtFalse),
-					acctest.CheckResourceAttrRFC3339(rName, names.AttrCreatedDate),
-					resource.TestCheckResourceAttr(rName, names.AttrDescription, "Bot to order flowers on the behalf of a user"),
-					resource.TestCheckResourceAttr(rName, "detect_sentiment", acctest.CtFalse),
-					resource.TestCheckResourceAttr(rName, "enable_model_improvements", acctest.CtFalse),
-					resource.TestCheckResourceAttr(rName, "failure_reason", ""),
-					resource.TestCheckResourceAttr(rName, "idle_session_ttl_in_seconds", "300"),
-					resource.TestCheckResourceAttr(rName, "intent.#", "1"),
-					acctest.CheckResourceAttrRFC3339(rName, names.AttrLastUpdatedDate),
-					resource.TestCheckResourceAttr(rName, "locale", "en-US"),
-					resource.TestCheckResourceAttr(rName, names.AttrName, testBotID),
-					resource.TestCheckResourceAttr(rName, "nlu_intent_confidence_threshold", "0"),
-					resource.TestCheckResourceAttr(rName, "process_behavior", "SAVE"),
-					resource.TestCheckResourceAttr(rName, names.AttrStatus, "NOT_BUILT"),
-					resource.TestCheckResourceAttr(rName, names.AttrVersion, tflexmodels.BotVersionLatest),
-					resource.TestCheckResourceAttr(rName, "voice_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.#", "1"),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "lex", "bot:{name}"),
+					resource.TestCheckResourceAttrSet(resourceName, "checksum"),
+					resource.TestCheckResourceAttr(resourceName, "child_directed", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "create_version", acctest.CtFalse),
+					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrCreatedDate),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Bot to order flowers on the behalf of a user"),
+					resource.TestCheckResourceAttr(resourceName, "detect_sentiment", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "enable_model_improvements", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "failure_reason", ""),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "idle_session_ttl_in_seconds", "300"),
+					resource.TestCheckResourceAttr(resourceName, "intent.#", "1"),
+					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrLastUpdatedDate),
+					resource.TestCheckResourceAttr(resourceName, "locale", "en-US"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, testBotName),
+					resource.TestCheckResourceAttr(resourceName, "nlu_intent_confidence_threshold", "0"),
+					resource.TestCheckResourceAttr(resourceName, "process_behavior", "SAVE"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrStatus, "NOT_BUILT"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, tflexmodels.BotVersionLatest),
+					resource.TestCheckResourceAttr(resourceName, "voice_id", ""),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
@@ -103,8 +104,8 @@ func TestAccLexModelsBot_Version_serial(t *testing.T) {
 func testAccBot_createVersion(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2 lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	// If this test runs in parallel with other Lex Bot tests, it loses its description
 	resource.Test(t, resource.TestCase{
@@ -118,31 +119,31 @@ func testAccBot_createVersion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v1),
-					testAccCheckBotNotExists(ctx, testBotID, "1"),
-					resource.TestCheckResourceAttr(rName, names.AttrVersion, tflexmodels.BotVersionLatest),
-					resource.TestCheckResourceAttr(rName, names.AttrDescription, "Bot to order flowers on the behalf of a user"),
+					testAccCheckBotExists(ctx, resourceName, &v1),
+					testAccCheckBotNotExists(ctx, testBotName, "1"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, tflexmodels.BotVersionLatest),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Bot to order flowers on the behalf of a user"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_createVersion(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_createVersion(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExistsWithVersion(ctx, rName, "1", &v2),
-					resource.TestCheckResourceAttr(rName, names.AttrVersion, "1"),
-					resource.TestCheckResourceAttr(rName, names.AttrDescription, "Bot to order flowers on the behalf of a user"),
+					testAccCheckBotExistsWithVersion(ctx, resourceName, "1", &v2),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "1"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Bot to order flowers on the behalf of a user"),
 				),
 			},
 		},
@@ -152,8 +153,8 @@ func testAccBot_createVersion(t *testing.T) {
 func TestAccLexModelsBot_abortStatement(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -166,44 +167,44 @@ func TestAccLexModelsBot_abortStatement(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_abortStatement(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_abortStatement(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "abort_statement.#", "1"),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.message.#", "1"),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.message.0.content", "Sorry, I'm not able to assist at this time"),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.message.0.content_type", "PlainText"),
-					resource.TestCheckNoResourceAttr(rName, "abort_statement.0.message.0.group_number"),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.response_card", ""),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.message.0.content", "Sorry, I'm not able to assist at this time"),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.message.0.content_type", "PlainText"),
+					resource.TestCheckNoResourceAttr(resourceName, "abort_statement.0.message.0.group_number"),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.response_card", ""),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_abortStatementUpdate(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_abortStatementUpdate(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.message.#", "2"),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.message.0.content", "Sorry, I'm not able to assist at this time"),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.message.0.group_number", "1"),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.message.1.content", "Sorry, I'm not able to assist at this time. Good bye."),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.message.1.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.message.1.group_number", "1"),
-					resource.TestCheckResourceAttr(rName, "abort_statement.0.response_card", "Sorry, I'm not able to assist at this time"),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.message.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.message.0.content", "Sorry, I'm not able to assist at this time"),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.message.0.group_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.message.1.content", "Sorry, I'm not able to assist at this time. Good bye."),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.message.1.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.message.1.group_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "abort_statement.0.response_card", "Sorry, I'm not able to assist at this time"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
@@ -215,8 +216,8 @@ func TestAccLexModelsBot_abortStatement(t *testing.T) {
 func TestAccLexModelsBot_clarificationPrompt(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -229,22 +230,22 @@ func TestAccLexModelsBot_clarificationPrompt(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_clarificationPrompt(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_clarificationPrompt(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.#", "1"),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.0.max_attempts", "2"),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.0.message.#", "1"),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.0.message.#", "1"),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.0.message.0.content", "I didn't understand you, what would you like to do?"),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.0.response_card", ""),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.0.max_attempts", "2"),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.0.message.0.content", "I didn't understand you, what would you like to do?"),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.0.response_card", ""),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -254,18 +255,18 @@ func TestAccLexModelsBot_clarificationPrompt(t *testing.T) {
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_clarificationPromptUpdate(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_clarificationPromptUpdate(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.0.max_attempts", "3"),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.0.message.#", "2"),
-					resource.TestCheckResourceAttr(rName, "clarification_prompt.0.response_card", "I didn't understand you, what would you like to do?"),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.0.max_attempts", "3"),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.0.message.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "clarification_prompt.0.response_card", "I didn't understand you, what would you like to do?"),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -280,8 +281,8 @@ func TestAccLexModelsBot_clarificationPrompt(t *testing.T) {
 func TestAccLexModelsBot_childDirected(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -294,31 +295,31 @@ func TestAccLexModelsBot_childDirected(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
+					testAccCheckBotExists(ctx, resourceName, &v),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_childDirectedUpdate(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_childDirectedUpdate(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "child_directed", acctest.CtTrue),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "child_directed", acctest.CtTrue),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
@@ -330,8 +331,8 @@ func TestAccLexModelsBot_childDirected(t *testing.T) {
 func TestAccLexModelsBot_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -344,31 +345,31 @@ func TestAccLexModelsBot_description(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
+					testAccCheckBotExists(ctx, resourceName, &v),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_descriptionUpdate(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_descriptionUpdate(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, names.AttrDescription, "Bot to order flowers"),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Bot to order flowers"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
@@ -380,8 +381,8 @@ func TestAccLexModelsBot_description(t *testing.T) {
 func TestAccLexModelsBot_detectSentiment(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -394,31 +395,31 @@ func TestAccLexModelsBot_detectSentiment(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
+					testAccCheckBotExists(ctx, resourceName, &v),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_detectSentimentUpdate(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_detectSentimentUpdate(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "detect_sentiment", acctest.CtTrue),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "detect_sentiment", acctest.CtTrue),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
@@ -430,8 +431,8 @@ func TestAccLexModelsBot_detectSentiment(t *testing.T) {
 func TestAccLexModelsBot_enableModelImprovements(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -444,32 +445,32 @@ func TestAccLexModelsBot_enableModelImprovements(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
+					testAccCheckBotExists(ctx, resourceName, &v),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_enableModelImprovementsUpdate(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_enableModelImprovementsUpdate(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "enable_model_improvements", acctest.CtTrue),
-					resource.TestCheckResourceAttr(rName, "nlu_intent_confidence_threshold", "0.5"),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "enable_model_improvements", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "nlu_intent_confidence_threshold", "0.5"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
@@ -481,8 +482,8 @@ func TestAccLexModelsBot_enableModelImprovements(t *testing.T) {
 func TestAccLexModelsBot_idleSessionTTLInSeconds(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -495,31 +496,31 @@ func TestAccLexModelsBot_idleSessionTTLInSeconds(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
+					testAccCheckBotExists(ctx, resourceName, &v),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_idleSessionTTLInSecondsUpdate(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_idleSessionTTLInSecondsUpdate(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "idle_session_ttl_in_seconds", "600"),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "idle_session_ttl_in_seconds", "600"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
@@ -531,8 +532,8 @@ func TestAccLexModelsBot_idleSessionTTLInSeconds(t *testing.T) {
 func TestAccLexModelsBot_intents(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -545,31 +546,31 @@ func TestAccLexModelsBot_intents(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intentMultiple(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intentMultiple(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
+					testAccCheckBotExists(ctx, resourceName, &v),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intentMultiple(testBotID),
-					testAccBotConfig_intentsUpdate(testBotID),
+					testAccBotConfig_intentMultiple(testBotName),
+					testAccBotConfig_intentsUpdate(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "intent.#", "2"),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "intent.#", "2"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
@@ -588,7 +589,7 @@ func TestAccLexModelsBot_computeVersion(t *testing.T) {
 	intentResourceName := "aws_lex_intent.test"
 	intentResourceName2 := "aws_lex_intent.test_2"
 
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -601,9 +602,9 @@ func TestAccLexModelsBot_computeVersion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_createVersion(testBotID),
-					testAccBotConfig_intentMultiple(testBotID),
-					testAccBotAliasConfig_basic(testBotID),
+					testAccBotConfig_createVersion(testBotName),
+					testAccBotConfig_intentMultiple(testBotName),
+					testAccBotAliasConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBotExistsWithVersion(ctx, botResourceName, "1", &v1),
@@ -617,9 +618,9 @@ func TestAccLexModelsBot_computeVersion(t *testing.T) {
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intentMultipleSecondUpdated(testBotID),
-					testAccBotConfig_multipleIntentsWithVersion(testBotID),
-					testAccBotAliasConfig_basic(testBotID),
+					testAccBotConfig_intentMultipleSecondUpdated(testBotName),
+					testAccBotConfig_multipleIntentsWithVersion(testBotName),
+					testAccBotAliasConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBotExistsWithVersion(ctx, botResourceName, "2", &v1),
@@ -639,8 +640,8 @@ func TestAccLexModelsBot_computeVersion(t *testing.T) {
 func TestAccLexModelsBot_locale(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -653,31 +654,31 @@ func TestAccLexModelsBot_locale(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
+					testAccCheckBotExists(ctx, resourceName, &v),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_localeUpdate(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_localeUpdate(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "locale", "en-GB"),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "locale", "en-GB"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
@@ -689,8 +690,8 @@ func TestAccLexModelsBot_locale(t *testing.T) {
 func TestAccLexModelsBot_voiceID(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -703,31 +704,31 @@ func TestAccLexModelsBot_voiceID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
+					testAccCheckBotExists(ctx, resourceName, &v),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_voiceIdUpdate(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_voiceIdUpdate(testBotName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "voice_id", "Justin"),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "voice_id", "Justin"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"abort_statement.0.message.0.group_number"},
@@ -739,8 +740,8 @@ func TestAccLexModelsBot_voiceID(t *testing.T) {
 func TestAccLexModelsBot_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetBotOutput
-	rName := "aws_lex_bot.test"
-	testBotID := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_bot.test"
+	testBotName := "test_bot_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -753,12 +754,12 @@ func TestAccLexModelsBot_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testBotID),
-					testAccBotConfig_basic(testBotID),
+					testAccBotConfig_intent(testBotName),
+					testAccBotConfig_basic(testBotName),
 				),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBotExists(ctx, rName, &v),
-					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflexmodels.ResourceBot(), rName),
+					testAccCheckBotExists(ctx, resourceName, &v),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflexmodels.ResourceBot(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -766,11 +767,11 @@ func TestAccLexModelsBot_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckBotExistsWithVersion(ctx context.Context, rName, botVersion string, v *lexmodelbuildingservice.GetBotOutput) resource.TestCheckFunc {
+func testAccCheckBotExistsWithVersion(ctx context.Context, resourceName, botVersion string, v *lexmodelbuildingservice.GetBotOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[rName]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", rName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		if rs.Primary.ID == "" {
@@ -791,8 +792,8 @@ func testAccCheckBotExistsWithVersion(ctx context.Context, rName, botVersion str
 	}
 }
 
-func testAccCheckBotExists(ctx context.Context, rName string, output *lexmodelbuildingservice.GetBotOutput) resource.TestCheckFunc {
-	return testAccCheckBotExistsWithVersion(ctx, rName, tflexmodels.BotVersionLatest, output)
+func testAccCheckBotExists(ctx context.Context, resourceName string, output *lexmodelbuildingservice.GetBotOutput) resource.TestCheckFunc {
+	return testAccCheckBotExistsWithVersion(ctx, resourceName, tflexmodels.BotVersionLatest, output)
 }
 
 func testAccCheckBotNotExists(ctx context.Context, botName, botVersion string) resource.TestCheckFunc {

--- a/internal/service/lexmodels/intent_test.go
+++ b/internal/service/lexmodels/intent_test.go
@@ -27,8 +27,8 @@ import (
 func TestAccLexModelsIntent_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -40,32 +40,32 @@ func TestAccLexModelsIntent_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckIntentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntentConfig_basic(testIntentID),
+				Config: testAccIntentConfig_basic(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					testAccCheckIntentNotExists(ctx, testIntentID, "1"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					testAccCheckIntentNotExists(ctx, testIntentName, "1"),
 
-					resource.TestCheckResourceAttrSet(rName, names.AttrARN),
-					resource.TestCheckResourceAttrSet(rName, "checksum"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.#", "0"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.#", "0"),
-					resource.TestCheckResourceAttr(rName, "create_version", acctest.CtFalse),
-					acctest.CheckResourceAttrRFC3339(rName, names.AttrCreatedDate),
-					resource.TestCheckResourceAttr(rName, names.AttrDescription, ""),
-					resource.TestCheckResourceAttr(rName, "dialog_code_hook.#", "0"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.#", "0"),
-					resource.TestCheckResourceAttr(rName, "fulfillment_activity.#", "1"),
-					acctest.CheckResourceAttrRFC3339(rName, names.AttrLastUpdatedDate),
-					resource.TestCheckResourceAttr(rName, names.AttrName, testIntentID),
-					resource.TestCheckResourceAttr(rName, "parent_intent_signature.#", "0"),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.#", "0"),
-					resource.TestCheckNoResourceAttr(rName, "sample_utterances"),
-					resource.TestCheckResourceAttr(rName, "slot.#", "0"),
-					resource.TestCheckResourceAttr(rName, names.AttrVersion, tflexmodels.IntentVersionLatest),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "lex", "intent:{name}"),
+					resource.TestCheckResourceAttrSet(resourceName, "checksum"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "create_version", acctest.CtFalse),
+					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrCreatedDate),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
+					resource.TestCheckResourceAttr(resourceName, "dialog_code_hook.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_activity.#", "1"),
+					acctest.CheckResourceAttrRFC3339(resourceName, names.AttrLastUpdatedDate),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, testIntentName),
+					resource.TestCheckResourceAttr(resourceName, "parent_intent_signature.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "sample_utterances"),
+					resource.TestCheckResourceAttr(resourceName, "slot.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, tflexmodels.IntentVersionLatest),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"create_version"},
@@ -77,8 +77,8 @@ func TestAccLexModelsIntent_basic(t *testing.T) {
 func TestAccLexModelsIntent_createVersion(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -90,28 +90,28 @@ func TestAccLexModelsIntent_createVersion(t *testing.T) {
 		CheckDestroy:             testAccCheckIntentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntentConfig_basic(testIntentID),
+				Config: testAccIntentConfig_basic(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					testAccCheckIntentNotExists(ctx, testIntentID, "1"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					testAccCheckIntentNotExists(ctx, testIntentName, "1"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"create_version"},
 			},
 			{
-				Config: testAccIntentConfig_createVersion(testIntentID),
+				Config: testAccIntentConfig_createVersion(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					testAccCheckIntentExistsWithVersion(ctx, rName, "1", &v),
-					resource.TestCheckResourceAttr(rName, names.AttrVersion, "1"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					testAccCheckIntentExistsWithVersion(ctx, resourceName, "1", &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "1"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"create_version"},
@@ -123,8 +123,8 @@ func TestAccLexModelsIntent_createVersion(t *testing.T) {
 func TestAccLexModelsIntent_conclusionStatement(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -136,19 +136,19 @@ func TestAccLexModelsIntent_conclusionStatement(t *testing.T) {
 		CheckDestroy:             testAccCheckIntentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntentConfig_conclusionStatement(testIntentID),
+				Config: testAccIntentConfig_conclusionStatement(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.#", "1"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.message.#", "1"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.message.0.content", "Your order for {FlowerType} has been placed and will be ready by {PickupTime} on {PickupDate}"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.message.0.content_type", "PlainText"),
-					resource.TestCheckNoResourceAttr(rName, "conclusion_statement.0.message.0.group_number"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.response_card", "Your order for {FlowerType} has been placed and will be ready by {PickupTime} on {PickupDate}"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.message.0.content", "Your order for {FlowerType} has been placed and will be ready by {PickupTime} on {PickupDate}"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.message.0.content_type", "PlainText"),
+					resource.TestCheckNoResourceAttr(resourceName, "conclusion_statement.0.message.0.group_number"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.response_card", "Your order for {FlowerType} has been placed and will be ready by {PickupTime} on {PickupDate}"),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -157,21 +157,21 @@ func TestAccLexModelsIntent_conclusionStatement(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccIntentConfig_conclusionStatementUpdate(testIntentID),
+				Config: testAccIntentConfig_conclusionStatementUpdate(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.message.#", "2"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.message.0.content", "Your order for {FlowerType} has been placed and will be ready by {PickupTime} on {PickupDate}"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.message.0.group_number", "1"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.message.1.content", "Your order for {FlowerType} has been placed"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.message.1.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.message.1.group_number", "1"),
-					resource.TestCheckResourceAttr(rName, "conclusion_statement.0.response_card", "Your order for {FlowerType} has been placed"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.message.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.message.0.content", "Your order for {FlowerType} has been placed and will be ready by {PickupTime} on {PickupDate}"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.message.0.group_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.message.1.content", "Your order for {FlowerType} has been placed"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.message.1.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.message.1.group_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "conclusion_statement.0.response_card", "Your order for {FlowerType} has been placed"),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -186,8 +186,8 @@ func TestAccLexModelsIntent_conclusionStatement(t *testing.T) {
 func TestAccLexModelsIntent_confirmationPromptAndRejectionStatement(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -199,24 +199,24 @@ func TestAccLexModelsIntent_confirmationPromptAndRejectionStatement(t *testing.T
 		CheckDestroy:             testAccCheckIntentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntentConfig_confirmationPromptAndRejectionStatement(testIntentID),
+				Config: testAccIntentConfig_confirmationPromptAndRejectionStatement(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.#", "1"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.max_attempts", "1"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.message.#", "1"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.message.0.content", "Okay, your {FlowerType} will be ready for pickup by {PickupTime} on {PickupDate}. Does this sound okay?"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"Okay, your {FlowerType} will be ready for pickup by {PickupTime} on {PickupDate}. Does this sound okay?\",\"buttons\":[{\"text\":\"Yes\",\"value\":\"yes\"},{\"text\":\"No\",\"value\":\"no\"}]}]}"),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.#", "1"),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.0.message.#", "1"),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.0.message.0.content", "Okay, I will not place your order."),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.0.response_card", "Okay, I will not place your order."),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.max_attempts", "1"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.message.0.content", "Okay, your {FlowerType} will be ready for pickup by {PickupTime} on {PickupDate}. Does this sound okay?"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"Okay, your {FlowerType} will be ready for pickup by {PickupTime} on {PickupDate}. Does this sound okay?\",\"buttons\":[{\"text\":\"Yes\",\"value\":\"yes\"},{\"text\":\"No\",\"value\":\"no\"}]}]}"),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.0.message.0.content", "Okay, I will not place your order."),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.0.response_card", "Okay, I will not place your order."),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -226,26 +226,26 @@ func TestAccLexModelsIntent_confirmationPromptAndRejectionStatement(t *testing.T
 				},
 			},
 			{
-				Config: testAccIntentConfig_confirmationPromptAndRejectionStatementUpdate(testIntentID),
+				Config: testAccIntentConfig_confirmationPromptAndRejectionStatementUpdate(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.max_attempts", "2"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.message.#", "2"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.message.0.content", "Okay, your {FlowerType} will be ready for pickup by {PickupTime} on {PickupDate}. Does this sound okay?"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.message.1.content", "Okay, your {FlowerType} will be ready for pickup on {PickupDate}. Does this sound okay?"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.message.1.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "confirmation_prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"Okay, your {FlowerType} will be ready for pickup on {PickupDate}. Does this sound okay?\",\"buttons\":[{\"text\":\"Yes\",\"value\":\"yes\"},{\"text\":\"No\",\"value\":\"no\"}]}]}"),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.0.message.#", "2"),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.0.message.0.content", "Okay, I will not place your order."),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.0.message.1.content", "Okay, your order has been cancelled."),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.0.message.1.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "rejection_statement.0.response_card", "Okay, your order has been cancelled."),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.max_attempts", "2"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.message.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.message.0.content", "Okay, your {FlowerType} will be ready for pickup by {PickupTime} on {PickupDate}. Does this sound okay?"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.message.1.content", "Okay, your {FlowerType} will be ready for pickup on {PickupDate}. Does this sound okay?"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.message.1.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "confirmation_prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"Okay, your {FlowerType} will be ready for pickup on {PickupDate}. Does this sound okay?\",\"buttons\":[{\"text\":\"Yes\",\"value\":\"yes\"},{\"text\":\"No\",\"value\":\"no\"}]}]}"),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.0.message.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.0.message.0.content", "Okay, I will not place your order."),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.0.message.1.content", "Okay, your order has been cancelled."),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.0.message.1.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "rejection_statement.0.response_card", "Okay, your order has been cancelled."),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -263,8 +263,8 @@ func TestAccLexModelsIntent_confirmationPromptAndRejectionStatement(t *testing.T
 func TestAccLexModelsIntent_dialogCodeHook(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -277,18 +277,18 @@ func TestAccLexModelsIntent_dialogCodeHook(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccIntentConfig_lambda(testIntentID),
-					testAccIntentConfig_dialogCodeHook(testIntentID),
+					testAccIntentConfig_lambda(testIntentName),
+					testAccIntentConfig_dialogCodeHook(testIntentName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "dialog_code_hook.#", "1"),
-					resource.TestCheckResourceAttr(rName, "dialog_code_hook.0.message_version", "1"),
-					resource.TestCheckResourceAttrSet(rName, "dialog_code_hook.0.uri"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "dialog_code_hook.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dialog_code_hook.0.message_version", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "dialog_code_hook.0.uri"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"create_version"},
@@ -300,8 +300,8 @@ func TestAccLexModelsIntent_dialogCodeHook(t *testing.T) {
 func TestAccLexModelsIntent_followUpPrompt(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -313,28 +313,28 @@ func TestAccLexModelsIntent_followUpPrompt(t *testing.T) {
 		CheckDestroy:             testAccCheckIntentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntentConfig_followUpPrompt(testIntentID),
+				Config: testAccIntentConfig_followUpPrompt(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
+					testAccCheckIntentExists(ctx, resourceName, &v),
 
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.#", "1"),
 
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.#", "1"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.max_attempts", "1"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.#", "1"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.0.content", "Would you like to order more flowers?"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"Would you like to order more flowers?\",\"buttons\":[{\"text\":\"Yes\",\"value\":\"yes\"},{\"text\":\"No\",\"value\":\"no\"}]}]}"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.max_attempts", "1"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.message.0.content", "Would you like to order more flowers?"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"Would you like to order more flowers?\",\"buttons\":[{\"text\":\"Yes\",\"value\":\"yes\"},{\"text\":\"No\",\"value\":\"no\"}]}]}"),
 
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.#", "1"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.0.message.#", "1"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.0.message.0.content", "Okay, no additional flowers will be ordered."),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.0.response_card", "Okay, no additional flowers will be ordered."),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.0.message.0.content", "Okay, no additional flowers will be ordered."),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.0.response_card", "Okay, no additional flowers will be ordered."),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -344,28 +344,28 @@ func TestAccLexModelsIntent_followUpPrompt(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccIntentConfig_followUpPromptUpdate(testIntentID),
+				Config: testAccIntentConfig_followUpPromptUpdate(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
+					testAccCheckIntentExists(ctx, resourceName, &v),
 
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.max_attempts", "2"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.#", "2"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.0.content", "Would you like to order more flowers?"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.1.content", "Would you like to start another order?"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.message.1.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"Would you like to start another order?\",\"buttons\":[{\"text\":\"Yes\",\"value\":\"yes\"},{\"text\":\"No\",\"value\":\"no\"}]}]}"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.max_attempts", "2"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.message.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.message.0.content", "Would you like to order more flowers?"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.message.1.content", "Would you like to start another order?"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.message.1.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"Would you like to start another order?\",\"buttons\":[{\"text\":\"Yes\",\"value\":\"yes\"},{\"text\":\"No\",\"value\":\"no\"}]}]}"),
 
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.0.message.#", "2"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.0.message.0.content", "Okay, additional flowers will be ordered."),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.0.message.1.content", "Okay, no additional flowers will be ordered."),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.0.message.1.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "follow_up_prompt.0.rejection_statement.0.response_card", "Okay, additional flowers will be ordered."),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.0.message.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.0.message.0.content", "Okay, additional flowers will be ordered."),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.0.message.1.content", "Okay, no additional flowers will be ordered."),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.0.message.1.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "follow_up_prompt.0.rejection_statement.0.response_card", "Okay, additional flowers will be ordered."),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -383,8 +383,8 @@ func TestAccLexModelsIntent_followUpPrompt(t *testing.T) {
 func TestAccLexModelsIntent_fulfillmentActivity(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -397,20 +397,20 @@ func TestAccLexModelsIntent_fulfillmentActivity(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccIntentConfig_lambda(testIntentID),
-					testAccIntentConfig_fulfillmentActivity(testIntentID),
+					testAccIntentConfig_lambda(testIntentName),
+					testAccIntentConfig_fulfillmentActivity(testIntentName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "fulfillment_activity.#", "1"),
-					resource.TestCheckResourceAttr(rName, "fulfillment_activity.0.code_hook.#", "1"),
-					resource.TestCheckResourceAttr(rName, "fulfillment_activity.0.code_hook.0.message_version", "1"),
-					resource.TestCheckResourceAttrSet(rName, "fulfillment_activity.0.code_hook.0.uri"),
-					resource.TestCheckResourceAttr(rName, "fulfillment_activity.0.type", "CodeHook"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_activity.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_activity.0.code_hook.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_activity.0.code_hook.0.message_version", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "fulfillment_activity.0.code_hook.0.uri"),
+					resource.TestCheckResourceAttr(resourceName, "fulfillment_activity.0.type", "CodeHook"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"create_version"},
@@ -422,8 +422,8 @@ func TestAccLexModelsIntent_fulfillmentActivity(t *testing.T) {
 func TestAccLexModelsIntent_sampleUtterances(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -435,28 +435,28 @@ func TestAccLexModelsIntent_sampleUtterances(t *testing.T) {
 		CheckDestroy:             testAccCheckIntentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntentConfig_sampleUtterances(testIntentID),
+				Config: testAccIntentConfig_sampleUtterances(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "sample_utterances.#", "1"),
-					resource.TestCheckResourceAttr(rName, "sample_utterances.0", "I would like to pick up flowers"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterances.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterances.0", "I would like to pick up flowers"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"create_version"},
 			},
 			{
-				Config: testAccIntentConfig_sampleUtterancesUpdate(testIntentID),
+				Config: testAccIntentConfig_sampleUtterancesUpdate(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "sample_utterances.#", "2"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "sample_utterances.#", "2"),
 				),
 			},
 			{
-				ResourceName:            rName,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"create_version"},
@@ -468,8 +468,8 @@ func TestAccLexModelsIntent_sampleUtterances(t *testing.T) {
 func TestAccLexModelsIntent_slots(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -481,26 +481,26 @@ func TestAccLexModelsIntent_slots(t *testing.T) {
 		CheckDestroy:             testAccCheckIntentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntentConfig_slots(testIntentID),
+				Config: testAccIntentConfig_slots(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "slot.#", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.description", "The date to pick up the flowers"),
-					resource.TestCheckResourceAttr(rName, "slot.0.name", "PickupDate"),
-					resource.TestCheckResourceAttr(rName, "slot.0.priority", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.sample_utterances.#", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.sample_utterances.0", "I would like to order {FlowerType}"),
-					resource.TestCheckResourceAttr(rName, "slot.0.slot_constraint", "Required"),
-					resource.TestCheckResourceAttr(rName, "slot.0.slot_type", "AMAZON.DATE"),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.#", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.0.max_attempts", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.0.message.#", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.0.message.0.content", "What day do you want the {FlowerType} to be picked up?"),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.0.message.0.content_type", "PlainText"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "slot.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.description", "The date to pick up the flowers"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.name", "PickupDate"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.sample_utterances.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.sample_utterances.0", "I would like to order {FlowerType}"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.slot_constraint", "Required"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.slot_type", "AMAZON.DATE"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.0.max_attempts", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.0.message.0.content", "What day do you want the {FlowerType} to be picked up?"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.0.message.0.content_type", "PlainText"),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -509,14 +509,14 @@ func TestAccLexModelsIntent_slots(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccIntentConfig_slotsUpdate(testIntentID),
+				Config: testAccIntentConfig_slotsUpdate(testIntentName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "slot.#", "2"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "slot.#", "2"),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -532,8 +532,8 @@ func TestAccLexModelsIntent_slots(t *testing.T) {
 func TestAccLexModelsIntent_slotsCustom(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -546,29 +546,29 @@ func TestAccLexModelsIntent_slotsCustom(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccSlotTypeConfig_basic(testIntentID),
-					testAccIntentConfig_slotsCustom(testIntentID),
+					testAccSlotTypeConfig_basic(testIntentName),
+					testAccIntentConfig_slotsCustom(testIntentName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					resource.TestCheckResourceAttr(rName, "slot.#", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.description", "Types of flowers to pick up"),
-					resource.TestCheckResourceAttr(rName, "slot.0.name", "FlowerType"),
-					resource.TestCheckResourceAttr(rName, "slot.0.priority", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.sample_utterances.#", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.sample_utterances.0", "I would like to order {FlowerType}"),
-					resource.TestCheckResourceAttr(rName, "slot.0.slot_constraint", "Required"),
-					resource.TestCheckResourceAttr(rName, "slot.0.slot_type", testIntentID),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.#", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.0.max_attempts", "2"),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.0.message.#", "1"),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.0.message.0.content", "What type of flowers would you like to order?"),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.0.message.0.content_type", "PlainText"),
-					resource.TestCheckResourceAttr(rName, "slot.0.value_elicitation_prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"What type of flowers?\",\"buttons\":[{\"text\":\"Tulips\",\"value\":\"tulips\"},{\"text\":\"Lilies\",\"value\":\"lilies\"},{\"text\":\"Roses\",\"value\":\"roses\"}]}]}"),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "slot.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.description", "Types of flowers to pick up"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.name", "FlowerType"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.sample_utterances.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.sample_utterances.0", "I would like to order {FlowerType}"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.slot_constraint", "Required"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.slot_type", testIntentName),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.0.max_attempts", "2"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.0.message.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.0.message.0.content", "What type of flowers would you like to order?"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.0.message.0.content_type", "PlainText"),
+					resource.TestCheckResourceAttr(resourceName, "slot.0.value_elicitation_prompt.0.response_card", "{\"version\":1,\"contentType\":\"application/vnd.amazonaws.card.generic\",\"genericAttachments\":[{\"title\":\"What type of flowers?\",\"buttons\":[{\"text\":\"Tulips\",\"value\":\"tulips\"},{\"text\":\"Lilies\",\"value\":\"lilies\"},{\"text\":\"Roses\",\"value\":\"roses\"}]}]}"),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -583,8 +583,8 @@ func TestAccLexModelsIntent_slotsCustom(t *testing.T) {
 func TestAccLexModelsIntent_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -596,10 +596,10 @@ func TestAccLexModelsIntent_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckIntentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntentConfig_basic(testIntentID),
+				Config: testAccIntentConfig_basic(testIntentName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflexmodels.ResourceIntent(), rName),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflexmodels.ResourceIntent(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -610,8 +610,8 @@ func TestAccLexModelsIntent_disappears(t *testing.T) {
 func TestAccLexModelsIntent_updateWithExternalChange(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lexmodelbuildingservice.GetIntentOutput
-	rName := "aws_lex_intent.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	resourceName := "aws_lex_intent.test"
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	testAccCheckAWSLexIntentUpdateDescription := func(provider *schema.Provider, _ *schema.Resource, resourceName string) resource.TestCheckFunc {
 		return func(s *terraform.State) error {
@@ -660,17 +660,17 @@ func TestAccLexModelsIntent_updateWithExternalChange(t *testing.T) {
 		CheckDestroy:             testAccCheckIntentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIntentConfig_basic(testIntentID),
+				Config: testAccIntentConfig_basic(testIntentName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
-					testAccCheckAWSLexIntentUpdateDescription(acctest.Provider, tflexmodels.ResourceIntent(), rName),
+					testAccCheckIntentExists(ctx, resourceName, &v),
+					testAccCheckAWSLexIntentUpdateDescription(acctest.Provider, tflexmodels.ResourceIntent(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccIntentConfig_basic(testIntentID),
+				Config: testAccIntentConfig_basic(testIntentName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIntentExists(ctx, rName, &v),
+					testAccCheckIntentExists(ctx, resourceName, &v),
 				),
 			},
 		},
@@ -684,7 +684,7 @@ func TestAccLexModelsIntent_computeVersion(t *testing.T) {
 
 	intentResourceName := "aws_lex_intent.test"
 	botResourceName := "aws_lex_bot.test"
-	testIntentID := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
+	testIntentName := "test_intent_" + sdkacctest.RandStringFromCharSet(8, sdkacctest.CharSetAlpha)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -697,8 +697,8 @@ func TestAccLexModelsIntent_computeVersion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: acctest.ConfigCompose(
-					testAccBotConfig_intent(testIntentID),
-					testAccBotConfig_createVersion(testIntentID),
+					testAccBotConfig_intent(testIntentName),
+					testAccBotConfig_createVersion(testIntentName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIntentExistsWithVersion(ctx, intentResourceName, "1", &v1),
@@ -712,8 +712,8 @@ func TestAccLexModelsIntent_computeVersion(t *testing.T) {
 			},
 			{
 				Config: acctest.ConfigCompose(
-					testAccIntentConfig_sampleUtterancesWithVersion(testIntentID),
-					testAccBotConfig_createVersion(testIntentID),
+					testAccIntentConfig_sampleUtterancesWithVersion(testIntentName),
+					testAccBotConfig_createVersion(testIntentName),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIntentExistsWithVersion(ctx, intentResourceName, "2", &v1),
@@ -729,11 +729,11 @@ func TestAccLexModelsIntent_computeVersion(t *testing.T) {
 	})
 }
 
-func testAccCheckIntentExistsWithVersion(ctx context.Context, rName, intentVersion string, output *lexmodelbuildingservice.GetIntentOutput) resource.TestCheckFunc {
+func testAccCheckIntentExistsWithVersion(ctx context.Context, resourceName, intentVersion string, output *lexmodelbuildingservice.GetIntentOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[rName]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", rName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		if rs.Primary.ID == "" {
@@ -758,8 +758,8 @@ func testAccCheckIntentExistsWithVersion(ctx context.Context, rName, intentVersi
 	}
 }
 
-func testAccCheckIntentExists(ctx context.Context, rName string, output *lexmodelbuildingservice.GetIntentOutput) resource.TestCheckFunc {
-	return testAccCheckIntentExistsWithVersion(ctx, rName, tflexmodels.IntentVersionLatest, output)
+func testAccCheckIntentExists(ctx context.Context, resourceName string, output *lexmodelbuildingservice.GetIntentOutput) resource.TestCheckFunc {
+	return testAccCheckIntentExistsWithVersion(ctx, resourceName, tflexmodels.IntentVersionLatest, output)
 }
 
 func testAccCheckIntentNotExists(ctx context.Context, intentName, intentVersion string) resource.TestCheckFunc {

--- a/internal/service/lightsail/container_service_test.go
+++ b/internal/service/lightsail/container_service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tflightsail "github.com/hashicorp/terraform-provider-aws/internal/service/lightsail"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -45,8 +46,9 @@ func TestAccLightsailContainerService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "power", string(types.ContainerServicePowerNameNano)),
 					resource.TestCheckResourceAttr(resourceName, "scale", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "is_disabled", acctest.CtFalse),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "lightsail", regexache.MustCompile(`ContainerService/`+verify.UUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrAvailabilityZone),
 					resource.TestCheckResourceAttrSet(resourceName, "power_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "principal_arn"),

--- a/internal/service/lightsail/database_test.go
+++ b/internal/service/lightsail/database_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfsync "github.com/hashicorp/terraform-provider-aws/internal/experimental/sync"
 	tflightsail "github.com/hashicorp/terraform-provider-aws/internal/service/lightsail"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -52,7 +53,7 @@ func testAccDatabase_basic(t *testing.T, semaphore tfsync.Semaphore) {
 					resource.TestCheckResourceAttr(resourceName, "master_database_name", "testdatabasename"),
 					resource.TestCheckResourceAttr(resourceName, "master_username", "test"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrAvailabilityZone),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "lightsail", regexache.MustCompile(`RelationalDatabase/`+verify.UUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedAt),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrEngine),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrEngineVersion),
@@ -62,6 +63,7 @@ func testAccDatabase_basic(t *testing.T, semaphore tfsync.Semaphore) {
 					resource.TestCheckResourceAttrSet(resourceName, "master_endpoint_port"),
 					resource.TestCheckResourceAttrSet(resourceName, "master_endpoint_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "support_code"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "relational_database_name"),
 				),
 			},
 			{

--- a/internal/service/lightsail/key_pair_test.go
+++ b/internal/service/lightsail/key_pair_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lightsail"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -18,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tflightsail "github.com/hashicorp/terraform-provider-aws/internal/service/lightsail"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -41,7 +43,7 @@ func TestAccLightsailKeyPair_basic(t *testing.T) {
 				Config: testAccKeyPairConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyPairExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "lightsail", regexache.MustCompile(`KeyPair/`+verify.UUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
@@ -78,7 +80,7 @@ func TestAccLightsailKeyPair_publicKey(t *testing.T) {
 				Config: testAccKeyPairConfig_imported(rName, publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyPairExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "lightsail", regexache.MustCompile(`KeyPair/`+verify.UUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrPublicKey),
 					resource.TestCheckNoResourceAttr(resourceName, "encrypted_fingerprint"),
@@ -110,10 +112,11 @@ func TestAccLightsailKeyPair_encrypted(t *testing.T) {
 				Config: testAccKeyPairConfig_encrypted(rName, testKeyPairPubKey1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyPairExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "lightsail", regexache.MustCompile(`KeyPair/`+verify.UUIDRegexPattern+`$`)),
 					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
 					resource.TestCheckResourceAttrSet(resourceName, "encrypted_fingerprint"),
 					resource.TestCheckResourceAttrSet(resourceName, "encrypted_private_key"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrPublicKey),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrPrivateKey),
 				),

--- a/internal/service/medialive/input_security_group_test.go
+++ b/internal/service/medialive/input_security_group_test.go
@@ -45,7 +45,7 @@ func TestAccMediaLiveInputSecurityGroup_basic(t *testing.T) {
 				Config: testAccInputSecurityGroupConfig_basic(rName, "10.0.0.8/32"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInputSecurityGroupExists(ctx, resourceName, &inputSecurityGroup),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "inputSecurityGroup:{id}"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "whitelist_rules.*", map[string]string{
 						"cidr": "10.0.0.8/32",
 					}),
@@ -84,7 +84,7 @@ func TestAccMediaLiveInputSecurityGroup_updateCIDR(t *testing.T) {
 				Config: testAccInputSecurityGroupConfig_basic(rName, "10.0.0.8/32"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInputSecurityGroupExists(ctx, resourceName, &inputSecurityGroup),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "inputSecurityGroup:{id}"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "whitelist_rules.*", map[string]string{
 						"cidr": "10.0.0.8/32",
 					}),
@@ -94,7 +94,7 @@ func TestAccMediaLiveInputSecurityGroup_updateCIDR(t *testing.T) {
 				Config: testAccInputSecurityGroupConfig_basic(rName, "10.2.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInputSecurityGroupExists(ctx, resourceName, &inputSecurityGroup),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "inputSecurityGroup:{id}"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "whitelist_rules.*", map[string]string{
 						"cidr": "10.2.0.0/16",
 					}),

--- a/internal/service/medialive/input_test.go
+++ b/internal/service/medialive/input_test.go
@@ -45,7 +45,7 @@ func TestAccMediaLiveInput_basic(t *testing.T) {
 				Config: testAccInputConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInputExists(ctx, resourceName, &input),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "input:{id}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrSet(resourceName, "input_class"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "UDP_PUSH"),
@@ -85,7 +85,7 @@ func TestAccMediaLiveInput_update(t *testing.T) {
 				Config: testAccInputConfig_basic(rName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInputExists(ctx, resourceName, &input),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "input:{id}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName1),
 					resource.TestCheckResourceAttrSet(resourceName, "input_class"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "UDP_PUSH"),
@@ -95,7 +95,7 @@ func TestAccMediaLiveInput_update(t *testing.T) {
 				Config: testAccInputConfig_basic(rName2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInputExists(ctx, resourceName, &input),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "input:{id}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName2),
 					resource.TestCheckResourceAttrSet(resourceName, "input_class"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "UDP_PUSH"),

--- a/internal/service/medialive/medialive_test.go
+++ b/internal/service/medialive/medialive_test.go
@@ -17,7 +17,7 @@ func TestAccMediaLive_serial(t *testing.T) {
 			acctest.CtBasic:      testAccMultiplex_basic,
 			acctest.CtDisappears: testAccMultiplex_disappears,
 			"update":             testAccMultiplex_update,
-			"updateTags":         testAccMediaLiveMultiplex_tagsSerial,
+			"tags":               testAccMediaLiveMultiplex_tagsSerial,
 			"start":              testAccMultiplex_start,
 		},
 		"MultiplexProgram": {

--- a/internal/service/medialive/multiplex_test.go
+++ b/internal/service/medialive/multiplex_test.go
@@ -46,7 +46,7 @@ func testAccMultiplex_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiplexExists(ctx, resourceName, &multiplex),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "multiplex:{id}"),
 					resource.TestCheckResourceAttr(resourceName, "multiplex_settings.0.transport_stream_bitrate", "1000000"),
 					resource.TestCheckResourceAttr(resourceName, "multiplex_settings.0.transport_stream_reserved_bitrate", "1"),
 					resource.TestCheckResourceAttr(resourceName, "multiplex_settings.0.transport_stream_id", "1"),
@@ -88,7 +88,7 @@ func testAccMultiplex_start(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiplexExists(ctx, resourceName, &multiplex),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "multiplex:{id}"),
 				),
 			},
 			{
@@ -96,7 +96,7 @@ func testAccMultiplex_start(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiplexExists(ctx, resourceName, &multiplex),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "multiplex:{id}"),
 				),
 			},
 		},
@@ -128,7 +128,7 @@ func testAccMultiplex_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiplexExists(ctx, resourceName, &multiplex),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "multiplex:{id}"),
 					resource.TestCheckResourceAttr(resourceName, "multiplex_settings.0.transport_stream_bitrate", "1000000"),
 					resource.TestCheckResourceAttr(resourceName, "multiplex_settings.0.transport_stream_reserved_bitrate", "1"),
 					resource.TestCheckResourceAttr(resourceName, "multiplex_settings.0.transport_stream_id", "1"),
@@ -140,7 +140,7 @@ func testAccMultiplex_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiplexExists(ctx, resourceName, &multiplex),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "medialive", "multiplex:{id}"),
 					resource.TestCheckResourceAttr(resourceName, "multiplex_settings.0.transport_stream_bitrate", "1000001"),
 					resource.TestCheckResourceAttr(resourceName, "multiplex_settings.0.transport_stream_reserved_bitrate", "1"),
 					resource.TestCheckResourceAttr(resourceName, "multiplex_settings.0.transport_stream_id", "2"),

--- a/internal/service/memorydb/multi_region_cluster_test.go
+++ b/internal/service/memorydb/multi_region_cluster_test.go
@@ -33,9 +33,9 @@ func TestAccMemoryDBMultiRegionCluster_basic(t *testing.T) {
 				Config: testAccMultiRegionClusterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMultiRegionClusterExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "memorydb", "multiregioncluster/{multi_region_cluster_name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "multi_region_cluster_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "multi_region_cluster_name_suffix"),
+					resource.TestCheckResourceAttr(resourceName, "multi_region_cluster_name_suffix", rName),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "db.r7g.xlarge"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrEngine),


### PR DESCRIPTION
### Description

Reduce uses of `resource.TestCheckResourceAttrSet` on ARN attributes in favour of explicit checks

Addresses `k` through `m` services