### PR TITLE
docs: update conflict details for ipv6 cidr block association

### DIFF
--- a/website/docs/r/vpc_ipv6_cidr_block_association.html.markdown
+++ b/website/docs/r/vpc_ipv6_cidr_block_association.html.markdown
@@ -31,9 +31,9 @@ This resource supports the following arguments:
 
 * `assign_generated_ipv6_cidr_block` - (Optional) Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IPv6 addresses, or the size of the CIDR block. Default is `false`. Conflicts with `ipv6_pam_pool_id`, `ipv6_pool`, `ipv6_cidr_block` and `ipv6_netmask_length`.
 * `ipv6_cidr_block` - (Optional) The IPv6 CIDR block for the VPC. CIDR can be explicitly set or it can be derived from IPAM using `ipv6_netmask_length`. This parameter is required if `ipv6_netmask_length` is not set and the IPAM pool does not have `allocation_default_netmask` set. Conflicts with `assign_generated_ipv6_cidr_block`.
-* `ipv6_ipam_pool_id` - - (Optional) The ID of an IPv6 IPAM pool you want to use for allocating this VPC's CIDR. IPAM is a VPC feature that you can use to automate your IP address management workflows including assigning, tracking, troubleshooting, and auditing IP addresses across AWS Regions and accounts. Conflict with `assign_generated_ipv6_cidr_block` and `ipv6_ipam_pool_id`.
-* `ipv6_netmask_length` - (Optional) The netmask length of the IPv6 CIDR you want to allocate to this VPC. Requires specifying a `ipv6_ipam_pool_id`. This parameter is optional if the IPAM pool has `allocation_default_netmask` set, otherwise it or `ipv6_cidr_block` are required. Conflicts with `assign_generated_ipv6_cidr_block` and `ipv6_ipam_pool_id`.
-* `ipv6_pool` - (Optional) The  ID of an IPv6 address pool from which to allocate the IPv6 CIDR block. Conflicts with `ipv6_pam_pool_id`, `ipv6_pool`.
+* `ipv6_ipam_pool_id` - (Optional) The ID of an IPv6 IPAM pool you want to use for allocating this VPC's CIDR. IPAM is a VPC feature that you can use to automate your IP address management workflows including assigning, tracking, troubleshooting, and auditing IP addresses across AWS Regions and accounts. Conflict with `assign_generated_ipv6_cidr_block` and `ipv6_pool`.
+* `ipv6_netmask_length` - (Optional) The netmask length of the IPv6 CIDR you want to allocate to this VPC. Requires specifying a `ipv6_ipam_pool_id`. This parameter is optional if the IPAM pool has `allocation_default_netmask` set, otherwise it or `ipv6_cidr_block` are required. Conflicts with `ipv6_cidr_block`.
+* `ipv6_pool` - (Optional) The  ID of an IPv6 address pool from which to allocate the IPv6 CIDR block. Conflicts with `assign_generated_ipv6_cidr_block` and `ipv6_pam_pool_id`.
 * `vpc_id` - (Required) The ID of the VPC to make the association with.
 
 ## Timeouts


### PR DESCRIPTION
### Description

For the resource [`aws_vpc_ipv6_cidr_block_association` ](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipv6_cidr_block_association.html) the attributes

* ipv6_ipam_pool_id
* ipv6_pool
* ipv6_netmask_length

do contain details on possible attribute conflict. The details in the current documentation are not correct and updated by this pull request.

One example from the current documentation:

> [ipv6_pool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_ipv6_cidr_block_association.html#ipv6_pool-1) - (Optional) The ID of an IPv6 address pool from which to allocate the IPv6 CIDR block. Conflicts with ipv6_pam_pool_id, ipv6_pool.

Here the attribute `ipv6_pool` is in conflict with itself.

### Relations

Closes #40977 

### References

- [Schema definition for resource](https://github.com/hashicorp/terraform-provider-aws/blob/302d58d1b5b52c5496e373338753d89481b9ad42/internal/service/ec2/vpc_ipv6_cidr_block_association.go#L44)

### Output from Acceptance Testing

No applicable, only documentation is updated.