### PR TITLE
r/aws_rds_cluster: recommend setting db_instance_parameter_group_name always

### DIFF
--- a/website/docs/cdktf/python/r/rds_cluster.html.markdown
+++ b/website/docs/cdktf/python/r/rds_cluster.html.markdown
@@ -312,7 +312,7 @@ This resource supports the following arguments:
 * `database_name` - (Optional) Name for an automatically created database on cluster creation. There are different naming restrictions per database engine: [RDS Naming Constraints][5]
 * `db_cluster_instance_class` - (Optional, Required for Multi-AZ DB cluster) The compute and memory capacity of each DB instance in the Multi-AZ DB cluster, for example `db.m6g.xlarge`. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes and availability for your engine, see [DB instance class](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html) in the Amazon RDS User Guide.
 * `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
-* `db_instance_parameter_group_name` - (Optional) Instance parameter group to associate with all instances of the DB cluster. The `db_instance_parameter_group_name` parameter is only valid in combination with the `allow_major_version_upgrade` parameter.
+* `db_instance_parameter_group_name` - (Optional) Instance parameter group to associate with all instances of the DB cluster. It can be set always since ignored when unnecessary.
 * `db_subnet_group_name` - (Optional) DB subnet group to associate with this DB cluster.
   **NOTE:** This must match the `db_subnet_group_name` specified on every [`aws_rds_cluster_instance`](/docs/providers/aws/r/rds_cluster_instance.html) in the cluster.
 * `db_system_id` - (Optional) For use with RDS Custom.

--- a/website/docs/cdktf/typescript/r/rds_cluster.html.markdown
+++ b/website/docs/cdktf/typescript/r/rds_cluster.html.markdown
@@ -348,7 +348,7 @@ This resource supports the following arguments:
 * `databaseName` - (Optional) Name for an automatically created database on cluster creation. There are different naming restrictions per database engine: [RDS Naming Constraints][5]
 * `dbClusterInstanceClass` - (Optional, Required for Multi-AZ DB cluster) The compute and memory capacity of each DB instance in the Multi-AZ DB cluster, for example `db.m6g.xlarge`. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes and availability for your engine, see [DB instance class](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html) in the Amazon RDS User Guide.
 * `dbClusterParameterGroupName` - (Optional) A cluster parameter group to associate with the cluster.
-* `dbInstanceParameterGroupName` - (Optional) Instance parameter group to associate with all instances of the DB cluster. The `dbInstanceParameterGroupName` parameter is only valid in combination with the `allowMajorVersionUpgrade` parameter.
+* `dbInstanceParameterGroupName` - (Optional) Instance parameter group to associate with all instances of the DB cluster. It can be set always since ignored when unnecessary.
 * `dbSubnetGroupName` - (Optional) DB subnet group to associate with this DB cluster.
   **NOTE:** This must match the `dbSubnetGroupName` specified on every [`aws_rds_cluster_instance`](/docs/providers/aws/r/rds_cluster_instance.html) in the cluster.
 * `dbSystemId` - (Optional) For use with RDS Custom.

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -218,7 +218,7 @@ This resource supports the following arguments:
 * `database_name` - (Optional) Name for an automatically created database on cluster creation. There are different naming restrictions per database engine: [RDS Naming Constraints][5]
 * `db_cluster_instance_class` - (Optional, Required for Multi-AZ DB cluster) The compute and memory capacity of each DB instance in the Multi-AZ DB cluster, for example `db.m6g.xlarge`. Not all DB instance classes are available in all AWS Regions, or for all database engines. For the full list of DB instance classes and availability for your engine, see [DB instance class](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html) in the Amazon RDS User Guide.
 * `db_cluster_parameter_group_name` - (Optional) A cluster parameter group to associate with the cluster.
-* `db_instance_parameter_group_name` - (Optional) Instance parameter group to associate with all instances of the DB cluster. The `db_instance_parameter_group_name` parameter is only valid in combination with the `allow_major_version_upgrade` parameter.
+* `db_instance_parameter_group_name` - (Optional) Instance parameter group to associate with all instances of the DB cluster. It can be set always since ignored when unnecessary.
 * `db_subnet_group_name` - (Optional) DB subnet group to associate with this DB cluster.
   **NOTE:** This must match the `db_subnet_group_name` specified on every [`aws_rds_cluster_instance`](/docs/providers/aws/r/rds_cluster_instance.html) in the cluster.
 * `db_system_id` - (Optional) For use with RDS Custom.


### PR DESCRIPTION
### Description

- Raise error if `db_instance_parameter_group_name` is missing on RDS Cluster major version upgrade
- Guide users to set `db_instance_parameter_group_name` always, since the parameter is automatically removed on retry if it  is not a major version upgrade.



### Relations
Closes #35385

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
