### PR TITLE
feat: Add concurrent_jobs arg for aws_media_convert_queue

### DIFF
--- a/.changelog/41012.txt
+++ b/.changelog/41012.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_media_convert_queue: Add `concurrent_jobs` argument
+```

--- a/internal/service/mediaconvert/queue.go
+++ b/internal/service/mediaconvert/queue.go
@@ -41,6 +41,11 @@ func resourceQueue() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"concurrent_jobs": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 			names.AttrDescription: {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -107,6 +112,10 @@ func resourceQueueCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		Tags:        getTagsIn(ctx),
 	}
 
+	if v, ok := d.GetOk("concurrent_jobs"); ok {
+		input.ConcurrentJobs = aws.Int32(int32(v.(int)))
+	}
+
 	if v, ok := d.GetOk(names.AttrDescription); ok {
 		input.Description = aws.String(v.(string))
 	}
@@ -143,6 +152,7 @@ func resourceQueueRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	d.Set(names.AttrARN, queue.Arn)
+	d.Set("concurrent_jobs", queue.ConcurrentJobs)
 	d.Set(names.AttrDescription, queue.Description)
 	d.Set(names.AttrName, queue.Name)
 	d.Set("pricing_plan", queue.PricingPlan)
@@ -166,6 +176,10 @@ func resourceQueueUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		input := &mediaconvert.UpdateQueueInput{
 			Name:   aws.String(d.Id()),
 			Status: types.QueueStatus(d.Get(names.AttrStatus).(string)),
+		}
+
+		if v, ok := d.GetOk("concurrent_jobs"); ok {
+			input.ConcurrentJobs = aws.Int32(int32(v.(int)))
 		}
 
 		if v, ok := d.GetOk(names.AttrDescription); ok {

--- a/website/docs/r/media_convert_queue.html.markdown
+++ b/website/docs/r/media_convert_queue.html.markdown
@@ -23,6 +23,7 @@ resource "aws_media_convert_queue" "test" {
 This resource supports the following arguments:
 
 * `name` - (Required) A unique identifier describing the queue
+* `concurrent_jobs` - (Optional) The maximum number of jobs your queue can process concurrently. For on-demand queues, the value you enter is constrained by your service quotas for Maximum concurrent jobs, per on-demand queue and Maximum concurrent jobs, per account. For reserved queues, specify the number of jobs you can process concurrently in your reservation plan instead.
 * `description` - (Optional) A description of the queue
 * `pricing_plan` - (Optional) Specifies whether the pricing plan for the queue is on-demand or reserved. Valid values are `ON_DEMAND` or `RESERVED`. Default to `ON_DEMAND`.
 * `reservation_plan_settings` - (Optional) A detail pricing plan of the  reserved queue. See below.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is for adding the `concurrent_jobs` argument to the `aws_media_convert_queue` resource. However, there are a few issues I found that would affect some edge cases:

1. The default value is different per region, so one cannot be set. 
2. The API does not allow un-setting `concurrent_jobs`, so removing it from the configuration and applying would simply retain the custom value.
3. The API returns a quota exception as a 429 error, leading to a long wait as it falls under the standard retry mechanism. I think this is a mis-categorization of the error at the AWS API level, so I will open a separate issue and an AWS support ticket to track it. But for now, if the provided concurrent job value exceeds the quota limit, it will only fail after an hour.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41003

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [Queues](https://docs.aws.amazon.com/mediaconvert/latest/apireference/queues.html#queues-prop-createqueuerequest-concurrentjobs) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccMediaConvertQueue_ PKG=mediaconvert
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/mediaconvert/... -v -count 1 -parallel 20 -run='TestAccMediaConvertQueue_'  -timeout 360m -vet=off
2025/01/20 17:29:42 Initializing Terraform AWS Provider...
=== RUN   TestAccMediaConvertQueue_basic
=== PAUSE TestAccMediaConvertQueue_basic
=== RUN   TestAccMediaConvertQueue_disappears
=== PAUSE TestAccMediaConvertQueue_disappears
=== RUN   TestAccMediaConvertQueue_withTags
=== PAUSE TestAccMediaConvertQueue_withTags
=== RUN   TestAccMediaConvertQueue_reservationPlanSettings
    queue_test.go:127: MediaConvert Reserved Queues are $400/month and cannot be deleted for 1 year.
--- SKIP: TestAccMediaConvertQueue_reservationPlanSettings (0.00s)
=== RUN   TestAccMediaConvertQueue_withStatus
=== PAUSE TestAccMediaConvertQueue_withStatus
=== RUN   TestAccMediaConvertQueue_withDescription
=== PAUSE TestAccMediaConvertQueue_withDescription
=== RUN   TestAccMediaConvertQueue_withConcurrentJobs
=== PAUSE TestAccMediaConvertQueue_withConcurrentJobs
=== CONT  TestAccMediaConvertQueue_basic
=== CONT  TestAccMediaConvertQueue_withStatus
=== CONT  TestAccMediaConvertQueue_disappears
=== CONT  TestAccMediaConvertQueue_withTags
=== CONT  TestAccMediaConvertQueue_withConcurrentJobs
=== CONT  TestAccMediaConvertQueue_withDescription
--- PASS: TestAccMediaConvertQueue_disappears (19.16s)
--- PASS: TestAccMediaConvertQueue_basic (22.10s)
--- PASS: TestAccMediaConvertQueue_withConcurrentJobs (27.95s)
--- PASS: TestAccMediaConvertQueue_withDescription (29.06s)
--- PASS: TestAccMediaConvertQueue_withStatus (33.42s)
--- PASS: TestAccMediaConvertQueue_withTags (43.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/mediaconvert       43.632s

$
```
