### PR TITLE
docs: add missing explicit auth flow option for cognito user pool client

### DIFF
--- a/website/docs/r/cognito_user_pool_client.html.markdown
+++ b/website/docs/r/cognito_user_pool_client.html.markdown
@@ -146,7 +146,7 @@ The following arguments are optional:
 * `default_redirect_uri` - (Optional) Default redirect URI and must be included in the list of callback URLs.
 * `enable_token_revocation` - (Optional) Enables or disables token revocation.
 * `enable_propagate_additional_user_context_data` - (Optional) Enables the propagation of additional user context data.
-* `explicit_auth_flows` - (Optional) List of authentication flows. The available options include ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY, USER_PASSWORD_AUTH, ALLOW_ADMIN_USER_PASSWORD_AUTH, ALLOW_CUSTOM_AUTH, ALLOW_USER_PASSWORD_AUTH, ALLOW_USER_SRP_AUTH, and ALLOW_REFRESH_TOKEN_AUTH.
+* `explicit_auth_flows` - (Optional) List of authentication flows. The available options include `ADMIN_NO_SRP_AUTH`, `CUSTOM_AUTH_FLOW_ONLY`, `USER_PASSWORD_AUTH`, `ALLOW_ADMIN_USER_PASSWORD_AUTH`, `ALLOW_CUSTOM_AUTH`, `ALLOW_USER_PASSWORD_AUTH`, `ALLOW_USER_SRP_AUTH`, `ALLOW_REFRESH_TOKEN_AUTH`, and `ALLOW_USER_AUTH`.
 * `generate_secret` - (Optional) Boolean flag indicating whether an application secret should be generated.
 * `id_token_validity` - (Optional) Time limit, between 5 minutes and 1 day, after which the ID token is no longer valid and cannot be used. By default, the unit is hours. The unit can be overridden by a value in `token_validity_units.id_token`.
 * `logout_urls` - (Optional) List of allowed logout URLs for the identity providers. `allowed_oauth_flows_user_pool_client` must be set to `true` before you can configure this option.


### PR DESCRIPTION
### Description

In the documentation for the resource [`aws_cognito_user_pool_client`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_client) the option  `ALLOW_USER_AUTH` for the argument [`explicit_auth_flows`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_client#explicit_auth_flows-1) is missing.

This PR adds the missing option and also formats the options for the argument `explicit_auth_flows` as `code`.

### Relations

Closes #41028 

### References

* [AWS Go SDK v2 release v1.47.0](https://github.com/aws/aws-sdk-go-v2/releases/tag/release-2024-11-22) containing the new flow, release 22 Nov 2024
* [Validation in provider source code](https://github.com/hashicorp/terraform-provider-aws/blob/1043db5c182e08c339273be64ef5233cad114064/internal/service/cognitoidp/user_pool_client.go#L164). The current provider version uses v1.48.6 of the `github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider`.

### Output from Acceptance Testing

Not applicable, only documentation is updated.