### PR TITLE
feat: Support resource import for aws_vpc_endpoint_security_group_association

### DIFF
--- a/.changelog/41042.txt
+++ b/.changelog/41042.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpc_endpoint_security_group_association: Add import support
+```

--- a/internal/service/ec2/vpc_endpoint_security_group_association.go
+++ b/internal/service/ec2/vpc_endpoint_security_group_association.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -25,6 +26,9 @@ func resourceVPCEndpointSecurityGroupAssociation() *schema.Resource {
 		CreateWithoutTimeout: resourceVPCEndpointSecurityGroupAssociationCreate,
 		ReadWithoutTimeout:   resourceVPCEndpointSecurityGroupAssociationRead,
 		DeleteWithoutTimeout: resourceVPCEndpointSecurityGroupAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVPCEndpointSecurityGroupAssociationImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"replace_default_association": {
@@ -206,4 +210,22 @@ func deleteVPCEndpointSecurityGroupAssociation(ctx context.Context, conn *ec2.Cl
 	}
 
 	return nil
+}
+
+func resourceVPCEndpointSecurityGroupAssociationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("wrong format of import ID (%s), use: 'vpc-endpoint-id/security-group-id'", d.Id())
+	}
+
+	endpointID := parts[0]
+	securityGroupID := parts[1]
+	log.Printf("[DEBUG] Importing VPC Endpoint (%s) Security Group (%s) Association", endpointID, securityGroupID)
+
+	d.SetId(vpcEndpointSecurityGroupAssociationCreateID(endpointID, securityGroupID))
+	d.Set(names.AttrVPCEndpointID, endpointID)
+	d.Set("security_group_id", securityGroupID)
+	d.Set("replace_default_association", false)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/service/ec2/vpc_endpoint_security_group_association_test.go
+++ b/internal/service/ec2/vpc_endpoint_security_group_association_test.go
@@ -38,6 +38,13 @@ func TestAccVPCEndpointSecurityGroupAssociation_basic(t *testing.T) {
 					testAccCheckVPCEndpointSecurityGroupAssociationNumAssociations(&v, 2),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccVPCEndpointSecurityGroupAssociationImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"replace_default_association"},
+			},
 		},
 	})
 }
@@ -112,6 +119,13 @@ func TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation(t *tes
 					testAccCheckVPCEndpointSecurityGroupAssociationNumAssociations(&v, 1),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccVPCEndpointSecurityGroupAssociationImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"replace_default_association"},
+			},
 		},
 	})
 }
@@ -170,6 +184,18 @@ func testAccCheckVPCEndpointSecurityGroupAssociationExists(ctx context.Context, 
 		*v = *output
 
 		return nil
+	}
+}
+
+func testAccVPCEndpointSecurityGroupAssociationImportStateIdFunc(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", n)
+		}
+
+		id := fmt.Sprintf("%s/%s", rs.Primary.Attributes[names.AttrVPCEndpointID], rs.Primary.Attributes["security_group_id"])
+		return id, nil
 	}
 }
 

--- a/website/docs/r/vpc_endpoint_security_group_association.html.markdown
+++ b/website/docs/r/vpc_endpoint_security_group_association.html.markdown
@@ -33,10 +33,27 @@ This resource supports the following arguments:
 
 * `security_group_id` - (Required) The ID of the security group to be associated with the VPC endpoint.
 * `vpc_endpoint_id` - (Required) The ID of the VPC endpoint with which the security group will be associated.
-* `replace_default_association` - (Optional) Whether this association should replace the association with the VPC's default security group that is created when no security groups are specified during VPC endpoint creation. At most 1 association per-VPC endpoint should be configured with `replace_default_association = true`.
+* `replace_default_association` - (Optional) Whether this association should replace the association with the VPC's default security group that is created when no security groups are specified during VPC endpoint creation. At most 1 association per-VPC endpoint should be configured with `replace_default_association = true`. `false` should be used when importing resources.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
 * `id` - The ID of the association.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import VPC Endpoint Security Group Associations using `vpc_endpoint_id` together with `security_group_id`. For example:
+
+```terraform
+import {
+  to = aws_vpc_endpoint_security_group_association.example
+  id = "vpce-aaaaaaaa/sg-bbbbbbbbbbbbbbbbb"
+}
+```
+
+Using `terraform import`, import VPC Endpoint Security Group Associations using `vpc_endpoint_id` together with `security_group_id`. For example:
+
+```console
+% terraform import aws_vpc_endpoint_security_group_association.example vpce-aaaaaaaa/sg-bbbbbbbbbbbbbbbbb
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add support for importing `aws_vpc_endpoint_security_group_association` resources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41039

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccVPCEndpointSecurityGroupAssociation_ PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpointSecurityGroupAssociation_'  -timeout 360m -vet=off
2025/01/22 23:45:03 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_basic
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_basic
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_disappears
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_disappears
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_multiple
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_multiple
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation
=== CONT  TestAccVPCEndpointSecurityGroupAssociation_basic
=== CONT  TestAccVPCEndpointSecurityGroupAssociation_multiple
=== CONT  TestAccVPCEndpointSecurityGroupAssociation_disappears
=== CONT  TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation
--- PASS: TestAccVPCEndpointSecurityGroupAssociation_basic (48.76s)
--- PASS: TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation (85.37s)
--- PASS: TestAccVPCEndpointSecurityGroupAssociation_disappears (85.96s)
--- PASS: TestAccVPCEndpointSecurityGroupAssociation_multiple (98.65s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        98.877s

$
```
