### PR TITLE
feat: Add orchestration_sending_role_arn arg for aws_pinpoint_email_channel

### DIFF
--- a/.changelog/41043.txt
+++ b/.changelog/41043.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_pinpoint_email_channel: Add `orchestration_sending_role_arn` argument
+```

--- a/internal/service/pinpoint/email_channel.go
+++ b/internal/service/pinpoint/email_channel.go
@@ -56,6 +56,11 @@ func resourceEmailChannel() *schema.Resource {
 				Required:     true,
 				ValidateFunc: verify.ValidARN,
 			},
+			"orchestration_sending_role_arn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: verify.ValidARN,
+			},
 			names.AttrRoleARN: {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -80,6 +85,10 @@ func resourceEmailChannelUpsert(ctx context.Context, d *schema.ResourceData, met
 	params.Enabled = aws.Bool(d.Get(names.AttrEnabled).(bool))
 	params.FromAddress = aws.String(d.Get("from_address").(string))
 	params.Identity = aws.String(d.Get("identity").(string))
+
+	if v, ok := d.GetOk("orchestration_sending_role_arn"); ok {
+		params.OrchestrationSendingRoleArn = aws.String(v.(string))
+	}
 
 	if v, ok := d.GetOk(names.AttrRoleARN); ok {
 		params.RoleArn = aws.String(v.(string))
@@ -126,6 +135,7 @@ func resourceEmailChannelRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set(names.AttrEnabled, output.Enabled)
 	d.Set("from_address", output.FromAddress)
 	d.Set("identity", output.Identity)
+	d.Set("orchestration_sending_role_arn", output.OrchestrationSendingRoleArn)
 	d.Set(names.AttrRoleARN, output.RoleArn)
 	d.Set("configuration_set", output.ConfigurationSet)
 	d.Set("messages_per_second", output.MessagesPerSecond)

--- a/website/docs/r/pinpoint_email_channel.html.markdown
+++ b/website/docs/r/pinpoint_email_channel.html.markdown
@@ -71,6 +71,7 @@ This resource supports the following arguments:
 * `configuration_set` - (Optional) The ARN of the Amazon SES configuration set that you want to apply to messages that you send through the channel.
 * `from_address` - (Required) The email address used to send emails from. You can use email only (`user@example.com`) or friendly address (`User <user@example.com>`). This field comply with [RFC 5322](https://www.ietf.org/rfc/rfc5322.txt).
 * `identity` - (Required) The ARN of an identity verified with SES.
+* `orchestration_sending_role_arn` - (Optional) The ARN of an IAM role for Amazon Pinpoint to use to send email from your campaigns or journeys through Amazon SES.
 * `role_arn` - (Optional) *Deprecated* The ARN of an IAM Role used to submit events to Mobile Analytics' event ingestion service.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `orchestration_sending_role_arn` argument to the `aws_pinpoint_email_channel` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40947

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [Email Channel](https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-channels-email.html#apps-application-id-channels-email-properties) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccPinpointEmailChannel_ PKG=pinpoint
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/pinpoint/... -v -count 1 -parallel 20 -run='TestAccPinpointEmailChannel_'  -timeout 360m -vet=off
2025/01/23 00:22:28 Initializing Terraform AWS Provider...
=== RUN   TestAccPinpointEmailChannel_basic
=== PAUSE TestAccPinpointEmailChannel_basic
=== RUN   TestAccPinpointEmailChannel_set
=== PAUSE TestAccPinpointEmailChannel_set
=== RUN   TestAccPinpointEmailChannel_noRole
=== PAUSE TestAccPinpointEmailChannel_noRole
=== RUN   TestAccPinpointEmailChannel_orchestrationSendingRoleArn
=== PAUSE TestAccPinpointEmailChannel_orchestrationSendingRoleArn
=== RUN   TestAccPinpointEmailChannel_disappears
=== PAUSE TestAccPinpointEmailChannel_disappears
=== CONT  TestAccPinpointEmailChannel_basic
=== CONT  TestAccPinpointEmailChannel_orchestrationSendingRoleArn
=== CONT  TestAccPinpointEmailChannel_disappears
=== CONT  TestAccPinpointEmailChannel_noRole
=== CONT  TestAccPinpointEmailChannel_set
--- PASS: TestAccPinpointEmailChannel_disappears (18.67s)
--- PASS: TestAccPinpointEmailChannel_orchestrationSendingRoleArn (21.11s)
--- PASS: TestAccPinpointEmailChannel_noRole (21.36s)
--- PASS: TestAccPinpointEmailChannel_set (21.37s)
--- PASS: TestAccPinpointEmailChannel_basic (32.31s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint   32.562s

$
```
