### PR TITLE
feat: Add update possibility if the content of an s3 file changes

### DIFF
--- a/internal/service/opensearch/package.go
+++ b/internal/service/opensearch/package.go
@@ -70,6 +70,10 @@ func resourcePackage() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"source_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},

--- a/website/docs/r/opensearch_package.html.markdown
+++ b/website/docs/r/opensearch_package.html.markdown
@@ -49,6 +49,7 @@ This resource supports the following arguments:
 
 * `s3_bucket_name` - (Required, Forces new resource) The name of the Amazon S3 bucket containing the package.
 * `s3_key` - (Required, Forces new resource) Key (file name) of the package.
+* `source_version` - (Optional) Reference to the file version (Etag for example). This ensures that the package gets update if the file content changes.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR introduces a new field on `aws_opensearch_package` that makes sure the resource gets an update when the content of the source s3 file changes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41052

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccOpenSearchPackage_upgradePossible PKG=opensearch
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/opensearch/... -v -count 1 -parallel 20 -run='TestAccOpenSearchPackage_upgradePossible'  -timeout 360m -vet=off
2025/01/23 15:34:11 Initializing Terraform AWS Provider...
=== RUN   TestAccOpenSearchPackage_upgradePossible
=== PAUSE TestAccOpenSearchPackage_upgradePossible
=== CONT  TestAccOpenSearchPackage_upgradePossible
--- PASS: TestAccOpenSearchPackage_upgradePossible (54.26s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearch 59.385s
...
```
