### PR TITLE
feat: Add configurable timeouts to aws_organizations_account

### DIFF
--- a/.changelog/41059.txt
+++ b/.changelog/41059.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_organizations_account: Add configurable timeouts for Create and Delete
+```

--- a/website/docs/r/organizations_account.html.markdown
+++ b/website/docs/r/organizations_account.html.markdown
@@ -49,6 +49,13 @@ This resource exports the following attributes in addition to the arguments abov
 * `status` - The status of the account in the organization.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `10m`)
+- `delete` - (Default `10m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import the AWS member account using the `account_id`. For example:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add configurable timeouts for create and delete to the `aws_organizations_account` resource. Based on the problem description in 40894, I also increased the default timeout from 5 minutes to 10 minutes, which hopefully will cover the general use cases.

**Note:** that I do not have a management account where I can freely create and close accounts. I would thus need assistance from a maintainer to help run the resource test cases. Thank you.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40894

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

TBD - I need help with running these tests in a management account!