### PR TITLE
fix: Don't force new resource on role_arn update for aws_bedrockagent_knowledge_base

### DIFF
--- a/.changelog/41072.txt
+++ b/.changelog/41072.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagent_knowledge_base: Remove [ForceNew](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew) behavior from `role_arn` argument
+```

--- a/internal/service/bedrockagent/knowledge_base.go
+++ b/internal/service/bedrockagent/knowledge_base.go
@@ -84,9 +84,6 @@ func (r *knowledgeBaseResource) Schema(ctx context.Context, request resource.Sch
 			names.AttrRoleARN: schema.StringAttribute{
 				CustomType: fwtypes.ARNType,
 				Required:   true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
@@ -529,7 +526,8 @@ func (r *knowledgeBaseResource) Update(ctx context.Context, request resource.Upd
 	conn := r.Meta().BedrockAgentClient(ctx)
 
 	if !new.Description.Equal(old.Description) ||
-		!new.Name.Equal(old.Name) {
+		!new.Name.Equal(old.Name) ||
+		!new.RoleARN.Equal(old.RoleARN) {
 		input := &bedrockagent.UpdateKnowledgeBaseInput{}
 		response.Diagnostics.Append(fwflex.Expand(ctx, new, input)...)
 		if response.Diagnostics.HasError() {

--- a/website/docs/r/bedrockagent_knowledge_base.html.markdown
+++ b/website/docs/r/bedrockagent_knowledge_base.html.markdown
@@ -41,10 +41,10 @@ resource "aws_bedrockagent_knowledge_base" "example" {
 
 The following arguments are required:
 
-* `knowledge_base_configuration` - (Required) Details about the embeddings configuration of the knowledge base. See [`knowledge_base_configuration` block](#knowledge_base_configuration-block) for details.
-* `name` - (Required, Forces new resource) Name of the knowledge base.
+* `knowledge_base_configuration` - (Required, Forces new resource) Details about the embeddings configuration of the knowledge base. See [`knowledge_base_configuration` block](#knowledge_base_configuration-block) for details.
+* `name` - (Required) Name of the knowledge base.
 * `role_arn` - (Required) ARN of the IAM role with permissions to invoke API operations on the knowledge base.
-* `storage_configuration` - (Required) Details about the storage configuration of the knowledge base. See [`storage_configuration` block](#storage_configuration-block) for details.
+* `storage_configuration` - (Required, Forces new resource) Details about the storage configuration of the knowledge base. See [`storage_configuration` block](#storage_configuration-block) for details.
 
 The following arguments are optional:
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to fix an issue with the `aws_bedrockagent_knowledge_base` resource where updating the `role_arn` argument would force new resource creation despite direct update is supported. The resource documentation is also incorrect on specifying which arguments would force new resources, so it is being fixed in this PR as well.

**Note:** For development I use a Windows machine with git bash, and the test cases are failing when running the `local-exec` commands in `null_resource.db_setup`. I had to add `interpreter = ["bash", "-c"]` temporarily just to get the commands to run with bash instead of cmd. I am not sure if adding the `interpreter` argument would break things, so I decided to leave it out of the test config for now.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41024

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [UpdateKnowledgeBase](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_UpdateKnowledgeBase.html) for specs.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccBedrockAgent_serial/KnowledgeBase/basicRDS PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/bedrockagent/... -v -count 1 -parallel 20 -run='TestAccBedrockAgent_serial/KnowledgeBase/basicRDS'  -timeout 360m -vet=off
2025/01/24 21:55:07 Initializing Terraform AWS Provider...
=== RUN   TestAccBedrockAgent_serial
=== PAUSE TestAccBedrockAgent_serial
=== CONT  TestAccBedrockAgent_serial
=== RUN   TestAccBedrockAgent_serial/KnowledgeBase
=== RUN   TestAccBedrockAgent_serial/KnowledgeBase/basicRDS
--- PASS: TestAccBedrockAgent_serial (1429.87s)
    --- PASS: TestAccBedrockAgent_serial/KnowledgeBase (1429.87s)
        --- PASS: TestAccBedrockAgent_serial/KnowledgeBase/basicRDS (1429.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       1430.115s

$
```
