### PR TITLE
feat: Add missing attributes to aws_ecs_task_definition data source

### DIFF
--- a/.changelog/41081.txt
+++ b/.changelog/41081.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ecs_task_definition: Add missing attributes
+```

--- a/internal/service/ecs/task_definition_data_source.go
+++ b/internal/service/ecs/task_definition_data_source.go
@@ -29,6 +29,30 @@ func dataSourceTaskDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"container_definitions": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cpu": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_fault_injection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ephemeral_storage": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"size_in_gib": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
 			names.AttrExecutionRoleARN: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -37,13 +61,101 @@ func dataSourceTaskDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"inference_accelerator": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrDeviceName: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"device_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ipc_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"network_mode": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"pid_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"placement_constraints": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrExpression: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrType: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"proxy_configuration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"container_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrProperties: {
+							Type:     schema.TypeMap,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						names.AttrType: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"requires_compatibilities": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"revision": {
 				Type:     schema.TypeInt,
 				Computed: true,
+			},
+			"runtime_platform": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"operating_system_family": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cpu_architecture": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			names.AttrStatus: {
 				Type:     schema.TypeString,
@@ -56,6 +168,128 @@ func dataSourceTaskDefinition() *schema.Resource {
 			"task_role_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"volume": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"configure_at_launch": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"docker_volume_configuration": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"autoprovision": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"driver": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"driver_opts": {
+										Type:     schema.TypeMap,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										Computed: true,
+									},
+									"labels": {
+										Type:     schema.TypeMap,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										Computed: true,
+									},
+									names.AttrScope: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"efs_volume_configuration": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"authorization_config": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"access_point_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"iam": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									names.AttrFileSystemID: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"root_directory": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"transit_encryption": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"transit_encryption_port": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"fsx_windows_file_server_volume_configuration": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"authorization_config": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"credentials_parameter": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												names.AttrDomain: {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									names.AttrFileSystemID: {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"root_directory": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"host_path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrName: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -79,12 +313,51 @@ func dataSourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(aws.ToString(taskDefinition.TaskDefinitionArn))
 	d.Set(names.AttrARN, taskDefinition.TaskDefinitionArn)
 	d.Set("arn_without_revision", taskDefinitionARNStripRevision(aws.ToString(taskDefinition.TaskDefinitionArn)))
+
+	orderedCDs := taskDefinition.ContainerDefinitions
+	containerDefinitions(orderedCDs).orderContainers()
+	containerDefinitions(orderedCDs).orderEnvironmentVariables()
+	containerDefinitions(orderedCDs).orderSecrets()
+	containerDefinitions(orderedCDs).compactArrays()
+	containerDefinitions, err := flattenContainerDefinitions(orderedCDs)
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
+
+	if err := d.Set("container_definitions", containerDefinitions); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting container_definitions: %s", err)
+	}
+
+	d.Set("cpu", taskDefinition.Cpu)
+	d.Set("enable_fault_injection", taskDefinition.EnableFaultInjection)
+	if err := d.Set("ephemeral_storage", flattenEphemeralStorage(taskDefinition.EphemeralStorage)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting ephemeral_storage: %s", err)
+	}
 	d.Set(names.AttrExecutionRoleARN, taskDefinition.ExecutionRoleArn)
 	d.Set(names.AttrFamily, taskDefinition.Family)
+	if err := d.Set("inference_accelerator", flattenInferenceAccelerators(taskDefinition.InferenceAccelerators)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting inference_accelerator: %s", err)
+	}
+	d.Set("ipc_mode", taskDefinition.IpcMode)
+	d.Set("memory", taskDefinition.Memory)
 	d.Set("network_mode", taskDefinition.NetworkMode)
+	d.Set("pid_mode", taskDefinition.PidMode)
+	if err := d.Set("placement_constraints", flattenTaskDefinitionPlacementConstraints(taskDefinition.PlacementConstraints)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting placement_constraints: %s", err)
+	}
+	if err := d.Set("proxy_configuration", flattenProxyConfiguration(taskDefinition.ProxyConfiguration)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting proxy_configuration: %s", err)
+	}
+	d.Set("requires_compatibilities", taskDefinition.RequiresCompatibilities)
 	d.Set("revision", taskDefinition.Revision)
+	if err := d.Set("runtime_platform", flattenRuntimePlatform(taskDefinition.RuntimePlatform)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting runtime_platform: %s", err)
+	}
 	d.Set(names.AttrStatus, taskDefinition.Status)
 	d.Set("task_role_arn", taskDefinition.TaskRoleArn)
+	if err := d.Set("volume", flattenVolumes(taskDefinition.Volumes)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting volume: %s", err)
+	}
 
 	return diags
 }

--- a/internal/service/ecs/task_definition_data_source_test.go
+++ b/internal/service/ecs/task_definition_data_source_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccECSTaskDefinitionDataSource_ecsTaskDefinition(t *testing.T) {
+func TestAccECSTaskDefinitionDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ecs_task_definition.test"
 	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(5))
@@ -28,12 +28,127 @@ func TestAccECSTaskDefinitionDataSource_ecsTaskDefinition(t *testing.T) {
 				Config: testAccTaskDefinitionDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, "aws_ecs_task_definition.test", names.AttrARN),
+					resource.TestCheckResourceAttrSet(dataSourceName, "container_definitions"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrExecutionRoleARN, "aws_iam_role.execution", names.AttrARN),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrFamily, rName),
 					resource.TestCheckResourceAttr(dataSourceName, "network_mode", "bridge"),
 					resource.TestMatchResourceAttr(dataSourceName, "revision", regexache.MustCompile("^[1-9][0-9]*$")),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrStatus, "ACTIVE"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "task_role_arn", "aws_iam_role.test", names.AttrARN),
+				),
+			},
+		},
+	})
+}
+
+func TestAccECSTaskDefinitionDataSource_ec2(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ecs_task_definition.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskDefinitionDataSourceConfig_ec2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, "aws_ecs_task_definition.test", names.AttrARN),
+					resource.TestCheckResourceAttrSet(dataSourceName, "container_definitions"),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrFamily, rName),
+					resource.TestCheckResourceAttr(dataSourceName, "inference_accelerator.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "inference_accelerator.0.device_name", "device_1"),
+					resource.TestCheckResourceAttr(dataSourceName, "inference_accelerator.0.device_type", "eia1.medium"),
+					resource.TestCheckResourceAttr(dataSourceName, "ipc_mode", "host"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_mode", "awsvpc"),
+					resource.TestCheckResourceAttr(dataSourceName, "pid_mode", "host"),
+					resource.TestCheckResourceAttr(dataSourceName, "placement_constraints.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "placement_constraints.0.expression"),
+					resource.TestCheckResourceAttr(dataSourceName, "placement_constraints.0.type", "memberOf"),
+					resource.TestCheckResourceAttr(dataSourceName, "requires_compatibilities.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "requires_compatibilities.0", "EC2"),
+					resource.TestMatchResourceAttr(dataSourceName, "revision", regexache.MustCompile("^[1-9][0-9]*$")),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrStatus, "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.0.name", "service-storage"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.0.docker_volume_configuration.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.0.docker_volume_configuration.0.scope", "shared"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.0.docker_volume_configuration.0.autoprovision", acctest.CtTrue),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.0.docker_volume_configuration.0.driver", "local"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.0.docker_volume_configuration.0.driver_opts.type", "nfs"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.0.docker_volume_configuration.0.driver_opts.device", "test-efs.internal:/"),
+					resource.TestCheckResourceAttr(dataSourceName, "volume.0.docker_volume_configuration.0.driver_opts.o", "addr=test-efs.internal,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccECSTaskDefinitionDataSource_fargate(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ecs_task_definition.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskDefinitionDataSourceConfig_fargate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, "aws_ecs_task_definition.test", names.AttrARN),
+					resource.TestCheckResourceAttrSet(dataSourceName, "container_definitions"),
+					resource.TestCheckResourceAttr(dataSourceName, "cpu", "1024"),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrFamily, rName),
+					resource.TestCheckResourceAttr(dataSourceName, "enable_fault_injection", acctest.CtTrue),
+					resource.TestCheckResourceAttr(dataSourceName, "ephemeral_storage.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "ephemeral_storage.0.size_in_gib", "30"),
+					resource.TestCheckResourceAttr(dataSourceName, "memory", "8192"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_mode", "awsvpc"),
+					resource.TestCheckResourceAttr(dataSourceName, "requires_compatibilities.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "requires_compatibilities.0", "FARGATE"),
+					resource.TestMatchResourceAttr(dataSourceName, "revision", regexache.MustCompile("^[1-9][0-9]*$")),
+					resource.TestCheckResourceAttr(dataSourceName, "runtime_platform.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "runtime_platform.0.cpu_architecture", "X86_64"),
+					resource.TestCheckResourceAttr(dataSourceName, "runtime_platform.0.operating_system_family", "WINDOWS_SERVER_2022_CORE"),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrStatus, "ACTIVE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccECSTaskDefinitionDataSource_proxyConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_ecs_task_definition.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", sdkacctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaskDefinitionDataSourceConfig_proxyConfiguration(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, "aws_ecs_task_definition.test", names.AttrARN),
+					resource.TestCheckResourceAttrSet(dataSourceName, "container_definitions"),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrFamily, rName),
+					resource.TestCheckResourceAttr(dataSourceName, "network_mode", "awsvpc"),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_configuration.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_configuration.0.type", "APPMESH"),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_configuration.0.container_name", "web"),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_configuration.0.properties.AppPorts", "80"),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_configuration.0.properties.EgressIgnoredIPs", "169.254.170.2,169.254.169.254"),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_configuration.0.properties.EgressIgnoredPorts", "5500"),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_configuration.0.properties.IgnoredGID", "999"),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_configuration.0.properties.IgnoredUID", "1337"),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_configuration.0.properties.ProxyEgressPort", "15001"),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_configuration.0.properties.ProxyIngressPort", "15000"),
+					resource.TestMatchResourceAttr(dataSourceName, "revision", regexache.MustCompile("^[1-9][0-9]*$")),
+					resource.TestCheckResourceAttr(dataSourceName, names.AttrStatus, "ACTIVE"),
 				),
 			},
 		},
@@ -79,10 +194,10 @@ POLICY
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family             = %[1]q
   execution_role_arn = aws_iam_role.execution.arn
-  task_role_arn      = aws_iam_role.test.arn
+  family             = %[1]q
   network_mode       = "bridge"
+  task_role_arn      = aws_iam_role.test.arn
 
   container_definitions = <<DEFINITION
 [
@@ -99,6 +214,156 @@ resource "aws_ecs_task_definition" "test" {
     "memory": 128,
     "memoryReservation": 64,
     "name": "mongodb"
+  }
+]
+DEFINITION
+}
+
+data "aws_ecs_task_definition" "test" {
+  task_definition = aws_ecs_task_definition.test.family
+}
+`, rName)
+}
+
+func testAccTaskDefinitionDataSourceConfig_ec2(rName string) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_ecs_task_definition" "test" {
+  family                   = %[1]q
+  ipc_mode                 = "host"
+  network_mode             = "awsvpc"
+  pid_mode                 = "host"
+  requires_compatibilities = ["EC2"]
+
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 256,
+    "command": ["sleep", "360"],
+    "memory": 2048,
+    "essential": true,
+    "portMappings": [{"protocol": "tcp", "containerPort": 8000}],
+     "resourceRequirements": [
+      {
+        "type": "InferenceAccelerator",
+        "value": "device_1"
+      }
+    ]
+  }
+]
+TASK_DEFINITION
+
+  inference_accelerator {
+    device_name = "device_1"
+    device_type = "eia1.medium"
+  }
+
+  placement_constraints {
+    expression = "attribute:ecs.availability-zone in [${data.aws_availability_zones.available.names[0]}, ${data.aws_availability_zones.available.names[1]}]"
+    type       = "memberOf"
+  }
+
+  volume {
+    name = "service-storage"
+
+    docker_volume_configuration {
+      scope         = "shared"
+      autoprovision = true
+      driver        = "local"
+
+      driver_opts = {
+        "type"   = "nfs"
+        "device" = "test-efs.internal:/"
+        "o"      = "addr=test-efs.internal,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport"
+      }
+    }
+  }
+}
+
+data "aws_ecs_task_definition" "test" {
+  task_definition = aws_ecs_task_definition.test.family
+}
+`, rName)
+}
+
+func testAccTaskDefinitionDataSourceConfig_fargate(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_task_definition" "test" {
+  cpu                      = "1024"
+  enable_fault_injection   = true
+  family                   = %[1]q
+  memory                   = "8192"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 256,
+    "command": ["sleep", "360"],
+    "memory": 2048,
+    "essential": true,
+    "portMappings": [{"protocol": "tcp", "containerPort": 8000}]
+  }
+]
+TASK_DEFINITION
+
+  ephemeral_storage {
+    size_in_gib = 30
+  }
+
+  runtime_platform {
+    cpu_architecture        = "X86_64"
+    operating_system_family = "WINDOWS_SERVER_2022_CORE"
+  }
+}
+
+data "aws_ecs_task_definition" "test" {
+  task_definition = aws_ecs_task_definition.test.family
+}
+`, rName)
+}
+
+func testAccTaskDefinitionDataSourceConfig_proxyConfiguration(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_task_definition" "test" {
+  family       = %[1]q
+  network_mode = "awsvpc"
+
+  proxy_configuration {
+    type           = "APPMESH"
+    container_name = "web"
+    properties = {
+      AppPorts           = "80"
+      EgressIgnoredPorts = "5500"
+      EgressIgnoredIPs   = "169.254.170.2,169.254.169.254"
+      IgnoredGID         = "999"
+      IgnoredUID         = "1337"
+      ProxyIngressPort   = "15000"
+      ProxyEgressPort    = "15001"
+    }
+  }
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "nginx:latest",
+    "memory": 128,
+    "name": "web"
   }
 ]
 DEFINITION

--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -64,12 +64,98 @@ This data source supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `id` - ARN of the task definition.
 * `arn` - ARN of the task definition.
 * `arn_without_revision` - ARN of the Task Definition with the trailing `revision` removed. This may be useful for situations where the latest task definition is always desired. If a revision isn't specified, the latest ACTIVE revision is used. See the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_StartTask.html#ECS-StartTask-request-taskDefinition) for details.
-* `execution_role_arn` - ARN of the task execution role that the Amazon ECS container agent and the Docker.
-* `family` - Family of this task definition.
-* `network_mode` - Docker networking mode to use for the containers in this task.
-* `revision` - Revision of this task definition.
-* `status` - Status of this task definition.
-* `task_role_arn` - ARN of the IAM role that containers in this task can assume.
+* `container_definitions` - A list of valid [container definitions](http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html) provided as a single valid JSON document. Please note that you should only provide values that are part of the container definition document. For a detailed description of what parameters are available, see the [Task Definition Parameters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) section from the official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide).
+* `cpu` - Number of cpu units used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.
+* `enable_fault_injection` - Enables fault injection and allows for fault injection requests to be accepted from the task's containers. Default is `false`.
+* `ephemeral_storage` - The amount of ephemeral storage to allocate for the task. This parameter is used to expand the total amount of ephemeral storage available, beyond the default amount, for tasks hosted on AWS Fargate. See [Ephemeral Storage](#ephemeral_storage).
+* `execution_role_arn` - ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
+* `family` - A unique name for your task definition.
+The following arguments are optional:
+* `inference_accelerator` - Configuration block(s) with Inference Accelerators settings. [Detailed below.](#inference_accelerator)
+* `ipc_mode` - IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
+* `memory` - Amount (in MiB) of memory used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.
+* `network_mode` - Docker networking mode to use for the containers in the task. Valid values are `none`, `bridge`, `awsvpc`, and `host`.
+* `pid_mode` - Process namespace to use for the containers in the task. The valid values are `host` and `task`.
+* `placement_constraints` - Configuration block for rules that are taken into consideration during task placement. Maximum number of `placement_constraints` is `10`. [Detailed below](#placement_constraints).
+* `proxy_configuration` - Configuration block for the App Mesh proxy. [Detailed below.](#proxy_configuration)
+* `requires_compatibilities` - Set of launch types required by the task. The valid values are `EC2` and `FARGATE`.
+* `revision` - Revision of the task in a particular family.
+* `runtime_platform` - Configuration block for [runtime_platform](#runtime_platform) that containers in your task may use.
+* `status` - Status of the task definition.
+* `task_role_arn` - ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
+* `volume` - Configuration block for [volumes](#volume) that containers in your task may use. Detailed below.
+
+### ephemeral_storage
+
+* `size_in_gib` - The total amount, in GiB, of ephemeral storage to set for the task. The minimum supported value is `21` GiB and the maximum supported value is `200` GiB.
+
+### inference_accelerator
+
+* `device_name` - Elastic Inference accelerator device name. The deviceName must also be referenced in a container definition as a ResourceRequirement.
+* `device_type` - Elastic Inference accelerator type to use.
+
+### placement_constraints
+
+* `expression` -  Cluster Query Language expression to apply to the constraint. For more information, see [Cluster Query Language in the Amazon EC2 Container Service Developer Guide](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html).
+* `type` - Type of constraint. Use `memberOf` to restrict selection to a group of valid candidates. Note that `distinctInstance` is not supported in task definitions.
+
+### proxy_configuration
+
+* `container_name` - Name of the container that will serve as the App Mesh proxy.
+* `properties` - Set of network configuration parameters to provide the Container Network Interface (CNI) plugin, specified a key-value mapping.
+* `type` - Proxy type. The default value is `APPMESH`. The only supported value is `APPMESH`.
+
+### runtime_platform
+
+* `operating_system_family` - If the `requires_compatibilities` is `FARGATE` this field is required; must be set to a valid option from the [operating system family in the runtime platform](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#runtime-platform) setting
+* `cpu_architecture` - Must be set to either `X86_64` or `ARM64`; see [cpu architecture](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#runtime-platform)
+
+### volume
+
+* `configure_at_launch` - Whether the volume should be configured at launch time. This is used to create Amazon EBS volumes for standalone tasks or tasks created as part of a service. Each task definition revision may only have one volume configured at launch in the volume configuration.
+* `docker_volume_configuration` - Configuration block to configure a [docker volume](#docker_volume_configuration). Detailed below.
+* `efs_volume_configuration` - Configuration block for an [EFS volume](#efs_volume_configuration). Detailed below.
+* `fsx_windows_file_server_volume_configuration` - Configuration block for an [FSX Windows File Server volume](#fsx_windows_file_server_volume_configuration). Detailed below.
+* `host_path` - Path on the host container instance that is presented to the container. If not set, ECS will create a nonpersistent data volume that starts empty and is deleted after the task has finished.
+* `name` - Name of the volume. This name is referenced in the `sourceVolume`
+parameter of container definition in the `mountPoints` section.
+
+### docker_volume_configuration
+
+For more information, see [Specifying a Docker volume in your Task Definition Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-volumes.html#specify-volume-config)
+
+* `autoprovision` - If this value is `true`, the Docker volume is created if it does not already exist. *Note*: This field is only used if the scope is `shared`.
+* `driver_opts` - Map of Docker driver specific options.
+* `driver` - Docker volume driver to use. The driver value must match the driver name provided by Docker because it is used for task placement.
+* `labels` - Map of custom metadata to add to your Docker volume.
+* `scope` - Scope for the Docker volume, which determines its lifecycle, either `task` or `shared`.  Docker volumes that are scoped to a `task` are automatically provisioned when the task starts and destroyed when the task stops. Docker volumes that are scoped as `shared` persist after the task stops.
+
+### efs_volume_configuration
+
+For more information, see [Specifying an EFS volume in your Task Definition Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/efs-volumes.html#specify-efs-config)
+
+* `authorization_config` - Configuration block for [authorization](#efs_volume_configuration-authorization_config) for the Amazon EFS file system. Detailed below.
+* `file_system_id` - ID of the EFS File System.
+* `root_directory` - Directory within the Amazon EFS file system to mount as the root directory inside the host. If this parameter is omitted, the root of the Amazon EFS volume will be used. Specifying / will have the same effect as omitting this parameter. This argument is ignored when using `authorization_config`.
+* `transit_encryption` - Whether or not to enable encryption for Amazon EFS data in transit between the Amazon ECS host and the Amazon EFS server. Transit encryption must be enabled if Amazon EFS IAM authorization is used. Valid values: `ENABLED`, `DISABLED`. If this parameter is omitted, the default value of `DISABLED` is used.
+* `transit_encryption_port` - Port to use for transit encryption. If you do not specify a transit encryption port, it will use the port selection strategy that the Amazon EFS mount helper uses.
+
+#### efs_volume_configuration authorization_config
+
+* `access_point_id` - Access point ID to use. If an access point is specified, the root directory value will be relative to the directory set for the access point. If specified, transit encryption must be enabled in the EFSVolumeConfiguration.
+* `iam` - Whether or not to use the Amazon ECS task IAM role defined in a task definition when mounting the Amazon EFS file system. If enabled, transit encryption must be enabled in the EFSVolumeConfiguration. Valid values: `ENABLED`, `DISABLED`. If this parameter is omitted, the default value of `DISABLED` is used.
+
+### fsx_windows_file_server_volume_configuration
+
+For more information, see [Specifying an FSX Windows File Server volume in your Task Definition Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/tutorial-wfsx-volumes.html)
+
+* `file_system_id` - The Amazon FSx for Windows File Server file system ID to use.
+* `root_directory` - The directory within the Amazon FSx for Windows File Server file system to mount as the root directory inside the host.
+* `authorization_config` - Configuration block for [authorization](#fsx_windows_file_server_volume_configuration-authorization_config) for the Amazon FSx for Windows File Server file system detailed below.
+
+#### fsx_windows_file_server_volume_configuration authorization_config
+
+* `credentials_parameter` - The authorization credential option to use. The authorization credential options can be provided using either the Amazon Resource Name (ARN) of an AWS Secrets Manager secret or AWS Systems Manager Parameter Store parameter. The ARNs refer to the stored credentials.
+* `domain` - A fully qualified domain name hosted by an AWS Directory Service Managed Microsoft AD (Active Directory) or self-hosted AD on Amazon EC2.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the missing attributes (compared to the resource) for the `aws_ecs_task_definition` data source.

Note that unit tests depend on #41078 because it needs the `enable_fault_injection` argument in the resource. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40214

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [TaskDefinition](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TaskDefinition.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccECSTaskDefinitionDataSource_" PKG=ecs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestAccECSTaskDefinitionDataSource_'  -timeout 360m -vet=off
2025/01/25 21:01:42 Initializing Terraform AWS Provider...
=== RUN   TestAccECSTaskDefinitionDataSource_basic
=== PAUSE TestAccECSTaskDefinitionDataSource_basic
=== RUN   TestAccECSTaskDefinitionDataSource_ec2
=== PAUSE TestAccECSTaskDefinitionDataSource_ec2
=== RUN   TestAccECSTaskDefinitionDataSource_fargate
=== PAUSE TestAccECSTaskDefinitionDataSource_fargate
=== RUN   TestAccECSTaskDefinitionDataSource_proxyConfiguration
=== PAUSE TestAccECSTaskDefinitionDataSource_proxyConfiguration
=== CONT  TestAccECSTaskDefinitionDataSource_basic
=== CONT  TestAccECSTaskDefinitionDataSource_fargate
=== CONT  TestAccECSTaskDefinitionDataSource_proxyConfiguration
=== CONT  TestAccECSTaskDefinitionDataSource_ec2

$
```
