### PR TITLE
feat: Add kms_key_identifier arg for aws_pipes_pipe

### DIFF
--- a/.changelog/41082.txt
+++ b/.changelog/41082.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_pipes_pipe: Add `kms_key_identifier` argument
+```

--- a/website/docs/r/pipes_pipe.html.markdown
+++ b/website/docs/r/pipes_pipe.html.markdown
@@ -205,6 +205,7 @@ The following arguments are optional:
 * `desired_state` - (Optional) The state the pipe should be in. One of: `RUNNING`, `STOPPED`.
 * `enrichment` - (Optional) Enrichment resource of the pipe (typically an ARN). Read more about enrichment in the [User Guide](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes.html#pipes-enrichment).
 * `enrichment_parameters` - (Optional) Parameters to configure enrichment for your pipe. Detailed below.
+* `kms_key_identifier` - (Optional) Identifier of the AWS KMS customer managed key for EventBridge to use, if you choose to use a customer managed key to encrypt pipe data. The identifier can be the key Amazon Resource Name (ARN), KeyId, key alias, or key alias ARN. If not set, EventBridge uses an AWS owned key to encrypt pipe data.
 * `log_configuration` - (Optional) Logging configuration settings for the pipe. Detailed below.
 * `name` - (Optional) Name of the pipe. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `kms_key_identifier` argument to the `aws_pipes_pipe` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39288

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreatePipe](https://docs.aws.amazon.com/eventbridge/latest/pipes-reference/API_CreatePipe.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc "TESTS=TestAccPipesPipe_basicSQS|TestAccPipesPipe_kmsKeyIdentifier" PKG=pipes
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/pipes/... -v -count 1 -parallel 20 -run='TestAccPipesPipe_basicSQS|TestAccPipesPipe_kmsKeyIdentifier'  -timeout 360m -vet=off
2025/01/25 23:29:01 Initializing Terraform AWS Provider...
=== RUN   TestAccPipesPipe_basicSQS
=== PAUSE TestAccPipesPipe_basicSQS
=== RUN   TestAccPipesPipe_kmsKeyIdentifier
=== PAUSE TestAccPipesPipe_kmsKeyIdentifier
=== CONT  TestAccPipesPipe_basicSQS
=== CONT  TestAccPipesPipe_kmsKeyIdentifier
--- PASS: TestAccPipesPipe_basicSQS (79.31s)
--- PASS: TestAccPipesPipe_kmsKeyIdentifier (140.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/pipes      140.276s

$
```
