### PR TITLE
feat: Add arn attribute to aws_ec2_transit_gateway_vpc_attachment resource and data source

### DIFF
--- a/.changelog/41084.txt
+++ b/.changelog/41084.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_ec2_transit_gateway_vpc_attachment: Add `arn` attribute
+```
+
+```release-note:enhancement
+data-source/aws_ec2_transit_gateway_vpc_attachment: Add `arn` attribute
+```

--- a/internal/service/ec2/transitgateway_vpc_attachment_data_source.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_data_source.go
@@ -5,9 +5,11 @@ package ec2
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -31,6 +33,10 @@ func dataSourceTransitGatewayVPCAttachment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"appliance_mode_support": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrARN: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -101,13 +107,22 @@ func dataSourceTransitGatewayVPCAttachmentRead(ctx context.Context, d *schema.Re
 
 	d.SetId(aws.ToString(transitGatewayVPCAttachment.TransitGatewayAttachmentId))
 	d.Set("appliance_mode_support", transitGatewayVPCAttachment.Options.ApplianceModeSupport)
+	vpcOwnerID := aws.ToString(transitGatewayVPCAttachment.VpcOwnerId)
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition(ctx),
+		Service:   names.EC2,
+		Region:    meta.(*conns.AWSClient).Region(ctx),
+		AccountID: vpcOwnerID,
+		Resource:  fmt.Sprintf("transit-gateway-attachment/%s", d.Id()),
+	}.String()
+	d.Set(names.AttrARN, arn)
 	d.Set("dns_support", transitGatewayVPCAttachment.Options.DnsSupport)
 	d.Set("ipv6_support", transitGatewayVPCAttachment.Options.Ipv6Support)
 	d.Set("security_group_referencing_support", transitGatewayVPCAttachment.Options.SecurityGroupReferencingSupport)
 	d.Set(names.AttrSubnetIDs, transitGatewayVPCAttachment.SubnetIds)
 	d.Set(names.AttrTransitGatewayID, transitGatewayVPCAttachment.TransitGatewayId)
 	d.Set(names.AttrVPCID, transitGatewayVPCAttachment.VpcId)
-	d.Set("vpc_owner_id", transitGatewayVPCAttachment.VpcOwnerId)
+	d.Set("vpc_owner_id", vpcOwnerID)
 
 	setTagsOut(ctx, transitGatewayVPCAttachment.Tags)
 

--- a/internal/service/ec2/transitgateway_vpc_attachment_data_source_test.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_data_source_test.go
@@ -33,6 +33,7 @@ func testAccTransitGatewayVPCAttachmentDataSource_Filter(t *testing.T, semaphore
 			{
 				Config: testAccTransitGatewayVPCAttachmentDataSourceConfig_filter(rName),
 				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, dataSourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttrPair(resourceName, "appliance_mode_support", dataSourceName, "appliance_mode_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "dns_support", dataSourceName, "dns_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_referencing_support", dataSourceName, "security_group_referencing_support"),
@@ -67,6 +68,7 @@ func testAccTransitGatewayVPCAttachmentDataSource_ID(t *testing.T, semaphore tfs
 			{
 				Config: testAccTransitGatewayVPCAttachmentDataSourceConfig_id(rName),
 				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, dataSourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttrPair(resourceName, "appliance_mode_support", dataSourceName, "appliance_mode_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "dns_support", dataSourceName, "dns_support"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_referencing_support", dataSourceName, "security_group_referencing_support"),

--- a/internal/service/ec2/transitgateway_vpc_attachment_test.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_test.go
@@ -50,6 +50,7 @@ func testAccTransitGatewayVPCAttachment_basic(t *testing.T, semaphore tfsync.Sem
 				Config: testAccTransitGatewayVPCAttachmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayVPCAttachmentExists(ctx, resourceName, &transitGatewayVpcAttachment1),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "dns_support", string(awstypes.DnsSupportValueEnable)),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_support", string(awstypes.Ipv6SupportValueDisable)),
 					resource.TestCheckResourceAttr(resourceName, "security_group_referencing_support", string(awstypes.SecurityGroupReferencingSupportValueEnable)),

--- a/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -47,6 +47,7 @@ This data source supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
+* `arn` - ARN of the attachment.
 * `appliance_mode_support` - Whether Appliance Mode support is enabled.
 * `dns_support` - Whether DNS support is enabled.
 * `security_group_referencing_support` - Whether Security Group Referencing Support is enabled.

--- a/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_vpc_attachment.html.markdown
@@ -41,7 +41,8 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - EC2 Transit Gateway Attachment identifier
+* `arn` - ARN of the attachment.
+* `id` - EC2 Transit Gateway Attachment identifier.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `vpc_owner_id` - Identifier of the AWS account that owns the EC2 VPC.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The PR is to add the (calculated) `arn` attribute to the `aws_ec2_transit_gateway_vpc_attachment` resource and data source.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #40923 (partly resolves it)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to ARN format in [Actions, resources, and condition keys for Amazon EC2](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html#amazonec2-transit-gateway-attachment) as referenced in the original GitHub issue.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

For the `aws_ec2_transit_gateway_vpc_attachment` resource:

```console
$ make testacc TESTS=TestAccTransitGateway_serial/VpcAttachment_basic PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccTransitGateway_serial/VpcAttachment_basic'  -timeout 360m -vet=off
2025/01/26 14:41:14 Initializing Terraform AWS Provider...
=== RUN   TestAccTransitGateway_serial
=== PAUSE TestAccTransitGateway_serial
=== CONT  TestAccTransitGateway_serial
=== RUN   TestAccTransitGateway_serial/VpcAttachment_basic
=== PAUSE TestAccTransitGateway_serial/VpcAttachment_basic
=== CONT  TestAccTransitGateway_serial/VpcAttachment_basic
--- PASS: TestAccTransitGateway_serial (0.00s)
    --- PASS: TestAccTransitGateway_serial/VpcAttachment_basic (288.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        289.211s

$
```

For the `aws_ec2_transit_gateway_vpc_attachment` data source:

```console
$ make testacc TESTS=TestAccTransitGatewayDataSource_serial/VpnAttachment PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccTransitGatewayDataSource_serial/VpnAttachment'  -timeout 360m -vet=off
2025/01/26 14:46:58 Initializing Terraform AWS Provider...
=== RUN   TestAccTransitGatewayDataSource_serial
=== PAUSE TestAccTransitGatewayDataSource_serial
=== CONT  TestAccTransitGatewayDataSource_serial
=== RUN   TestAccTransitGatewayDataSource_serial/VpnAttachment_Filter
=== PAUSE TestAccTransitGatewayDataSource_serial/VpnAttachment_Filter
=== RUN   TestAccTransitGatewayDataSource_serial/VpnAttachment_TransitGatewayIdAndVpnConnectionId
=== PAUSE TestAccTransitGatewayDataSource_serial/VpnAttachment_TransitGatewayIdAndVpnConnectionId
=== CONT  TestAccTransitGatewayDataSource_serial/VpnAttachment_Filter
=== CONT  TestAccTransitGatewayDataSource_serial/VpnAttachment_TransitGatewayIdAndVpnConnectionId
--- PASS: TestAccTransitGatewayDataSource_serial (0.00s)
    --- PASS: TestAccTransitGatewayDataSource_serial/VpnAttachment_TransitGatewayIdAndVpnConnectionId (411.24s)
    --- PASS: TestAccTransitGatewayDataSource_serial/VpnAttachment_Filter (411.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        411.728s

$
```
