### PR TITLE
feat: Add arn attribute to aws_ec2_transit_gateway_dx_gateway_attachment data source

### DIFF
--- a/.changelog/41086.txt
+++ b/.changelog/41086.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ec2_transit_gateway_dx_gateway_attachment: Add `arn` attribute
+```

--- a/internal/service/ec2/transitgateway_dx_gateway_attachment_data_source.go
+++ b/internal/service/ec2/transitgateway_dx_gateway_attachment_data_source.go
@@ -5,9 +5,11 @@ package ec2
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -31,6 +33,10 @@ func dataSourceTransitGatewayDxGatewayAttachment() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"dx_gateway_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -85,6 +91,15 @@ func dataSourceTransitGatewayDxGatewayAttachmentRead(ctx context.Context, d *sch
 	}
 
 	d.SetId(aws.ToString(transitGatewayAttachment.TransitGatewayAttachmentId))
+	resourceOwnerID := aws.ToString(transitGatewayAttachment.ResourceOwnerId)
+	arn := arn.ARN{
+		Partition: meta.(*conns.AWSClient).Partition(ctx),
+		Service:   names.EC2,
+		Region:    meta.(*conns.AWSClient).Region(ctx),
+		AccountID: resourceOwnerID,
+		Resource:  fmt.Sprintf("transit-gateway-attachment/%s", d.Id()),
+	}.String()
+	d.Set(names.AttrARN, arn)
 	d.Set("dx_gateway_id", transitGatewayAttachment.ResourceId)
 	d.Set(names.AttrTransitGatewayID, transitGatewayAttachment.TransitGatewayId)
 

--- a/internal/service/ec2/transitgateway_dx_gateway_attachment_data_source_test.go
+++ b/internal/service/ec2/transitgateway_dx_gateway_attachment_data_source_test.go
@@ -35,6 +35,7 @@ func testAccTransitGatewayDxGatewayAttachmentDataSource_TransitGatewayIdAndDxGat
 			{
 				Config: testAccTransitGatewayDxGatewayAttachmentDataSourceConfig_transit(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, dataSourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "dx_gateway_id", dxGatewayResourceName, names.AttrID),
 					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrTransitGatewayID, transitGatewayResourceName, names.AttrID),
@@ -65,6 +66,7 @@ func testAccTransitGatewayDxGatewayAttachmentDataSource_filter(t *testing.T, sem
 			{
 				Config: testAccTransitGatewayDxGatewayAttachmentDataSourceConfig_transitFilter(rName, rBgpAsn),
 				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, dataSourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "dx_gateway_id", dxGatewayResourceName, names.AttrID),
 					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrTransitGatewayID, transitGatewayResourceName, names.AttrID),

--- a/website/docs/d/ec2_transit_gateway_dx_gateway_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_dx_gateway_attachment.html.markdown
@@ -41,8 +41,9 @@ The `filter` configuration block supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `id` - EC2 Transit Gateway Attachment identifier
-* `tags` - Key-value tags for the EC2 Transit Gateway Attachment
+* `arn` - ARN of the attachment.
+* `id` - EC2 Transit Gateway Attachment identifier,
+* `tags` - Key-value tags for the EC2 Transit Gateway Attachment.
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The PR is to add the (calculated) `arn` attribute to the `aws_ec2_transit_gateway_dx_gateway_attachment` data source.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #40923 (partly resolves it)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to ARN format in [Actions, resources, and condition keys for Amazon EC2](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html#amazonec2-transit-gateway-attachment) as referenced in the original GitHub issue.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccTransitGatewayDataSource_serial/DxGatewayAttachment PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccTransitGatewayDataSource_serial/DxGatewayAttachment'  -timeout 360m -vet=off
2025/01/26 15:04:30 Initializing Terraform AWS Provider...
=== RUN   TestAccTransitGatewayDataSource_serial
=== PAUSE TestAccTransitGatewayDataSource_serial
=== CONT  TestAccTransitGatewayDataSource_serial
=== RUN   TestAccTransitGatewayDataSource_serial/DxGatewayAttachment_Filter
=== PAUSE TestAccTransitGatewayDataSource_serial/DxGatewayAttachment_Filter
=== RUN   TestAccTransitGatewayDataSource_serial/DxGatewayAttachment_TransitGatewayIdAndDxGatewayId
=== PAUSE TestAccTransitGatewayDataSource_serial/DxGatewayAttachment_TransitGatewayIdAndDxGatewayId
=== CONT  TestAccTransitGatewayDataSource_serial/DxGatewayAttachment_Filter
=== CONT  TestAccTransitGatewayDataSource_serial/DxGatewayAttachment_TransitGatewayIdAndDxGatewayId
--- PASS: TestAccTransitGatewayDataSource_serial (0.00s)
    --- PASS: TestAccTransitGatewayDataSource_serial/DxGatewayAttachment_TransitGatewayIdAndDxGatewayId (1319.43s)
    --- PASS: TestAccTransitGatewayDataSource_serial/DxGatewayAttachment_Filter (1319.54s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        1319.824s

$
```
