### PR TITLE
feat: Add arn attribute to aws_ec2_transit_gateway_peering_attachment resource and data source

### DIFF
--- a/.changelog/41087.txt
+++ b/.changelog/41087.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_ec2_transit_gateway_peering_attachment: Add `arn` attribute
+```
+
+```release-note:enhancement
+data-source/aws_ec2_transit_gateway_peering_attachment: Add `arn` attribute
+```

--- a/internal/service/ec2/transitgateway_peering_attachment_data_source_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_data_source_test.go
@@ -32,6 +32,7 @@ func testAccTransitGatewayPeeringAttachmentDataSource_Filter_sameAccount(t *test
 			{
 				Config: testAccTransitGatewayPeeringAttachmentDataSourceConfig_filterSameAccount(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, dataSourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_account_id", dataSourceName, "peer_account_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_region", dataSourceName, "peer_region"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_transit_gateway_id", dataSourceName, "peer_transit_gateway_id"),
@@ -65,6 +66,7 @@ func testAccTransitGatewayPeeringAttachmentDataSource_Filter_differentAccount(t 
 			{
 				Config: testAccTransitGatewayPeeringAttachmentDataSourceConfig_filterDifferentAccount(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, dataSourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttrPair(transitGatewayResourceName, names.AttrOwnerID, dataSourceName, "peer_account_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "peer_region", acctest.Region()),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_transit_gateway_id", dataSourceName, names.AttrTransitGatewayID),
@@ -95,6 +97,7 @@ func testAccTransitGatewayPeeringAttachmentDataSource_ID_sameAccount(t *testing.
 			{
 				Config: testAccTransitGatewayPeeringAttachmentDataSourceConfig_idSameAccount(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, dataSourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_account_id", dataSourceName, "peer_account_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_region", dataSourceName, "peer_region"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_transit_gateway_id", dataSourceName, "peer_transit_gateway_id"),
@@ -127,6 +130,7 @@ func testAccTransitGatewayPeeringAttachmentDataSource_ID_differentAccount(t *tes
 			{
 				Config: testAccTransitGatewayPeeringAttachmentDataSourceConfig_iDDifferentAccount(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, dataSourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttrPair(transitGatewayResourceName, names.AttrOwnerID, dataSourceName, "peer_account_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "peer_region", acctest.Region()),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_transit_gateway_id", dataSourceName, names.AttrTransitGatewayID),
@@ -157,6 +161,7 @@ func testAccTransitGatewayPeeringAttachmentDataSource_Tags(t *testing.T, semapho
 			{
 				Config: testAccTransitGatewayPeeringAttachmentDataSourceConfig_tagsSameAccount(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, dataSourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_account_id", dataSourceName, "peer_account_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_region", dataSourceName, "peer_region"),
 					resource.TestCheckResourceAttrPair(resourceName, "peer_transit_gateway_id", dataSourceName, "peer_transit_gateway_id"),

--- a/internal/service/ec2/transitgateway_peering_attachment_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_test.go
@@ -43,6 +43,7 @@ func testAccTransitGatewayPeeringAttachment_basic(t *testing.T, semaphore tfsync
 				Config: testAccTransitGatewayPeeringAttachmentConfig_sameAccount(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTransitGatewayPeeringAttachmentExists(ctx, resourceName, &transitGatewayPeeringAttachment),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "ec2", "transit-gateway-attachment/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "options.#", "0"),
 					acctest.CheckResourceAttrAccountID(ctx, resourceName, "peer_account_id"),
 					resource.TestCheckResourceAttr(resourceName, "peer_region", acctest.AlternateRegion()),

--- a/website/docs/d/ec2_transit_gateway_peering_attachment.html.markdown
+++ b/website/docs/d/ec2_transit_gateway_peering_attachment.html.markdown
@@ -52,10 +52,11 @@ which take the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `peer_account_id` - Identifier of the peer AWS account
-* `peer_region` - Identifier of the peer AWS region
-* `peer_transit_gateway_id` - Identifier of the peer EC2 Transit Gateway
-* `transit_gateway_id` - Identifier of the local EC2 Transit Gateway
+* `arn` - ARN of the attachment.
+* `peer_account_id` - Identifier of the peer AWS account.
+* `peer_region` - Identifier of the peer AWS region.
+* `peer_transit_gateway_id` - Identifier of the peer EC2 Transit Gateway.
+* `transit_gateway_id` - Identifier of the local EC2 Transit Gateway.
 
 ## Timeouts
 

--- a/website/docs/r/ec2_transit_gateway_peering_attachment.html.markdown
+++ b/website/docs/r/ec2_transit_gateway_peering_attachment.html.markdown
@@ -79,7 +79,8 @@ The `options` block supports the following:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - EC2 Transit Gateway Attachment identifier
+* `arn` - ARN of the attachment.
+* `id` - EC2 Transit Gateway Attachment identifier.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The PR is to add the (calculated) `arn` attribute to the `aws_ec2_transit_gateway_peering_attachment` resource and data source.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40923 (along with #41084 and #41086)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to ARN format in [Actions, resources, and condition keys for Amazon EC2](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html#amazonec2-transit-gateway-attachment) as referenced in the original GitHub issue.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

For the `aws_ec2_transit_gateway_peering_attachment` resource:

```console
$ make testacc TESTS=TestAccTransitGateway_serial/PeeringAttachment_basic PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccTransitGateway_serial/PeeringAttachment_basic'  -timeout 360m -vet=off
2025/01/26 15:49:04 Initializing Terraform AWS Provider...
=== RUN   TestAccTransitGateway_serial
=== PAUSE TestAccTransitGateway_serial
=== CONT  TestAccTransitGateway_serial
=== RUN   TestAccTransitGateway_serial/PeeringAttachment_basic
=== PAUSE TestAccTransitGateway_serial/PeeringAttachment_basic
=== CONT  TestAccTransitGateway_serial/PeeringAttachment_basic
--- PASS: TestAccTransitGateway_serial (0.00s)
    --- PASS: TestAccTransitGateway_serial/PeeringAttachment_basic (267.14s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        267.372s

$
```

For the `aws_ec2_transit_gateway_peering_attachment` data source:

```console
$ make testacc TESTS=TestAccTransitGatewayDataSource_serial/PeeringAttachment PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccTransitGatewayDataSource_serial/PeeringAttachment'  -timeout 360m -vet=off
2025/01/26 15:42:54 Initializing Terraform AWS Provider...
=== RUN   TestAccTransitGatewayDataSource_serial
=== PAUSE TestAccTransitGatewayDataSource_serial
=== CONT  TestAccTransitGatewayDataSource_serial
=== RUN   TestAccTransitGatewayDataSource_serial/PeeringAttachments_Filter
=== PAUSE TestAccTransitGatewayDataSource_serial/PeeringAttachments_Filter
=== RUN   TestAccTransitGatewayDataSource_serial/PeeringAttachment_IDDifferentAccount
=== PAUSE TestAccTransitGatewayDataSource_serial/PeeringAttachment_IDDifferentAccount
=== RUN   TestAccTransitGatewayDataSource_serial/PeeringAttachment_Tags
=== PAUSE TestAccTransitGatewayDataSource_serial/PeeringAttachment_Tags
=== RUN   TestAccTransitGatewayDataSource_serial/PeeringAttachment_FilterSameAccount
=== PAUSE TestAccTransitGatewayDataSource_serial/PeeringAttachment_FilterSameAccount
=== RUN   TestAccTransitGatewayDataSource_serial/PeeringAttachment_FilterDifferentAccount
=== PAUSE TestAccTransitGatewayDataSource_serial/PeeringAttachment_FilterDifferentAccount
=== RUN   TestAccTransitGatewayDataSource_serial/PeeringAttachment_IDSameAccount
=== PAUSE TestAccTransitGatewayDataSource_serial/PeeringAttachment_IDSameAccount
=== CONT  TestAccTransitGatewayDataSource_serial/PeeringAttachments_Filter
=== CONT  TestAccTransitGatewayDataSource_serial/PeeringAttachment_FilterSameAccount
=== CONT  TestAccTransitGatewayDataSource_serial/PeeringAttachment_IDSameAccount
=== CONT  TestAccTransitGatewayDataSource_serial/PeeringAttachment_FilterDifferentAccount
=== CONT  TestAccTransitGatewayDataSource_serial/PeeringAttachment_Tags
=== CONT  TestAccTransitGatewayDataSource_serial/PeeringAttachment_IDDifferentAccount
=== NAME  TestAccTransitGatewayDataSource_serial/PeeringAttachment_FilterDifferentAccount
    transitgateway_peering_attachment_data_source_test.go:61: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
=== NAME  TestAccTransitGatewayDataSource_serial/PeeringAttachment_IDDifferentAccount
    transitgateway_peering_attachment_data_source_test.go:125: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- PASS: TestAccTransitGatewayDataSource_serial (0.00s)
    --- SKIP: TestAccTransitGatewayDataSource_serial/PeeringAttachment_FilterDifferentAccount (0.94s)
    --- SKIP: TestAccTransitGatewayDataSource_serial/PeeringAttachment_IDDifferentAccount (0.95s)
    --- PASS: TestAccTransitGatewayDataSource_serial/PeeringAttachment_FilterSameAccount (272.80s)
    --- PASS: TestAccTransitGatewayDataSource_serial/PeeringAttachment_IDSameAccount (303.04s)
    --- PASS: TestAccTransitGatewayDataSource_serial/PeeringAttachments_Filter (303.54s)
    --- PASS: TestAccTransitGatewayDataSource_serial/PeeringAttachment_Tags (303.68s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        303.926s

$
```
