### PR TITLE
chore: Remove reamining use of deprecated strings.Title function and its linter exclusion

### DIFF
--- a/.ci/.golangci4.yml
+++ b/.ci/.golangci4.yml
@@ -23,10 +23,6 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019: \\w+.\\w+ is deprecated: Use \\w+Context or \\w+WithoutTimeout instead"
-      # go: strings.Title
-    - linters:
-        - staticcheck
-      text: "SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0"
     # Per-Service
     - linters:
         - staticcheck

--- a/internal/service/workspaces/ip_group_test.go
+++ b/internal/service/workspaces/ip_group_test.go
@@ -26,7 +26,7 @@ func testAccIPGroup_basic(t *testing.T) {
 	var v types.WorkspacesIpGroup
 	ipGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	ipGroupNewName := sdkacctest.RandomWithPrefix("tf-acc-test-upd")
-	ipGroupDescription := fmt.Sprintf("Terraform Acceptance Test %s", strings.Title(sdkacctest.RandString(20)))
+	ipGroupDescription := fmt.Sprintf("Terraform Acceptance Test %s", sdkacctest.RandString(20))
 	resourceName := "aws_workspaces_ip_group.test"
 
 	resource.Test(t, resource.TestCase{
@@ -118,7 +118,7 @@ func testAccIPGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.WorkspacesIpGroup
 	ipGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	ipGroupDescription := fmt.Sprintf("Terraform Acceptance Test %s", strings.Title(sdkacctest.RandString(20)))
+	ipGroupDescription := fmt.Sprintf("Terraform Acceptance Test %s", sdkacctest.RandString(20))
 	resourceName := "aws_workspaces_ip_group.test"
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to remove the remaining use of deprecated function `strings.Title` and the associated linter exclusion.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30321

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccWorkSpaces_serial/IpGroup/ PKG=workspaces
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/workspaces/... -v -count 1 -parallel 20 -run='TestAccWorkSpaces_serial/IpGroup/'  -timeout 360m -vet=off
2025/01/26 16:59:03 Initializing Terraform AWS Provider...
=== RUN   TestAccWorkSpaces_serial
=== PAUSE TestAccWorkSpaces_serial
=== CONT  TestAccWorkSpaces_serial
=== RUN   TestAccWorkSpaces_serial/IpGroup
=== RUN   TestAccWorkSpaces_serial/IpGroup/basic
=== RUN   TestAccWorkSpaces_serial/IpGroup/disappears
=== RUN   TestAccWorkSpaces_serial/IpGroup/multipleDirectories
=== RUN   TestAccWorkSpaces_serial/IpGroup/tags
--- PASS: TestAccWorkSpaces_serial (884.06s)
    --- PASS: TestAccWorkSpaces_serial/IpGroup (884.06s)
        --- PASS: TestAccWorkSpaces_serial/IpGroup/basic (29.34s)
        --- PASS: TestAccWorkSpaces_serial/IpGroup/disappears (13.13s)
        --- PASS: TestAccWorkSpaces_serial/IpGroup/multipleDirectories (806.39s)
        --- PASS: TestAccWorkSpaces_serial/IpGroup/tags (35.20s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/workspaces 884.348s

$
```
