### PR TITLE
Tech debt: Fix `goreleaser` error `• DEPRECATED: archives.format should not be used any more`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ archives:
       # Ensure only built binary and license file are archived
       - src: LICENSE
         dst: LICENSE.txt
-    format: zip
+    formats: ['zip']
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 before:
   hooks:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes goreleaser error: https://github.com/hashicorp/terraform-provider-aws/actions/runs/12956906005/job/36144213625.

```
Run goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf
  with:
    args: check
    distribution: goreleaser
    version: ~> v[2](https://github.com/hashicorp/terraform-provider-aws/actions/runs/12956906005/job/36144213625#step:5:2)
    workdir: .
    install-only: false
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.6.1/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/8dd0f82d-0[3](https://github.com/hashicorp/terraform-provider-aws/actions/runs/12956906005/job/36144213625#step:5:3)a1-4470-a496-dbdfbf05f21[4](https://github.com/hashicorp/terraform-provider-aws/actions/runs/12956906005/job/36144213625#step:5:4) -f /home/runner/work/_temp/666[5](https://github.com/hashicorp/terraform-provider-aws/actions/runs/12956906005/job/36144213625#step:5:5)3c5a-7c35-4540-a70c-1ceb2d48b88f
GoReleaser ~> v2 installed successfully
/opt/hostedtoolcache/goreleaser-action/2.[6](https://github.com/hashicorp/terraform-provider-aws/actions/runs/12956906005/job/36144213625#step:5:6).1/x64/goreleaser check
  • checking                                 path=.goreleaser.yml
  • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.6.1/x64/goreleaser' failed with exit code 2
```

See https://goreleaser.com/deprecations/#archivesformat.