### PR TITLE
fix: `aws_dms_replication_task` - type assertion to avoid nil pointer panics

### DIFF
--- a/.changelog/41096.txt
+++ b/.changelog/41096.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dms_replication_task: Fix `panic: interface conversion: interface {} is float64, not string`
+```

--- a/internal/service/dms/task_settings_json.go
+++ b/internal/service/dms/task_settings_json.go
@@ -76,18 +76,19 @@ func taskSettingsEqual(state, proposed any) bool {
 		return x == p
 
 	case map[string]any:
-		proposedMap, ok := proposed.(map[string]any)
+		p, ok := proposed.(map[string]any)
 		if !ok {
 			return false
 		}
 		for k, v := range x {
-			if !taskSettingsEqual(v, proposedMap[k]) {
+			if !taskSettingsEqual(v, p[k]) {
 				return false
 			}
-			delete(proposedMap, k)
+			delete(p, k)
 		}
-		return len(proposedMap) == 0
+		return len(p) == 0
 	}
+
 	return false
 }
 

--- a/internal/service/dms/task_settings_json.go
+++ b/internal/service/dms/task_settings_json.go
@@ -55,19 +55,31 @@ func taskSettingsEqual(state, proposed any) bool {
 
 	switch x := state.(type) {
 	case bool:
-		p := proposed.(bool)
+		p, ok := proposed.(bool)
+		if !ok {
+			return false
+		}
 		return x == p
 
 	case float64:
-		p := proposed.(float64)
+		p, ok := proposed.(float64)
+		if !ok {
+			return false
+		}
 		return x == p
 
 	case string:
-		p := proposed.(string)
+		p, ok := proposed.(string)
+		if !ok {
+			return false
+		}
 		return x == p
 
 	case map[string]any:
-		proposedMap := proposed.(map[string]any)
+		proposedMap, ok := proposed.(map[string]any)
+		if !ok {
+			return false
+		}
 		for k, v := range x {
 			if !taskSettingsEqual(v, proposedMap[k]) {
 				return false

--- a/internal/service/dms/task_settings_json_test.go
+++ b/internal/service/dms/task_settings_json_test.go
@@ -54,6 +54,11 @@ func TestTaskSettingsEqual(t *testing.T) {
 				b:        false,
 				expected: false,
 			},
+			"incompatible types": {
+				a:        true,
+				b:        acctest.CtTrue,
+				expected: false,
+			},
 		},
 		"float64": {
 			"equal": {
@@ -74,6 +79,11 @@ func TestTaskSettingsEqual(t *testing.T) {
 			"null proposed value": {
 				a:        nil,
 				b:        float64(1),
+				expected: false,
+			},
+			"incompatible types": {
+				a:        float64(1),
+				b:        "1",
 				expected: false,
 			},
 		},
@@ -101,6 +111,11 @@ func TestTaskSettingsEqual(t *testing.T) {
 			"null proposed value": {
 				a:        nil,
 				b:        names.AttrValue,
+				expected: false,
+			},
+			"incompatible types": {
+				a:        names.AttrValue,
+				b:        false,
 				expected: false,
 			},
 		},
@@ -149,6 +164,21 @@ func TestTaskSettingsEqual(t *testing.T) {
 					},
 				},
 				expected: true,
+			},
+			"incompatible types": {
+				a: map[string]any{
+					acctest.CtKey1: names.AttrValue,
+					acctest.CtKey2: map[string]any{
+						"key3": names.AttrValue,
+					},
+				},
+				b: map[int]any{
+					0: names.AttrValue,
+					1: map[int]any{
+						10: names.AttrValue,
+					},
+				},
+				expected: false,
 			},
 		},
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The task setting validation has no proper type assertion what results into broken plan change when the types cannot be converted (or do not match):
```
  ╷
  │ Error: Request cancelled
  │ 
  │   with module.database_migration_service.aws_dms_replication_task.this["cdc_ex"],
  │   on .terraform/modules/database_migration_service/main.tf line 386, in resource "aws_dms_replication_task" "this":
  │  386: resource "aws_dms_replication_task" "this" {
  │ 
  │ The plugin.(*GRPCProvider).PlanResourceChange request was cancelled.
  ╵
  
  Stack trace from the terraform-provider-aws_v5.84.0_x5 plugin:
  
  panic: interface conversion: interface {} is float64, not string
  
  goroutine 510 [running]:
  github.com/hashicorp/terraform-provider-aws/internal/service/dms.taskSettingsEqual({0x17942720?, 0xc003096680?}, {0x17942ae0?, 0x26d94220?})
  	github.com/hashicorp/terraform-provider-aws/internal/service/dms/task_settings_json.go:66 +0x1e9
  github.com/hashicorp/terraform-provider-aws/internal/service/dms.taskSettingsEqual({0x18187520?, 0xc002fe99b0?}, {0x18187520?, 0xc002fe9b60})
  	github.com/hashicorp/terraform-provider-aws/internal/service/dms/task_settings_json.go:72 +0x26c
  github.com/hashicorp/terraform-provider-aws/internal/service/dms.taskSettingsEqual({0x18187520?, 0xc002fe9980?}, {0x18187520?, 0xc002fe9b30})
  	github.com/hashicorp/terraform-provider-aws/internal/service/dms/task_settings_json.go:72 +0x26c
  github.com/hashicorp/terraform-provider-aws/internal/service/dms.taskSettingsEqual({0x18187520?, 0xc002fe9470?}, {0x18187520?, 0xc002fe9a70})
  	github.com/hashicorp/terraform-provider-aws/internal/service/dms/task_settings_json.go:72 +0x26c
  github.com/hashicorp/terraform-provider-aws/internal/service/dms.suppressEquivalentTaskSettings({0x0?, 0xc002fe9440?}, {0xc002fea000, 0xf51}, {0xc002ff4800, 0x7c4}, 0xc001d49100?)
  	github.com/hashicorp/terraform-provider-aws/internal/service/dms/task_settings_json.go:48 +0x49a
  github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.diff(0xc0012f4300, {0x1c54ebe8, 0xc002fe81b0}, {0x1a0cd5ff, 0x19}, 0xc0013b3040, 0xc001d49080, {0x1c5a8800, 0xc001d49100}, 0x0)
  	github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/schema.go:1143 +0x39d
  github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.schemaMap.Diff(0xc0012f4300, {0x1c54ebe8, 0xc002fe81b0}, 0xc001e744e0, 0xc002f2bb80, 0xc000f4c8e8, {0x19f99500, 0xc000434900}, 0x0)
  	github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/schema.go:678 +0x332
  github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).SimpleDiff(0x1c54efa8?, {0x1c54ebe8?, 0xc002fe81b0?}, 0xc001e744e0, 0xc002fe81e0?, {0x19f99500?, 0xc000434900?})
  	github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/resource.go:990 +0xdb
  github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).PlanResourceChange(0xc0016405e8, {0x1c54ebe8?, 0xc002fe80c0?}, 0xc002f2b4f0)
  	github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/grpc_provider.go:860 +0xbdf
  github.com/hashicorp/terraform-plugin-mux/tf5muxserver.(*muxServer).PlanResourceChange(0xc00319a880, {0x1c54ebe8?, 0xc002fb9d70?}, 0xc002f2b4f0)
  	github.com/hashicorp/terraform-plugin-mux@v0.17.0/tf5muxserver/mux_server_PlanResourceChange.go:73 +0x2ad
  github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).PlanResourceChange(0xc002027ea0, {0x1c54ebe8?, 0xc002fb9530?}, 0xc001d48d80)
  	github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov5/tf5server/server.go:825 +0x3dc
  github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_PlanResourceChange_Handler({0x19e209c0, 0xc002027ea0}, {0x1c54ebe8, 0xc002fb9530}, 0xc001d48d00, 0x0)
  	github.com/hashicorp/terraform-plugin-go@v0.25.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:593 +0x1a6
  google.golang.org/grpc.(*Server).processUnaryRPC(0xc0010d8a00, {0x1c54ebe8, 0xc002fb94a0}, {0x1c5d5d40, 0xc001a064e0}, 0xc002fda120, 0xc001d37d10, 0x27982640, 0x0)
  	google.golang.org/grpc@v1.68.1/server.go:1394 +0xe2b
  google.golang.org/grpc.(*Server).handleStream(0xc0010d8a00, {0x1c5d5d40, 0xc001a064e0}, 0xc002fda120)
  	google.golang.org/grpc@v1.68.1/server.go:1805 +0xe8b
  google.golang.org/grpc.(*Server).serveStreams.func2.1()
  	google.golang.org/grpc@v1.68.1/server.go:1029 +0x7f
  created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 59
  	google.golang.org/grpc@v1.68.1/server.go:1040 +0x125
  
  Error: The terraform-provider-aws_v5.84.0_x5 plugin crashed!
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
