### PR TITLE
d/aws_opensearch_serverless_collection: fix autoflex failure

### DIFF
--- a/.changelog/41105.txt
+++ b/.changelog/41105.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_opensearchserverless_collection: Prevent errant AutoFlex errors when setting `created_date` and `last_modified_date` attributes
+```

--- a/internal/service/opensearchserverless/service_package_gen.go
+++ b/internal/service/opensearchserverless/service_package_gen.go
@@ -25,6 +25,9 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 			Factory:  newDataSourceCollection,
 			TypeName: "aws_opensearchserverless_collection",
 			Name:     "Collection",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			},
 		},
 		{
 			Factory:  newDataSourceLifecyclePolicy,

--- a/website/docs/d/opensearchserverless_collection.html.markdown
+++ b/website/docs/d/opensearchserverless_collection.html.markdown
@@ -22,10 +22,12 @@ data "aws_opensearchserverless_collection" "example" {
 
 ## Argument Reference
 
-The following arguments are required:
+The following arguments are optional:
 
-* `id` - (Required) ID of the collection. Either `id` or `name` must be provided.
-* `name` - (Required) Name of the collection. Either `name` or `id` must be provided.
+~> Exactly one of `id` or `name` is required.
+
+* `id` - (Optional) ID of the collection.
+* `name` - (Optional) Name of the collection.
 
 ## Attribute Reference
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The `created_date` and `last_modified_date` attributes are string types, while the AWS data structure represents these fields in Unix time as `int64` pointers. The mismatch between types resulted in AutoFlex diagnostic errors being printed to stdout, despite the custom handling being present on the Read method to covert Unix time to an RFC3339 formatted string. This change adds an option to ignore these fields during the flatten operation to prevent errant error logs.

```
2025-01-27T11:41:39.949-0500 [ERROR] aws.autoflex: AutoFlex Flatten; incompatible types: autoflex.source.type="*int64" tf_rpc=ReadDataSource tf_provider_addr=registry.terraform.io/hashicorp/aws tf_req_id=440f6267-4953-4dbb-2934-fc20eece0f95 tf_mux_provider="*proto5server.Server" autoflex.target.path=CreatedDate to=basetypes.StringType from=int64 tf_data_source_type=aws_opensearchserverless_collection autoflex.source.path=CreatedDate autoflex.target.type=github.com/hashicorp/terraform-plugin-framework/types/basetypes.StringValue
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=opensearchserverless TESTS="TestAccOpenSearchServerlessCollectionDataSource_"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20 -run='TestAccOpenSearchServerlessCollectionDataSource_'  -timeout 360m -vet=off
2025/01/27 13:26:29 Initializing Terraform AWS Provider...

--- PASS: TestAccOpenSearchServerlessCollectionDataSource_name (285.96s)
--- PASS: TestAccOpenSearchServerlessCollectionDataSource_basic (286.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless       293.610s
```
