### PR TITLE
testing: Reduce uses of `resource.TestCheckResourceAttrSet` with ARN attributes: `oam`

### DIFF
--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -16,7 +16,6 @@ rules:
         - "internal/service/memorydb"
         - "internal/service/networkmanager"
         - "internal/service/networkmonitor"
-        - "internal/service/oam"
         - "internal/service/organizations"
         - "internal/service/pinpoint"
         - "internal/service/redshift"

--- a/internal/service/oam/link_data_source_test.go
+++ b/internal/service/oam/link_data_source_test.go
@@ -158,7 +158,7 @@ resource "aws_oam_sink" "test" {
 resource "aws_oam_sink_policy" "test" {
   provider = "awsalternate"
 
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -182,7 +182,7 @@ resource "aws_oam_sink_policy" "test" {
 resource "aws_oam_link" "test" {
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
 
   tags = {
     key1 = "value1"
@@ -190,7 +190,7 @@ resource "aws_oam_link" "test" {
 }
 
 data aws_oam_link "test" {
-  link_identifier = aws_oam_link.test.id
+  link_identifier = aws_oam_link.test.arn
 }
 `, rName))
 }
@@ -218,7 +218,7 @@ resource "aws_oam_sink" "test" {
 resource "aws_oam_sink_policy" "test" {
   provider = "awsalternate"
 
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -247,7 +247,7 @@ resource "aws_oam_link" "test" {
     }
   }
   resource_types  = ["AWS::Logs::LogGroup"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
 
   tags = {
     key1 = "value1"
@@ -255,7 +255,7 @@ resource "aws_oam_link" "test" {
 }
 
 data aws_oam_link "test" {
-  link_identifier = aws_oam_link.test.id
+  link_identifier = aws_oam_link.test.arn
 }
 `, rName, filter))
 }
@@ -283,7 +283,7 @@ resource "aws_oam_sink" "test" {
 resource "aws_oam_sink_policy" "test" {
   provider = "awsalternate"
 
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -312,7 +312,7 @@ resource "aws_oam_link" "test" {
     }
   }
   resource_types  = ["AWS::CloudWatch::Metric"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
 
   tags = {
     key1 = "value1"
@@ -320,7 +320,7 @@ resource "aws_oam_link" "test" {
 }
 
 data aws_oam_link "test" {
-  link_identifier = aws_oam_link.test.id
+  link_identifier = aws_oam_link.test.arn
 }
 `, rName, filter))
 }

--- a/internal/service/oam/link_data_source_test.go
+++ b/internal/service/oam/link_data_source_test.go
@@ -189,6 +189,10 @@ resource "aws_oam_link" "test" {
   tags = {
     key1 = "value1"
   }
+
+  depends_on = [
+    aws_oam_sink_policy.test
+  ]
 }
 
 data aws_oam_link "test" {
@@ -254,6 +258,10 @@ resource "aws_oam_link" "test" {
   tags = {
     key1 = "value1"
   }
+
+  depends_on = [
+    aws_oam_sink_policy.test
+  ]
 }
 
 data aws_oam_link "test" {
@@ -319,6 +327,10 @@ resource "aws_oam_link" "test" {
   tags = {
     key1 = "value1"
   }
+
+  depends_on = [
+    aws_oam_sink_policy.test
+  ]
 }
 
 data aws_oam_link "test" {

--- a/internal/service/oam/link_data_source_test.go
+++ b/internal/service/oam/link_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/YakDriver/regexache"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -22,6 +21,7 @@ func testAccObservabilityAccessManagerLinkDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_oam_link.test"
+	resourceName := "aws_oam_link.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -36,13 +36,13 @@ func testAccObservabilityAccessManagerLinkDataSource_basic(t *testing.T) {
 			{
 				Config: testAccLinkDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					acctest.MatchResourceAttrRegionalARN(ctx, dataSourceName, names.AttrARN, "oam", regexache.MustCompile(`link/.+$`)),
-					resource.TestCheckResourceAttrSet(dataSourceName, "label"),
-					resource.TestCheckResourceAttr(dataSourceName, "label_template", "$AccountName"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "link_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "label", resourceName, "label"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "label_template", resourceName, "label_template"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "link_id", resourceName, "link_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "resource_types.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "resource_types.0", "AWS::CloudWatch::Metric"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "sink_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sink_arn", resourceName, "sink_arn"),
 					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
@@ -59,6 +59,7 @@ func testAccObservabilityAccessManagerLinkDataSource_logGroupConfiguration(t *te
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_oam_link.test"
+	resourceName := "aws_oam_link.test"
 	filter := "LogGroupName LIKE 'aws/lambda/%' OR LogGroupName LIKE 'AWSLogs%'"
 
 	resource.Test(t, resource.TestCase{
@@ -74,17 +75,17 @@ func testAccObservabilityAccessManagerLinkDataSource_logGroupConfiguration(t *te
 			{
 				Config: testAccLinkDataSourceConfig_logGroupConfiguration(rName, filter),
 				Check: resource.ComposeTestCheckFunc(
-					acctest.MatchResourceAttrRegionalARN(ctx, dataSourceName, names.AttrARN, "oam", regexache.MustCompile(`link/.+$`)),
-					resource.TestCheckResourceAttrSet(dataSourceName, "label"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "label", resourceName, "label"),
 					resource.TestCheckResourceAttr(dataSourceName, "label_template", "$AccountName"),
 					resource.TestCheckResourceAttr(dataSourceName, "link_configuration.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "link_configuration.0.log_group_configuration.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "link_configuration.0.log_group_configuration.0.filter", filter),
 					resource.TestCheckResourceAttr(dataSourceName, "link_configuration.0.metric_configuration.#", "0"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "link_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "link_id", resourceName, "link_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "resource_types.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "resource_types.0", "AWS::Logs::LogGroup"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "sink_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sink_arn", resourceName, "sink_arn"),
 					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
@@ -101,6 +102,7 @@ func testAccObservabilityAccessManagerLinkDataSource_metricConfiguration(t *test
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_oam_link.test"
+	resourceName := "aws_oam_link.test"
 	filter := "Namespace IN ('AWS/EC2', 'AWS/ELB', 'AWS/S3')"
 
 	resource.Test(t, resource.TestCase{
@@ -116,17 +118,17 @@ func testAccObservabilityAccessManagerLinkDataSource_metricConfiguration(t *test
 			{
 				Config: testAccLinkDataSourceConfig_metricConfiguration(rName, filter),
 				Check: resource.ComposeTestCheckFunc(
-					acctest.MatchResourceAttrRegionalARN(ctx, dataSourceName, names.AttrARN, "oam", regexache.MustCompile(`link/.+$`)),
-					resource.TestCheckResourceAttrSet(dataSourceName, "label"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "label", resourceName, "label"),
 					resource.TestCheckResourceAttr(dataSourceName, "label_template", "$AccountName"),
 					resource.TestCheckResourceAttr(dataSourceName, "link_configuration.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "link_configuration.0.log_group_configuration.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "link_configuration.0.metric_configuration.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "link_configuration.0.metric_configuration.0.filter", filter),
-					resource.TestCheckResourceAttrSet(dataSourceName, "link_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "link_id", resourceName, "link_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "resource_types.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "resource_types.0", "AWS::CloudWatch::Metric"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "sink_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sink_arn", resourceName, "sink_arn"),
 					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),

--- a/internal/service/oam/link_test.go
+++ b/internal/service/oam/link_test.go
@@ -48,7 +48,7 @@ func testAccObservabilityAccessManagerLink_basic(t *testing.T) {
 				Config: testAccLinkConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinkExists(ctx, resourceName, &link),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "oam", regexache.MustCompile(`link/.+$`)),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "oam", "link/{link_id}"),
 					resource.TestCheckResourceAttrSet(resourceName, "label"),
 					resource.TestCheckResourceAttr(resourceName, "label_template", "$AccountName"),
 					resource.TestCheckResourceAttrSet(resourceName, "link_id"),

--- a/internal/service/oam/link_test.go
+++ b/internal/service/oam/link_test.go
@@ -421,6 +421,10 @@ resource "aws_oam_link" "test" {
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric"]
   sink_identifier = aws_oam_sink.test.arn
+
+  depends_on = [
+    aws_oam_sink_policy.test
+  ]
 }
 `, rName))
 }
@@ -473,6 +477,10 @@ resource "aws_oam_link" "test" {
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
   sink_identifier = aws_oam_sink.test.arn
+
+  depends_on = [
+    aws_oam_sink_policy.test
+  ]
 }
 `, rName))
 }
@@ -528,6 +536,10 @@ resource "aws_oam_link" "test" {
   tags = {
     %[2]q = %[3]q
   }
+
+  depends_on = [
+    aws_oam_sink_policy.test
+  ]
 }
 `, rName, tag1Key, tag1Value))
 }
@@ -585,6 +597,10 @@ resource "aws_oam_link" "test" {
     %[2]q = %[3]q
     %[4]q = %[5]q
   }
+
+  depends_on = [
+    aws_oam_sink_policy.test
+  ]
 }
 `, rName, tag1Key, tag1Value, tag2Key, tag2Value))
 }
@@ -642,6 +658,10 @@ resource "aws_oam_link" "test" {
   }
   resource_types  = ["AWS::Logs::LogGroup"]
   sink_identifier = aws_oam_sink.test.arn
+
+  depends_on = [
+    aws_oam_sink_policy.test
+  ]
 }
 `, rName, filter))
 }
@@ -699,6 +719,10 @@ resource "aws_oam_link" "test" {
   }
   resource_types  = ["AWS::CloudWatch::Metric"]
   sink_identifier = aws_oam_sink.test.arn
+
+  depends_on = [
+    aws_oam_sink_policy.test
+  ]
 }
 `, rName, filter))
 }

--- a/internal/service/oam/link_test.go
+++ b/internal/service/oam/link_test.go
@@ -396,7 +396,7 @@ resource "aws_oam_sink" "test" {
 resource "aws_oam_sink_policy" "test" {
   provider = "awsalternate"
 
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -420,7 +420,7 @@ resource "aws_oam_sink_policy" "test" {
 resource "aws_oam_link" "test" {
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
 }
 `, rName))
 }
@@ -448,7 +448,7 @@ resource "aws_oam_sink" "test" {
 resource "aws_oam_sink_policy" "test" {
   provider = "awsalternate"
 
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -472,7 +472,7 @@ resource "aws_oam_sink_policy" "test" {
 resource "aws_oam_link" "test" {
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
 }
 `, rName))
 }
@@ -500,7 +500,7 @@ resource "aws_oam_sink" "test" {
 resource "aws_oam_sink_policy" "test" {
   provider = "awsalternate"
 
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -524,7 +524,7 @@ resource "aws_oam_sink_policy" "test" {
 resource "aws_oam_link" "test" {
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   tags = {
     %[2]q = %[3]q
   }
@@ -555,7 +555,7 @@ resource "aws_oam_sink" "test" {
 resource "aws_oam_sink_policy" "test" {
   provider = "awsalternate"
 
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -579,7 +579,7 @@ resource "aws_oam_sink_policy" "test" {
 resource "aws_oam_link" "test" {
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
 
   tags = {
     %[2]q = %[3]q
@@ -612,7 +612,7 @@ resource "aws_oam_sink" "test" {
 resource "aws_oam_sink_policy" "test" {
   provider = "awsalternate"
 
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -641,7 +641,7 @@ resource "aws_oam_link" "test" {
     }
   }
   resource_types  = ["AWS::Logs::LogGroup"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
 }
 `, rName, filter))
 }
@@ -669,7 +669,7 @@ resource "aws_oam_sink" "test" {
 resource "aws_oam_sink_policy" "test" {
   provider = "awsalternate"
 
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -698,7 +698,7 @@ resource "aws_oam_link" "test" {
     }
   }
   resource_types  = ["AWS::CloudWatch::Metric"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
 }
 `, rName, filter))
 }

--- a/internal/service/oam/links_data_source_test.go
+++ b/internal/service/oam/links_data_source_test.go
@@ -89,8 +89,6 @@ resource "aws_oam_sink_policy" "test" {
 }
 
 resource "aws_oam_link" "test" {
-  depends_on = [aws_oam_sink_policy.test]
-
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric"]
   sink_identifier = aws_oam_sink.test.arn
@@ -98,6 +96,10 @@ resource "aws_oam_link" "test" {
   tags = {
     key1 = "value1"
   }
+
+  depends_on = [
+    aws_oam_sink_policy.test
+  ]
 }
 
 data aws_oam_links "test" {

--- a/internal/service/oam/links_data_source_test.go
+++ b/internal/service/oam/links_data_source_test.go
@@ -67,7 +67,7 @@ resource "aws_oam_sink" "test" {
 resource "aws_oam_sink_policy" "test" {
   provider = "awsalternate"
 
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -93,7 +93,7 @@ resource "aws_oam_link" "test" {
 
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
 
   tags = {
     key1 = "value1"

--- a/internal/service/oam/sink_data_source_test.go
+++ b/internal/service/oam/sink_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/oam"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -23,6 +22,7 @@ func testAccObservabilityAccessManagerSinkDataSource_basic(t *testing.T) {
 	var sink oam.GetSinkOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_oam_sink.test"
+	resourceName := "aws_oam_sink.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -38,13 +38,12 @@ func testAccObservabilityAccessManagerSinkDataSource_basic(t *testing.T) {
 				Config: testAccSinkDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSinkExists(ctx, dataSourceName, &sink),
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrARN),
-					resource.TestCheckResourceAttr(dataSourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(dataSourceName, "sink_id"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "sink_identifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sink_id", resourceName, "sink_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sink_identifier", resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(dataSourceName, acctest.CtTagsKey1, acctest.CtValue1),
-					acctest.MatchResourceAttrRegionalARN(ctx, dataSourceName, names.AttrARN, "oam", regexache.MustCompile(`sink/.+$`)),
 				),
 			},
 		},

--- a/internal/service/oam/sink_policy_test.go
+++ b/internal/service/oam/sink_policy_test.go
@@ -233,7 +233,7 @@ resource "aws_oam_sink" "test" {
 }
 
 resource "aws_oam_sink_policy" "test" {
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -266,7 +266,7 @@ resource "aws_oam_sink" "test" {
 }
 
 resource "aws_oam_sink_policy" "test" {
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.test.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/internal/service/oam/sink_policy_test.go
+++ b/internal/service/oam/sink_policy_test.go
@@ -47,7 +47,7 @@ func testAccObservabilityAccessManagerSinkPolicy_basic(t *testing.T) {
 				Config: testAccSinkPolicyConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSinkPolicyExists(ctx, resourceName, &sinkPolicy),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "oam", regexache.MustCompile(`sink/.+$`)),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, "aws_oam_sink.test", names.AttrARN),
 					resource.TestCheckResourceAttrWith(resourceName, names.AttrPolicy, func(value string) error {
 						_, err := awspolicy.PoliciesAreEquivalent(value, fmt.Sprintf(`
 {

--- a/internal/service/oam/sink_test.go
+++ b/internal/service/oam/sink_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/oam"
 	"github.com/aws/aws-sdk-go-v2/service/oam/types"
@@ -47,7 +46,8 @@ func testAccObservabilityAccessManagerSink_basic(t *testing.T) {
 				Config: testAccSinkConfigBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSinkExists(ctx, resourceName, &sink),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "oam", regexache.MustCompile(`sink/.+$`)),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "oam", "sink/{sink_id}"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrSet(resourceName, "sink_id"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),

--- a/website/docs/d/oam_link.html.markdown
+++ b/website/docs/d/oam_link.html.markdown
@@ -31,7 +31,7 @@ The following arguments are required:
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the link.
-* `id` - ARN of the link.
+* `id` - ARN of the link. Use `arn` instead.
 * `label` - Label that is assigned to this link.
 * `label_template` - Human-readable name used to identify this source account when you are viewing data from it in the monitoring account.
 * `link_configuration` - Configuration for creating filters that specify that only some metric namespaces or log groups are to be shared from the source account to the monitoring account. See [`link_configuration` Block](#link_configuration-block) for details.

--- a/website/docs/d/oam_sink.html.markdown
+++ b/website/docs/d/oam_sink.html.markdown
@@ -31,7 +31,7 @@ The following arguments are required:
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the sink.
-* `id` - ARN of the sink.
+* `id` - ARN of the sink. Use `arn` instead.
 * `name` - Name of the sink.
 * `sink_id` - Random ID string that AWS generated as part of the sink ARN.
 * `tags` - Tags assigned to the sink.

--- a/website/docs/r/oam_link.html.markdown
+++ b/website/docs/r/oam_link.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Terraform resource for managing an AWS CloudWatch Observability Access Manager Link.
 
+~> **NOTE:** Creating an `aws_oam_link` may sometimes fail if the `aws_oam_sink_policy` for the attached `aws_oam_sink` is not created before the `aws_oam_link`. To prevent this, declare an explicit dependency using a [`depends_on`](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) meta-argument.
+
 ## Example Usage
 
 ### Basic Usage
@@ -22,6 +24,19 @@ resource "aws_oam_link" "example" {
   tags = {
     Env = "prod"
   }
+
+  depends_on = [
+    aws_oam_sink_policy.example
+  ]
+}
+
+resource "aws_oam_sink" "example" {
+  # ...
+}
+
+resource "aws_oam_sink_policy" "example" {
+  sink_identifier = aws_oam_sink.example.arn
+  # ...
 }
 ```
 
@@ -37,6 +52,10 @@ resource "aws_oam_link" "example" {
   }
   resource_types  = ["AWS::Logs::LogGroup"]
   sink_identifier = aws_oam_sink.example.arn
+
+  depends_on = [
+    aws_oam_sink_policy.example
+  ]
 }
 ```
 
@@ -52,6 +71,10 @@ resource "aws_oam_link" "example" {
   }
   resource_types  = ["AWS::CloudWatch::Metric"]
   sink_identifier = aws_oam_sink.example.arn
+
+  depends_on = [
+    aws_oam_sink_policy.example
+  ]
 }
 ```
 

--- a/website/docs/r/oam_link.html.markdown
+++ b/website/docs/r/oam_link.html.markdown
@@ -18,7 +18,7 @@ Terraform resource for managing an AWS CloudWatch Observability Access Manager L
 resource "aws_oam_link" "example" {
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.example.arn
   tags = {
     Env = "prod"
   }
@@ -36,7 +36,7 @@ resource "aws_oam_link" "example" {
     }
   }
   resource_types  = ["AWS::Logs::LogGroup"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.example.arn
 }
 ```
 
@@ -51,7 +51,7 @@ resource "aws_oam_link" "example" {
     }
   }
   resource_types  = ["AWS::CloudWatch::Metric"]
-  sink_identifier = aws_oam_sink.test.id
+  sink_identifier = aws_oam_sink.example.arn
 }
 ```
 
@@ -92,7 +92,7 @@ The `metric_configuration` configuration block supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the link.
-* `id` - ARN of the link.
+* `id` - ARN of the link. Use `arn` instead.
 * `label` - Label that is assigned to this link.
 * `link_id` - ID string that AWS generated as part of the link ARN.
 * `sink_arn` - ARN of the sink that is used for this link.

--- a/website/docs/r/oam_sink.html.markdown
+++ b/website/docs/r/oam_sink.html.markdown
@@ -39,7 +39,7 @@ The following arguments are optional:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the Sink.
-* `id` - ARN of the Sink.
+* `id` - ARN of the Sink. Use `arn` instead.
 * `sink_id` - ID string that AWS generated as part of the sink ARN.
 
 ## Timeouts

--- a/website/docs/r/oam_sink_policy.html.markdown
+++ b/website/docs/r/oam_sink_policy.html.markdown
@@ -20,7 +20,7 @@ resource "aws_oam_sink" "example" {
 }
 
 resource "aws_oam_sink_policy" "example" {
-  sink_identifier = aws_oam_sink.example.id
+  sink_identifier = aws_oam_sink.example.arn
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -54,7 +54,6 @@ The following arguments are required:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the Sink.
-* `id` - ARN of the sink to attach this policy to.
 * `sink_id` - ID string that AWS generated as part of the sink ARN.
 
 ## Timeouts


### PR DESCRIPTION
### Description

Reduce uses of `resource.TestCheckResourceAttrSet` on ARN attributes in favour of explicit checks.

Also:
* replaces use of `id` in acceptance tests and documentation with `arn`
* adds `depends_on` relationship with `aws_oam_sink_policy` to prevent intermittent failures
