### PR TITLE
fix(rds): cluster enabled_cloudwatch_logs_exports doesn't allow instance

### DIFF
--- a/.changelog/41111.txt
+++ b/.changelog/41111.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_cluster: Support `instance` as a valid value for `enabled_cloudwatch_logs_exports`
+```

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -1230,6 +1230,35 @@ func TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql(t *testing
 	})
 }
 
+func TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql_instance(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var dbCluster1 types.DBCluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_rds_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsWest2RegionID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_enabledCloudWatchLogsExportsAuroraPostgreSQL(rName, "postgresql", "instance"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &dbCluster1),
+					resource.TestCheckResourceAttr(resourceName, "enabled_cloudwatch_logs_exports.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "enabled_cloudwatch_logs_exports.*", "postgresql"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "enabled_cloudwatch_logs_exports.*", "instance"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRDSCluster_updateIAMRoles(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBCluster

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -218,6 +218,7 @@ const (
 	exportableLogTypeError          = "error"
 	exportableLogTypeGeneral        = "general"
 	exportableLogTypeIAMDBAuthError = "iam-db-auth-error"
+	exportableLogTypeInstance       = "instance"
 	exportableLogTypeListener       = "listener"
 	exportableLogTypeNotifyLog      = "notify.log"
 	exportableLogTypeOEMAgent       = "oemagent"
@@ -233,6 +234,7 @@ func clusterExportableLogType_Values() []string {
 		exportableLogTypeError,
 		exportableLogTypeGeneral,
 		exportableLogTypeIAMDBAuthError,
+		exportableLogTypeInstance,
 		exportableLogTypePostgreSQL,
 		exportableLogTypeSlowQuery,
 		exportableLogTypeUpgrade,


### PR DESCRIPTION
There is a new value `instance` for aurora-postgresql that is accepted in the `enabled_cloudwatch_logs_exports` field. It looks like this is currently being rolled out and is only available in some regions (can be tested in `us-west-2`).

**Output from Acceptance Testing**

```
% make testacc TESTS=TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql_instance PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql_instance'  -timeout 360m -vet=off
2025/01/27 15:05:24 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql_instance
=== PAUSE TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql_instance
=== CONT  TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql_instance
--- PASS: TestAccRDSCluster_EnabledCloudWatchLogsExports_aurora_postgresql_instance (119.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        124.502s
```

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes [#41108](https://github.com/hashicorp/terraform-provider-aws/issues/41108)

### References
Similar to https://github.com/hashicorp/terraform-provider-aws/pull/40789