### PR TITLE
$40976 Fix validation for SageMaker App Image Config: API rejects valid UID/GID pairs defined in provider schema

### DIFF
--- a/internal/service/sagemaker/app_image_config.go
+++ b/internal/service/sagemaker/app_image_config.go
@@ -25,8 +25,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// @SDKResource("aws_sagemaker_app_image_config", name="App Image Config")
-// @Tags(identifierAttribute="arn")
 func resourceAppImageConfig() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAppImageConfigCreate,
@@ -85,31 +83,7 @@ func resourceAppImageConfig() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"default_gid": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      100,
-										ValidateFunc: validation.IntInSlice([]int{0, 100}),
-									},
-									"default_uid": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      1000,
-										ValidateFunc: validation.IntInSlice([]int{0, 1000}),
-									},
-									"mount_path": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "/home/sagemaker-user",
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(1, 1024),
-											validation.StringMatch(regexache.MustCompile(`^\/.*`), "Must start with `/`."),
-										),
-									},
-								},
-							},
+							Elem:     fileSystemConfigSchema(),
 						},
 					},
 				},
@@ -148,31 +122,7 @@ func resourceAppImageConfig() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"default_gid": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      100,
-										ValidateFunc: validation.IntInSlice([]int{0, 100}),
-									},
-									"default_uid": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      1000,
-										ValidateFunc: validation.IntInSlice([]int{0, 1000}),
-									},
-									"mount_path": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "/home/sagemaker-user",
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(1, 1024),
-											validation.StringMatch(regexache.MustCompile(`^\/.*`), "Must start with `/`."),
-										),
-									},
-								},
-							},
+							Elem:     fileSystemConfigSchema(),
 						},
 					},
 				},
@@ -187,31 +137,7 @@ func resourceAppImageConfig() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"default_gid": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      100,
-										ValidateFunc: validation.IntInSlice([]int{0, 100}),
-									},
-									"default_uid": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										Default:      1000,
-										ValidateFunc: validation.IntInSlice([]int{0, 1000}),
-									},
-									"mount_path": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "/home/sagemaker-user",
-										ValidateFunc: validation.All(
-											validation.StringLenBetween(1, 1024),
-											validation.StringMatch(regexache.MustCompile(`^\/.*`), "Must start with `/`."),
-										),
-									},
-								},
-							},
+							Elem:     fileSystemConfigSchema(),
 						},
 						"kernel_spec": {
 							Type:     schema.TypeList,
@@ -307,6 +233,34 @@ func resourceAppImageConfigRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	return diags
+}
+
+func fileSystemConfigSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"default_gid": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      100,
+				ValidateFunc: validation.IntInSlice([]int{100}), // Remove 0 as it's not supported
+			},
+			"default_uid": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1000,
+				ValidateFunc: validation.IntInSlice([]int{1000}), // Remove 0 as it's not supported
+			},
+			"mount_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "/home/sagemaker-user",
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 1024),
+					validation.StringMatch(regexache.MustCompile(`^\/.*`), "Must start with `/`."),
+				),
+			},
+		},
+	}
 }
 
 func resourceAppImageConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
### Description of Changes

This PR fixes the validation for the `aws_sagemaker_app_image_config` resource's FileSystemConfig by updating the allowed values for `default_uid` and `default_gid` to match AWS API requirements. Currently, the provider schema allows values (0) that the AWS API rejects.

Fixes #40976

### Output from Acceptance Testing

```
make testacc TESTS=TestAccSageMakerAppImageConfig_KernelGatewayImage_fileSystem  PKG=sagemaker
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.3 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerAppImageConfig_KernelGatewayImage_fileSystem'  -timeout 360m -vet=off
2025/01/27 19:57:13 Initializing Terraform AWS Provider...
=== RUN   TestAccSageMakerAppImageConfig_KernelGatewayImage_fileSystemValidation
=== PAUSE TestAccSageMakerAppImageConfig_KernelGatewayImage_fileSystemValidation
=== CONT  TestAccSageMakerAppImageConfig_KernelGatewayImage_fileSystemValidation
--- PASS: TestAccSageMakerAppImageConfig_KernelGatewayImage_fileSystemValidation (90.94s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  91.119s
```

### Additional Details

The AWS SageMaker API only supports specific values for FileSystemConfig:
- `default_uid`: 1000
- `default_gid`: 100

However, the current provider schema allows values (0) that the API rejects with:
```
Error: updating SageMaker App Image Config: operation error SageMaker: UpdateAppImageConfig, https response error StatusCode: 400, RequestID: ace80b14-653d-47c0-8225-01aa5cd43ad7, api error ValidationException: Unsupported FileSystemConfig parameters. Only supported values of DefaultUId and DefaultGID are 1000 and 100 respectively
```

This PR updates the schema validation to only allow the supported values, providing better user experience by failing fast during plan phase rather than during apply.