### PR TITLE
fix(aws_dynamodb_table): Specify "name" for GlobalSecondaryIndex in `flattenTableGlobalSecondaryIndex`

### DIFF
--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -2127,10 +2127,11 @@ func flattenTableGlobalSecondaryIndex(gsi []awstypes.GlobalSecondaryIndexDescrip
 	for _, g := range gsi {
 		gsi := make(map[string]interface{})
 
+		gsi[names.AttrName] = aws.ToString(g.IndexName)
+
 		if g.ProvisionedThroughput != nil {
 			gsi["write_capacity"] = aws.ToInt64(g.ProvisionedThroughput.WriteCapacityUnits)
 			gsi["read_capacity"] = aws.ToInt64(g.ProvisionedThroughput.ReadCapacityUnits)
-			gsi[names.AttrName] = aws.ToString(g.IndexName)
 		}
 
 		for _, attribute := range g.KeySchema {


### PR DESCRIPTION
### Description

Resolves #41110. When applying an `aws_dynamodb_table` with a Global Secondary Index (GSI) against the DynamoDB local emulator, Terraform consistently shows diffs for the GSI, even though no actual changes are made.

Investigation revealed that if `ProvisionedThroughput` is not configured, the `name` property for the GSI remains empty. This PR ensures that the `name` property is always set, preventing unnecessary diffs.

### Relations

Closes #41110 (`aws_dynamodb_table` GSI shows unexpected diffs when using DynamoDB local emulator)

### Output from Acceptance Testing

I was not able to setup environment for this test... 🙏 
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
