### PR TITLE
[documentation] Update Documentation for `aws_securityhub_automation_rule` and `aws_securityhub_insight` to Reflect All Supported Comparison Operations

### DIFF
--- a/website/docs/r/securityhub_automation_rule.html.markdown
+++ b/website/docs/r/securityhub_automation_rule.html.markdown
@@ -115,7 +115,7 @@ The `criteria` configuration block supports the following attributes:
 
 The string filter configuration block supports the following arguments:
 
-* `comparison` - (Required) The condition to apply to a string value when querying for findings. Valid values include: `EQUALS`, `PREFIX`, `NOT_EQUALS`, `PREFIX_NOT_EQUALS`.
+* `comparison` - (Required) The condition to apply to a string value when querying for findings. Valid values include: `EQUALS`, `PREFIX`, `NOT_EQUALS`, `PREFIX_NOT_EQUALS`, `CONTAINS`, and `NOT_CONTAINS`.
 * `value` - (Required) The string filter value. Filter values are case sensitive.
 
 ### Number Filter Argument reference

--- a/website/docs/r/securityhub_insight.html.markdown
+++ b/website/docs/r/securityhub_insight.html.markdown
@@ -275,14 +275,14 @@ The number filter configuration block supports the following arguments:
 
 The string filter configuration block supports the following arguments:
 
-* `comparison` - (Required) The condition to apply to a string value when querying for findings. Valid values include: `EQUALS`, `PREFIX`, `NOT_EQUALS`, `PREFIX_NOT_EQUALS`.
+* `comparison` - (Required) The condition to apply to a string value when querying for findings. Valid values include: `EQUALS`, `PREFIX`, `NOT_EQUALS`, `PREFIX_NOT_EQUALS`, `CONTAINS`, and `NOT_CONTAINS`.
 * `value` - (Required) The string filter value. Filter values are case sensitive.
 
 ### Workflow Status Filter Argument reference
 
 The workflow status filter configuration block supports the following arguments:
 
-* `comparison` - (Required) The condition to apply to a string value when querying for findings. Valid values include: `EQUALS`, `PREFIX`, `NOT_EQUALS`, `PREFIX_NOT_EQUALS`.
+* `comparison` - (Required) The condition to apply to a string value when querying for findings. Valid values include: `EQUALS`, `PREFIX`, `NOT_EQUALS`, `PREFIX_NOT_EQUALS`, `CONTAINS`, and `NOT_CONTAINS`.
 * `value` - (Required) The string filter value. Valid values include: `NEW`, `NOTIFIED`, `SUPPRESSED`, and `RESOLVED`.
 
 ## Attribute Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Update the documentations for the following resources:
  - resource: `aws_securityhub_automation_rule`
    - argument: criteria
      - change: string filters also support `CONTAINS` and `NOT_CONTAINS` comparison
  - resource: `aws_securityhub_insight`
    - argument: filters
      - change: string filters also support `CONTAINS` and `NOT_CONTAINS` comparison
      - change: workflow_status filters also support `CONTAINS` and `NOT_CONTAINS` comparison
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #40895
--->

Closes #40895

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- [AWS Security Hub Automation Rule Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_automation_rule#string-filter-argument-reference)
- [AWS Security Hub Custom Insights Doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_insight#string-filter-argument-reference)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
N/A
