### PR TITLE
Sweeper fixes

### DIFF
--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -729,6 +729,12 @@ func sweepVirtualMFADevice(ctx context.Context, client *conns.AWSClient) ([]swee
 			d := r.Data(nil)
 			d.SetId(serialNum)
 
+			if user := device.User; user != nil {
+				if userName := aws.ToString(user.UserName); userName != "" {
+					d.Set(names.AttrUserName, userName)
+				}
+			}
+
 			sweepResources = append(sweepResources, sdk.NewSweepResource(r, d, client))
 		}
 	}

--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -41,6 +41,10 @@ func SkipSweepError(err error) bool {
 	if tfawserr.ErrCodeEquals(err, "ForbiddenException") {
 		return true
 	}
+	// Example (GovCloud): HttpConnectionTimeoutException: Failed to connect to ...
+	if tfawserr.ErrMessageContains(err, "HttpConnectionTimeoutException", "Failed to connect to") {
+		return true
+	}
 	// Example (GovCloud): InvalidAction: DescribeDBProxies is not available in this region
 	if tfawserr.ErrMessageContains(err, "InvalidAction", "is not available") {
 		return true


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes sweeper errors:

##### US GovCloud

```
2025/01/30 08:22:13 [ERROR] Error running Sweeper (aws_cloudwatch_log_anomaly_detector) in region (us-gov-west-1): listing "aws_cloudwatch_log_anomaly_detector" (us-gov-west-1): operation error CloudWatch Logs: ListLogAnomalyDetectors, https response error StatusCode: 400, RequestID: bee6e7a5-91fa-4293-ba63-43173e80e5c0, api error HttpConnectionTimeoutException: Failed to connect to us-gov-west-1.prod.logsanalysiscp01.cloudwatchlogs.aws.dev/<unresolved>:443 !
```

### Commercial

```
2025/01/30 08:41:33 [ERROR] Error running Sweeper (aws_iam_virtual_mfa_device) in region (us-east-2): sweeping "aws_iam_virtual_mfa_device" (us-east-2): 1 error occurred:
	* deleting IAM Virtual MFA Device (arn:aws:iam::123456789012:mfa/test2): operation error IAM: DeleteVirtualMFADevice, https response error StatusCode: 409, RequestID: 3270320b-437f-4d01-a856-2ac5dead7b91, DeleteConflict: MFA VirtualDevice in use. Must deactivate first.
```