### PR TITLE
r/aws_macie2_invitation_accepter: properly set `invitation_id` during creation

### DIFF
--- a/.changelog/41163.txt
+++ b/.changelog/41163.txt
@@ -1,0 +1,6 @@
+```release-note:note
+resource/aws_macie2_invitation_accepter: Maintainers are unable to acceptance test the regression fix included in this release. This patch is best effort, and we ask for community help in assessing the change.
+```
+```release-note:bug
+resource/aws_macie2_invitation_accepter: Properly set `invitation_id` when calling the `AcceptInvitation` API
+```

--- a/internal/service/macie2/invitation_accepter.go
+++ b/internal/service/macie2/invitation_accepter.go
@@ -58,10 +58,11 @@ func resourceInvitationAccepterCreate(ctx context.Context, d *schema.ResourceDat
 	conn := meta.(*conns.AWSClient).Macie2Client(ctx)
 
 	adminAccountID := d.Get("administrator_account_id").(string)
-	var invitationID string
 
-	err := retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
-		invitationID, err := findInvitationByAccount(ctx, conn, adminAccountID)
+	var invitationID string
+	var err error
+	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
+		invitationID, err = findInvitationByAccount(ctx, conn, adminAccountID)
 
 		if err != nil {
 			if tfawserr.ErrCodeEquals(err, string(awstypes.ErrorCodeClientError)) {


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This fixes a regression introduced during migration of the `macie2` service to AWS SDK V2. Specifically, the `invitationID` variable inside the create retrier shadows a variable of the same name at the root of the create function. This led to the `InvitationId` value always being sent as an empty string in the `AcceptInvitation` API request, despite being successfully retrieved from the `ListInvitations` API. The variable from the outer scope is now used inside the retrier's scope (rather than a new variable), which should return the original intended behavior.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40587
Relates #37999


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

> [!NOTE]
> Acceptance tests for this resource require out of band email verification for the Macie2 service, which maintainers do not currently have the capability to do in our testing accounts. As such, this implementation is best effort and we ask for community help in verifying the fix.