### PR TITLE
feat: Add sns_topic_arn attr to aws_cloudtrail

### DIFF
--- a/.changelog/41168.txt
+++ b/.changelog/41168.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudtrail : Add `sns_topic_arn` attribute
+```

--- a/.ci/.golangci4.yml
+++ b/.ci/.golangci4.yml
@@ -42,10 +42,6 @@ issues:
       text: "SA1019: \\w+.(\\w+) is deprecated: This member has been deprecated"
     - linters:
         - staticcheck
-      path: "internal/service/cloudtrail"
-      text: "SA1019: \\w+.(\\w+) is deprecated: This member has been deprecated"
-    - linters:
-        - staticcheck
       path: internal/service/detective/
       text: "SA1019: member.VolumeUsageInBytes is deprecated: This property is deprecated. Use VolumeUsageByDatasourcePackage instead"
     - linters:

--- a/internal/service/cloudtrail/cloudtrail_test.go
+++ b/internal/service/cloudtrail/cloudtrail_test.go
@@ -39,6 +39,7 @@ func TestAccCloudTrail_serial(t *testing.T) {
 			"organization":          testAccTrail_organization,
 			"logValidation":         testAccTrail_logValidation,
 			"kmsKey":                testAccTrail_kmsKey,
+			"snsTopicName":          testAccTrail_snsTopicName,
 			"tags":                  testAccTrail_tags,
 			"eventSelector":         testAccTrail_eventSelector,
 			"eventSelectorDynamoDB": testAccTrail_eventSelectorDynamoDB,

--- a/internal/service/cloudtrail/trail.go
+++ b/internal/service/cloudtrail/trail.go
@@ -253,6 +253,10 @@ func resourceTrail() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 2000),
 			},
+			names.AttrSNSTopicARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"sns_topic_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -376,8 +380,7 @@ func resourceTrailRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	trail := outputRaw.(*types.Trail)
-	arn := aws.ToString(trail.TrailARN)
-	d.Set(names.AttrARN, arn)
+	d.Set(names.AttrARN, trail.TrailARN)
 	d.Set("cloud_watch_logs_group_arn", trail.CloudWatchLogsLogGroupArn)
 	d.Set("cloud_watch_logs_role_arn", trail.CloudWatchLogsRoleArn)
 	d.Set("enable_log_file_validation", trail.LogFileValidationEnabled)
@@ -389,7 +392,16 @@ func resourceTrailRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set(names.AttrName, trail.Name)
 	d.Set(names.AttrS3BucketName, trail.S3BucketName)
 	d.Set(names.AttrS3KeyPrefix, trail.S3KeyPrefix)
-	d.Set("sns_topic_name", trail.SnsTopicName)
+	d.Set(names.AttrSNSTopicARN, trail.SnsTopicARN)
+	if trail.SnsTopicARN != nil {
+		parsedSNSTopicARN, err := arn.Parse(*trail.SnsTopicARN)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "parsing SNS Topic ARN (%s): %s", aws.ToString(trail.SnsTopicARN), err)
+		}
+		d.Set("sns_topic_name", parsedSNSTopicARN.Resource)
+	} else {
+		d.Set("sns_topic_name", nil)
+	}
 
 	if output, err := conn.GetTrailStatus(ctx, &cloudtrail.GetTrailStatusInput{
 		Name: aws.String(d.Id()),

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -374,6 +374,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - ARN of the trail.
 * `home_region` - Region in which the trail was created.
 * `id` - ARN of the trail.
+* `sns_topic_arn` - ARN of the Amazon SNS topic that CloudTrail uses to send notifications when log files are delivered.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `sns_topic_arn` attribute to the `aws_cloudtrail` resource. Also the `sns_topic_name` argument, which is a deprecated API response field but still a valid request field interestingly, is derived from `sns_topic_arn` on read. Lastly the linter exclusion rule for deprecated field is removed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30329

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateTrail](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_CreateTrail.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccCloudTrail_serial/Trail/basic|TestAccCloudTrail_serial/Trail/snsTopicName" PKG=cloudtrail
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/cloudtrail/... -v -count 1 -parallel 20 -run='TestAccCloudTrail_serial/Trail/basic|TestAccCloudTrail_serial/Trail/snsTopicName'  -timeout 360m -vet=off
2025/01/31 01:03:03 Initializing Terraform AWS Provider...
=== RUN   TestAccCloudTrail_serial
=== PAUSE TestAccCloudTrail_serial
=== CONT  TestAccCloudTrail_serial
=== RUN   TestAccCloudTrail_serial/Trail
=== RUN   TestAccCloudTrail_serial/Trail/snsTopicName
=== RUN   TestAccCloudTrail_serial/Trail/basic
--- PASS: TestAccCloudTrail_serial (83.92s)
    --- PASS: TestAccCloudTrail_serial/Trail (83.92s)
        --- PASS: TestAccCloudTrail_serial/Trail/snsTopicName (41.07s)
        --- PASS: TestAccCloudTrail_serial/Trail/basic (42.86s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudtrail 84.132s

$
```
