### PR TITLE
docs: fix argument names for resource aws_wafv2_web_acl

### DIFF
--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -820,7 +820,7 @@ The `managed_rule_group_configs` block support the following arguments:
 
 ### `address_fields` Block
 
-* `identifier` - (Required) The name of a single primary address field.
+* `identifiers` - (Required) The names of the address fields.
 
 ### `email_field` Block
 
@@ -832,7 +832,7 @@ The `managed_rule_group_configs` block support the following arguments:
 
 ### `phone_number_fields` Block
 
-* `identifier` - (Required) The name of a single primary phone number field.
+* `identifiers` - (Required) The names of the phone number fields.
 
 ### `username_field` Block
 


### PR DESCRIPTION
### Description
Update  the documentation of the resource `aws_wafv2_web_acl` by changing `identifier` to `identifiers` in the blocks `address_fields` and `phone_number_fields`.
This is required to match the implementation of the resource. The section References contains links to the relevant lines in the source code.

### Relations

Closes #41182 

### References

References in provider source code
- [`identifiers` in `address_fields`](https://github.com/hashicorp/terraform-provider-aws/blob/2a3e17f26ff3aaac571448c11e99aecd0d230219/internal/service/wafv2/schemas.go#L1378)
- [`identifiers` in `phone_number_fields`](https://github.com/hashicorp/terraform-provider-aws/blob/2a3e17f26ff3aaac571448c11e99aecd0d230219/internal/service/wafv2/schemas.go#L1427)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.