### PR TITLE
fix: Allow name, name_prefix_and path update for aws_iam_server_certificate

### DIFF
--- a/.changelog/41186.txt
+++ b/.changelog/41186.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_iam_server_certificate: Allow update of `name`, `name_prefix`, and `path` without forcing new resource
+```

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -74,7 +74,6 @@ func resourceServerCertificate() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{names.AttrNamePrefix},
 				ValidateFunc:  validation.StringLenBetween(0, 128),
 			},
@@ -82,7 +81,6 @@ func resourceServerCertificate() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{names.AttrName},
 				ValidateFunc:  validation.StringLenBetween(0, 128-id.UniqueIDSuffixLength),
 			},
@@ -90,7 +88,6 @@ func resourceServerCertificate() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "/",
-				ForceNew: true,
 			},
 			names.AttrPrivateKey: {
 				Type:             schema.TypeString,
@@ -209,7 +206,49 @@ func resourceServerCertificateRead(ctx context.Context, d *schema.ResourceData, 
 func resourceServerCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	// Tags only.
+	conn := meta.(*conns.AWSClient).IAMClient(ctx)
+
+	if d.HasChanges(names.AttrName, names.AttrNamePrefix, names.AttrPath) {
+		input := &iam.UpdateServerCertificateInput{}
+
+		if d.HasChange(names.AttrName) {
+			oldName, newName := d.GetChange(names.AttrName)
+
+			// Handle both a name change and a switch to using a name prefix
+			newSSLCertName := create.Name(newName.(string), d.Get(names.AttrNamePrefix).(string))
+
+			input.ServerCertificateName = aws.String(oldName.(string))
+			input.NewServerCertificateName = aws.String(newSSLCertName)
+		} else if d.HasChange(names.AttrNamePrefix) {
+			oldName := d.Get(names.AttrName).(string)
+
+			// Handle only a name prefix change using an empty string as name (as it hasn't been changed)
+			newSSLCertName := create.Name("", d.Get(names.AttrNamePrefix).(string))
+
+			input.ServerCertificateName = aws.String(oldName)
+			input.NewServerCertificateName = aws.String(newSSLCertName)
+		}
+		nameChanged := input.NewServerCertificateName != nil
+
+		if d.HasChange(names.AttrPath) {
+			if !nameChanged {
+				name := d.Get(names.AttrName).(string)
+				input.ServerCertificateName = aws.String(name)
+			}
+			input.NewPath = aws.String(d.Get(names.AttrPath).(string))
+		}
+
+		_, err := conn.UpdateServerCertificate(ctx, input)
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "updating IAM Server Certificate (%s): %s", d.Id(), err)
+		}
+
+		// If the name was changed, the new name must be set in the state for tag update that precedes resource read
+		if nameChanged {
+			d.Set(names.AttrName, input.NewServerCertificateName)
+		}
+	}
 
 	return append(diags, resourceServerCertificateRead(ctx, d, meta)...)
 }

--- a/website/docs/r/iam_server_certificate.html.markdown
+++ b/website/docs/r/iam_server_certificate.html.markdown
@@ -93,20 +93,19 @@ resource "aws_elb" "ourapp" {
 
 This resource supports the following arguments:
 
-* `name` - (Optional) The name of the Server Certificate. Do not include the
-  path in this value. If omitted, Terraform will assign a random, unique name.
-* `name_prefix` - (Optional) Creates a unique name beginning with the specified
-  prefix. Conflicts with `name`.
-* `certificate_body` – (Required) The contents of the public key certificate in
+* `certificate_body` – (Required, Forces new resource) The contents of the public key certificate in
   PEM-encoded format.
-* `certificate_chain` – (Optional) The contents of the certificate chain.
+* `certificate_chain` – (Optional, Forces new resource) The contents of the certificate chain.
   This is typically a concatenation of the PEM-encoded public key certificates
   of the chain.
-* `private_key` – (Required) The contents of the private key in PEM-encoded format.
+* `name` - (Optional) The name of the Server Certificate. Do not include the path in this value. If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified
+  prefix. Conflicts with `name`.
 * `path` - (Optional) The IAM path for the server certificate.  If it is not
     included, it defaults to a slash (/). If this certificate is for use with
     AWS CloudFront, the path must be in format `/cloudfront/your_path_here`.
     See [IAM Identifiers][1] for more details on IAM Paths.
+* `private_key` – (Required, Forces new resource) The contents of the private key in PEM-encoded format.
 * `tags` - (Optional) Map of resource tags for the server certificate. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ~> **NOTE:** AWS performs behind-the-scenes modifications to some certificate files if they do not adhere to a specific format. These modifications will result in terraform forever believing that it needs to update the resources since the local and AWS file contents will not match after theses modifications occur. In order to prevent this from happening you must ensure that all your PEM-encoded files use UNIX line-breaks and that `certificate_body` contains only one certificate. All other certificates should go in `certificate_chain`. It is common for some Certificate Authorities to issue certificate files that have DOS line-breaks and that are actually multiple certificates concatenated together in order to form a full certificate chain.
@@ -118,7 +117,6 @@ This resource exports the following attributes in addition to the arguments abov
 * `arn` - The Amazon Resource Name (ARN) specifying the server certificate.
 * `expiration` - Date and time in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) on which the certificate is set to expire.
 * `id` - The unique Server Certificate name
-* `name` - The name of the Server Certificate
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `upload_date` - Date and time in [RFC3339 format](https://tools.ietf.org/html/rfc3339#section-5.8) when the server certificate was uploaded.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to allow updating the `name`, `name_prefix`, and `path` arguments of the `aws_iam_server_certificate` resource without force creating a new one.

Note that there is still one limitation, where you cannot update the resource with both `name` and `name_prefix` set to null to change to a fully-generated name. Since both of these arguments are optional + computed, the plan will simply detect no changes.

As well, there is an account-level quota limit on 20 IAM server certificates. You'll either have to request for a quota increase (which I did, to 40) or set `-parallel` to a smaller number than 20.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #37479

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [UpdateServerCertificate](https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateServerCertificate.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccIAMServerCertificate_      PKG=iam
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/iam/... -v -count 1 -parallel 20 -run='TestAccIAMServerCertificate_'  -timeout 360m -vet=off
2025/02/01 16:12:25 Initializing Terraform AWS Provider...
=== RUN   TestAccIAMServerCertificate_tags
=== PAUSE TestAccIAMServerCertificate_tags
=== RUN   TestAccIAMServerCertificate_tags_null
=== PAUSE TestAccIAMServerCertificate_tags_null
=== RUN   TestAccIAMServerCertificate_tags_EmptyMap
=== PAUSE TestAccIAMServerCertificate_tags_EmptyMap
=== RUN   TestAccIAMServerCertificate_tags_AddOnUpdate
=== PAUSE TestAccIAMServerCertificate_tags_AddOnUpdate
=== RUN   TestAccIAMServerCertificate_tags_EmptyTag_OnCreate
=== PAUSE TestAccIAMServerCertificate_tags_EmptyTag_OnCreate
=== RUN   TestAccIAMServerCertificate_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccIAMServerCertificate_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccIAMServerCertificate_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccIAMServerCertificate_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccIAMServerCertificate_tags_DefaultTags_providerOnly
=== PAUSE TestAccIAMServerCertificate_tags_DefaultTags_providerOnly
=== RUN   TestAccIAMServerCertificate_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccIAMServerCertificate_tags_DefaultTags_nonOverlapping
=== RUN   TestAccIAMServerCertificate_tags_DefaultTags_overlapping
=== PAUSE TestAccIAMServerCertificate_tags_DefaultTags_overlapping
=== RUN   TestAccIAMServerCertificate_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccIAMServerCertificate_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccIAMServerCertificate_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccIAMServerCertificate_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccIAMServerCertificate_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccIAMServerCertificate_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccIAMServerCertificate_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccIAMServerCertificate_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccIAMServerCertificate_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccIAMServerCertificate_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccIAMServerCertificate_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccIAMServerCertificate_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccIAMServerCertificate_tags_ComputedTag_OnCreate
=== PAUSE TestAccIAMServerCertificate_tags_ComputedTag_OnCreate
=== RUN   TestAccIAMServerCertificate_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccIAMServerCertificate_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccIAMServerCertificate_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccIAMServerCertificate_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccIAMServerCertificate_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccIAMServerCertificate_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccIAMServerCertificate_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccIAMServerCertificate_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccIAMServerCertificate_basic
=== PAUSE TestAccIAMServerCertificate_basic
=== RUN   TestAccIAMServerCertificate_nameGenerated
=== PAUSE TestAccIAMServerCertificate_nameGenerated
=== RUN   TestAccIAMServerCertificate_namePrefix
=== PAUSE TestAccIAMServerCertificate_namePrefix
=== RUN   TestAccIAMServerCertificate_disappears
=== PAUSE TestAccIAMServerCertificate_disappears
=== RUN   TestAccIAMServerCertificate_file
=== PAUSE TestAccIAMServerCertificate_file
=== RUN   TestAccIAMServerCertificate_path
=== PAUSE TestAccIAMServerCertificate_path
=== CONT  TestAccIAMServerCertificate_tags
=== CONT  TestAccIAMServerCertificate_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccIAMServerCertificate_path
=== CONT  TestAccIAMServerCertificate_file
=== CONT  TestAccIAMServerCertificate_disappears
=== CONT  TestAccIAMServerCertificate_namePrefix
=== CONT  TestAccIAMServerCertificate_nameGenerated
=== CONT  TestAccIAMServerCertificate_basic
=== CONT  TestAccIAMServerCertificate_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccIAMServerCertificate_tags_IgnoreTags_Overlap_DefaultTag
=== CONT  TestAccIAMServerCertificate_tags_ComputedTag_OnUpdate_Replace
=== CONT  TestAccIAMServerCertificate_tags_ComputedTag_OnUpdate_Add
=== CONT  TestAccIAMServerCertificate_tags_ComputedTag_OnCreate
=== CONT  TestAccIAMServerCertificate_tags_DefaultTags_providerOnly
=== CONT  TestAccIAMServerCertificate_tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccIAMServerCertificate_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccIAMServerCertificate_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccIAMServerCertificate_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccIAMServerCertificate_tags_EmptyTag_OnCreate
=== CONT  TestAccIAMServerCertificate_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccIAMServerCertificate_nameGenerated (40.32s)
=== CONT  TestAccIAMServerCertificate_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccIAMServerCertificate_disappears (41.27s)
=== CONT  TestAccIAMServerCertificate_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccIAMServerCertificate_tags_DefaultTags_emptyProviderOnlyTag (54.93s)
=== CONT  TestAccIAMServerCertificate_tags_DefaultTags_overlapping
--- PASS: TestAccIAMServerCertificate_tags_DefaultTags_nullNonOverlappingResourceTag (57.39s)
=== CONT  TestAccIAMServerCertificate_tags_EmptyMap
--- PASS: TestAccIAMServerCertificate_tags_DefaultTags_nullOverlappingResourceTag (58.36s)
=== CONT  TestAccIAMServerCertificate_tags_AddOnUpdate
--- PASS: TestAccIAMServerCertificate_tags_DefaultTags_emptyResourceTag (59.37s)
=== CONT  TestAccIAMServerCertificate_tags_DefaultTags_nonOverlapping
--- PASS: TestAccIAMServerCertificate_tags_ComputedTag_OnCreate (63.38s)
=== CONT  TestAccIAMServerCertificate_tags_null
--- PASS: TestAccIAMServerCertificate_file (75.16s)
--- PASS: TestAccIAMServerCertificate_basic (83.18s)
--- PASS: TestAccIAMServerCertificate_tags_DefaultTags_updateToResourceOnly (86.24s)
--- PASS: TestAccIAMServerCertificate_tags_DefaultTags_updateToProviderOnly (93.21s)
--- PASS: TestAccIAMServerCertificate_tags_ComputedTag_OnUpdate_Add (98.26s)
--- PASS: TestAccIAMServerCertificate_tags_ComputedTag_OnUpdate_Replace (98.97s)
--- PASS: TestAccIAMServerCertificate_tags_EmptyTag_OnCreate (100.51s)
--- PASS: TestAccIAMServerCertificate_path (105.76s)
--- PASS: TestAccIAMServerCertificate_tags_IgnoreTags_Overlap_DefaultTag (109.71s)
--- PASS: TestAccIAMServerCertificate_namePrefix (115.21s)
--- PASS: TestAccIAMServerCertificate_tags_EmptyMap (58.04s)
--- PASS: TestAccIAMServerCertificate_tags_EmptyTag_OnUpdate_Replace (76.03s)
--- PASS: TestAccIAMServerCertificate_tags_null (55.89s)
--- PASS: TestAccIAMServerCertificate_tags_AddOnUpdate (66.99s)
--- PASS: TestAccIAMServerCertificate_tags_IgnoreTags_Overlap_ResourceTag (128.95s)
--- PASS: TestAccIAMServerCertificate_tags_EmptyTag_OnUpdate_Add (94.52s)
--- PASS: TestAccIAMServerCertificate_tags (140.48s)
--- PASS: TestAccIAMServerCertificate_tags_DefaultTags_providerOnly (142.77s)
--- PASS: TestAccIAMServerCertificate_tags_DefaultTags_overlapping (90.18s)
--- PASS: TestAccIAMServerCertificate_tags_DefaultTags_nonOverlapping (86.39s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        148.480s

$
```
