### PR TITLE
fix: Fix string length checks for UTF-8 fields for aws_cognito_identity_provider, aws_cognito_user_group, and aws_cognito_user_pool_client

### DIFF
--- a/.changelog/41187.txt
+++ b/.changelog/41187.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+resource/aws_cognito_identity_provider: Correct plan-time validation of `provider_name` to count UTF-8 characters properly
+```
+
+```release-note:bug
+resource/aws_cognito_user_group: Correct plan-time validation of `name` to count UTF-8 characters properly
+```
+
+```release-note:bug
+resource/aws_cognito_user_pool_client: Correct plan-time validation of `callback_urls, `default_redirect_uri`, `logout_urls`, and `supported_identity_providers` to count UTF-8 characters properly
+```

--- a/internal/service/cognitoidp/identity_provider.go
+++ b/internal/service/cognitoidp/identity_provider.go
@@ -65,13 +65,10 @@ func resourceIdentityProvider() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			names.AttrProviderName: {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 32),
-					validation.StringMatch(regexache.MustCompile(`^[^_][\p{L}\p{M}\p{S}\p{N}\p{P}][^_]+$`), "see https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html#API_CreateIdentityProvider_RequestSyntax"),
-				),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validIdentityProviderName,
 			},
 			"provider_type": {
 				Type:             schema.TypeString,

--- a/internal/service/cognitoidp/user_group_test.go
+++ b/internal/service/cognitoidp/user_group_test.go
@@ -6,6 +6,7 @@ package cognitoidp_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -23,6 +24,7 @@ func TestAccCognitoIDPUserGroup_basic(t *testing.T) {
 	poolName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	groupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	updatedGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	updatedGroupNameUTF8 := strings.Repeat("あ", 128)
 	resourceName := "aws_cognito_user_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -48,6 +50,13 @@ func TestAccCognitoIDPUserGroup_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckUserGroupExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, updatedGroupName),
+				),
+			},
+			{
+				Config: testAccUserGroupConfig_basic(poolName, updatedGroupNameUTF8),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserGroupExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, updatedGroupNameUTF8),
 				),
 			},
 		},

--- a/internal/service/cognitoidp/validate.go
+++ b/internal/service/cognitoidp/validate.go
@@ -12,6 +12,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
+func validIdentityProviderName(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+	count := utf8.RuneCountInString(value)
+	if count < 1 {
+		es = append(es, fmt.Errorf("%q cannot be less than 1 UTF-8 character", k))
+	}
+
+	if count > 32 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 32 UTF-8 characters", k))
+	}
+	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}\s]+`).MatchString(value) {
+		es = append(es, fmt.Errorf(`%q must satisfy regular expression pattern: [\p{L}\p{M}\p{S}\p{N}\p{P}\s]+`, k))
+	}
+	return
+}
+
 func validResourceServerScopeName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
@@ -19,7 +35,7 @@ func validResourceServerScopeName(v interface{}, k string) (ws []string, errors 
 		errors = append(errors, fmt.Errorf("%q cannot be less than 1 character", k))
 	}
 	if len(value) > 256 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 256 character", k))
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 256 characters", k))
 	}
 	if !regexache.MustCompile(`[\x21\x23-\x2E\x30-\x5B\x5D-\x7E]+`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(`%q must satisfy regular expression pattern: [\x21\x23-\x2E\x30-\x5B\x5D-\x7E]+`, k))
@@ -29,12 +45,13 @@ func validResourceServerScopeName(v interface{}, k string) (ws []string, errors 
 
 func validUserGroupName(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-	if len(value) < 1 {
-		es = append(es, fmt.Errorf("%q cannot be less than 1 character", k))
+	count := utf8.RuneCountInString(value)
+	if count < 1 {
+		es = append(es, fmt.Errorf("%q cannot be less than 1 UTF-8 character", k))
 	}
 
-	if len(value) > 128 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 128 character", k))
+	if count > 128 {
+		es = append(es, fmt.Errorf("%q cannot be longer than 128 UTF-8 characters", k))
 	}
 
 	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}]+`).MatchString(value) {
@@ -134,7 +151,7 @@ func validUserPoolSchemaName(v interface{}, k string) (ws []string, es []error) 
 	}
 
 	if len(value) > 20 {
-		es = append(es, fmt.Errorf("%q cannot be longer than 20 character", k))
+		es = append(es, fmt.Errorf("%q cannot be longer than 20 characters", k))
 	}
 
 	if !regexache.MustCompile(`[\p{L}\p{M}\p{S}\p{N}\p{P}]+`).MatchString(value) {
@@ -263,7 +280,7 @@ func validUserPoolTemplateSMSMessage(v interface{}, k string) (ws []string, es [
 }
 
 var userPoolClientIdentityProviderValidator = []validator.String{
-	stringvalidator.LengthBetween(1, 32),
+	stringvalidator.UTF8LengthBetween(1, 32),
 	stringValidatorpLpMpSpNpP,
 }
 
@@ -273,7 +290,7 @@ var userPoolClientNameValidator = []validator.String{
 }
 
 var userPoolClientURLValidator = []validator.String{
-	stringvalidator.LengthBetween(1, 1024),
+	stringvalidator.UTF8LengthBetween(1, 1024),
 	stringValidatorpLpMpSpNpP,
 }
 

--- a/internal/service/cognitoidp/validate_test.go
+++ b/internal/service/cognitoidp/validate_test.go
@@ -10,6 +10,42 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+func TestValidIdentityProviderName(t *testing.T) {
+	t.Parallel()
+
+	validValues := []string{
+		"foo",
+		"7346241598935552",
+		"foo_bar",
+		"foo:bar",
+		"foo/bar",
+		"foo-bar",
+		"$foobar",
+		strings.Repeat("W", 32),
+		strings.Repeat("あ", 32), // UTF-8 (2 bytes/char)
+	}
+
+	for _, s := range validValues {
+		_, errors := validIdentityProviderName(s, names.AttrName)
+		if len(errors) > 0 {
+			t.Fatalf("%q should be a valid Cognito Identity Provider Name: %v", s, errors)
+		}
+	}
+
+	invalidValues := []string{
+		"",
+		strings.Repeat("W", 33), // > 32
+		strings.Repeat("あ", 33), // UTF-8 (2 bytes/char)
+	}
+
+	for _, s := range invalidValues {
+		_, errors := validIdentityProviderName(s, names.AttrName)
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid Cognito Identity Provider Name: %v", s, errors)
+		}
+	}
+}
+
 func TestValidUserGroupName(t *testing.T) {
 	t.Parallel()
 
@@ -22,6 +58,7 @@ func TestValidUserGroupName(t *testing.T) {
 		"foo-bar",
 		"$foobar",
 		strings.Repeat("W", 128),
+		strings.Repeat("あ", 128), // UTF-8 (2 bytes/char)
 	}
 
 	for _, s := range validValues {
@@ -34,6 +71,7 @@ func TestValidUserGroupName(t *testing.T) {
 	invalidValues := []string{
 		"",
 		strings.Repeat("W", 129), // > 128
+		strings.Repeat("あ", 129), // UTF-8 (2 bytes/char)
 	}
 
 	for _, s := range invalidValues {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes the string length validation logic to account for UTF-8 characters for the following resources and argument:

- For `aws_cognito_identity_provider`, the `provider_name` argument
- For `aws_cognito_user_group`, the `name` argument
- For `aws_cognito_user_pool_client`, the `callback_urls`, `default_redirect_uri`, `logout_urls`, and `supported_identity_providers` arguments

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41171

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateIdentityProvider](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateIdentityProvider.html), [CreateGroup](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateGroup.html) , and [CreateUserPoolClient](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html) for specs.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

For `aws_cognito_identity_provider`:

```console
$ make testacc TESTS="TestAccCognitoIDPIdentityProvider_basic|TestAccCognitoIDPIdentityProvider_saml" PKG=cognitoidp
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPIdentityProvider_basic|TestAccCognitoIDPIdentityProvider_saml'  -timeout 360m -vet=off
2025/02/01 18:58:34 Initializing Terraform AWS Provider...
=== RUN   TestAccCognitoIDPIdentityProvider_basic
=== PAUSE TestAccCognitoIDPIdentityProvider_basic
=== RUN   TestAccCognitoIDPIdentityProvider_saml
=== PAUSE TestAccCognitoIDPIdentityProvider_saml
=== CONT  TestAccCognitoIDPIdentityProvider_basic
=== CONT  TestAccCognitoIDPIdentityProvider_saml
--- PASS: TestAccCognitoIDPIdentityProvider_basic (29.91s)
--- PASS: TestAccCognitoIDPIdentityProvider_saml (40.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 40.517s

$
```

For `aws_cognito_user_group`:

```console
$ make testacc TESTS=TestAccCognitoIDPUserGroup_basic PKG=cognitoidp
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserGroup_basic'  -timeout 360m -vet=off
2025/02/01 19:39:54 Initializing Terraform AWS Provider...
=== RUN   TestAccCognitoIDPUserGroup_basic
=== PAUSE TestAccCognitoIDPUserGroup_basic
=== CONT  TestAccCognitoIDPUserGroup_basic
--- PASS: TestAccCognitoIDPUserGroup_basic (40.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 40.931s

$
```

For `aws_cognito_user_pool_client`:

```console
$ make testacc TESTS="TestAccCognitoIDPUserPoolClient_basic|TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8|TestAccCognitoIDPUserPoolClient_urls_utf8" PKG=cognitoidp
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPoolClient_basic|TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8|TestAccCognitoIDPUserPoolClient_urls_utf8'  -timeout 360m -vet=off
2025/02/01 19:05:02 Initializing Terraform AWS Provider...
=== RUN   TestAccCognitoIDPUserPoolClient_basic
=== PAUSE TestAccCognitoIDPUserPoolClient_basic
=== RUN   TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8
=== PAUSE TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8
=== RUN   TestAccCognitoIDPUserPoolClient_urls_utf8
=== PAUSE TestAccCognitoIDPUserPoolClient_urls_utf8
=== CONT  TestAccCognitoIDPUserPoolClient_basic
=== CONT  TestAccCognitoIDPUserPoolClient_urls_utf8
=== CONT  TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8
--- PASS: TestAccCognitoIDPUserPoolClient_urls_utf8 (19.41s)
--- PASS: TestAccCognitoIDPUserPoolClient_basic (19.91s)
--- PASS: TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8 (20.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 20.815s

$
```

For `validate.go`:

```console
$ make testacc TESTS="TestValidIdentityProviderName|TestValidUserGroupName" PKG=cognitoidp
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestValidIdentityProviderName|TestValidUserGroupName'  -timeout 360m -vet=off
2025/02/01 19:37:36 Initializing Terraform AWS Provider...
=== RUN   TestValidIdentityProviderName
=== PAUSE TestValidIdentityProviderName
=== RUN   TestValidUserGroupName
=== PAUSE TestValidUserGroupName
=== CONT  TestValidIdentityProviderName
=== CONT  TestValidUserGroupName
--- PASS: TestValidIdentityProviderName (0.00s)
--- PASS: TestValidUserGroupName (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 0.199s

$
```