### PR TITLE
feat: Add tagging support for aws_rekognition_project

### DIFF
--- a/.changelog/41192.txt
+++ b/.changelog/41192.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rekognition_project: Add `tags` argument and `tags_all` attribute
+```

--- a/internal/service/rekognition/service_package_gen.go
+++ b/internal/service/rekognition/service_package_gen.go
@@ -32,6 +32,9 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			Factory:  newResourceProject,
 			TypeName: "aws_rekognition_project",
 			Name:     "Project",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			},
 		},
 		{
 			Factory:  newResourceStreamProcessor,

--- a/website/docs/r/rekognition_project.html.markdown
+++ b/website/docs/r/rekognition_project.html.markdown
@@ -24,18 +24,20 @@ resource "aws_rekognition_project" "example" {
 
 The following arguments are required:
 
-* `name` - (Required) Desired name of the project
+* `name` - (Required) Desired name of the project.
 
 The following arguments are optional:
 
-* `auto_update` - (Optional) Specify if automatic retraining should occur. Valid values are `ENABLED` or `DISABLED`. Defaults to `DISABLED`
-* `feature` - (Optional) Specify the feature being customized. Valid values are `CONTENT_MODERATION` or `CUSTOM_LABELS`. Defaults to `CUSTOM_LABELS`
+* `auto_update` - (Optional) Specify if automatic retraining should occur. Valid values are `ENABLED` or `DISABLED`. Defaults to `DISABLED`.
+* `feature` - (Optional) Specify the feature being customized. Valid values are `CONTENT_MODERATION` or `CUSTOM_LABELS`. Defaults to `CUSTOM_LABELS`.
+* `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](/docs/providers/aws/index.html#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the Project.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add tagging support to the `aws_rekognition_project` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41102

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateProject](https://docs.aws.amazon.com/rekognition/latest/APIReference/API_CreateProject.html) for specs.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccRekognitionProject_ PKG=rekognition
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/rekognition/... -v -count 1 -parallel 20 -run='TestAccRekognitionProject_'  -timeout 360m -vet=off
2025/02/02 16:08:18 Initializing Terraform AWS Provider...
=== RUN   TestAccRekognitionProject_basic
=== PAUSE TestAccRekognitionProject_basic
=== RUN   TestAccRekognitionProject_ContentModeration
=== PAUSE TestAccRekognitionProject_ContentModeration
=== RUN   TestAccRekognitionProject_CustomLabels
=== PAUSE TestAccRekognitionProject_CustomLabels
=== RUN   TestAccRekognitionProject_disappears
=== PAUSE TestAccRekognitionProject_disappears
=== RUN   TestAccRekognitionProject_tags
=== PAUSE TestAccRekognitionProject_tags
=== CONT  TestAccRekognitionProject_basic
=== CONT  TestAccRekognitionProject_disappears
=== CONT  TestAccRekognitionProject_tags
=== CONT  TestAccRekognitionProject_CustomLabels
=== CONT  TestAccRekognitionProject_ContentModeration
--- PASS: TestAccRekognitionProject_disappears (21.41s)
--- PASS: TestAccRekognitionProject_basic (23.89s)
--- PASS: TestAccRekognitionProject_CustomLabels (24.00s)
--- PASS: TestAccRekognitionProject_ContentModeration (32.27s)
--- PASS: TestAccRekognitionProject_tags (42.99s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rekognition        43.228s

$
```
