### PR TITLE
feat: add aws_db_proxies data source

### DIFF
--- a/.changelog/41193.txt
+++ b/.changelog/41193.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_db_proxies
+```

--- a/internal/service/rds/proxies_data_source.go
+++ b/internal/service/rds/proxies_data_source.go
@@ -1,0 +1,86 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_db_proxies",name=Proxies)
+func newDBProxiesDataSource(_ context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dbProxiesDataSource{}, nil
+}
+
+type dbProxiesDataSource struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dbProxiesDataSource) Metadata(_ context.Context, _ datasource.MetadataRequest, response *datasource.MetadataResponse) {
+	response.TypeName = "aws_db_proxies"
+}
+
+func (d *dbProxiesDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"proxy_arns": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			names.AttrNames: schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *dbProxiesDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data proxiesDataSourceModel
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().RDSClient(ctx)
+
+	// It is not possible to filter by the proxy parameters, for future use
+	input := &rds.DescribeDBProxiesInput{}
+
+	proxies, err := findDBProxies(ctx, conn, input, tfslices.PredicateTrue[*rdsTypes.DBProxy]())
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading RDS Proxies: %s"), err.Error())
+		return
+	}
+
+	var proxyARNs []string
+	var proxyNames []string
+
+	for _, proxy := range proxies {
+		proxyARNs = append(proxyARNs, aws.ToString(proxy.DBProxyArn))
+		proxyNames = append(proxyNames, aws.ToString(proxy.DBProxyName))
+	}
+
+	data.Names = fwflex.FlattenFrameworkStringValueSetLegacy(ctx, proxyNames)
+	data.ProxyARNs = fwflex.FlattenFrameworkStringValueSetLegacy(ctx, proxyARNs)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+type proxiesDataSourceModel struct {
+	ProxyARNs types.Set `tfsdk:"proxy_arns"`
+	Names     types.Set `tfsdk:"proxy_names"`
+}

--- a/internal/service/rds/proxies_data_source_test.go
+++ b/internal/service/rds/proxies_data_source_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds_test
+
+import (
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDBProxiesDataSource(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_db_proxies.test"
+	resourceName := "aws_db_proxy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProxiesDataSourceConfig_filter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_arns.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "proxy_arns.0", resourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(dataSourceName, "proxy_names.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "proxy_names.0", resourceName, names.AttrName),
+				),
+			},
+		},
+	})
+}
+
+func testAccProxiesDataSourceConfig_filter(rName string) string {
+	return acctest.ConfigCompose(testAccProxyConfig_basic(rName), testAccProxyConfig_basic(rName), `
+data "aws_db_Proxies "test" {}
+`)
+}

--- a/website/docs/d/rds_proxies.html.markdown
+++ b/website/docs/d/rds_proxies.html.markdown
@@ -1,0 +1,28 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_db_Proxies"
+description: |-
+  Terraform data source for managing an AWS RDS (Relational Database) Proxies.
+---
+
+# Data Source: aws_db_Proxies
+
+Terraform data source for managing an AWS RDS (Relational Database) DB Proxies.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_db_Proxies" "example" {}
+```
+
+## Argument Reference
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `proxy_arns` - Set of ARNs of the RDS DB proxies.
+* `proxy_names` - Set of names of the RDS DB proxies.


### PR DESCRIPTION
### Description

Add new `aws_db_proxies`  that will return all the available RDS proxies.

### Relations

Closes #41174


### References

API: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBProxies.html


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccDBProxiesDataSource PKG=rds

...
```
