### PR TITLE
Fix spot instance request cleanup

### DIFF
--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -2221,7 +2221,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
-	if v, ok := d.GetOk("instance_lifecycle"); ok && v == awstypes.InstanceLifecycleSpot {
+	if v, ok := d.GetOk("instance_lifecycle"); ok && v == string(awstypes.InstanceLifecycleSpot) {
 		spotInstanceRequestID := d.Get("spot_instance_request_id").(string)
 		_, err := conn.CancelSpotInstanceRequests(ctx, &ec2.CancelSpotInstanceRequestsInput{
 			SpotInstanceRequestIds: []string{spotInstanceRequestID},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes the issue described in #38142. During destruction of a persistent spot ec2 instance created via instance_market_options, the step to cleanup the spot requests is not triggered due to the unmatched condition at:
https://github.com/hashicorp/terraform-provider-aws/blob/658a64579f91e53276d2a71da00aa43b854d3de7/internal/service/ec2/ec2_instance.go#L2224

Currently, the destruction reports successfully completed with no errors, but the spot request is left uncancelled. This results in the ec2 instance being recreated by the still live spot request. Thus, at least two untracked resources are left after destruction.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38142

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

Example debug output during spot instance destruction where spot request cleanup was skipped over:
```
  | <Response><Errors><Error><Code>UnsupportedOperation</Code><Message>Modifying 'disableApiTermination' is not supported for spot instances.</Message></Error></Errors><RequestID>62bb4b08-2e7d-4c10-9626-5b0f3a2daccc</RequestID></Response>
   http.response.header.vary=accept-encoding rpc.system=aws-api timestamp="2025-02-03T22:59:55.822+0800"
2025-02-03T22:59:55.822+0800 [DEBUG] provider.terraform-provider-aws_v5.84.0_x5: request failed with unretryable error https response error StatusCode: 400, RequestID: 62bb4b08-2e7d-4c10-9626-5b0f3a2daccc, api error UnsupportedOperation: Modifying 'disableApiTermination' is not supported for spot instances.: @module=aws tf_aws.sdk=aws-sdk-go-v2 tf_resource_type=aws_instance @caller=github.com/hashicorp/aws-sdk-go-base/v2@v2.0.0-beta.61/logging/tf_logger.go:45 rpc.service=EC2 aws.region=ap-east-1 tf_rpc=ApplyResourceChange rpc.system=aws-api tf_mux_provider="*schema.GRPCProviderServer" tf_provider_addr=registry.terraform.io/hashicorp/aws tf_req_id=cf8eb421-0e52-41eb-b09e-c4667d26a74f rpc.method=ModifyInstanceAttribute timestamp="2025-02-03T22:59:55.822+0800"
2025-02-03T22:59:55.822+0800 [WARN]  provider.terraform-provider-aws_v5.84.0_x5: [WARN] failed to modify EC2 Instance (i-0c9efa2a723b96e8c) attribute: operation error EC2: ModifyInstanceAttribute, https response error StatusCode: 400, RequestID: 62bb4b08-2e7d-4c10-9626-5b0f3a2daccc, api error UnsupportedOperation: Modifying 'disableApiTermination' is not supported for spot instances.
2025-02-03T22:59:55.823+0800 [DEBUG] provider.terraform-provider-aws_v5.84.0_x5: [DEBUG] Terminating EC2 Instance: i-0c9efa2a723b96e8c
2025-02-03T22:59:55.823+0800 [DEBUG] provider.terraform-provider-aws_v5.84.0_x5: HTTP Request Sent: tf_aws.signing_region="" http.request.header.amz_sdk_invocation_id=6cfec01f-0fb1-4ee1-8afd-98b7e27e2786 rpc.method=TerminateInstances rpc.service=EC2 tf_aws.sdk=aws-sdk-go-v2 tf_resource_type=aws_instance
```
Compared to the code at:
https://github.com/hashicorp/terraform-provider-aws/blob/111488f34aee1539e1931711d744454572fd64c4/internal/service/ec2/ec2_instance.go#L2214-L2237