### PR TITLE
d aws_route53_records alias target for globalaccelerator_accelerator

### DIFF
--- a/website/docs/r/route53_record.html.markdown
+++ b/website/docs/r/route53_record.html.markdown
@@ -111,6 +111,28 @@ resource "aws_route53_record" "www" {
 }
 ```
 
+### Alias record for AWS Global Accelerator
+
+```terraform
+resource "aws_globalaccelerator_accelerator" "main" {
+  name               = "foobar-terraform-accelerator"
+  enabled            = true
+  ip_address_type    = "IPV4"
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = "example.com"
+  type    = "A"
+
+  alias {
+    name                   = aws_globalaccelerator_accelerator.main.dns_name
+    zone_id                = aws_globalaccelerator_accelerator.main.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+```
+
 ### NS and SOA Record Management
 
 When creating Route 53 zones, the `NS` and `SOA` records for the zone are automatically created. Enabling the `allow_overwrite` argument will allow managing these records in a single Terraform run without the requirement for `terraform import`.
@@ -164,8 +186,8 @@ Exactly one of `records` or `alias` must be specified: this determines whether i
 
 Alias records support the following:
 
-* `name` - (Required) DNS domain name for a CloudFront distribution, S3 bucket, ELB, or another resource record set in this hosted zone.
-* `zone_id` - (Required) Hosted zone ID for a CloudFront distribution, S3 bucket, ELB, or Route 53 hosted zone. See [`resource_elb.zone_id`](/docs/providers/aws/r/elb.html#zone_id) for example.
+* `name` - (Required) DNS domain name for a CloudFront distribution, S3 bucket, ELB, AWS Global Accelerator, or another resource record set in this hosted zone.
+* `zone_id` - (Required) Hosted zone ID for a CloudFront distribution, S3 bucket, ELB, AWS Global Accelerator, or Route 53 hosted zone. See [`resource_elb.zone_id`](/docs/providers/aws/r/elb.html#zone_id) for example.
 * `evaluate_target_health` - (Required) Set to `true` if you want Route 53 to determine whether to respond to DNS queries using this resource record set by checking the health of the resource record set. Some resources have special requirements, see [related part of documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values.html#rrsets-values-alias-evaluate-target-health).
 
 ### CIDR Routing Policy


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
An example of how to configure an alias record that points to an AWS Global Accelerator is added in this PR.

Changes:

- Added a new "Alias record for AWS Global Accelerator" example under the Example Usage section.
- Updated the Alias section to explicitly mention that AWS Global Accelerator can be used as an alias target.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41130 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record#alias
https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html

...
```
