### PR TITLE
aws_sqs_queue: Add customizable timeouts

### DIFF
--- a/.changelog/41232.txt
+++ b/.changelog/41232.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_sqs_queue: Accommodate accounts that take longer to process with customizable `timeouts`.
+```

--- a/internal/service/sqs/attribute_funcs.go
+++ b/internal/service/sqs/attribute_funcs.go
@@ -46,9 +46,9 @@ func (h *queueAttributeHandler) Upsert(ctx context.Context, d *schema.ResourceDa
 		QueueUrl:   aws.String(url),
 	}
 
-	deadline := tfresource.NewDeadline(d.Timeout(schema.TimeoutUpdate))
+	deadline := tfresource.NewDeadline(d.Timeout(schema.TimeoutCreate))
 
-	_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, deadline.Remaining(), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, d.Timeout(schema.TimeoutCreate)/2, func() (interface{}, error) {
 		return conn.SetQueueAttributes(ctx, input)
 	}, errCodeInvalidAttributeValue, "Invalid value for the parameter Policy")
 

--- a/internal/service/sqs/attribute_funcs.go
+++ b/internal/service/sqs/attribute_funcs.go
@@ -46,7 +46,9 @@ func (h *queueAttributeHandler) Upsert(ctx context.Context, d *schema.ResourceDa
 		QueueUrl:   aws.String(url),
 	}
 
-	_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
+	deadline := tfresource.NewDeadline(d.Timeout(schema.TimeoutUpdate))
+
+	_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, deadline.Remaining(), func() (interface{}, error) {
 		return conn.SetQueueAttributes(ctx, input)
 	}, errCodeInvalidAttributeValue, "Invalid value for the parameter Policy")
 
@@ -56,7 +58,7 @@ func (h *queueAttributeHandler) Upsert(ctx context.Context, d *schema.ResourceDa
 
 	d.SetId(url)
 
-	if err := waitQueueAttributesPropagated(ctx, conn, d.Id(), attributes); err != nil {
+	if err := waitQueueAttributesPropagated(ctx, conn, d.Id(), attributes, deadline.Remaining()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for SQS Queue (%s) attribute (%s) create: %s", d.Id(), h.AttributeName, err)
 	}
 
@@ -120,7 +122,7 @@ func (h *queueAttributeHandler) Delete(ctx context.Context, d *schema.ResourceDa
 		return sdkdiag.AppendErrorf(diags, "deleting SQS Queue (%s) attribute (%s): %s", d.Id(), h.AttributeName, err)
 	}
 
-	if err := waitQueueAttributesPropagated(ctx, conn, d.Id(), attributes); err != nil {
+	if err := waitQueueAttributesPropagated(ctx, conn, d.Id(), attributes, d.Timeout(schema.TimeoutDelete)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for SQS Queue (%s) attribute (%s) delete: %s", d.Id(), h.AttributeName, err)
 	}
 

--- a/internal/service/sqs/consts.go
+++ b/internal/service/sqs/consts.go
@@ -3,12 +3,6 @@
 
 package sqs
 
-import "time"
-
-const (
-	propagationTimeout = 1 * time.Minute
-)
-
 const (
 	fifoQueueNameSuffix = ".fifo"
 )

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -844,6 +844,28 @@ func TestAccSQSQueue_ManagedEncryption_kmsDataKeyReusePeriodSeconds(t *testing.T
 	})
 }
 
+func TestAccSQSQueue_timeouts(t *testing.T) {
+	ctx := acctest.Context(t)
+	var queueAttributes map[types.QueueAttributeName]string
+	resourceName := "aws_sqs_queue.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckQueueDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueueConfig_timeouts(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueueExists(ctx, resourceName, &queueAttributes),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckQueuePolicyAttribute(ctx context.Context, queueAttributes *map[types.QueueAttributeName]string, rName, policyTemplate string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		expectedPolicy := fmt.Sprintf(policyTemplate, acctest.Partition(), acctest.Region(), acctest.AccountID(ctx), rName)
@@ -1260,10 +1282,45 @@ resource "aws_sqs_queue" "test" {
   sqs_managed_sse_enabled           = true
   visibility_timeout_seconds        = "60"
   receive_wait_time_seconds         = "10"
+}
+`, rName)
+}
+
+// 29497
+func testAccQueueConfig_timeouts(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_sqs_queue" "test" {
+  name = %[1]q
 
   timeouts {
     create = "10m"
   }
+}
+
+resource "aws_sqs_queue_policy" "test" {
+  queue_url = aws_sqs_queue.test.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "SQS-Queue-Access-Policy"
+      Effect = "Allow"
+      Principal = {
+        Service = "s3.amazonaws.com"
+      }
+      Action   = "SQS:SendMessage"
+      Resource = aws_sqs_queue.test.arn
+      Condition = {
+        ArnLike = {
+          "aws:SourceArn" = aws_s3_bucket.test.arn
+        }
+      }
+    }]
+  })
 }
 `, rName)
 }

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -1260,6 +1260,10 @@ resource "aws_sqs_queue" "test" {
   sqs_managed_sse_enabled           = true
   visibility_timeout_seconds        = "60"
   receive_wait_time_seconds         = "10"
+
+  timeouts {
+    create = "10m"
+  }
 }
 `, rName)
 }

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -129,6 +129,14 @@ This resource exports the following attributes in addition to the arguments abov
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `url` - Same as `id`: The URL for the created Amazon SQS queue.
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `3m`)
+- `update` - (Default `3m`)
+- `delete` - (Default `3m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SQS Queues using the queue `url`. For example:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

There are concerns that long timeouts cause problems because mistakes take too long to surface. This is a note and constant being removed with this PR:

```go
	// Maximum amount of time to wait for SQS queue attribute changes to propagate
	// This timeout should not be increased without strong consideration
	// as this will negatively impact user experience when configurations
	// have incorrect references or permissions.
	// Reference: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html
	queueAttributePropagationTimeout = 2 * time.Minute
```

The trouble is that SQS seems to vary from region to region, partition to partition, and account to account. Some accounts cannot create a queue within 2 minutes with `kms_data_key_reuse_period_seconds` set in `us-east-1`, for example.

This PR is an attempt to balance the concern of not too long timeouts with the ability to customize timeouts. This changes the approach from hardcoded, fixed timeouts for each step, to bounded and customizable timeouts. For example, the new default timeout is `3m`. Creating the queue is alloted up to 50% of the timeout and propagation the remaining time.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41234

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
