### PR TITLE
flex: add write only flex functions

### DIFF
--- a/internal/flex/write_only.go
+++ b/internal/flex/write_only.go
@@ -1,0 +1,32 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package flex
+
+import (
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+)
+
+type writeOnlyAttrGetter interface {
+	GetRawConfigAt(path cty.Path) (cty.Value, diag.Diagnostics)
+	Id() string
+}
+
+// GetWriteOnlyValue returns the value of the write-only attribute from the config.
+func GetWriteOnlyValue(d writeOnlyAttrGetter, path cty.Path, attrType cty.Type) (cty.Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	valueWO, di := d.GetRawConfigAt(path)
+	if di.HasError() {
+		diags = append(diags, di...)
+		return cty.Value{}, diags
+	}
+
+	if !valueWO.Type().Equals(attrType) {
+		return cty.Value{}, sdkdiag.AppendErrorf(diags, "invalid type (%s) for resource(%s)", attrType, d.Id())
+	}
+
+	return valueWO, diags
+}

--- a/internal/flex/write_only.go
+++ b/internal/flex/write_only.go
@@ -14,6 +14,21 @@ type writeOnlyAttrGetter interface {
 	Id() string
 }
 
+// GetWriteOnlyStringValue returns the string value of the write-only attribute from the config.
+func GetWriteOnlyStringValue(d writeOnlyAttrGetter, path cty.Path, attrType cty.Type) (string, diag.Diagnostics) {
+	valueWO, diags := GetWriteOnlyValue(d, path, attrType)
+	if diags.HasError() {
+		return "", diags
+	}
+
+	var value string
+	if attrType == cty.String && !valueWO.IsNull() {
+		value = valueWO.AsString()
+	}
+
+	return value, diags
+}
+
 // GetWriteOnlyValue returns the value of the write-only attribute from the config.
 func GetWriteOnlyValue(d writeOnlyAttrGetter, path cty.Path, attrType cty.Type) (cty.Value, diag.Diagnostics) {
 	var diags diag.Diagnostics

--- a/internal/flex/write_only_test.go
+++ b/internal/flex/write_only_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package flex_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+)
+
+type mockWriteOnlyAttrGetter struct {
+	path  cty.Path
+	value cty.Value
+}
+
+func (m *mockWriteOnlyAttrGetter) GetRawConfigAt(path cty.Path) (cty.Value, diag.Diagnostics) {
+	if !path.Equals(m.path) {
+		return cty.NilVal, diag.Diagnostics{
+			diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       "Invalid config Path",
+				Detail:        fmt.Sprintf("expected: %v, got: %v", m.path, path),
+				AttributePath: path,
+			},
+		}
+	}
+	return m.value, nil
+}
+
+func (m *mockWriteOnlyAttrGetter) Id() string {
+	return "id"
+}
+
+func TestGetWriteOnlyValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input       cty.Path
+		setPath     cty.Path
+		inputType   cty.Type
+		value       cty.Value
+		expectError bool
+	}{
+		"valid value type": {
+			input:     cty.GetAttrPath("test_path"),
+			inputType: cty.String,
+			value:     cty.StringVal("test_value"),
+		},
+		"invalid value type": {
+			input:       cty.GetAttrPath("test_path"),
+			inputType:   cty.String,
+			value:       cty.BoolVal(true),
+			expectError: true,
+		},
+		"invalid path": {
+			input:       cty.GetAttrPath("invalid_path"),
+			setPath:     cty.GetAttrPath("test_path"),
+			inputType:   cty.String,
+			value:       cty.StringVal("test_value"),
+			expectError: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := mockWriteOnlyAttrGetter{
+				path:  testCase.setPath,
+				value: testCase.value,
+			}
+			_, diags := flex.GetWriteOnlyValue(&m, testCase.input, testCase.inputType)
+
+			if testCase.expectError && !diags.HasError() {
+				t.Fatalf("expected error, got none")
+			}
+		})
+	}
+}

--- a/internal/flex/write_only_test.go
+++ b/internal/flex/write_only_test.go
@@ -47,11 +47,13 @@ func TestGetWriteOnlyValue(t *testing.T) {
 	}{
 		"valid value type": {
 			input:     cty.GetAttrPath("test_path"),
+			setPath:   cty.GetAttrPath("test_path"),
 			inputType: cty.String,
 			value:     cty.StringVal("test_value"),
 		},
 		"invalid value type": {
 			input:       cty.GetAttrPath("test_path"),
+			setPath:     cty.GetAttrPath("test_path"),
 			inputType:   cty.String,
 			value:       cty.BoolVal(true),
 			expectError: true,
@@ -77,6 +79,53 @@ func TestGetWriteOnlyValue(t *testing.T) {
 
 			if testCase.expectError && !diags.HasError() {
 				t.Fatalf("expected error, got none")
+			}
+		})
+	}
+}
+
+func TestGetWriteOnlyStringValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input         cty.Path
+		setPath       cty.Path
+		inputType     cty.Type
+		value         cty.Value
+		expectedValue string
+	}{
+		"valid value": {
+			input:         cty.GetAttrPath("test_path"),
+			setPath:       cty.GetAttrPath("test_path"),
+			inputType:     cty.String,
+			value:         cty.StringVal("test_value"),
+			expectedValue: "test_value",
+		},
+		"value empty string": {
+			input:         cty.GetAttrPath("test_path"),
+			setPath:       cty.GetAttrPath("test_path"),
+			inputType:     cty.String,
+			value:         cty.StringVal(""),
+			expectedValue: "",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := mockWriteOnlyAttrGetter{
+				path:  testCase.setPath,
+				value: testCase.value,
+			}
+			value, diags := flex.GetWriteOnlyStringValue(&m, testCase.input, testCase.inputType)
+
+			if diags.HasError() {
+				t.Fatalf("unexpected error: %v", diags)
+			}
+
+			if testCase.expectedValue != value {
+				t.Fatalf("expected value: %s, got: %s", testCase.expectedValue, value)
 			}
 		})
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

add flex functions to simplify getting write-only attributes from config

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -count=1 -v ./internal/flex/... -run='TestGetWriteOnly'

=== RUN   TestGetWriteOnlyValue
=== PAUSE TestGetWriteOnlyValue
=== RUN   TestGetWriteOnlyStringValue
=== PAUSE TestGetWriteOnlyStringValue
=== CONT  TestGetWriteOnlyValue
=== RUN   TestGetWriteOnlyValue/invalid_value_type
=== PAUSE TestGetWriteOnlyValue/invalid_value_type
=== RUN   TestGetWriteOnlyValue/invalid_path
=== CONT  TestGetWriteOnlyStringValue
=== RUN   TestGetWriteOnlyStringValue/valid_value
=== PAUSE TestGetWriteOnlyStringValue/valid_value
=== RUN   TestGetWriteOnlyStringValue/value_empty_string
=== PAUSE TestGetWriteOnlyStringValue/value_empty_string
=== CONT  TestGetWriteOnlyStringValue/valid_value
=== PAUSE TestGetWriteOnlyValue/invalid_path
=== RUN   TestGetWriteOnlyValue/valid_value_type
=== CONT  TestGetWriteOnlyStringValue/value_empty_string
=== PAUSE TestGetWriteOnlyValue/valid_value_type
=== CONT  TestGetWriteOnlyValue/invalid_value_type
=== CONT  TestGetWriteOnlyValue/valid_value_type
=== CONT  TestGetWriteOnlyValue/invalid_path
--- PASS: TestGetWriteOnlyStringValue (0.00s)
    --- PASS: TestGetWriteOnlyStringValue/valid_value (0.00s)
    --- PASS: TestGetWriteOnlyStringValue/value_empty_string (0.00s)
--- PASS: TestGetWriteOnlyValue (0.00s)
    --- PASS: TestGetWriteOnlyValue/invalid_value_type (0.00s)
    --- PASS: TestGetWriteOnlyValue/valid_value_type (0.00s)
    --- PASS: TestGetWriteOnlyValue/invalid_path (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/flex	0.720s
```
