### PR TITLE
flex: simplify func signature for string write-only

### DIFF
--- a/internal/flex/write_only.go
+++ b/internal/flex/write_only.go
@@ -15,14 +15,14 @@ type writeOnlyAttrGetter interface {
 }
 
 // GetWriteOnlyStringValue returns the string value of the write-only attribute from the config.
-func GetWriteOnlyStringValue(d writeOnlyAttrGetter, path cty.Path, attrType cty.Type) (string, diag.Diagnostics) {
-	valueWO, diags := GetWriteOnlyValue(d, path, attrType)
+func GetWriteOnlyStringValue(d writeOnlyAttrGetter, path cty.Path) (string, diag.Diagnostics) {
+	valueWO, diags := GetWriteOnlyValue(d, path, cty.String)
 	if diags.HasError() {
 		return "", diags
 	}
 
 	var value string
-	if attrType == cty.String && !valueWO.IsNull() {
+	if !valueWO.IsNull() {
 		value = valueWO.AsString()
 	}
 

--- a/internal/flex/write_only_test.go
+++ b/internal/flex/write_only_test.go
@@ -90,21 +90,18 @@ func TestGetWriteOnlyStringValue(t *testing.T) {
 	testCases := map[string]struct {
 		input         cty.Path
 		setPath       cty.Path
-		inputType     cty.Type
 		value         cty.Value
 		expectedValue string
 	}{
 		"valid value": {
 			input:         cty.GetAttrPath("test_path"),
 			setPath:       cty.GetAttrPath("test_path"),
-			inputType:     cty.String,
 			value:         cty.StringVal("test_value"),
 			expectedValue: "test_value",
 		},
 		"value empty string": {
 			input:         cty.GetAttrPath("test_path"),
 			setPath:       cty.GetAttrPath("test_path"),
-			inputType:     cty.String,
 			value:         cty.StringVal(""),
 			expectedValue: "",
 		},
@@ -118,7 +115,7 @@ func TestGetWriteOnlyStringValue(t *testing.T) {
 				path:  testCase.setPath,
 				value: testCase.value,
 			}
-			value, diags := flex.GetWriteOnlyStringValue(&m, testCase.input, testCase.inputType)
+			value, diags := flex.GetWriteOnlyStringValue(&m, testCase.input)
 
 			if diags.HasError() {
 				t.Fatalf("unexpected error: %v", diags)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #41255

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -count=1 -v ./internal/flex/... -run='TestGetWriteOnlyStringValue'

=== RUN   TestGetWriteOnlyStringValue
=== PAUSE TestGetWriteOnlyStringValue
=== CONT  TestGetWriteOnlyStringValue
=== RUN   TestGetWriteOnlyStringValue/valid_value
=== PAUSE TestGetWriteOnlyStringValue/valid_value
=== RUN   TestGetWriteOnlyStringValue/value_empty_string
=== PAUSE TestGetWriteOnlyStringValue/value_empty_string
=== CONT  TestGetWriteOnlyStringValue/valid_value
=== CONT  TestGetWriteOnlyStringValue/value_empty_string
--- PASS: TestGetWriteOnlyStringValue (0.00s)
    --- PASS: TestGetWriteOnlyStringValue/valid_value (0.00s)
    --- PASS: TestGetWriteOnlyStringValue/value_empty_string (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/flex	0.586s
```
