### PR TITLE
r/aws_route53_zone: Fix crash when deleting the resource would otherwise return an error

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_zone: Fix `panic: runtime error: invalid memory address or nil pointer dereference` when deleting the resource would otherwise return an error
+```

--- a/internal/service/route53/zone.go
+++ b/internal/service/route53/zone.go
@@ -353,6 +353,10 @@ func deleteHostedZone(ctx context.Context, conn *route53.Client, hostedZoneID, h
 		return nil
 	}
 
+	if err != nil {
+		return fmt.Errorf("deleting Route53 Hosted Zone (%s): %w", hostedZoneID, err)
+	}
+
 	if output.ChangeInfo != nil {
 		if _, err := waitChangeInsync(ctx, conn, aws.ToString(output.ChangeInfo.Id)); err != nil {
 			return fmt.Errorf("waiting for Route 53 Hosted Zone (%s) synchronize: %w", hostedZoneID, err)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Missing error handling leads to `nil` pointer exception.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/41247.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
