### PR TITLE
docs: add storage configuration block for eks_cluster resource

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -407,11 +407,13 @@ The `remote_pod_networks` configuration block supports the following arguments:
 
 ### vpc_config Arguments
 
+* `cluster_security_group_id` - (Computed) Cluster security group that is created by Amazon EKS for the cluster. Managed node groups use this security group for control-plane-to-data-plane communication.
 * `endpoint_private_access` - (Optional) Whether the Amazon EKS private API server endpoint is enabled. Default is `false`.
 * `endpoint_public_access` - (Optional) Whether the Amazon EKS public API server endpoint is enabled. Default is `true`.
 * `public_access_cidrs` - (Optional) List of CIDR blocks. Indicates which CIDR blocks can access the Amazon EKS public API server endpoint when enabled. EKS defaults this to a list with `0.0.0.0/0`. Terraform will only perform drift detection of its value when present in a configuration.
 * `security_group_ids` – (Optional) List of security group IDs for the cross-account elastic network interfaces that Amazon EKS creates to use to allow communication between your worker nodes and the Kubernetes control plane.
 * `subnet_ids` – (Required) List of subnet IDs. Must be in at least two different availability zones. Amazon EKS creates cross-account elastic network interfaces in these subnets to allow communication between your worker nodes and the Kubernetes control plane.
+* `vpc_id` - (Computed) ID of the VPC associated with your cluster.
 
 ### kubernetes_network_config
 
@@ -425,6 +427,8 @@ The `kubernetes_network_config` configuration block supports the following argum
     * Doesn't overlap with any CIDR block assigned to the VPC that you selected for VPC.
 
     * Between /24 and /12.
+
+* `service_ipv6_cidr` - (Computed) The CIDR block that Kubernetes pod and service IP addresses are assigned from if you specify `ipv6` for `ip_family` when you create the cluster. Kubernetes assigns service addresses from the unique local address range (fc00::/7) because you can't specify a custom IPv6 CIDR block when you create the cluster.
 * `ip_family` - (Optional) The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`. You can only specify an IP family when you create a cluster, changing this value will force a new cluster to be created.
 
 #### elastic_load_balancing
@@ -489,11 +493,9 @@ This resource exports the following attributes in addition to the arguments abov
 * `endpoint` - Endpoint for your Kubernetes API server.
 * `id` - Name of the cluster.
 * `identity` - Attribute block containing identity provider information for your cluster. Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019. Detailed below.
-* `kubernetes_network_config` - Attribute block containing Kubernetes network configuration for the cluster. [Detailed](#kubernetes_network_config-1) below.
 * `platform_version` - Platform version for the cluster.
 * `status` - Status of the EKS cluster. One of `CREATING`, `ACTIVE`, `DELETING`, `FAILED`.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
-* `vpc_config` - Configuration block _argument_ that also includes attributes for the VPC associated with your cluster. Detailed below.
 
 ### certificate_authority
 
@@ -503,18 +505,9 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `oidc` - Nested block containing [OpenID Connect](https://openid.net/connect/) identity provider information for the cluster. Detailed below.
 
-### kubernetes_network_config
-
-* `service_ipv6_cidr` - The CIDR block that Kubernetes pod and service IP addresses are assigned from if you specified `ipv6` for `ip_family` when you created the cluster. Kubernetes assigns service addresses from the unique local address range (fc00::/7) because you can't specify a custom IPv6 CIDR block when you create the cluster.
-
 ### oidc
 
 * `issuer` - Issuer URL for the OpenID Connect identity provider.
-
-### vpc_config Attributes
-
-* `cluster_security_group_id` - Cluster security group that was created by Amazon EKS for the cluster. Managed node groups use this security group for control-plane-to-data-plane communication.
-* `vpc_id` - ID of the VPC associated with your cluster.
 
 ## Timeouts
 

--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -344,19 +344,19 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `access_config` - (Optional) Configuration block for the access config associated with your cluster, see [Amazon EKS Access Entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html).
+* `access_config` - (Optional) Configuration block for the access config associated with your cluster, see [Amazon EKS Access Entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html). [Detailed](#access_config) below.
 * `bootstrap_self_managed_addons` - (Optional) Install default unmanaged add-ons, such as `aws-cni`, `kube-proxy`, and CoreDNS during cluster creation. If `false`, you must manually install desired add-ons. Changing this value will force a new cluster to be created. Defaults to `true`.
-* `compute_config` - (Optional) Configuration block with compute configuration for EKS Auto Mode. Detailed below.
+* `compute_config` - (Optional) Configuration block with compute configuration for EKS Auto Mode. [Detailed](#compute_config) below.
 * `enabled_cluster_log_types` - (Optional) List of the desired control plane logging to enable. For more information, see [Amazon EKS Control Plane Logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html).
-* `encryption_config` - (Optional) Configuration block with encryption configuration for the cluster. Detailed below.
-* `kubernetes_network_config` - (Optional) Configuration block with kubernetes network configuration for the cluster. Detailed below. If removed, Terraform will only perform drift detection if a configuration value is provided.
+* `encryption_config` - (Optional) Configuration block with encryption configuration for the cluster. [Detailed](#encryption_config) below.
+* `kubernetes_network_config` - (Optional) Configuration block with kubernetes network configuration for the cluster. [Detailed](#kubernetes_network_config) below. If removed, Terraform will only perform drift detection if a configuration value is provided.
 * `outpost_config` - (Optional) Configuration block representing the configuration of your local Amazon EKS cluster on an AWS Outpost. This block isn't available for creating Amazon EKS clusters on the AWS cloud.
-* `remote_network_config` - (Optional) Configuration block with remote network configuration for EKS Hybrid Nodes. Detailed below.
-* `storage_config` - (Optional) Configuration block with storage configuration for EKS Auto Mode. Detailed below.
+* `remote_network_config` - (Optional) Configuration block with remote network configuration for EKS Hybrid Nodes. [Detailed](#remote_network_config) below.
+* `storage_config` - (Optional) Configuration block with storage configuration for EKS Auto Mode. [Detailed](#storage_config) below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `upgrade_policy` - (Optional) Configuration block for the support policy to use for the cluster.  See [upgrade_policy](#upgrade_policy) for details.
 * `version` – (Optional) Desired Kubernetes master version. If you do not specify a value, the latest available version at resource creation is used and no upgrades will occur except those automatically triggered by EKS. The value must be configured and increased to upgrade the version when desired. Downgrades are not supported by EKS.
-* `zonal_shift_config` - (Optional) Configuration block with zonal shift configuration for the cluster. Detailed below.
+* `zonal_shift_config` - (Optional) Configuration block with zonal shift configuration for the cluster. [Detailed](#zonal_shift_config) below.
 
 ### access_config
 
@@ -454,6 +454,18 @@ The `control_plane_placement` configuration block supports the following argumen
 
 * `outpost_arns` - (Required) The ARN of the Outpost that you want to use for your local Amazon EKS cluster on Outposts. This argument is a list of arns, but only a single Outpost ARN is supported currently.
 
+### storage_config
+
+The `storage_config` configuration block supports the following arguments:
+
+* `block_storage` - (Optional) Configuration block with block storage configuration for the cluster. [Detailed](#block_storage) below.
+
+### block_storage
+
+The `block_storage` configuration block supports the following arguments:
+
+* `enabled` - (Optional) Indicates if the block storage capability is enabled on your EKS Auto Mode cluster. If the block storage capability is enabled, EKS Auto Mode will create and delete block storage volumes in your Amazon Web Services account.
+
 ### upgrade_policy
 
 The `upgrade_policy` configuration block supports the following arguments:
@@ -477,7 +489,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `endpoint` - Endpoint for your Kubernetes API server.
 * `id` - Name of the cluster.
 * `identity` - Attribute block containing identity provider information for your cluster. Only available on Kubernetes version 1.13 and 1.14 clusters created or upgraded on or after September 3, 2019. Detailed below.
-* `kubernetes_network_config` - Attribute block containing Kubernetes network configuration for the cluster. Detailed below.
+* `kubernetes_network_config` - Attribute block containing Kubernetes network configuration for the cluster. [Detailed](#kubernetes_network_config-1) below.
 * `platform_version` - Platform version for the cluster.
 * `status` - Status of the EKS cluster. One of `CREATING`, `ACTIVE`, `DELETING`, `FAILED`.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).


### PR DESCRIPTION
### Description

* The resource `aws_eks_cluster`  contains a `storage_config` block, see e.g. example code available [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#eks-cluster-with-eks-auto-mode).
* The provider documentation is missing details on the `storage_config`. 

The pull requests 
- adds the missing documentation for `storage_config`
- adds links from "config block" argument to the corresponding description.

### Relations

Closes #41226 

### References

- [AWS Provider Source code](https://github.com/hashicorp/terraform-provider-aws/blob/16b3f1f59e22a57aedfe0fbe37926031608910b2/internal/service/eks/cluster.go#L394)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.