### PR TITLE
testing: Reduce uses of `resource.TestCheckResourceAttrSet` with ARN attributes: `n` to `z` services

### DIFF
--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -7,7 +7,6 @@ rules:
         - "internal/service/controltower"
         - "internal/service/organizations"
         - "internal/service/redshift"
-        - "internal/service/rekognition"
         - "internal/service/resourcegroups"
         - "internal/service/route53resolver"
         - "internal/service/s3"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -7,7 +7,6 @@ rules:
         - "internal/service/controltower"
         - "internal/service/organizations"
         - "internal/service/redshift"
-        - "internal/service/resourcegroups"
         - "internal/service/route53resolver"
         - "internal/service/s3"
         - "internal/service/servicediscovery"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -6,7 +6,6 @@ rules:
       exclude:
         - "internal/service/controltower"
         - "internal/service/organizations"
-        - "internal/service/pinpoint"
         - "internal/service/redshift"
         - "internal/service/rekognition"
         - "internal/service/resourcegroups"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -7,7 +7,6 @@ rules:
         - "internal/service/controltower"
         - "internal/service/organizations"
         - "internal/service/redshift"
-        - "internal/service/s3"
         - "internal/service/servicediscovery"
         - "internal/service/ses"
         - "internal/service/signer"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -7,7 +7,6 @@ rules:
         - "internal/service/controltower"
         - "internal/service/organizations"
         - "internal/service/redshift"
-        - "internal/service/signer"
         - "internal/service/transcribe"
         - "internal/service/transfer"
     patterns:

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -5,7 +5,6 @@ rules:
     paths:
       exclude:
         - "internal/service/controltower"
-        - "internal/service/networkmonitor"
         - "internal/service/organizations"
         - "internal/service/pinpoint"
         - "internal/service/redshift"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -7,7 +7,6 @@ rules:
         - "internal/service/controltower"
         - "internal/service/organizations"
         - "internal/service/redshift"
-        - "internal/service/transcribe"
     patterns:
       - pattern: |
           resource.TestCheckResourceAttrSet($NAME, $ATTR)

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -8,7 +8,6 @@ rules:
         - "internal/service/organizations"
         - "internal/service/redshift"
         - "internal/service/transcribe"
-        - "internal/service/transfer"
     patterns:
       - pattern: |
           resource.TestCheckResourceAttrSet($NAME, $ATTR)

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -7,7 +7,6 @@ rules:
         - "internal/service/controltower"
         - "internal/service/organizations"
         - "internal/service/redshift"
-        - "internal/service/servicediscovery"
         - "internal/service/ses"
         - "internal/service/signer"
         - "internal/service/transcribe"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -7,7 +7,6 @@ rules:
         - "internal/service/controltower"
         - "internal/service/organizations"
         - "internal/service/redshift"
-        - "internal/service/route53resolver"
         - "internal/service/s3"
         - "internal/service/servicediscovery"
         - "internal/service/ses"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -5,7 +5,6 @@ rules:
     paths:
       exclude:
         - "internal/service/controltower"
-        - "internal/service/networkmanager"
         - "internal/service/networkmonitor"
         - "internal/service/organizations"
         - "internal/service/pinpoint"

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -7,7 +7,6 @@ rules:
         - "internal/service/controltower"
         - "internal/service/organizations"
         - "internal/service/redshift"
-        - "internal/service/ses"
         - "internal/service/signer"
         - "internal/service/transcribe"
         - "internal/service/transfer"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -70,6 +70,7 @@ project {
         if (acmCertificateRootDomain != "") {
             text("env.ACM_CERTIFICATE_ROOT_DOMAIN", acmCertificateRootDomain, display = ParameterDisplay.HIDDEN)
             text("env.AMPLIFY_DOMAIN_NAME", acmCertificateRootDomain, display = ParameterDisplay.HIDDEN)
+            text("env.SES_DOMAIN_IDENTITY_ROOT_DOMAIN", acmCertificateRootDomain, display = ParameterDisplay.HIDDEN)
         }
 
         val securityGroupRulesPerGroup = DslContext.getParameter("security_group_rules_per_group", "")

--- a/internal/acctest/arn.go
+++ b/internal/acctest/arn.go
@@ -23,6 +23,17 @@ func CheckResourceAttrGlobalARNFormat(ctx context.Context, resourceName, attribu
 	}
 }
 
+func CheckResourceAttrGlobalARNNoAccountFormat(resourceName, attributeName, arnService, arnFormat string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resource, err := populateARNFormat(s, resourceName, arnFormat)
+		if err != nil {
+			return err
+		}
+
+		return CheckResourceAttrGlobalARNNoAccount(resourceName, attributeName, arnService, resource)(s)
+	}
+}
+
 func CheckResourceAttrRegionalARNFormat(ctx context.Context, resourceName, attributeName, arnService, arnFormat string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resource, err := populateARNFormat(s, resourceName, arnFormat)

--- a/internal/service/networkmanager/connection_test.go
+++ b/internal/service/networkmanager/connection_test.go
@@ -46,7 +46,7 @@ func testAccConnection_basic(t *testing.T) {
 				Config: testAccConnectionConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectionExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "networkmanager", "connection/{global_network_id}/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "connected_link_id", ""),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, "link_id", ""),

--- a/internal/service/networkmanager/device_test.go
+++ b/internal/service/networkmanager/device_test.go
@@ -33,7 +33,7 @@ func TestAccNetworkManagerDevice_basic(t *testing.T) {
 				Config: testAccDeviceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDeviceExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "networkmanager", "device/{global_network_id}/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "aws_location.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, "location.#", "0"),

--- a/internal/service/networkmanager/link_test.go
+++ b/internal/service/networkmanager/link_test.go
@@ -33,7 +33,7 @@ func TestAccNetworkManagerLink_basic(t *testing.T) {
 				Config: testAccLinkConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLinkExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "networkmanager", "link/{global_network_id}/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.download_speed", "50"),
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.upload_speed", "10"),

--- a/internal/service/networkmanager/site_test.go
+++ b/internal/service/networkmanager/site_test.go
@@ -33,7 +33,7 @@ func TestAccNetworkManagerSite_basic(t *testing.T) {
 				Config: testAccSiteConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSiteExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "networkmanager", "site/{global_network_id}/{id}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, "location.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),

--- a/internal/service/networkmonitor/monitor_test.go
+++ b/internal/service/networkmonitor/monitor_test.go
@@ -37,7 +37,7 @@ func TestAccNetworkMonitorMonitor_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckMonitorExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "aggregation_period", "60"),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "networkmonitor", fmt.Sprintf("monitor/%s", rName)),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "networkmonitor", "monitor/{monitor_name}"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "monitor_name"),
 					resource.TestCheckResourceAttr(resourceName, "monitor_name", rName),
 				),

--- a/internal/service/networkmonitor/probe_test.go
+++ b/internal/service/networkmonitor/probe_test.go
@@ -42,7 +42,7 @@ func TestAccNetworkMonitorProbe_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckProbeExists(ctx, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "address_family"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "networkmonitor", "probe/{probe_id}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDestination, "10.0.0.1"),
 					resource.TestCheckNoResourceAttr(resourceName, "destination_port"),
 					resource.TestCheckResourceAttrSet(resourceName, "packet_size"),
@@ -121,7 +121,7 @@ func TestAccNetworkMonitorProbe_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProbeExists(ctx, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "address_family"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "networkmonitor", "probe/{probe_id}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDestination, "10.0.0.1"),
 					resource.TestCheckResourceAttr(resourceName, "destination_port", "8080"),
 					resource.TestCheckResourceAttr(resourceName, "packet_size", "256"),
@@ -140,7 +140,7 @@ func TestAccNetworkMonitorProbe_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProbeExists(ctx, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "address_family"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "networkmonitor", "probe/{probe_id}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDestination, "10.0.0.2"),
 					resource.TestCheckResourceAttr(resourceName, "destination_port", "8443"),
 					resource.TestCheckResourceAttr(resourceName, "packet_size", "512"),

--- a/internal/service/pinpoint/app_test.go
+++ b/internal/service/pinpoint/app_test.go
@@ -40,7 +40,8 @@ func TestAccPinpointApp_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAppExists(ctx, resourceName, &application),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrApplicationID),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "mobiletargeting", "apps/{id}"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrApplicationID),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
 				),

--- a/internal/service/rekognition/collection_test.go
+++ b/internal/service/rekognition/collection_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -41,12 +44,15 @@ func TestAccRekognitionCollection_basic(t *testing.T) {
 				Config: testAccCollectionConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCollectionExists(ctx, resourceName),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "rekognition", "collection/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "collection_id", rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrSet(resourceName, "face_model_version"),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsAllPercent, "1"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "collection_id"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTagsAll), knownvalue.MapExact(map[string]knownvalue.Check{})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -212,10 +218,6 @@ func testAccCollectionConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_rekognition_collection" "test" {
   collection_id = %[1]q
-
-  tags = {
-    test = 1
-  }
 }
 `, rName)
 }

--- a/internal/service/rekognition/project_test.go
+++ b/internal/service/rekognition/project_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/rekognition"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/rekognition/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -25,7 +26,7 @@ import (
 func TestAccRekognitionProject_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rProjectId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_rekognition_project.test"
 	feature := "CONTENT_MODERATION"
 	autoUpdate := "ENABLED"
@@ -38,15 +39,15 @@ func TestAccRekognitionProject_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.RekognitionServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckProjectDestroy(ctx, feature, rProjectId),
+		CheckDestroy:             testAccCheckProjectDestroy(ctx, feature, rName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_contentModeration(rProjectId, autoUpdate),
+				Config: testAccProjectConfig_contentModeration(rName, autoUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, names.AttrID, rProjectId),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rProjectId),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rekognition", regexache.MustCompile(`project/`+rName+`/\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "auto_update", autoUpdate),
 					resource.TestCheckResourceAttr(resourceName, "feature", feature),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
@@ -65,7 +66,7 @@ func TestAccRekognitionProject_basic(t *testing.T) {
 func TestAccRekognitionProject_ContentModeration(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rProjectId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_rekognition_project.test"
 	feature := "CONTENT_MODERATION"
 
@@ -79,23 +80,23 @@ func TestAccRekognitionProject_ContentModeration(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_contentModeration(rProjectId+"-1", "ENABLED"),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccProjectConfig_contentModeration(rName+"-1", "ENABLED"),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckProjectExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, names.AttrID, rProjectId+"-1"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rProjectId+"-1"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, names.AttrID, rName+"-1"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName+"-1"),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rekognition", regexache.MustCompile(`project/`+rName+`-1/\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "auto_update", "ENABLED"),
 					resource.TestCheckResourceAttr(resourceName, "feature", feature),
 				),
 			},
 			{
-				Config: testAccProjectConfig_contentModeration(rProjectId+"-2", "DISABLED"),
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccProjectConfig_contentModeration(rName+"-2", "DISABLED"),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckProjectExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, names.AttrID, rProjectId+"-2"),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rProjectId+"-2"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, names.AttrID, rName+"-2"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName+"-2"),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rekognition", regexache.MustCompile(`project/`+rName+`-2/\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "auto_update", "DISABLED"),
 					resource.TestCheckResourceAttr(resourceName, "feature", feature),
 				),
@@ -107,7 +108,7 @@ func TestAccRekognitionProject_ContentModeration(t *testing.T) {
 func TestAccRekognitionProject_CustomLabels(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rProjectId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_rekognition_project.test"
 	feature := "CUSTOM_LABELS"
 
@@ -119,16 +120,17 @@ func TestAccRekognitionProject_CustomLabels(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.RekognitionServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckProjectDestroy(ctx, feature, rProjectId),
+		CheckDestroy:             testAccCheckProjectDestroy(ctx, feature, rName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_customLabels(rProjectId),
+				Config: testAccProjectConfig_customLabels(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
-					resource.TestCheckResourceAttr(resourceName, names.AttrID, rProjectId),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, rProjectId),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rekognition", regexache.MustCompile(`project/`+rName+`/\d+$`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrID, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "feature", feature),
+					resource.TestCheckNoResourceAttr(resourceName, "auto_update"),
 				),
 			},
 			{
@@ -143,7 +145,7 @@ func TestAccRekognitionProject_CustomLabels(t *testing.T) {
 func TestAccRekognitionProject_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 
-	rProjectId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_rekognition_project.test"
 	feature := "CONTENT_MODERATION"
 	autoUpdate := "ENABLED"
@@ -156,10 +158,10 @@ func TestAccRekognitionProject_disappears(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.RekognitionServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckProjectDestroy(ctx, feature, rProjectId),
+		CheckDestroy:             testAccCheckProjectDestroy(ctx, feature, rName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig_contentModeration(rProjectId, autoUpdate),
+				Config: testAccProjectConfig_contentModeration(rName, autoUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(ctx, resourceName),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfrekognition.ResourceProject, resourceName),
@@ -294,24 +296,24 @@ func testAccProjectPreCheck(ctx context.Context, t *testing.T) {
 	}
 }
 
-func testAccProjectConfig_contentModeration(rProjectId string, autoUpdate string) string {
+func testAccProjectConfig_contentModeration(rName string, autoUpdate string) string {
 	return fmt.Sprintf(`
 resource "aws_rekognition_project" "test" {
   name        = %[1]q
   auto_update = %[2]q
   feature     = "CONTENT_MODERATION"
 }
-`, rProjectId, autoUpdate)
+`, rName, autoUpdate)
 }
 
 // auto-update not supported for custom_labels
-func testAccProjectConfig_customLabels(rProjectId string) string {
+func testAccProjectConfig_customLabels(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_rekognition_project" "test" {
   name    = %[1]q
   feature = "CUSTOM_LABELS"
 }
-`, rProjectId)
+`, rName)
 }
 
 func testAccProjectConfig_tags(rName, tags string) string {

--- a/internal/service/rekognition/service_package_gen.go
+++ b/internal/service/rekognition/service_package_gen.go
@@ -41,7 +41,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			TypeName: "aws_rekognition_stream_processor",
 			Name:     "Stream Processor",
 			Tags: &types.ServicePackageResourceTags{
-				IdentifierAttribute: "stream_processor_arn",
+				IdentifierAttribute: names.AttrARN,
 			},
 		},
 	}

--- a/internal/service/rekognition/stream_processor.go
+++ b/internal/service/rekognition/stream_processor.go
@@ -73,7 +73,7 @@ var (
 )
 
 // @FrameworkResource("aws_rekognition_stream_processor", name="Stream Processor")
-// @Tags(identifierAttribute="stream_processor_arn")
+// @Tags(identifierAttribute="arn")
 func newResourceStreamProcessor(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceStreamProcessor{}
 	r.SetDefaultCreateTimeout(30 * time.Minute)
@@ -99,6 +99,7 @@ func (r *resourceStreamProcessor) Metadata(_ context.Context, req resource.Metad
 func (r *resourceStreamProcessor) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
 			names.AttrKMSKeyID: schema.StringAttribute{
 				Description: "The identifier for your AWS Key Management Service key (AWS KMS key). You can supply the Amazon Resource Name (ARN) of your KMS key, the ID of your KMS key, an alias for your KMS key, or an alias ARN.",
 				Optional:    true,
@@ -134,6 +135,7 @@ func (r *resourceStreamProcessor) Schema(ctx context.Context, req resource.Schem
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+				DeprecationMessage: "Use 'arn' instead. This attribute will be removed in a future verion of the provider.",
 			},
 			names.AttrTags:    tftags.TagsAttribute(),
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
@@ -483,8 +485,6 @@ func (r *resourceStreamProcessor) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	plan.StreamProcessorARN = fwflex.StringToFrameworkARN(ctx, out.StreamProcessorArn)
-
 	if plan.DataSharingPreference.IsNull() {
 		dataSharing, diag := fwtypes.NewListNestedObjectValueOfPtr(ctx, &dataSharingPreferenceModel{OptIn: basetypes.NewBoolValue(false)})
 		resp.Diagnostics.Append(diag...)
@@ -506,6 +506,7 @@ func (r *resourceStreamProcessor) Create(ctx context.Context, req resource.Creat
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	plan.ARN = fwflex.StringToFramework(ctx, out.StreamProcessorArn)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -537,6 +538,7 @@ func (r *resourceStreamProcessor) Read(ctx context.Context, req resource.ReadReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	state.ARN = fwflex.StringToFramework(ctx, out.StreamProcessorArn)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -670,6 +672,7 @@ func (r *resourceStreamProcessor) Update(ctx context.Context, req resource.Updat
 		if resp.Diagnostics.HasError() {
 			return
 		}
+		plan.ARN = fwflex.StringToFramework(ctx, updated.StreamProcessorArn)
 
 		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	}
@@ -829,6 +832,7 @@ func unwrapListNestedObjectValueOf[T any](ctx context.Context, diagnostics diag.
 }
 
 type resourceStreamProcessorDataModel struct {
+	ARN                   types.String                                                `tfsdk:"arn"`
 	DataSharingPreference fwtypes.ListNestedObjectValueOf[dataSharingPreferenceModel] `tfsdk:"data_sharing_preference"`
 	Input                 fwtypes.ListNestedObjectValueOf[inputModel]                 `tfsdk:"input"`
 	KmsKeyId              types.String                                                `tfsdk:"kms_key_id"`

--- a/internal/service/rekognition/stream_processor_test.go
+++ b/internal/service/rekognition/stream_processor_test.go
@@ -44,8 +44,9 @@ func TestAccRekognitionStreamProcessor_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamProcessorConfig_connectedHome(rName, ""),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamProcessorExists(ctx, resourceName, &streamprocessor),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "rekognition", "streamprocessor/{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "data_sharing_preference.0.opt_in", acctest.CtTrue),
 					resource.TestCheckResourceAttrPair(resourceName, "output.0.s3_destination.0.bucket", s3BucketResourceName, names.AttrBucket),
@@ -54,7 +55,7 @@ func TestAccRekognitionStreamProcessor_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "settings.0.connected_home.0.labels.*", "ALL"),
 					resource.TestCheckResourceAttrPair(resourceName, "input.0.kinesis_video_stream.0.arn", kinesisVideoStreamResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(resourceName, "notification_channel.0.sns_topic_arn", snsTopicResourceName, names.AttrARN),
-					resource.TestCheckResourceAttrSet(resourceName, "stream_processor_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "stream_processor_arn", resourceName, names.AttrARN),
 				),
 			},
 			{
@@ -87,7 +88,7 @@ func TestAccRekognitionStreamProcessor_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamProcessorConfig_connectedHome(rName, ""),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamProcessorExists(ctx, resourceName, &streamprocessor),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfrekognition.ResourceStreamProcessor, resourceName),
 				),
@@ -116,7 +117,7 @@ func TestAccRekognitionStreamProcessor_connectedHome(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamProcessorConfig_connectedHome(rName, testAccStreamProcessorConfig_boundingBox()),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamProcessorExists(ctx, resourceName, &streamprocessor),
 					resource.TestCheckResourceAttr(resourceName, "regions_of_interest.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "regions_of_interest.0.polygon.#", "0"),
@@ -128,7 +129,7 @@ func TestAccRekognitionStreamProcessor_connectedHome(t *testing.T) {
 			},
 			{
 				Config: testAccStreamProcessorConfig_connectedHome(rName, testAccStreamProcessorConfig_polygons()),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamProcessorExists(ctx, resourceName, &streamprocessor2),
 					testAccCheckStreamProcessorNotRecreated(&streamprocessor, &streamprocessor2),
 					resource.TestCheckResourceAttr(resourceName, "regions_of_interest.#", "1"),
@@ -165,7 +166,7 @@ func TestAccRekognitionStreamProcessor_faceRecognition(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamProcessorConfig_faceRecognition(rName, ""),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamProcessorExists(ctx, resourceName, &streamprocessor),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 				),
@@ -200,7 +201,7 @@ func TestAccRekognitionStreamProcessor_faceRecognition_boundingBox(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamProcessorConfig_faceRecognition(rName, testAccStreamProcessorConfig_boundingBox()),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamProcessorExists(ctx, resourceName, &streamprocessor),
 					resource.TestCheckResourceAttr(resourceName, "regions_of_interest.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "regions_of_interest.0.polygon.#", "0"),
@@ -233,7 +234,7 @@ func TestAccRekognitionStreamProcessor_faceRecognition_polygon(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamProcessorConfig_faceRecognition(rName, testAccStreamProcessorConfig_polygons()),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamProcessorExists(ctx, resourceName, &streamprocessor),
 					resource.TestCheckResourceAttr(resourceName, "regions_of_interest.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "regions_of_interest.0.polygon.#", "3"),
@@ -268,7 +269,7 @@ func TestAccRekognitionStreamProcessor_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamProcessorConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamProcessorExists(ctx, resourceName, &streamprocessor),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
@@ -283,7 +284,7 @@ func TestAccRekognitionStreamProcessor_tags(t *testing.T) {
 			},
 			{
 				Config: testAccStreamProcessorConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamProcessorExists(ctx, resourceName, &streamprocessor),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
@@ -292,7 +293,7 @@ func TestAccRekognitionStreamProcessor_tags(t *testing.T) {
 			},
 			{
 				Config: testAccStreamProcessorConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckStreamProcessorExists(ctx, resourceName, &streamprocessor),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),

--- a/internal/service/resourcegroups/group_test.go
+++ b/internal/service/resourcegroups/group_test.go
@@ -55,8 +55,9 @@ func TestAccResourceGroupsGroup_basic(t *testing.T) {
 					testAccCheckResourceGroupExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, desc1),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "resource_query.0.query", testAccResourceGroupQueryConfig+"\n"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "resource-groups", "group/{name}"),
 				),
 			},
 			{
@@ -175,7 +176,7 @@ func TestAccResourceGroupsGroup_Configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.0.name", "allowed-host-families"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.0.values.0", "mac1"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "resource-groups", "group/{name}"),
 				),
 			},
 			{
@@ -196,7 +197,7 @@ func TestAccResourceGroupsGroup_Configuration(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.#", "4"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.2.name", "auto-allocate-host"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.parameters.2.values.0", acctest.CtTrue),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "resource-groups", "group/{name}"),
 				),
 			},
 			{
@@ -234,7 +235,7 @@ func TestAccResourceGroupsGroup_configurationParametersOptional(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGroupExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "resource-groups", "group/{name}"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.type", configType1),
 					resource.TestCheckResourceAttr(resourceName, "configuration.1.type", configType2),
@@ -270,7 +271,7 @@ func TestAccResourceGroupsGroup_resourceQueryAndConfiguration(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGroupExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "resource-groups", "group/{name}"),
 					resource.TestCheckResourceAttr(resourceName, "resource_query.0.query", testAccResourceGroupQueryConfig+"\n"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.type", configType),

--- a/internal/service/route53resolver/endpoint_test.go
+++ b/internal/service/route53resolver/endpoint_test.go
@@ -37,10 +37,11 @@ func TestAccRoute53ResolverEndpoint_basic(t *testing.T) {
 				Config: testAccEndpointConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName, &ep),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "route53resolver", "resolver-endpoint/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "direction", "INBOUND"),
 					resource.TestCheckResourceAttr(resourceName, "resolver_endpoint_type", "IPV4"),
 					resource.TestCheckResourceAttrPair(resourceName, "host_vpc_id", vpcResourceName, names.AttrID),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "ip_address.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, ""),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "2"),
@@ -73,7 +74,7 @@ func TestAccRoute53ResolverEndpoint_basic_ipv6(t *testing.T) {
 				Config: testAccEndpointConfig_basic_ipv6(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointExists(ctx, resourceName, &ep),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "route53resolver", "resolver-endpoint/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "direction", "INBOUND"),
 					resource.TestCheckResourceAttr(resourceName, "resolver_endpoint_type", "IPV6"),
 					resource.TestCheckResourceAttrPair(resourceName, "host_vpc_id", vpcResourceName, names.AttrID),

--- a/internal/service/route53resolver/firewall_domain_list_test.go
+++ b/internal/service/route53resolver/firewall_domain_list_test.go
@@ -35,8 +35,9 @@ func TestAccRoute53ResolverFirewallDomainList_basic(t *testing.T) {
 				Config: testAccFirewallDomainListConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFirewallDomainListExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "route53resolver", "firewall-domain-list/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "domains.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),

--- a/internal/service/route53resolver/rule_test.go
+++ b/internal/service/route53resolver/rule_test.go
@@ -36,8 +36,9 @@ func TestAccRoute53ResolverRule_basic(t *testing.T) {
 				Config: testAccRuleConfig_basic(domainName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRuleExists(ctx, resourceName, &rule),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "route53resolver", "resolver-rule/{id}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, domainName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, ""),
 					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrOwnerID),
 					resource.TestCheckResourceAttr(resourceName, "resolver_endpoint_id", ""),

--- a/internal/service/s3/bucket_data_source_test.go
+++ b/internal/service/s3/bucket_data_source_test.go
@@ -100,7 +100,7 @@ func TestAccS3BucketDataSource_accessPointAlias(t *testing.T) {
 			{
 				Config: testAccBucketDataSourceConfig_accessPointAlias(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNNoAccountFormat(dataSourceName, names.AttrARN, "s3", "{bucket}"),
 				),
 			},
 		},

--- a/internal/service/servicediscovery/http_namespace_test.go
+++ b/internal/service/servicediscovery/http_namespace_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/YakDriver/regexache"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -38,8 +37,7 @@ func TestAccServiceDiscoveryHTTPNamespace_basic(t *testing.T) {
 				Config: testAccHTTPNamespaceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHTTPNamespaceExists(ctx, resourceName),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "servicediscovery", regexache.MustCompile(`namespace/.+`)),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "servicediscovery", "namespace/{id}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "http_name", rName),

--- a/internal/service/ses/domain_identity_data_source_test.go
+++ b/internal/service/ses/domain_identity_data_source_test.go
@@ -16,6 +16,9 @@ func TestAccSESDomainIdentityDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	domain := acctest.RandomDomainName()
 
+	dataSourceName := "data.aws_ses_domain_identity.test"
+	resourceName := "aws_ses_domain_identity.test"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESServiceID),
@@ -25,8 +28,11 @@ func TestAccSESDomainIdentityDataSource_basic(t *testing.T) {
 			{
 				Config: testAccDomainIdentityDataSourceConfig_basic(domain),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDomainIdentityExists(ctx, "aws_ses_domain_identity.test"),
-					testAccCheckDomainIdentityARN(ctx, "data.aws_ses_domain_identity.test", domain),
+					testAccCheckDomainIdentityExists(ctx, dataSourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDomain, resourceName, names.AttrDomain),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrID, dataSourceName, names.AttrDomain),
+					resource.TestCheckResourceAttrPair(dataSourceName, "verification_token", resourceName, "verification_token"),
 				),
 			},
 		},

--- a/internal/service/ses/domain_identity_verification_test.go
+++ b/internal/service/ses/domain_identity_verification_test.go
@@ -40,8 +40,11 @@ func TestAccSESDomainIdentityVerification_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDomainIdentityVerificationConfig_basic(rootDomain, domain),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "ses", "identity/{domain}"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, "aws_ses_domain_identity.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDomain, domain),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrDomain),
 				),
 			},
 		},

--- a/internal/service/ses/domain_identity_verification_test.go
+++ b/internal/service/ses/domain_identity_verification_test.go
@@ -97,14 +97,14 @@ resource "aws_ses_domain_identity" "test" {
 
 resource "aws_route53_record" "domain_identity_verification" {
   zone_id = data.aws_route53_zone.test.id
-  name    = "_amazonses.${aws_ses_domain_identity.test.id}"
+  name    = "_amazonses.${aws_ses_domain_identity.test.domain}"
   type    = "TXT"
   ttl     = "600"
   records = [aws_ses_domain_identity.test.verification_token]
 }
 
 resource "aws_ses_domain_identity_verification" "test" {
-  domain = aws_ses_domain_identity.test.id
+  domain = aws_ses_domain_identity.test.domain
 
   depends_on = [aws_route53_record.domain_identity_verification]
 }
@@ -118,7 +118,7 @@ resource "aws_ses_domain_identity" "test" {
 }
 
 resource "aws_ses_domain_identity_verification" "test" {
-  domain = aws_ses_domain_identity.test.id
+  domain = aws_ses_domain_identity.test.domain
 
   timeouts {
     create = "5s"

--- a/internal/service/ses/domain_identity_verification_test.go
+++ b/internal/service/ses/domain_identity_verification_test.go
@@ -30,7 +30,7 @@ func TestAccSESDomainIdentityVerification_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	rootDomain := testAccDomainIdentityDomainFromEnv(t)
 	domain := fmt.Sprintf("tf-acc-%d.%s", sdkacctest.RandInt(), rootDomain)
-	resourceName := "aws_ses_domain_identity.test"
+	resourceName := "aws_ses_domain_identity_verification.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },

--- a/internal/service/signer/signing_profile_test.go
+++ b/internal/service/signer/signing_profile_test.go
@@ -40,7 +40,8 @@ func TestAccSignerSigningProfile_basic(t *testing.T) {
 				Config: testAccSigningProfileConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSigningProfileExists(ctx, resourceName, &conf),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "signer", "/signing-profiles/{name}"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
 					resource.TestCheckResourceAttrSet(resourceName, "platform_display_name"),

--- a/internal/service/transcribe/language_model_test.go
+++ b/internal/service/transcribe/language_model_test.go
@@ -44,9 +44,11 @@ func TestAccTranscribeLanguageModel_basic(t *testing.T) {
 				Config: testAccLanguageModelConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLanguageModelExists(ctx, resourceName, &languageModel),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "language-model/{model_name}"),
 					resource.TestCheckResourceAttr(resourceName, "base_model_name", "NarrowBand"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "model_name"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrLanguageCode, "en-US"),
+					resource.TestCheckResourceAttr(resourceName, "model_name", rName),
 				),
 			},
 			{

--- a/internal/service/transcribe/medical_vocabulary_test.go
+++ b/internal/service/transcribe/medical_vocabulary_test.go
@@ -43,9 +43,11 @@ func TestAccTranscribeMedicalVocabulary_basic(t *testing.T) {
 				Config: testAccMedicalVocabularyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMedicalVocabularyExists(ctx, resourceName, &medicalVocabulary),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "medical-vocabulary/{vocabulary_name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "download_uri"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "vocabulary_name"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrLanguageCode, "en-US"),
+					resource.TestCheckResourceAttr(resourceName, "vocabulary_name", rName),
 				),
 			},
 			{
@@ -84,7 +86,7 @@ func TestAccTranscribeMedicalVocabulary_updateS3URI(t *testing.T) {
 				Config: testAccMedicalVocabularyConfig_updateFile(rName, file1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMedicalVocabularyExists(ctx, resourceName, &medicalVocabulary),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "medical-vocabulary/{vocabulary_name}"),
 					resource.TestCheckResourceAttr(resourceName, "vocabulary_file_uri", "s3://"+rName+"/transcribe/test1.txt"),
 				),
 			},
@@ -92,7 +94,7 @@ func TestAccTranscribeMedicalVocabulary_updateS3URI(t *testing.T) {
 				Config: testAccMedicalVocabularyConfig_updateFile(rName, file2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMedicalVocabularyExists(ctx, resourceName, &medicalVocabulary),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "medical-vocabulary/{vocabulary_name}"),
 					resource.TestCheckResourceAttr(resourceName, "vocabulary_file_uri", "s3://"+rName+"/transcribe/test2.txt"),
 				),
 			},

--- a/internal/service/transcribe/vocabulary_filter_test.go
+++ b/internal/service/transcribe/vocabulary_filter_test.go
@@ -45,8 +45,9 @@ func TestAccTranscribeVocabularyFilter_basic(t *testing.T) {
 				Config: testAccVocabularyFilterConfig_basicFile(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVocabularyFilterExists(ctx, resourceName, &vocabularyFilter),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "vocabulary-filter/{vocabulary_filter_name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "download_uri"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "vocabulary_filter_name"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrLanguageCode, "en-US"),
 				),
 			},
@@ -84,7 +85,7 @@ func TestAccTranscribeVocabularyFilter_basicWords(t *testing.T) {
 				Config: testAccVocabularyFilterConfig_basicWords(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVocabularyFilterExists(ctx, resourceName, &vocabularyFilter),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "vocabulary-filter/{vocabulary_filter_name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "download_uri"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrLanguageCode, "en-US"),
 				),
@@ -117,7 +118,7 @@ func TestAccTranscribeVocabularyFilter_update(t *testing.T) {
 				Config: testAccVocabularyFilterConfig_basicFile(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVocabularyFilterExists(ctx, resourceName, &vocabularyFilter),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "vocabulary-filter/{vocabulary_filter_name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "download_uri"),
 					resource.TestCheckResourceAttr(resourceName, "vocabulary_filter_file_uri", "s3://"+rName+"/transcribe/test1.txt"),
 				),
@@ -126,7 +127,7 @@ func TestAccTranscribeVocabularyFilter_update(t *testing.T) {
 				Config: testAccVocabularyFilterConfig_basicWords(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVocabularyFilterExists(ctx, resourceName, &vocabularyFilter),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "vocabulary-filter/{vocabulary_filter_name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "download_uri"),
 					resource.TestCheckResourceAttr(resourceName, "words.#", "3"),
 				),

--- a/internal/service/transcribe/vocabulary_test.go
+++ b/internal/service/transcribe/vocabulary_test.go
@@ -45,8 +45,9 @@ func TestAccTranscribeVocabulary_basic(t *testing.T) {
 				Config: testAccVocabularyConfig_basicFile(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVocabularyExists(ctx, resourceName, &vocabulary),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "vocabulary/{vocabulary_name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "download_uri"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "vocabulary_name"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrLanguageCode, "en-US"),
 				),
 			},
@@ -84,7 +85,7 @@ func TestAccTranscribeVocabulary_basicPhrases(t *testing.T) {
 				Config: testAccVocabularyConfig_basicPhrases(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVocabularyExists(ctx, resourceName, &vocabulary),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "vocabulary/{vocabulary_name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "download_uri"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrLanguageCode, "en-US"),
 				),
@@ -119,7 +120,7 @@ func TestAccTranscribeVocabulary_updateS3URI(t *testing.T) {
 				Config: testAccVocabularyConfig_updateFile(rName, file1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVocabularyExists(ctx, resourceName, &vocabulary),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "vocabulary/{vocabulary_name}"),
 					resource.TestCheckResourceAttr(resourceName, "vocabulary_file_uri", "s3://"+rName+"/transcribe/test1.txt"),
 				),
 			},
@@ -127,7 +128,7 @@ func TestAccTranscribeVocabulary_updateS3URI(t *testing.T) {
 				Config: testAccVocabularyConfig_updateFile(rName, file2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVocabularyExists(ctx, resourceName, &vocabulary),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transcribe", "vocabulary/{vocabulary_name}"),
 					resource.TestCheckResourceAttr(resourceName, "vocabulary_file_uri", "s3://"+rName+"/transcribe/test2.txt"),
 				),
 			},

--- a/internal/service/transfer/agreement_test.go
+++ b/internal/service/transfer/agreement_test.go
@@ -41,7 +41,7 @@ func testAccAgreement_basic(t *testing.T) {
 				Config: testAccAgreementConfig_basic(rName, baseDirectory1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAgreementExists(ctx, resourceName, &conf),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transfer", "agreement/{server_id}/{agreement_id}"),
 					resource.TestCheckResourceAttr(resourceName, "base_directory", baseDirectory1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),

--- a/internal/service/transfer/certificate_test.go
+++ b/internal/service/transfer/certificate_test.go
@@ -44,7 +44,8 @@ func TestAccTransferCertificate_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCertificateExists(ctx, resourceName, &conf),
 					acctest.CheckResourceAttrRFC3339(resourceName, "active_date"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transfer", "certificate/{id}"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "certificate_id"),
 					acctest.CheckResourceAttrRFC3339(resourceName, "inactive_date"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, "usage", "SIGNING"),

--- a/internal/service/transfer/connector_test.go
+++ b/internal/service/transfer/connector_test.go
@@ -39,7 +39,8 @@ func TestAccTransferConnector_basic(t *testing.T) {
 				Config: testAccConnectorConfig_basic(rName, "http://www.example.com"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectorExists(ctx, resourceName, &conf),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transfer", "connector/{id}"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "connector_id"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURL, "http://www.example.com"),
 				),
@@ -82,7 +83,7 @@ func TestAccTransferConnector_sftpConfig(t *testing.T) {
 				Config: testAccConnectorConfig_sftpConfig(rName, "sftp://s-fakeserver.server.transfer.test.amazonaws.com", publicKey),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectorExists(ctx, resourceName, &conf),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transfer", "connector/{id}"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrURL, "sftp://s-fakeserver.server.transfer.test.amazonaws.com"),
 				),

--- a/internal/service/transfer/profile_test.go
+++ b/internal/service/transfer/profile_test.go
@@ -39,9 +39,10 @@ func TestAccTransferProfile_basic(t *testing.T) {
 				Config: testAccProfileConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckProfileExists(ctx, resourceName, &conf),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "transfer", "profile/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "as2_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "certificate_ids.#", "0"),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, "profile_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "profile_id"),
 					resource.TestCheckResourceAttr(resourceName, "profile_type", "LOCAL"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),

--- a/website/docs/r/rekognition_stream_processor.html.markdown
+++ b/website/docs/r/rekognition_stream_processor.html.markdown
@@ -301,7 +301,9 @@ If using `polygon`, a minimum of 3 per region is required, with a maximum of 10.
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `stream_processor_arn` - ARN of the Stream Processor.
+* `arn` - ARN of the Stream Processor.
+* `stream_processor_arn` - (**Deprecated**) ARN of the Stream Processor.
+  Use `arn` instead.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts

--- a/website/docs/r/ses_domain_identity_verification.html.markdown
+++ b/website/docs/r/ses_domain_identity_verification.html.markdown
@@ -25,14 +25,14 @@ resource "aws_ses_domain_identity" "example" {
 
 resource "aws_route53_record" "example_amazonses_verification_record" {
   zone_id = aws_route53_zone.example.zone_id
-  name    = "_amazonses.${aws_ses_domain_identity.example.id}"
+  name    = "_amazonses.${aws_ses_domain_identity.example.domain}"
   type    = "TXT"
   ttl     = "600"
   records = [aws_ses_domain_identity.example.verification_token]
 }
 
 resource "aws_ses_domain_identity_verification" "example_verification" {
-  domain = aws_ses_domain_identity.example.id
+  domain = aws_ses_domain_identity.example.domain
 
   depends_on = [aws_route53_record.example_amazonses_verification_record]
 }


### PR DESCRIPTION
### Description

Reduce uses of `resource.TestCheckResourceAttrSet` on ARN attributes in favour of explicit checks

Addresses `n` through `z` services. Excludes `organizations` and `redshift`