### PR TITLE
Fix missing arguments in `spot_options` block for `aws_ec2_fleet` resource

### DIFF
--- a/.changelog/41272.txt
+++ b/.changelog/41272.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ec2_fleet: Implement the missing `spot_options` arguments that are mentioned in the provider documentation: `max_total_price`, `min_target_capacity`, `single_instance_type`, and `single_availability_zone`
+resource/aws_ec2_fleet: Add `spot_options.max_total_price`, `spot_options.min_target_capacity`, `spot_options.single_instance_type`, and `spot_options.single_availability_zone` arguments
 ```

--- a/.changelog/41272.txt
+++ b/.changelog/41272.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_fleet: Implement the missing `spot_options` arguments that are mentioned in the provider documentation: `max_total_price`, `min_target_capacity`, `single_instance_type`, and `single_availability_zone`
+```

--- a/internal/service/ec2/ec2_fleet.go
+++ b/internal/service/ec2/ec2_fleet.go
@@ -592,6 +592,22 @@ func resourceFleet() *schema.Resource {
 								},
 							},
 						},
+						"max_total_price": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"min_target_capacity": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"single_availability_zone": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"single_instance_type": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -1152,6 +1168,22 @@ func expandSpotOptionsRequest(tfMap map[string]interface{}) *awstypes.SpotOption
 		apiObject.MaintenanceStrategies = expandFleetSpotMaintenanceStrategiesRequest(v[0].(map[string]interface{}))
 	}
 
+	if v, ok := tfMap["max_total_price"].(string); ok && v != "" {
+		apiObject.MaxTotalPrice = aws.String(v)
+	}
+
+	if v, ok := tfMap["min_target_capacity"].(int); ok {
+		apiObject.MinTargetCapacity = aws.Int32(int32(v))
+	}
+
+	if v, ok := tfMap["single_availability_zone"].(bool); ok {
+		apiObject.SingleAvailabilityZone = aws.Bool(v)
+	}
+
+	if v, ok := tfMap["single_instance_type"].(bool); ok {
+		apiObject.SingleInstanceType = aws.Bool(v)
+	}
+
 	return apiObject
 }
 
@@ -1511,6 +1543,22 @@ func flattenSpotOptions(apiObject *awstypes.SpotOptions) map[string]interface{} 
 
 	if v := apiObject.MaintenanceStrategies; v != nil {
 		tfMap["maintenance_strategies"] = []interface{}{flattenFleetSpotMaintenanceStrategies(v)}
+	}
+
+	if v := apiObject.MaxTotalPrice; v != nil {
+		tfMap["max_total_price"] = aws.ToString(v)
+	}
+
+	if v := apiObject.MinTargetCapacity; v != nil {
+		tfMap["min_target_capacity"] = aws.ToInt32(v)
+	}
+
+	if v := apiObject.SingleAvailabilityZone; v != nil {
+		tfMap["single_availability_zone"] = aws.ToBool(v)
+	}
+
+	if v := apiObject.SingleInstanceType; v != nil {
+		tfMap["single_instance_type"] = aws.ToBool(v)
 	}
 
 	return tfMap

--- a/internal/service/ec2/ec2_fleet.go
+++ b/internal/service/ec2/ec2_fleet.go
@@ -595,18 +595,22 @@ func resourceFleet() *schema.Resource {
 						"max_total_price": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"min_target_capacity": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							ForceNew: true,
 						},
 						"single_availability_zone": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 						},
 						"single_instance_type": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Implement the missing `spot_options` arguments from #41237 

The code is pretty much copy and pasted from the `on_demand_options` implementation of the same arguments (added in #29181)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41237

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccEC2Fleet_SpotOptions PKG=ec2 ACCTEST_PARALLELISM=5
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/ec2/... -v -count 1 -parallel 5 -run='TestAccEC2Fleet_SpotOptions'  -timeout 360m -vet=off
2025/02/06 22:10:26 Initializing Terraform AWS Provider...
=== RUN   TestAccEC2Fleet_SpotOptions_allocationStrategy
=== PAUSE TestAccEC2Fleet_SpotOptions_allocationStrategy
=== RUN   TestAccEC2Fleet_SpotOptions_capacityRebalance
=== PAUSE TestAccEC2Fleet_SpotOptions_capacityRebalance
=== RUN   TestAccEC2Fleet_SpotOptions_MaxTotalPrice
=== PAUSE TestAccEC2Fleet_SpotOptions_MaxTotalPrice
=== RUN   TestAccEC2Fleet_SpotOptions_MinTargetCapacity
=== PAUSE TestAccEC2Fleet_SpotOptions_MinTargetCapacity
=== RUN   TestAccEC2Fleet_SpotOptions_SingleAvailabilityZone
=== PAUSE TestAccEC2Fleet_SpotOptions_SingleAvailabilityZone
=== RUN   TestAccEC2Fleet_SpotOptions_SingleInstanceType
=== PAUSE TestAccEC2Fleet_SpotOptions_SingleInstanceType
=== RUN   TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior
=== PAUSE TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior
=== RUN   TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount
=== PAUSE TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount
=== CONT  TestAccEC2Fleet_SpotOptions_allocationStrategy
=== CONT  TestAccEC2Fleet_SpotOptions_SingleAvailabilityZone
=== CONT  TestAccEC2Fleet_SpotOptions_MaxTotalPrice
=== CONT  TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior
=== CONT  TestAccEC2Fleet_SpotOptions_MinTargetCapacity
--- PASS: TestAccEC2Fleet_SpotOptions_MinTargetCapacity (36.76s)
=== CONT  TestAccEC2Fleet_SpotOptions_capacityRebalance
--- PASS: TestAccEC2Fleet_SpotOptions_SingleAvailabilityZone (39.19s)
=== CONT  TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount
--- PASS: TestAccEC2Fleet_SpotOptions_MaxTotalPrice (65.86s)
=== CONT  TestAccEC2Fleet_SpotOptions_SingleInstanceType
--- PASS: TestAccEC2Fleet_SpotOptions_capacityRebalance (57.97s)
--- PASS: TestAccEC2Fleet_SpotOptions_SingleInstanceType (37.10s)
--- PASS: TestAccEC2Fleet_SpotOptions_instanceInterruptionBehavior (110.43s)
--- PASS: TestAccEC2Fleet_SpotOptions_allocationStrategy (112.36s)
--- PASS: TestAccEC2Fleet_SpotOptions_instancePoolsToUseCount (94.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	150.016s
```