### PR TITLE
fix: format for godebug for 1.23

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -692,11 +692,11 @@ tools: prereq-go ## Install tools
 	cd .ci/tools && $(GO_VER) install github.com/golangci/golangci-lint/cmd/golangci-lint
 	cd .ci/tools && $(GO_VER) install github.com/hashicorp/copywrite
 	cd .ci/tools && $(GO_VER) install github.com/hashicorp/go-changelog/cmd/changelog-build
-	cd .ci/tools && $(GO_VER) install github.com/katbyte/terrafmt
+	cd .ci/tools && $(GO_VER) install github.com/katbyte/terrafmt@v0.5.4
 	cd .ci/tools && $(GO_VER) install github.com/pavius/impi/cmd/impi
 	cd .ci/tools && $(GO_VER) install github.com/rhysd/actionlint/cmd/actionlint
 	cd .ci/tools && $(GO_VER) install github.com/terraform-linters/tflint
-	cd .ci/tools && $(GO_VER) install github.com/uber-go/gopatch
+	cd .ci/tools && $(GO_VER) install github.com/uber-go/gopatch@v0.4.0
 	cd .ci/tools && $(GO_VER) install mvdan.cc/gofumpt
 
 ts: testacc-short ## Alias to testacc-short

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,7 @@ go 1.23.5
 
 // Disable experimental post-quantum key exchange mechanism X25519Kyber768Draft00
 // This was causing errors with AWS Network Firewall
-godebug (
-        tlskyber=0
-)
+godebug tlskyber=0
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.5

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.23.5
 
 // Disable experimental post-quantum key exchange mechanism X25519Kyber768Draft00
 // This was causing errors with AWS Network Firewall
-godebug tlskyber=0
+godebug (
+        tlskyber=0
+)
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.5


### PR DESCRIPTION
Discovered during `make clean-go` 

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://go.dev/doc/godebug

> To override these defaults, starting in Go 1.23, the work module’s go.mod or the workspace’s go.work can list one or more godebug lines:
> 
> godebug (
>     default=go1.21
>     panicnil=1
>     asynctimerchan=0
> )
> 
> The defaults from the go and godebug lines apply to all main packages that are built. For more fine-grained control, starting in Go 1.21, a main package’s source files can include one or more //go:debug directives at the top of the file (preceding the package statement). The godebug lines in the previous example would be written:
> 
> //go:debug default=go1.21
> //go:debug panicnil=1
> //go:debug asynctimerchan=0

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
