### PR TITLE
Avoid recreating aws_ec2_transit_gateway_route_table_association when unnecessary

### DIFF
--- a/.changelog/41292.txt
+++ b/.changelog/41292.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_transit_gateway_route_table_association: Fix deleting and recreating resource when dependencies changes don't require the resource be recreated.
+```

--- a/internal/service/ec2/transitgateway_route_table_association.go
+++ b/internal/service/ec2/transitgateway_route_table_association.go
@@ -14,6 +14,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -51,7 +52,6 @@ func resourceTransitGatewayRouteTableAssociation() *schema.Resource {
 			names.AttrTransitGatewayAttachmentID: {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
 			"transit_gateway_route_table_id": {
@@ -61,6 +61,43 @@ func resourceTransitGatewayRouteTableAssociation() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 		},
+
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+				if !d.HasChange(names.AttrTransitGatewayAttachmentID) {
+					return nil
+				}
+
+				// See https://github.com/hashicorp/terraform-provider-aws/issues/30085
+				// In all cases, changes should force new except:
+				//   o is not empty string AND
+				//   n is empty string AND
+				//   plan is unknown AND
+				//   state is known
+				o, n := d.GetChange(names.AttrTransitGatewayAttachmentID)
+				if o.(string) == "" || n.(string) != "" {
+					return d.ForceNew(names.AttrTransitGatewayAttachmentID)
+				}
+
+				rawPlan := d.GetRawPlan()
+				plan := rawPlan.GetAttr(names.AttrTransitGatewayAttachmentID)
+				if plan.IsKnown() {
+					return d.ForceNew(names.AttrTransitGatewayAttachmentID)
+				}
+
+				rawState := d.GetRawState()
+				if rawState.IsNull() || !rawState.IsKnown() {
+					return d.ForceNew(names.AttrTransitGatewayAttachmentID)
+				}
+
+				state := rawState.GetAttr(names.AttrTransitGatewayAttachmentID)
+				if !state.IsKnown() {
+					return d.ForceNew(names.AttrTransitGatewayAttachmentID)
+				}
+
+				return nil
+			},
+		),
 	}
 }
 

--- a/internal/service/ec2/transitgateway_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_route_table_association_test.go
@@ -6,8 +6,10 @@ package ec2_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -54,6 +56,40 @@ func testAccTransitGatewayRouteTableAssociation_basic(t *testing.T, semaphore tf
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"replace_existing_association"},
+			},
+		},
+	})
+}
+
+func testAccTransitGatewayRouteTableAssociation_notRecreatedDXGateway(t *testing.T, semaphore tfsync.Semaphore) {
+	ctx := acctest.Context(t)
+	var a, b awstypes.TransitGatewayRouteTableAssociation
+	resourceName := "aws_ec2_transit_gateway_route_table_association.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rBGPASN := sdkacctest.RandIntRange(64512, 65534)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckTransitGatewaySynchronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckTransitGateway(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTransitGatewayRouteTableAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitGatewayRouteTableAssociationConfig_recreationByDXGateway(rName, rBGPASN, []string{"10.255.255.0/30"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayRouteTableAssociationExists(ctx, resourceName, &a),
+				),
+			},
+			{
+				Config: testAccTransitGatewayRouteTableAssociationConfig_recreationByDXGateway(rName, rBGPASN, []string{"10.255.255.0/30", "10.255.255.8/30"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayRouteTableAssociationExists(ctx, resourceName, &b),
+					testAccCheckRouteTableAssociationNotRecreated(&a, &b),
+				),
 			},
 		},
 	})
@@ -175,6 +211,15 @@ func testAccCheckTransitGatewayRouteTableAssociationDestroy(ctx context.Context)
 	}
 }
 
+func testAccCheckRouteTableAssociationNotRecreated(i, j *awstypes.TransitGatewayRouteTableAssociation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if aws.ToString(i.ResourceId) != aws.ToString(j.ResourceId) || aws.ToString(i.TransitGatewayAttachmentId) != aws.ToString(j.TransitGatewayAttachmentId) {
+			return fmt.Errorf("Transit Gateway Route Table Association recreated")
+		}
+		return nil
+	}
+}
+
 func testAccTransitGatewayRouteTableAssociationConfig_base(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
 resource "aws_ec2_transit_gateway" "test" {
@@ -233,4 +278,52 @@ resource "aws_ec2_transit_gateway_route_table_association" "test" {
   replace_existing_association = true
 }
 `, rName))
+}
+
+func testAccTransitGatewayRouteTableAssociationConfig_recreationByDXGateway(rName string, rBGPASN int, allowedPrefixes []string) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  amazon_side_asn = "%[2]d"
+  name            = %[1]q
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  default_route_table_association = "disable"
+  default_route_table_propagation = "disable"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_transit_gateway_route_table" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_dx_gateway_association" "test" {
+  dx_gateway_id         = aws_dx_gateway.test.id
+  associated_gateway_id = aws_ec2_transit_gateway.test.id
+
+  allowed_prefixes = ["%[3]s"]
+}
+
+data "aws_ec2_transit_gateway_dx_gateway_attachment" "test" {
+  transit_gateway_id = aws_dx_gateway_association.test.associated_gateway_id
+  dx_gateway_id      = aws_dx_gateway_association.test.dx_gateway_id
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "test" {
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_dx_gateway_attachment.test.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.test.id
+}
+
+resource "aws_ec2_transit_gateway_route_table_propagation" "test" {
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_dx_gateway_attachment.test.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.test.id
+}
+`, rName, rBGPASN, strings.Join(allowedPrefixes, `", "`))
 }

--- a/internal/service/ec2/transitgateway_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_route_table_association_test.go
@@ -151,7 +151,7 @@ func testAccTransitGatewayRouteTableAssociation_notRecreatedDXGateway(t *testing
 	var a awstypes.TransitGatewayRouteTableAssociation
 	resourceName := "aws_ec2_transit_gateway_route_table_association.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rBGPASN := sdkacctest.RandIntRange(64512, 65534)
+	rBGPASN := sdkacctest.RandIntRange(4200000000, 4294967294)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/service/ec2/transitgateway_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_route_table_association_test.go
@@ -174,6 +174,8 @@ func testAccTransitGatewayRouteTableAssociation_notRecreatedDXGateway(t *testing
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTransitGatewayRouteTableAssociationExists(ctx, resourceName, &a),
 				),
+				// Calling a NotRecreated function, such as testAccCheckRouteTableAssociationNotRecreated, as is typical,
+				// won't work here because the recreated resource ID will be the same, because it's two IDs pegged together.
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
@@ -232,7 +234,8 @@ func testAccCheckTransitGatewayRouteTableAssociationDestroy(ctx context.Context)
 }
 
 // testAccCheckRouteTableAssociationNotRecreated function, as is typical, cannot work here because
-// the resource ID will be the same, even if the association is recreated.
+// the resource ID will be the same, even if the association is recreated. See the test for
+// notRecreatedDXGateway for more details.
 
 func testAccTransitGatewayRouteTableAssociationConfig_base(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`

--- a/internal/service/ec2/transitgateway_route_table_association_test.go
+++ b/internal/service/ec2/transitgateway_route_table_association_test.go
@@ -23,6 +23,10 @@ import (
 )
 
 func testAccTransitGatewayRouteTableAssociation_basic(t *testing.T, semaphore tfsync.Semaphore) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	ctx := acctest.Context(t)
 	var v awstypes.TransitGatewayRouteTableAssociation
 	resourceName := "aws_ec2_transit_gateway_route_table_association.test"
@@ -61,45 +65,11 @@ func testAccTransitGatewayRouteTableAssociation_basic(t *testing.T, semaphore tf
 	})
 }
 
-func testAccTransitGatewayRouteTableAssociation_notRecreatedDXGateway(t *testing.T, semaphore tfsync.Semaphore) {
-	ctx := acctest.Context(t)
-	var a awstypes.TransitGatewayRouteTableAssociation
-	resourceName := "aws_ec2_transit_gateway_route_table_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	rBGPASN := sdkacctest.RandIntRange(64512, 65534)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheckTransitGatewaySynchronize(t, semaphore)
-			acctest.PreCheck(ctx, t)
-			testAccPreCheckTransitGateway(ctx, t)
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTransitGatewayRouteTableAssociationDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTransitGatewayRouteTableAssociationConfig_recreationByDXGateway(rName, rBGPASN, []string{"10.255.255.0/30"}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTransitGatewayRouteTableAssociationExists(ctx, resourceName, &a),
-				),
-			},
-			{
-				Config: testAccTransitGatewayRouteTableAssociationConfig_recreationByDXGateway(rName, rBGPASN, []string{"10.255.255.0/30", "10.255.255.8/30"}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTransitGatewayRouteTableAssociationExists(ctx, resourceName, &a),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-					},
-				},
-			},
-		},
-	})
-}
-
 func testAccTransitGatewayRouteTableAssociation_disappears(t *testing.T, semaphore tfsync.Semaphore) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	ctx := acctest.Context(t)
 	var v awstypes.TransitGatewayRouteTableAssociation
 	resourceName := "aws_ec2_transit_gateway_route_table_association.test"
@@ -128,6 +98,10 @@ func testAccTransitGatewayRouteTableAssociation_disappears(t *testing.T, semapho
 }
 
 func testAccTransitGatewayRouteTableAssociation_replaceExistingAssociation(t *testing.T, semaphore tfsync.Semaphore) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
 	ctx := acctest.Context(t)
 	var v awstypes.TransitGatewayRouteTableAssociation
 	resourceName := "aws_ec2_transit_gateway_route_table_association.test"
@@ -163,6 +137,48 @@ func testAccTransitGatewayRouteTableAssociation_replaceExistingAssociation(t *te
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"replace_existing_association"},
+			},
+		},
+	})
+}
+
+func testAccTransitGatewayRouteTableAssociation_notRecreatedDXGateway(t *testing.T, semaphore tfsync.Semaphore) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	var a awstypes.TransitGatewayRouteTableAssociation
+	resourceName := "aws_ec2_transit_gateway_route_table_association.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rBGPASN := sdkacctest.RandIntRange(64512, 65534)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckTransitGatewaySynchronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckTransitGateway(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTransitGatewayRouteTableAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitGatewayRouteTableAssociationConfig_recreationByDXGateway(rName, rBGPASN, []string{"10.255.255.0/30"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayRouteTableAssociationExists(ctx, resourceName, &a),
+				),
+			},
+			{
+				Config: testAccTransitGatewayRouteTableAssociationConfig_recreationByDXGateway(rName, rBGPASN, []string{"10.255.255.0/30", "10.255.255.8/30"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayRouteTableAssociationExists(ctx, resourceName, &a),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -281,7 +297,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "test" {
 func testAccTransitGatewayRouteTableAssociationConfig_recreationByDXGateway(rName string, rBGPASN int, allowedPrefixes []string) string {
 	return fmt.Sprintf(`
 resource "aws_dx_gateway" "test" {
-  amazon_side_asn = "4200000000"
+  amazon_side_asn = "%[2]d"
   name            = %[1]q
 }
 

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -145,6 +145,7 @@ func TestAccTransitGateway_serial(t *testing.T) {
 			acctest.CtBasic:              testAccTransitGatewayRouteTableAssociation_basic,
 			acctest.CtDisappears:         testAccTransitGatewayRouteTableAssociation_disappears,
 			"ReplaceExistingAssociation": testAccTransitGatewayRouteTableAssociation_replaceExistingAssociation,
+			"NotRecreatedDXGateway":      testAccTransitGatewayRouteTableAssociation_notRecreatedDXGateway,
 		},
 		"RouteTablePropagation": {
 			acctest.CtBasic:      testAccTransitGatewayRouteTablePropagation_basic,

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -39,17 +39,17 @@ func TestAccTransitGateway_serial(t *testing.T) {
 			acctest.CtBasic:      testAccTransitGatewayConnect_basic,
 			acctest.CtDisappears: testAccTransitGatewayConnect_disappears,
 			"tags":               testAccTransitGatewayConnect_tags,
-			"TransitGatewayDefaultRouteTableAssociation":                       testAccTransitGatewayConnect_TransitGatewayDefaultRouteTableAssociation,
-			"TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled": testAccTransitGatewayConnect_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled,
-			"TransitGatewayDefaultRouteTablePropagation":                       testAccTransitGatewayConnect_TransitGatewayDefaultRouteTablePropagation,
+			"transitGatewayDefaultRouteTableAssociation":                       testAccTransitGatewayConnect_TransitGatewayDefaultRouteTableAssociation,
+			"transitGatewayDefaultRouteTableAssociationAndPropagationDisabled": testAccTransitGatewayConnect_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled,
+			"transitGatewayDefaultRouteTablePropagation":                       testAccTransitGatewayConnect_TransitGatewayDefaultRouteTablePropagation,
 		},
 		"ConnectPeer": {
 			acctest.CtBasic:         testAccTransitGatewayConnectPeer_basic,
 			acctest.CtDisappears:    testAccTransitGatewayConnectPeer_disappears,
 			"tags":                  testAccTransitGatewayConnectPeer_tags,
-			"BgpAsn":                testAccTransitGatewayConnectPeer_bgpASN,
-			"InsideCidrBlocks":      testAccTransitGatewayConnectPeer_insideCIDRBlocks,
-			"TransitGatewayAddress": testAccTransitGatewayConnectPeer_TransitGatewayAddress,
+			"bgpASN":                testAccTransitGatewayConnectPeer_bgpASN,
+			"insideCIDRBlocks":      testAccTransitGatewayConnectPeer_insideCIDRBlocks,
+			"transitGatewayAddress": testAccTransitGatewayConnectPeer_TransitGatewayAddress,
 		},
 		"DefaultRouteTableAssociation": {
 			acctest.CtBasic:            testAccTransitGatewayDefaultRouteTableAssociation_basic,
@@ -65,52 +65,52 @@ func TestAccTransitGateway_serial(t *testing.T) {
 			acctest.CtBasic:               testAccTransitGateway_basic,
 			acctest.CtDisappears:          testAccTransitGateway_disappears,
 			"tags":                        testAccTransitGateway_tags,
-			"AmazonSideASN":               testAccTransitGateway_AmazonSideASN,
-			"AutoAcceptSharedAttachments": testAccTransitGateway_AutoAcceptSharedAttachments,
-			"CidrBlocks":                  testAccTransitGateway_cidrBlocks,
-			"DefaultRouteTableAssociationAndPropagationDisabled": testAccTransitGateway_DefaultRouteTableAssociationAndPropagationDisabled,
-			"DefaultRouteTableAssociation":                       testAccTransitGateway_DefaultRouteTableAssociation,
-			"DefaultRouteTablePropagation":                       testAccTransitGateway_DefaultRouteTablePropagation,
-			"Description":                                        testAccTransitGateway_Description,
-			"DnsSupport":                                         testAccTransitGateway_DNSSupport,
-			"SecurityGroupReferencingSupport":                    testAccTransitGateway_SecurityGroupReferencingSupport,
-			"SecurityGroupReferencingSupportExistingResource":    testAccTransitGateway_SecurityGroupReferencingSupportExistingResource,
-			"VpnEcmpSupport":                                     testAccTransitGateway_VPNECMPSupport,
+			"amazonSideASN":               testAccTransitGateway_amazonSideASN,
+			"autoAcceptSharedAttachments": testAccTransitGateway_autoAcceptSharedAttachments,
+			"cidrBlocks":                  testAccTransitGateway_cidrBlocks,
+			"defaultRouteTableAssociationAndPropagationDisabled": testAccTransitGateway_defaultRouteTableAssociationAndPropagationDisabled,
+			"defaultRouteTableAssociation":                       testAccTransitGateway_defaultRouteTableAssociation,
+			"defaultRouteTablePropagation":                       testAccTransitGateway_defaultRouteTablePropagation,
+			"description":                                        testAccTransitGateway_description,
+			"dnsSupport":                                         testAccTransitGateway_dnsSupport,
+			"securityGroupReferencingSupport":                    testAccTransitGateway_securityGroupReferencingSupport,
+			"securityGroupReferencingSupportExistingResource":    testAccTransitGateway_securityGroupReferencingSupportExistingResource,
+			"vpnEcmpSupport":                                     testAccTransitGateway_vpnECMPSupport,
 		},
 		"MulticastDomain": {
 			acctest.CtBasic:      testAccTransitGatewayMulticastDomain_basic,
 			acctest.CtDisappears: testAccTransitGatewayMulticastDomain_disappears,
 			"tags":               testAccTransitGatewayMulticastDomain_tags,
-			"IGMPv2Support":      testAccTransitGatewayMulticastDomain_igmpv2Support,
+			"igmpv2Support":      testAccTransitGatewayMulticastDomain_igmpv2Support,
 		},
 		"MulticastDomainAssociation": {
 			acctest.CtBasic:      testAccTransitGatewayMulticastDomainAssociation_basic,
 			acctest.CtDisappears: testAccTransitGatewayMulticastDomainAssociation_disappears,
-			"DomainDisappears":   testAccTransitGatewayMulticastDomainAssociation_Disappears_domain,
-			"TwoAssociations":    testAccTransitGatewayMulticastDomainAssociation_twoAssociations,
+			"domainDisappears":   testAccTransitGatewayMulticastDomainAssociation_Disappears_domain,
+			"twoAssociations":    testAccTransitGatewayMulticastDomainAssociation_twoAssociations,
 		},
 		"MulticastGroupMember": {
 			acctest.CtBasic:      testAccTransitGatewayMulticastGroupMember_basic,
 			acctest.CtDisappears: testAccTransitGatewayMulticastGroupMember_disappears,
-			"DomainDisappears":   testAccTransitGatewayMulticastGroupMember_Disappears_domain,
-			"TwoMembers":         testAccTransitGatewayMulticastGroupMember_twoMembers,
+			"domainDisappears":   testAccTransitGatewayMulticastGroupMember_Disappears_domain,
+			"twoMembers":         testAccTransitGatewayMulticastGroupMember_twoMembers,
 		},
 		"MulticastGroupSource": {
 			acctest.CtBasic:      testAccTransitGatewayMulticastGroupSource_basic,
 			acctest.CtDisappears: testAccTransitGatewayMulticastGroupSource_disappears,
-			"DomainDisappears":   testAccTransitGatewayMulticastGroupSource_Disappears_domain,
+			"domainDisappears":   testAccTransitGatewayMulticastGroupSource_Disappears_domain,
 		},
 		"PeeringAttachment": {
 			acctest.CtBasic:      testAccTransitGatewayPeeringAttachment_basic,
 			acctest.CtDisappears: testAccTransitGatewayPeeringAttachment_disappears,
 			"tags":               testAccTransitGatewayPeeringAttachment_tags,
-			"DifferentAccount":   testAccTransitGatewayPeeringAttachment_differentAccount,
+			"differentAccount":   testAccTransitGatewayPeeringAttachment_differentAccount,
 			"options":            testAccTransitGatewayPeeringAttachment_options,
 		},
 		"PeeringAttachmentAccepter": {
 			acctest.CtBasic:    testAccTransitGatewayPeeringAttachmentAccepter_basic,
 			"tags":             testAccTransitGatewayPeeringAttachmentAccepter_tags,
-			"DifferentAccount": testAccTransitGatewayPeeringAttachmentAccepter_differentAccount,
+			"differentAccount": testAccTransitGatewayPeeringAttachmentAccepter_differentAccount,
 		},
 		"PolicyTable": {
 			acctest.CtBasic:            testAccTransitGatewayPolicyTable_basic,
@@ -126,7 +126,7 @@ func TestAccTransitGateway_serial(t *testing.T) {
 			acctest.CtBasic:              testAccTransitGatewayPrefixListReference_basic,
 			acctest.CtDisappears:         testAccTransitGatewayPrefixListReference_disappears,
 			"disappearsTransitGateway":   testAccTransitGatewayPrefixListReference_disappears_TransitGateway,
-			"TransitGatewayAttachmentId": testAccTransitGatewayPrefixListReference_TransitGatewayAttachmentID,
+			"transitGatewayAttachmentID": testAccTransitGatewayPrefixListReference_TransitGatewayAttachmentID,
 		},
 		"Route": {
 			acctest.CtBasic:                      testAccTransitGatewayRoute_basic,
@@ -144,33 +144,33 @@ func TestAccTransitGateway_serial(t *testing.T) {
 		"RouteTableAssociation": {
 			acctest.CtBasic:              testAccTransitGatewayRouteTableAssociation_basic,
 			acctest.CtDisappears:         testAccTransitGatewayRouteTableAssociation_disappears,
-			"ReplaceExistingAssociation": testAccTransitGatewayRouteTableAssociation_replaceExistingAssociation,
-			"NotRecreatedDXGateway":      testAccTransitGatewayRouteTableAssociation_notRecreatedDXGateway,
+			"replaceExistingAssociation": testAccTransitGatewayRouteTableAssociation_replaceExistingAssociation,
+			"notRecreatedDXGateway":      testAccTransitGatewayRouteTableAssociation_notRecreatedDXGateway,
 		},
 		"RouteTablePropagation": {
 			acctest.CtBasic:      testAccTransitGatewayRouteTablePropagation_basic,
 			acctest.CtDisappears: testAccTransitGatewayRouteTablePropagation_disappears,
 		},
-		"VpcAttachment": {
+		"VPCAttachment": {
 			acctest.CtBasic:                   testAccTransitGatewayVPCAttachment_basic,
 			acctest.CtDisappears:              testAccTransitGatewayVPCAttachment_disappears,
 			"tags":                            testAccTransitGatewayVPCAttachment_tags,
-			"ApplianceModeSupport":            testAccTransitGatewayVPCAttachment_ApplianceModeSupport,
-			"DnsSupport":                      testAccTransitGatewayVPCAttachment_DNSSupport,
-			"Ipv6Support":                     testAccTransitGatewayVPCAttachment_IPv6Support,
-			"SecurityGroupReferencingSupport": testAccTransitGatewayVPCAttachment_SecurityGroupReferencingSupport,
-			"SecurityGroupReferencingSupportV5690Diff":                         testAccTransitGatewayVPCAttachment_SecurityGroupReferencingSupportV5690Diff,
-			"SecurityGroupReferencingSupportExistingResource":                  testAccTransitGatewayVPCAttachment_SecurityGroupReferencingSupportExistingResource,
-			"SharedTransitGateway":                                             testAccTransitGatewayVPCAttachment_SharedTransitGateway,
-			"SubnetIds":                                                        testAccTransitGatewayVPCAttachment_SubnetIDs,
-			"TransitGatewayDefaultRouteTableAssociation":                       testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociation,
-			"TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled": testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled,
-			"TransitGatewayDefaultRouteTablePropagation":                       testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTablePropagation,
+			"applianceModeSupport":            testAccTransitGatewayVPCAttachment_applianceModeSupport,
+			"dnsSupport":                      testAccTransitGatewayVPCAttachment_dnsSupport,
+			"ipv6Support":                     testAccTransitGatewayVPCAttachment_ipv6Support,
+			"securityGroupReferencingSupport": testAccTransitGatewayVPCAttachment_securityGroupReferencingSupport,
+			"securityGroupReferencingSupportV5690Diff":                         testAccTransitGatewayVPCAttachment_securityGroupReferencingSupportV5690Diff,
+			"securityGroupReferencingSupportExistingResource":                  testAccTransitGatewayVPCAttachment_securityGroupReferencingSupportExistingResource,
+			"sharedTransitGateway":                                             testAccTransitGatewayVPCAttachment_sharedTransitGateway,
+			"subnetIDs":                                                        testAccTransitGatewayVPCAttachment_subnetIDs,
+			"transitGatewayDefaultRouteTableAssociation":                       testAccTransitGatewayVPCAttachment_transitGatewayDefaultRouteTableAssociation,
+			"transitGatewayDefaultRouteTableAssociationAndPropagationDisabled": testAccTransitGatewayVPCAttachment_transitGatewayDefaultRouteTableAssociationAndPropagationDisabled,
+			"transitGatewayDefaultRouteTablePropagation":                       testAccTransitGatewayVPCAttachment_transitGatewayDefaultRouteTablePropagation,
 		},
-		"VpcAttachmentAccepter": {
+		"VPCAttachmentAccepter": {
 			acctest.CtBasic: testAccTransitGatewayVPCAttachmentAccepter_basic,
 			"tags":          testAccTransitGatewayVPCAttachmentAccepter_tags,
-			"TransitGatewayDefaultRouteTableAssociationAndPropagation": testAccTransitGatewayVPCAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation,
+			"transitGatewayDefaultRouteTableAssociationAndPropagation": testAccTransitGatewayVPCAttachmentAccepter_transitGatewayDefaultRouteTableAssociationAndPropagation,
 		},
 	}
 
@@ -252,7 +252,7 @@ func testAccTransitGateway_disappears(t *testing.T, semaphore tfsync.Semaphore) 
 	})
 }
 
-func testAccTransitGateway_AmazonSideASN(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGateway_amazonSideASN(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2 awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
@@ -292,7 +292,7 @@ func testAccTransitGateway_AmazonSideASN(t *testing.T, semaphore tfsync.Semaphor
 	})
 }
 
-func testAccTransitGateway_AutoAcceptSharedAttachments(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGateway_autoAcceptSharedAttachments(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2 awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
@@ -385,7 +385,7 @@ func testAccTransitGateway_cidrBlocks(t *testing.T, semaphore tfsync.Semaphore) 
 	})
 }
 
-func testAccTransitGateway_DefaultRouteTableAssociationAndPropagationDisabled(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGateway_defaultRouteTableAssociationAndPropagationDisabled(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1 awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
@@ -418,7 +418,7 @@ func testAccTransitGateway_DefaultRouteTableAssociationAndPropagationDisabled(t 
 	})
 }
 
-func testAccTransitGateway_DefaultRouteTableAssociation(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGateway_defaultRouteTableAssociation(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2, transitGateway3 awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
@@ -466,7 +466,7 @@ func testAccTransitGateway_DefaultRouteTableAssociation(t *testing.T, semaphore 
 	})
 }
 
-func testAccTransitGateway_DefaultRouteTablePropagation(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGateway_defaultRouteTablePropagation(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2, transitGateway3 awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
@@ -514,7 +514,7 @@ func testAccTransitGateway_DefaultRouteTablePropagation(t *testing.T, semaphore 
 	})
 }
 
-func testAccTransitGateway_DNSSupport(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGateway_dnsSupport(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2 awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
@@ -554,7 +554,7 @@ func testAccTransitGateway_DNSSupport(t *testing.T, semaphore tfsync.Semaphore) 
 	})
 }
 
-func testAccTransitGateway_SecurityGroupReferencingSupport(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGateway_securityGroupReferencingSupport(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2 awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
@@ -594,7 +594,7 @@ func testAccTransitGateway_SecurityGroupReferencingSupport(t *testing.T, semapho
 	})
 }
 
-func testAccTransitGateway_SecurityGroupReferencingSupportExistingResource(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGateway_securityGroupReferencingSupportExistingResource(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1 awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
@@ -650,7 +650,7 @@ func testAccTransitGateway_SecurityGroupReferencingSupportExistingResource(t *te
 	})
 }
 
-func testAccTransitGateway_VPNECMPSupport(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGateway_vpnECMPSupport(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2 awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"
@@ -690,7 +690,7 @@ func testAccTransitGateway_VPNECMPSupport(t *testing.T, semaphore tfsync.Semapho
 	})
 }
 
-func testAccTransitGateway_Description(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGateway_description(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2 awstypes.TransitGateway
 	resourceName := "aws_ec2_transit_gateway.test"

--- a/internal/service/ec2/transitgateway_vpc_attachment_accepter_test.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_accepter_test.go
@@ -116,7 +116,7 @@ func testAccTransitGatewayVPCAttachmentAccepter_tags(t *testing.T, semaphore tfs
 	})
 }
 
-func testAccTransitGatewayVPCAttachmentAccepter_TransitGatewayDefaultRouteTableAssociationAndPropagation(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachmentAccepter_transitGatewayDefaultRouteTableAssociationAndPropagation(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway awstypes.TransitGateway
 	var transitGatewayVpcAttachment awstypes.TransitGatewayVpcAttachment

--- a/internal/service/ec2/transitgateway_vpc_attachment_test.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_test.go
@@ -100,7 +100,7 @@ func testAccTransitGatewayVPCAttachment_disappears(t *testing.T, semaphore tfsyn
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_ApplianceModeSupport(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_applianceModeSupport(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2 awstypes.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
@@ -140,7 +140,7 @@ func testAccTransitGatewayVPCAttachment_ApplianceModeSupport(t *testing.T, semap
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_DNSSupport(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_dnsSupport(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2 awstypes.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
@@ -180,7 +180,7 @@ func testAccTransitGatewayVPCAttachment_DNSSupport(t *testing.T, semaphore tfsyn
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_IPv6Support(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_ipv6Support(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2 awstypes.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
@@ -220,7 +220,7 @@ func testAccTransitGatewayVPCAttachment_IPv6Support(t *testing.T, semaphore tfsy
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_SecurityGroupReferencingSupport(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_securityGroupReferencingSupport(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2 awstypes.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
@@ -262,7 +262,7 @@ func testAccTransitGatewayVPCAttachment_SecurityGroupReferencingSupport(t *testi
 
 // https://github.com/hashicorp/terraform-provider-aws/issues/39518.
 // Resources created at <= v5.58.0 show drift after upgrade to v5.69.0.
-func testAccTransitGatewayVPCAttachment_SecurityGroupReferencingSupportV5690Diff(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_securityGroupReferencingSupportV5690Diff(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGatewayVpcAttachment1 awstypes.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
@@ -325,7 +325,7 @@ func testAccTransitGatewayVPCAttachment_SecurityGroupReferencingSupportV5690Diff
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_SecurityGroupReferencingSupportExistingResource(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_securityGroupReferencingSupportExistingResource(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGatewayVpcAttachment1 awstypes.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
@@ -382,7 +382,7 @@ func testAccTransitGatewayVPCAttachment_SecurityGroupReferencingSupportExistingR
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_SharedTransitGateway(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_sharedTransitGateway(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGatewayVpcAttachment1 awstypes.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
@@ -415,7 +415,7 @@ func testAccTransitGatewayVPCAttachment_SharedTransitGateway(t *testing.T, semap
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_SubnetIDs(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_subnetIDs(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2, transitGatewayVpcAttachment3 awstypes.TransitGatewayVpcAttachment
 	resourceName := "aws_ec2_transit_gateway_vpc_attachment.test"
@@ -515,7 +515,7 @@ func testAccTransitGatewayVPCAttachment_tags(t *testing.T, semaphore tfsync.Sema
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociationAndPropagationDisabled(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_transitGatewayDefaultRouteTableAssociationAndPropagationDisabled(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1 awstypes.TransitGateway
 	var transitGatewayVpcAttachment1 awstypes.TransitGatewayVpcAttachment
@@ -553,7 +553,7 @@ func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociati
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociation(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_transitGatewayDefaultRouteTableAssociation(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2, transitGateway3 awstypes.TransitGateway
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2, transitGatewayVpcAttachment3 awstypes.TransitGatewayVpcAttachment
@@ -609,7 +609,7 @@ func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTableAssociati
 	})
 }
 
-func testAccTransitGatewayVPCAttachment_TransitGatewayDefaultRouteTablePropagation(t *testing.T, semaphore tfsync.Semaphore) {
+func testAccTransitGatewayVPCAttachment_transitGatewayDefaultRouteTablePropagation(t *testing.T, semaphore tfsync.Semaphore) {
 	ctx := acctest.Context(t)
 	var transitGateway1, transitGateway2, transitGateway3 awstypes.TransitGateway
 	var transitGatewayVpcAttachment1, transitGatewayVpcAttachment2, transitGatewayVpcAttachment3 awstypes.TransitGatewayVpcAttachment


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Previously, we would ForceNew always on changes to `transit_gateway_attachment_id` regardless. However, there are times when the `transit_gateway_attachment_id` is not known because a dependency changes, such as described in #30085, but the `transit_gateway_attachment_id` won't change. In these cases, the resource should not be ForceNew based on the `transit_gateway_attachment_id` change.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #30085

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T='TestAccTransitGateway_serial/RouteTableAssociation_' K=ec2            
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccTransitGateway_serial/RouteTableAssociation_'  -timeout 360m -vet=off
2025/02/10 17:03:47 Initializing Terraform AWS Provider...
=== RUN   TestAccTransitGateway_serial
=== PAUSE TestAccTransitGateway_serial
=== CONT  TestAccTransitGateway_serial
=== RUN   TestAccTransitGateway_serial/RouteTableAssociation_basic
=== PAUSE TestAccTransitGateway_serial/RouteTableAssociation_basic
=== RUN   TestAccTransitGateway_serial/RouteTableAssociation_disappears
=== PAUSE TestAccTransitGateway_serial/RouteTableAssociation_disappears
=== RUN   TestAccTransitGateway_serial/RouteTableAssociation_replaceExistingAssociation
=== PAUSE TestAccTransitGateway_serial/RouteTableAssociation_replaceExistingAssociation
=== RUN   TestAccTransitGateway_serial/RouteTableAssociation_notRecreatedDXGateway
=== PAUSE TestAccTransitGateway_serial/RouteTableAssociation_notRecreatedDXGateway
=== RUN   TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappears
=== PAUSE TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappears
=== RUN   TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappearsTransitGateway
=== PAUSE TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappearsTransitGateway
=== RUN   TestAccTransitGateway_serial/DefaultRouteTableAssociation_basic
=== PAUSE TestAccTransitGateway_serial/DefaultRouteTableAssociation_basic
=== CONT  TestAccTransitGateway_serial/RouteTableAssociation_basic
=== CONT  TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappears
=== CONT  TestAccTransitGateway_serial/RouteTableAssociation_replaceExistingAssociation
=== CONT  TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappearsTransitGateway
=== CONT  TestAccTransitGateway_serial/DefaultRouteTableAssociation_basic
=== CONT  TestAccTransitGateway_serial/RouteTableAssociation_notRecreatedDXGateway
=== CONT  TestAccTransitGateway_serial/RouteTableAssociation_disappears
--- PASS: TestAccTransitGateway_serial (0.00s)
    --- PASS: TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappearsTransitGateway (166.90s)
    --- PASS: TestAccTransitGateway_serial/DefaultRouteTableAssociation_basic (375.42s)
    --- PASS: TestAccTransitGateway_serial/RouteTableAssociation_replaceExistingAssociation (377.53s)
    --- PASS: TestAccTransitGateway_serial/RouteTableAssociation_basic (418.27s)
    --- PASS: TestAccTransitGateway_serial/RouteTableAssociation_disappears (447.17s)
    --- PASS: TestAccTransitGateway_serial/DefaultRouteTableAssociation_disappears (554.61s)
    --- PASS: TestAccTransitGateway_serial/RouteTableAssociation_notRecreatedDXGateway (1886.13s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	1890.621s
```
