### PR TITLE
docs: fix invalid value for type in resource aws_backup_selection

### DIFF
--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -140,7 +140,7 @@ This resource supports the following arguments:
 
 Tag conditions (`selection_tag`) support the following:
 
-* `type` - (Required) An operation, such as `StringEquals`, that is applied to a key-value pair used to filter resources in a selection.
+* `type` - (Required) An operation, such as `STRINGEQUALS`, that is applied to a key-value pair used to filter resources in a selection.
 * `key` - (Required) The key in a key-value pair.
 * `value` - (Required) The value in a key-value pair.
 


### PR DESCRIPTION
### Description
The [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_selection) for the resource `aws_backup_selection` mentions

> [type](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_selection#type-1) - (Required) An operation, such as `StringEquals`, that is applied to a key-value pair used to filter resources in a selection.

Actually `StringEquals` is not correct. It should read `STRINGEQUALS`.

### Relations

- Relates #41191 
  The wrong value was spotted while working on this issue.

### References

- [AWS Provider source code](https://github.com/hashicorp/terraform-provider-aws/blob/5772b4568fdadb632f8769c921864a041f72f166/internal/service/backup/selection.go#L166)  
 Here one can see for the argument `type`:
  ```go
  ValidateDiagFunc: enum.Validate[awstypes.ConditionType](),
  ```
     In the referenced AWS SDK Go v2 there is
  
  ```go
  type ConditionType string

  // Enum values for ConditionType
  const (
  	ConditionTypeStringequals ConditionType = "STRINGEQUALS"
  )
  ```

### Output from Acceptance Testing

Not applicable. Only documentation is updated.