### PR TITLE
Fix AccessDeniedError listing tags in aws_vpclattice_service_network, aws_vpclattice_service data sources

### DIFF
--- a/.changelog/41295.txt
+++ b/.changelog/41295.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+data-source/aws_vpclattice_service_network: Fix regression resulting in `AccessDeniedError` attempting to list tags
+```
+
+```release-note:bug
+data-source/aws_vpclattice_service: Fix regression resulting in `AccessDeniedError` attempting to list tags
+```

--- a/internal/service/ram/principal_association.go
+++ b/internal/service/ram/principal_association.go
@@ -127,13 +127,13 @@ func resourcePrincipalAssociationRead(ctx context.Context, d *schema.ResourceDat
 	principalAssociation, err := findPrincipalAssociationByTwoPartKey(ctx, conn, resourceShareARN, principal)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] RAM Resource Association %s not found, removing from state", d.Id())
+		log.Printf("[WARN] RAM Principal Association %s not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "reading RAM Resource Association (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading RAM Principal Association (%s): %s", d.Id(), err)
 	}
 
 	d.Set(names.AttrPrincipal, principalAssociation.AssociatedEntity)

--- a/internal/service/sts/caller_identity_data_source.go
+++ b/internal/service/sts/caller_identity_data_source.go
@@ -5,7 +5,6 @@ package sts
 
 import (
 	"context"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -81,8 +80,6 @@ func (d *callerIdentityDataSource) Read(ctx context.Context, request datasource.
 
 func findCallerIdentity(ctx context.Context, conn *sts.Client) (*sts.GetCallerIdentityOutput, error) {
 	input := &sts.GetCallerIdentityInput{}
-
-	time.Sleep(15 * time.Second)
 
 	output, err := conn.GetCallerIdentity(ctx, input)
 

--- a/internal/service/sts/caller_identity_data_source.go
+++ b/internal/service/sts/caller_identity_data_source.go
@@ -5,6 +5,7 @@ package sts
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -80,6 +81,8 @@ func (d *callerIdentityDataSource) Read(ctx context.Context, request datasource.
 
 func findCallerIdentity(ctx context.Context, conn *sts.Client) (*sts.GetCallerIdentityOutput, error) {
 	input := &sts.GetCallerIdentityInput{}
+
+	time.Sleep(15 * time.Second)
 
 	output, err := conn.GetCallerIdentity(ctx, input)
 

--- a/internal/service/vpclattice/service_data_source.go
+++ b/internal/service/vpclattice/service_data_source.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -18,8 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+// Caution: Because of cross account usage, using Tags(identifierAttribute="arn") causes Access Denied
+// errors because tags need special handling. See crossAccountSetTags().
+
 // @SDKDataSource("aws_vpclattice_service", name="Service")
-// @Tags(identifierAttribute="arn")
+// @Tags
 // @Testing(tagsTest=false)
 func dataSourceService() *schema.Resource {
 	return &schema.Resource{
@@ -129,23 +131,5 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("service_identifier", out.Id)
 	d.Set(names.AttrStatus, out.Status)
 
-	// https://docs.aws.amazon.com/vpc-lattice/latest/ug/sharing.html#sharing-perms
-	// Owners and consumers can list tags and can tag/untag resources in a service network that the account created.
-	// They can't list tags and tag/untag resources in a service network that aren't created by the account.
-	parsedARN, err := arn.Parse(serviceARN)
-	if err != nil {
-		return sdkdiag.AppendFromErr(diags, err)
-	}
-
-	if parsedARN.AccountID == meta.(*conns.AWSClient).AccountID(ctx) {
-		tags, err := listTags(ctx, conn, serviceARN)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "listing tags for VPC Lattice Service (%s): %s", serviceARN, err)
-		}
-
-		setTagsOut(ctx, Tags(tags))
-	}
-
-	return diags
+	return crossAccountSetTags(ctx, conn, diags, serviceARN, meta.(*conns.AWSClient).AccountID(ctx), "Service")
 }

--- a/internal/service/vpclattice/service_network_data_source.go
+++ b/internal/service/vpclattice/service_network_data_source.go
@@ -107,7 +107,7 @@ func crossAccountSetTags(ctx context.Context, conn *vpclattice.Client, diags dia
 	if parsedARN.AccountID == accountID {
 		tags, err := listTags(ctx, conn, resARN)
 
-		if err != nil && errs.Contains(err, ErrCodeAccessDeniedException) {
+		if errs.Contains(err, ErrCodeAccessDeniedException) {
 			return diags
 		}
 

--- a/internal/service/vpclattice/service_network_data_source.go
+++ b/internal/service/vpclattice/service_network_data_source.go
@@ -8,16 +8,25 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+const (
+	ErrCodeAccessDeniedException = "AccessDeniedException"
+)
+
+// Caution: Because of cross account usage, using Tags(identifierAttribute="arn") causes Access Denied
+// errors because tags need special handling. See crossAccountSetTags().
+
 // @SDKDataSource("aws_vpclattice_service_network", name="Service Network")
-// @Tags(identifierAttribute="arn")
+// @Tags
 // @Testing(tagsTest=false)
 func dataSourceServiceNetwork() *schema.Resource {
 	return &schema.Resource{
@@ -83,19 +92,27 @@ func dataSourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set("number_of_associated_vpcs", out.NumberOfAssociatedVPCs)
 	d.Set("service_network_identifier", out.Id)
 
+	return crossAccountSetTags(ctx, conn, diags, serviceNetworkARN, meta.(*conns.AWSClient).AccountID(ctx), "Service Network")
+}
+
+func crossAccountSetTags(ctx context.Context, conn *vpclattice.Client, diags diag.Diagnostics, resARN, accountID, resName string) diag.Diagnostics {
 	// https://docs.aws.amazon.com/vpc-lattice/latest/ug/sharing.html#sharing-perms
 	// Owners and consumers can list tags and can tag/untag resources in a service network that the account created.
 	// They can't list tags and tag/untag resources in a service network that aren't created by the account.
-	parsedARN, err := arn.Parse(serviceNetworkARN)
+	parsedARN, err := arn.Parse(resARN)
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	if parsedARN.AccountID == meta.(*conns.AWSClient).AccountID(ctx) {
-		tags, err := listTags(ctx, conn, serviceNetworkARN)
+	if parsedARN.AccountID == accountID {
+		tags, err := listTags(ctx, conn, resARN)
+
+		if err != nil && errs.Contains(err, ErrCodeAccessDeniedException) {
+			return diags
+		}
 
 		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "listing tags for VPC Lattice Service Network (%s): %s", serviceNetworkARN, err)
+			return sdkdiag.AppendErrorf(diags, "listing tags for VPC Lattice %s (%s): %s", resName, resARN, err)
 		}
 
 		setTagsOut(ctx, Tags(tags))

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -68,17 +68,13 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Factory:  dataSourceService,
 			TypeName: "aws_vpclattice_service",
 			Name:     "Service",
-			Tags: &types.ServicePackageResourceTags{
-				IdentifierAttribute: names.AttrARN,
-			},
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 		{
 			Factory:  dataSourceServiceNetwork,
 			TypeName: "aws_vpclattice_service_network",
 			Name:     "Service Network",
-			Tags: &types.ServicePackageResourceTags{
-				IdentifierAttribute: names.AttrARN,
-			},
+			Tags:     &types.ServicePackageResourceTags{},
 		},
 	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Using tags interceptor does not work for these shareable resources since tags cannot be listed for another account. This skips tags when the account is not the same or Access is denied.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41270 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* Fixes regression in #41019
* Relates #32938 
* Relates #32939 


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
