### PR TITLE
feat: Add service_network_log_type arg for aws_vpclattice_access_log_subscription

### DIFF
--- a/.changelog/41304.txt
+++ b/.changelog/41304.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_vpclattice_access_log_subscription: Add `service_network_log_type` argument
+```

--- a/website/docs/r/vpclattice_access_log_subscription.html.markdown
+++ b/website/docs/r/vpclattice_access_log_subscription.html.markdown
@@ -25,8 +25,12 @@ resource "aws_vpclattice_access_log_subscription" "example" {
 
 The following arguments are required:
 
-* `destination_arn` - (Required) Amazon Resource Name (ARN) of the log destination.
-* `resource_identifier` - (Required) The ID or Amazon Resource Identifier (ARN) of the service network or service. You must use the ARN if the resources specified in the operation are in different accounts.
+* `destination_arn` - (Required, Forces new resource) Amazon Resource Name (ARN) of the log destination.
+* `resource_identifier` - (Required, Forces new resource) The ID or Amazon Resource Identifier (ARN) of the service network or service. You must use the ARN if the resources specified in the operation are in different accounts.
+
+The following arguments are optional:
+
+* `service_network_log_type` - (Optional, Forces new resource) Type of log that monitors your Amazon VPC Lattice service networks. Valid values are: `SERVICE`, `RESOURCE`. Defaults to `SERVICE`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `service_network_log_type`a argument to the `aws_vpclattice_access_log_subscription` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41286

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [API_CreateAccessLogSubscription](https://docs.aws.amazon.com/vpc-lattice/latest/APIReference/API_CreateAccessLogSubscription.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccVPCLatticeAccessLogSubscription_" PKG=vpclattice
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeAccessLogSubscription_'  -timeout 360m -vet=off
2025/02/09 21:31:34 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCLatticeAccessLogSubscription_basic
=== PAUSE TestAccVPCLatticeAccessLogSubscription_basic
=== RUN   TestAccVPCLatticeAccessLogSubscription_disappears
=== PAUSE TestAccVPCLatticeAccessLogSubscription_disappears
=== RUN   TestAccVPCLatticeAccessLogSubscription_arn
=== PAUSE TestAccVPCLatticeAccessLogSubscription_arn
=== RUN   TestAccVPCLatticeAccessLogSubscription_tags
=== PAUSE TestAccVPCLatticeAccessLogSubscription_tags
=== RUN   TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard
=== PAUSE TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard
=== RUN   TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard
=== PAUSE TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard
=== RUN   TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType
=== PAUSE TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType
=== CONT  TestAccVPCLatticeAccessLogSubscription_basic
=== CONT  TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard
=== CONT  TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType
=== CONT  TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard
=== CONT  TestAccVPCLatticeAccessLogSubscription_arn
=== CONT  TestAccVPCLatticeAccessLogSubscription_tags
=== CONT  TestAccVPCLatticeAccessLogSubscription_disappears
--- PASS: TestAccVPCLatticeAccessLogSubscription_disappears (24.43s)
--- PASS: TestAccVPCLatticeAccessLogSubscription_basic (27.56s)
--- PASS: TestAccVPCLatticeAccessLogSubscription_arn (27.64s)
--- PASS: TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType (52.25s)
--- PASS: TestAccVPCLatticeAccessLogSubscription_tags (56.25s)
--- PASS: TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard (69.05s)
--- PASS: TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard (72.99s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice 73.217s

$
```
