### PR TITLE
Move inputs off heap with autofix: `a` and `w` services

### DIFF
--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/appconfig"
         - "internal/service/appfabric"
         - "internal/service/appflow"
         - "internal/service/appintegrations"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/appsync"
         - "internal/service/athena"
         - "internal/service/auditmanager"
         - "internal/service/autoscaling"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/appintegrations"
         - "internal/service/applicationinsights"
         - "internal/service/appmesh"
         - "internal/service/apprunner"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -52,7 +52,6 @@ rules:
       exclude:
         - "internal/service/auditmanager"
         - "internal/service/autoscaling"
-        - "internal/service/autoscalingplans"
         - "internal/service/b*"
         - "internal/service/c*"
         - "internal/service/d*"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/appflow"
         - "internal/service/appintegrations"
         - "internal/service/applicationinsights"
         - "internal/service/appmesh"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -51,7 +51,6 @@ rules:
     paths:
       exclude:
         - "internal/service/auditmanager"
-        - "internal/service/autoscaling"
         - "internal/service/b*"
         - "internal/service/c*"
         - "internal/service/d*"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -82,7 +82,6 @@ rules:
         - "internal/service/s*"
         - "internal/service/t*"
         - "internal/service/v*"
-        - "internal/service/wafv2"
         - "internal/service/worklink"
     patterns:
       - pattern-either:

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/apigatewayv2"
         - "internal/service/appconfig"
         - "internal/service/appfabric"
         - "internal/service/appflow"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/appstream"
         - "internal/service/appsync"
         - "internal/service/athena"
         - "internal/service/auditmanager"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -82,7 +82,6 @@ rules:
         - "internal/service/s*"
         - "internal/service/t*"
         - "internal/service/v*"
-        - "internal/service/wafregional"
         - "internal/service/wafv2"
         - "internal/service/worklink"
     patterns:

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/athena"
         - "internal/service/auditmanager"
         - "internal/service/autoscaling"
         - "internal/service/autoscalingplans"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/appfabric"
         - "internal/service/appflow"
         - "internal/service/appintegrations"
         - "internal/service/applicationinsights"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/apprunner"
         - "internal/service/appstream"
         - "internal/service/appsync"
         - "internal/service/athena"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -38,12 +38,61 @@ rules:
         - "internal/service/v*"
         - "internal/service/w*"
     patterns:
-      - pattern-either:
-          - pattern: |
-              $X := &$PKG.$INPUT{ ... }
-          - pattern: |
-              $FUNC(ctx, &$PKG.$INPUT{ ... }, ...)
+      - pattern: |
+          $X := &$PKG.$INPUT{ ... }
       - metavariable-regex:
           metavariable: $INPUT
           regex: \w+Input
+    severity: WARNING
+
+  - id: input-on-heap-inline
+    languages: [go]
+    message: Create the $PKG.$INPUT struct on the stack instead of on the heap
+    paths:
+      exclude:
+        - "internal/service/apigatewayv2"
+        - "internal/service/appconfig"
+        - "internal/service/appfabric"
+        - "internal/service/appflow"
+        - "internal/service/appintegrations"
+        - "internal/service/applicationinsights"
+        - "internal/service/appmesh"
+        - "internal/service/apprunner"
+        - "internal/service/appstream"
+        - "internal/service/appsync"
+        - "internal/service/athena"
+        - "internal/service/auditmanager"
+        - "internal/service/autoscaling"
+        - "internal/service/autoscalingplans"
+        - "internal/service/b*"
+        - "internal/service/c*"
+        - "internal/service/d*"
+        - "internal/service/e*"
+        - "internal/service/f*"
+        - "internal/service/g*"
+        - "internal/service/i*"
+        - "internal/service/k*"
+        - "internal/service/l*"
+        - "internal/service/m*"
+        - "internal/service/n*"
+        - "internal/service/o*"
+        - "internal/service/p*"
+        - "internal/service/q*"
+        - "internal/service/r*"
+        - "internal/service/s*"
+        - "internal/service/t*"
+        - "internal/service/v*"
+        - "internal/service/w*"
+    patterns:
+      - pattern-either:
+          - pattern: |
+              ... = $FUNC(ctx, &$PKG.$INPUT{ ... }, ...)
+      - metavariable-regex:
+          metavariable: $INPUT
+          regex: \w+Input
+    fix-regex:
+      regex: '(?s)(.+= \w+\.\w+\(\w+, &)(\w+\.\w+\{.*\})(\))'
+      replacement: |
+        input := \2
+        \1input\3
     severity: WARNING

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/applicationinsights"
         - "internal/service/appmesh"
         - "internal/service/apprunner"
         - "internal/service/appstream"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -82,7 +82,6 @@ rules:
         - "internal/service/s*"
         - "internal/service/t*"
         - "internal/service/v*"
-        - "internal/service/worklink"
     patterns:
       - pattern-either:
           - pattern: |

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -82,7 +82,9 @@ rules:
         - "internal/service/s*"
         - "internal/service/t*"
         - "internal/service/v*"
-        - "internal/service/w*"
+        - "internal/service/wafregional"
+        - "internal/service/wafv2"
+        - "internal/service/worklink"
     patterns:
       - pattern-either:
           - pattern: |

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -50,7 +50,6 @@ rules:
     message: Create the $PKG.$INPUT struct on the stack instead of on the heap
     paths:
       exclude:
-        - "internal/service/appmesh"
         - "internal/service/apprunner"
         - "internal/service/appstream"
         - "internal/service/appsync"

--- a/internal/service/apigatewayv2/api.go
+++ b/internal/service/apigatewayv2/api.go
@@ -347,9 +347,10 @@ func resourceAPIDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 API: %s", d.Id())
-	_, err := conn.DeleteApi(ctx, &apigatewayv2.DeleteApiInput{
+	input := apigatewayv2.DeleteApiInput{
 		ApiId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteApi(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apigatewayv2/api_mapping.go
+++ b/internal/service/apigatewayv2/api_mapping.go
@@ -137,10 +137,11 @@ func resourceAPIMappingDelete(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 API Mapping (%s)", d.Id())
-	_, err := conn.DeleteApiMapping(ctx, &apigatewayv2.DeleteApiMappingInput{
+	input := apigatewayv2.DeleteApiMappingInput{
 		ApiMappingId: aws.String(d.Id()),
 		DomainName:   aws.String(d.Get(names.AttrDomainName).(string)),
-	})
+	}
+	_, err := conn.DeleteApiMapping(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apigatewayv2/api_mapping_test.go
+++ b/internal/service/apigatewayv2/api_mapping_test.go
@@ -173,13 +173,14 @@ func testAccCheckAPIMappingCreateCertificate(ctx context.Context, t *testing.T, 
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ACMClient(ctx)
 
-		output, err := conn.ImportCertificate(ctx, &acm.ImportCertificateInput{
+		input := acm.ImportCertificateInput{
 			Certificate: []byte(certificate),
 			PrivateKey:  []byte(privateKey),
 			Tags: tfacm.Tags(tftags.New(ctx, map[string]interface{}{
 				"Name": rName,
 			}).IgnoreAWS()),
-		})
+		}
+		output, err := conn.ImportCertificate(ctx, &input)
 
 		if err != nil {
 			return err

--- a/internal/service/apigatewayv2/deployment.go
+++ b/internal/service/apigatewayv2/deployment.go
@@ -145,10 +145,11 @@ func resourceDeploymentDelete(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 Deployment (%s)", d.Id())
-	_, err := conn.DeleteDeployment(ctx, &apigatewayv2.DeleteDeploymentInput{
+	input := apigatewayv2.DeleteDeploymentInput{
 		ApiId:        aws.String(d.Get("api_id").(string)),
 		DeploymentId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteDeployment(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apigatewayv2/domain_name.go
+++ b/internal/service/apigatewayv2/domain_name.go
@@ -242,9 +242,10 @@ func resourceDomainNameDelete(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 Domain Name: %s", d.Id())
-	_, err := conn.DeleteDomainName(ctx, &apigatewayv2.DeleteDomainNameInput{
+	input := apigatewayv2.DeleteDomainNameInput{
 		DomainName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteDomainName(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apigatewayv2/integration.go
+++ b/internal/service/apigatewayv2/integration.go
@@ -436,10 +436,11 @@ func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 Integration: %s", d.Id())
-	_, err := conn.DeleteIntegration(ctx, &apigatewayv2.DeleteIntegrationInput{
+	input := apigatewayv2.DeleteIntegrationInput{
 		ApiId:         aws.String(d.Get("api_id").(string)),
 		IntegrationId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteIntegration(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apigatewayv2/integration_response.go
+++ b/internal/service/apigatewayv2/integration_response.go
@@ -168,11 +168,12 @@ func resourceIntegrationResponseDelete(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 Integration Response: %s", d.Id())
-	_, err := conn.DeleteIntegrationResponse(ctx, &apigatewayv2.DeleteIntegrationResponseInput{
+	input := apigatewayv2.DeleteIntegrationResponseInput{
 		ApiId:                 aws.String(d.Get("api_id").(string)),
 		IntegrationId:         aws.String(d.Get("integration_id").(string)),
 		IntegrationResponseId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteIntegrationResponse(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apigatewayv2/model.go
+++ b/internal/service/apigatewayv2/model.go
@@ -170,10 +170,11 @@ func resourceModelDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 Model: %s", d.Id())
-	_, err := conn.DeleteModel(ctx, &apigatewayv2.DeleteModelInput{
+	input := apigatewayv2.DeleteModelInput{
 		ApiId:   aws.String(d.Get("api_id").(string)),
 		ModelId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteModel(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apigatewayv2/route.go
+++ b/internal/service/apigatewayv2/route.go
@@ -304,10 +304,11 @@ func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 Route: %s", d.Id())
-	_, err := conn.DeleteRoute(ctx, &apigatewayv2.DeleteRouteInput{
+	input := apigatewayv2.DeleteRouteInput{
 		ApiId:   aws.String(d.Get("api_id").(string)),
 		RouteId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteRoute(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apigatewayv2/route_response.go
+++ b/internal/service/apigatewayv2/route_response.go
@@ -150,11 +150,12 @@ func resourceRouteResponseDelete(ctx context.Context, d *schema.ResourceData, me
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 Route Response: %s", d.Id())
-	_, err := conn.DeleteRouteResponse(ctx, &apigatewayv2.DeleteRouteResponseInput{
+	input := apigatewayv2.DeleteRouteResponseInput{
 		ApiId:           aws.String(d.Get("api_id").(string)),
 		RouteId:         aws.String(d.Get("route_id").(string)),
 		RouteResponseId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteRouteResponse(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apigatewayv2/stage.go
+++ b/internal/service/apigatewayv2/stage.go
@@ -397,10 +397,11 @@ func resourceStageDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 Stage: %s", d.Id())
-	_, err := conn.DeleteStage(ctx, &apigatewayv2.DeleteStageInput{
+	input := apigatewayv2.DeleteStageInput{
 		ApiId:     aws.String(d.Get("api_id").(string)),
 		StageName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteStage(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apigatewayv2/stage_test.go
+++ b/internal/service/apigatewayv2/stage_test.go
@@ -1488,7 +1488,8 @@ resource "aws_apigatewayv2_stage" "test" {
 func testAccPreCheckAPIGatewayAccountCloudWatchRoleARN(ctx context.Context, t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
 
-	output, err := conn.GetAccount(ctx, &apigateway.GetAccountInput{})
+	input := apigateway.GetAccountInput{}
+	output, err := conn.GetAccount(ctx, &input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping tests: %s", err)

--- a/internal/service/apigatewayv2/vpc_link.go
+++ b/internal/service/apigatewayv2/vpc_link.go
@@ -149,9 +149,10 @@ func resourceVPCLinkDelete(ctx context.Context, d *schema.ResourceData, meta int
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 VPC Link: %s", d.Id())
-	_, err := conn.DeleteVpcLink(ctx, &apigatewayv2.DeleteVpcLinkInput{
+	input := apigatewayv2.DeleteVpcLinkInput{
 		VpcLinkId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteVpcLink(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/appconfig/application.go
+++ b/internal/service/appconfig/application.go
@@ -157,9 +157,10 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
 	log.Printf("[INFO] Deleting AppConfig Application: %s", d.Id())
-	_, err := conn.DeleteApplication(ctx, &appconfig.DeleteApplicationInput{
+	input := appconfig.DeleteApplicationInput{
 		ApplicationId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteApplication(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appconfig/configuration_profile.go
+++ b/internal/service/appconfig/configuration_profile.go
@@ -279,10 +279,11 @@ func resourceConfigurationProfileDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	log.Printf("[INFO] Deleting AppConfig Configuration Profile: %s", d.Id())
-	_, err = conn.DeleteConfigurationProfile(ctx, &appconfig.DeleteConfigurationProfileInput{
+	input := appconfig.DeleteConfigurationProfileInput{
 		ApplicationId:          aws.String(appID),
 		ConfigurationProfileId: aws.String(confProfID),
-	})
+	}
+	_, err = conn.DeleteConfigurationProfile(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appconfig/configuration_profile_data_source.go
+++ b/internal/service/appconfig/configuration_profile_data_source.go
@@ -132,10 +132,11 @@ func dataSourceConfigurationProfileRead(ctx context.Context, d *schema.ResourceD
 }
 
 func findConfigurationProfileByApplicationAndProfile(ctx context.Context, conn *appconfig.Client, appId string, cpId string) (*appconfig.GetConfigurationProfileOutput, error) {
-	res, err := conn.GetConfigurationProfile(ctx, &appconfig.GetConfigurationProfileInput{
+	input := appconfig.GetConfigurationProfileInput{
 		ApplicationId:          aws.String(appId),
 		ConfigurationProfileId: aws.String(cpId),
-	})
+	}
+	res, err := conn.GetConfigurationProfile(ctx, &input)
 
 	if err != nil {
 		return nil, err

--- a/internal/service/appconfig/configuration_profile_test.go
+++ b/internal/service/appconfig/configuration_profile_test.go
@@ -363,10 +363,11 @@ func testAccCheckConfigurationProfileExists(ctx context.Context, resourceName st
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigClient(ctx)
 
-		output, err := conn.GetConfigurationProfile(ctx, &appconfig.GetConfigurationProfileInput{
+		input := appconfig.GetConfigurationProfileInput{
 			ApplicationId:          aws.String(appID),
 			ConfigurationProfileId: aws.String(confProfID),
-		})
+		}
+		output, err := conn.GetConfigurationProfile(ctx, &input)
 
 		if err != nil {
 			return fmt.Errorf("error reading AppConfig Configuration Profile (%s) for Application (%s): %w", confProfID, appID, err)

--- a/internal/service/appconfig/deployment_strategy.go
+++ b/internal/service/appconfig/deployment_strategy.go
@@ -207,9 +207,10 @@ func resourceDeploymentStrategyDelete(ctx context.Context, d *schema.ResourceDat
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
 	log.Printf("[INFO] Deleting AppConfig Deployment Strategy: %s", d.Id())
-	_, err := conn.DeleteDeploymentStrategy(ctx, &appconfig.DeleteDeploymentStrategyInput{
+	input := appconfig.DeleteDeploymentStrategyInput{
 		DeploymentStrategyId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteDeploymentStrategy(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appconfig/environment_data_source.go
+++ b/internal/service/appconfig/environment_data_source.go
@@ -107,10 +107,11 @@ func dataSourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func findEnvironmentByApplicationAndEnvironment(ctx context.Context, conn *appconfig.Client, appId string, envId string) (*appconfig.GetEnvironmentOutput, error) {
-	res, err := conn.GetEnvironment(ctx, &appconfig.GetEnvironmentInput{
+	input := appconfig.GetEnvironmentInput{
 		ApplicationId: aws.String(appId),
 		EnvironmentId: aws.String(envId),
-	})
+	}
+	res, err := conn.GetEnvironment(ctx, &input)
 
 	if err != nil {
 		return nil, err

--- a/internal/service/appconfig/extension.go
+++ b/internal/service/appconfig/extension.go
@@ -231,9 +231,10 @@ func resourceExtensionDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
-	_, err := conn.DeleteExtension(ctx, &appconfig.DeleteExtensionInput{
+	input := appconfig.DeleteExtensionInput{
 		ExtensionIdentifier: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteExtension(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appconfig/extension_association.go
+++ b/internal/service/appconfig/extension_association.go
@@ -156,9 +156,10 @@ func resourceExtensionAssociationDelete(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
 	log.Printf("[INFO] Deleting AppConfig Hosted Extension Association: %s", d.Id())
-	_, err := conn.DeleteExtensionAssociation(ctx, &appconfig.DeleteExtensionAssociationInput{
+	input := appconfig.DeleteExtensionAssociationInput{
 		ExtensionAssociationId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteExtensionAssociation(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appconfig/hosted_configuration_version.go
+++ b/internal/service/appconfig/hosted_configuration_version.go
@@ -168,11 +168,12 @@ func resourceHostedConfigurationVersionDelete(ctx context.Context, d *schema.Res
 	}
 
 	log.Printf("[INFO] Deleting AppConfig Hosted Configuration Version: %s", d.Id())
-	_, err = conn.DeleteHostedConfigurationVersion(ctx, &appconfig.DeleteHostedConfigurationVersionInput{
+	input := appconfig.DeleteHostedConfigurationVersionInput{
 		ApplicationId:          aws.String(appID),
 		ConfigurationProfileId: aws.String(confProfID),
 		VersionNumber:          aws.Int32(versionNumber),
-	})
+	}
+	_, err = conn.DeleteHostedConfigurationVersion(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appconfig/hosted_configuration_version_test.go
+++ b/internal/service/appconfig/hosted_configuration_version_test.go
@@ -137,11 +137,12 @@ func testAccCheckHostedConfigurationVersionExists(ctx context.Context, resourceN
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppConfigClient(ctx)
 
-		output, err := conn.GetHostedConfigurationVersion(ctx, &appconfig.GetHostedConfigurationVersionInput{
+		input := appconfig.GetHostedConfigurationVersionInput{
 			ApplicationId:          aws.String(appID),
 			ConfigurationProfileId: aws.String(confProfID),
 			VersionNumber:          aws.Int32(versionNumber),
-		})
+		}
+		output, err := conn.GetHostedConfigurationVersion(ctx, &input)
 
 		if err != nil {
 			return fmt.Errorf("error reading AppConfig Hosted Configuration Version (%s): %w", rs.Primary.ID, err)

--- a/internal/service/appfabric/app_authorization.go
+++ b/internal/service/appfabric/app_authorization.go
@@ -383,10 +383,11 @@ func (r *appAuthorizationResource) Delete(ctx context.Context, request resource.
 
 	conn := r.Meta().AppFabricClient(ctx)
 
-	_, err := conn.DeleteAppAuthorization(ctx, &appfabric.DeleteAppAuthorizationInput{
+	input := appfabric.DeleteAppAuthorizationInput{
 		AppAuthorizationIdentifier: fwflex.StringFromFramework(ctx, data.AppAuthorizationARN),
 		AppBundleIdentifier:        fwflex.StringFromFramework(ctx, data.AppBundleARN),
-	})
+	}
+	_, err := conn.DeleteAppAuthorization(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/appfabric/app_bundle.go
+++ b/internal/service/appfabric/app_bundle.go
@@ -147,9 +147,10 @@ func (r *appBundleResource) Delete(ctx context.Context, request resource.DeleteR
 
 	conn := r.Meta().AppFabricClient(ctx)
 
-	_, err := conn.DeleteAppBundle(ctx, &appfabric.DeleteAppBundleInput{
+	input := appfabric.DeleteAppBundleInput{
 		AppBundleIdentifier: data.ID.ValueStringPointer(),
-	})
+	}
+	_, err := conn.DeleteAppBundle(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/appfabric/ingestion.go
+++ b/internal/service/appfabric/ingestion.go
@@ -191,10 +191,11 @@ func (r *ingestionResource) Delete(ctx context.Context, request resource.DeleteR
 
 	conn := r.Meta().AppFabricClient(ctx)
 
-	_, err := conn.DeleteIngestion(ctx, &appfabric.DeleteIngestionInput{
+	input := appfabric.DeleteIngestionInput{
 		AppBundleIdentifier: data.AppBundleARN.ValueStringPointer(),
 		IngestionIdentifier: data.ARN.ValueStringPointer(),
-	})
+	}
+	_, err := conn.DeleteIngestion(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/appfabric/ingestion_destination.go
+++ b/internal/service/appfabric/ingestion_destination.go
@@ -354,11 +354,12 @@ func (r *ingestionDestinationResource) Delete(ctx context.Context, request resou
 
 	conn := r.Meta().AppFabricClient(ctx)
 
-	_, err := conn.DeleteIngestionDestination(ctx, &appfabric.DeleteIngestionDestinationInput{
+	input := appfabric.DeleteIngestionDestinationInput{
 		AppBundleIdentifier:            data.AppBundleARN.ValueStringPointer(),
 		IngestionDestinationIdentifier: data.ARN.ValueStringPointer(),
 		IngestionIdentifier:            data.IngestionARN.ValueStringPointer(),
-	})
+	}
+	_, err := conn.DeleteIngestionDestination(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/appflow/connector_profile.go
+++ b/internal/service/appflow/connector_profile.go
@@ -1533,9 +1533,10 @@ func resourceConnectorProfileDelete(ctx context.Context, d *schema.ResourceData,
 	conn := meta.(*conns.AWSClient).AppFlowClient(ctx)
 
 	log.Printf("[INFO] Deleting AppFlow Connector Profile: %s", d.Id())
-	_, err := conn.DeleteConnectorProfile(ctx, &appflow.DeleteConnectorProfileInput{
+	input := appflow.DeleteConnectorProfileInput{
 		ConnectorProfileName: aws.String(d.Get(names.AttrName).(string)),
-	})
+	}
+	_, err := conn.DeleteConnectorProfile(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appflow/connector_profile_test.go
+++ b/internal/service/appflow/connector_profile_test.go
@@ -235,7 +235,7 @@ resource "aws_redshift_cluster" "test" {
   master_password = %[2]q
   master_username = %[3]q
 
-  publicly_accessible = true
+  publicly_accessible = false
 
   node_type           = "dc2.large"
   skip_final_snapshot = true

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -1487,9 +1487,10 @@ func resourceFlowDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	conn := meta.(*conns.AWSClient).AppFlowClient(ctx)
 
 	log.Printf("[INFO] Deleting AppFlow Flow: %s", d.Get(names.AttrName))
-	_, err := conn.DeleteFlow(ctx, &appflow.DeleteFlowInput{
+	input := appflow.DeleteFlowInput{
 		FlowName: aws.String(d.Get(names.AttrName).(string)),
-	})
+	}
+	_, err := conn.DeleteFlow(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appintegrations/data_integration.go
+++ b/internal/service/appintegrations/data_integration.go
@@ -146,9 +146,10 @@ func resourceDataIntegrationRead(ctx context.Context, d *schema.ResourceData, me
 
 	conn := meta.(*conns.AWSClient).AppIntegrationsClient(ctx)
 
-	output, err := conn.GetDataIntegration(ctx, &appintegrations.GetDataIntegrationInput{
+	input := appintegrations.GetDataIntegrationInput{
 		Identifier: aws.String(d.Id()),
-	})
+	}
+	output, err := conn.GetDataIntegration(ctx, &input)
 
 	if !d.IsNewResource() && errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		log.Printf("[WARN] AppIntegrations Data Integration (%s) not found, removing from state", d.Id())
@@ -180,11 +181,12 @@ func resourceDataIntegrationUpdate(ctx context.Context, d *schema.ResourceData, 
 	conn := meta.(*conns.AWSClient).AppIntegrationsClient(ctx)
 
 	if d.HasChanges(names.AttrDescription, names.AttrName) {
-		_, err := conn.UpdateDataIntegration(ctx, &appintegrations.UpdateDataIntegrationInput{
+		input := appintegrations.UpdateDataIntegrationInput{
 			Description: aws.String(d.Get(names.AttrDescription).(string)),
 			Identifier:  aws.String(d.Id()),
 			Name:        aws.String(d.Get(names.AttrName).(string)),
-		})
+		}
+		_, err := conn.UpdateDataIntegration(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating AppIntegrations Data Integration (%s): %s", d.Id(), err)
@@ -199,9 +201,10 @@ func resourceDataIntegrationDelete(ctx context.Context, d *schema.ResourceData, 
 
 	conn := meta.(*conns.AWSClient).AppIntegrationsClient(ctx)
 
-	_, err := conn.DeleteDataIntegration(ctx, &appintegrations.DeleteDataIntegrationInput{
+	input := appintegrations.DeleteDataIntegrationInput{
 		DataIntegrationIdentifier: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteDataIntegration(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting AppIntegrations Data Integration (%s): %s", d.Id(), err)

--- a/internal/service/appintegrations/event_integration.go
+++ b/internal/service/appintegrations/event_integration.go
@@ -122,9 +122,10 @@ func resourceEventIntegrationRead(ctx context.Context, d *schema.ResourceData, m
 
 	name := d.Id()
 
-	resp, err := conn.GetEventIntegration(ctx, &appintegrations.GetEventIntegrationInput{
+	input := appintegrations.GetEventIntegrationInput{
 		Name: aws.String(name),
-	})
+	}
+	resp, err := conn.GetEventIntegration(ctx, &input)
 
 	if !d.IsNewResource() && errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		log.Printf("[WARN] AppIntegrations Event Integration (%s) not found, removing from state", d.Id())
@@ -162,10 +163,11 @@ func resourceEventIntegrationUpdate(ctx context.Context, d *schema.ResourceData,
 	name := d.Id()
 
 	if d.HasChange(names.AttrDescription) {
-		_, err := conn.UpdateEventIntegration(ctx, &appintegrations.UpdateEventIntegrationInput{
+		input := appintegrations.UpdateEventIntegrationInput{
 			Name:        aws.String(name),
 			Description: aws.String(d.Get(names.AttrDescription).(string)),
-		})
+		}
+		_, err := conn.UpdateEventIntegration(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating EventIntegration (%s): %s", d.Id(), err)
@@ -182,9 +184,10 @@ func resourceEventIntegrationDelete(ctx context.Context, d *schema.ResourceData,
 
 	name := d.Id()
 
-	_, err := conn.DeleteEventIntegration(ctx, &appintegrations.DeleteEventIntegrationInput{
+	input := appintegrations.DeleteEventIntegrationInput{
 		Name: aws.String(name),
-	})
+	}
+	_, err := conn.DeleteEventIntegration(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appintegrations/event_integration_data_source.go
+++ b/internal/service/appintegrations/event_integration_data_source.go
@@ -63,9 +63,10 @@ func dataSourceEventIntegrationRead(ctx context.Context, d *schema.ResourceData,
 	conn := meta.(*conns.AWSClient).AppIntegrationsClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	output, err := conn.GetEventIntegration(ctx, &appintegrations.GetEventIntegrationInput{
+	input := appintegrations.GetEventIntegrationInput{
 		Name: aws.String(name),
-	})
+	}
+	output, err := conn.GetEventIntegration(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading AppIntegrations Event Integration (%s): %s", name, err)

--- a/internal/service/applicationinsights/application.go
+++ b/internal/service/applicationinsights/application.go
@@ -200,9 +200,10 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).ApplicationInsightsClient(ctx)
 
 	log.Printf("[DEBUG] Deleting ApplicationInsights Application: %s", d.Id())
-	_, err := conn.DeleteApplication(ctx, &applicationinsights.DeleteApplicationInput{
+	input := applicationinsights.DeleteApplicationInput{
 		ResourceGroupName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteApplication(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appmesh/mesh.go
+++ b/internal/service/appmesh/mesh.go
@@ -203,9 +203,10 @@ func resourceMeshDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	log.Printf("[DEBUG] Deleting App Mesh Service Mesh: %s", d.Id())
-	_, err := conn.DeleteMesh(ctx, &appmesh.DeleteMeshInput{
+	input := appmesh.DeleteMeshInput{
 		MeshName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteMesh(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/apprunner/auto_scaling_configuration_version.go
+++ b/internal/service/apprunner/auto_scaling_configuration_version.go
@@ -177,9 +177,10 @@ func resourceAutoScalingConfigurationDelete(ctx context.Context, d *schema.Resou
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
 
 	log.Printf("[INFO] Deleting App Runner AutoScaling Configuration Version: %s", d.Id())
-	_, err := conn.DeleteAutoScalingConfiguration(ctx, &apprunner.DeleteAutoScalingConfigurationInput{
+	input := apprunner.DeleteAutoScalingConfigurationInput{
 		AutoScalingConfigurationArn: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteAutoScalingConfiguration(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) || errs.IsAErrorMessageContains[*types.InvalidRequestException](err, "The auto scaling configuration you specified has been deleted") {
 		return diags

--- a/internal/service/apprunner/connection.go
+++ b/internal/service/apprunner/connection.go
@@ -124,9 +124,10 @@ func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
 
 	log.Printf("[INFO] Deleting App Runner Connection: %s", d.Id())
-	_, err := conn.DeleteConnection(ctx, &apprunner.DeleteConnectionInput{
+	input := apprunner.DeleteConnectionInput{
 		ConnectionArn: aws.String(d.Get(names.AttrARN).(string)),
-	})
+	}
+	_, err := conn.DeleteConnection(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/apprunner/custom_domain_association.go
+++ b/internal/service/apprunner/custom_domain_association.go
@@ -166,10 +166,11 @@ func resourceCustomDomainAssociationDelete(ctx context.Context, d *schema.Resour
 	}
 
 	log.Printf("[INFO] Deleting App Runner Custom Domain Association: %s", d.Id())
-	_, err = conn.DisassociateCustomDomain(ctx, &apprunner.DisassociateCustomDomainInput{
+	input := apprunner.DisassociateCustomDomainInput{
 		DomainName: aws.String(domainName),
 		ServiceArn: aws.String(serviceARN),
-	})
+	}
+	_, err = conn.DisassociateCustomDomain(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/apprunner/observability_configuration.go
+++ b/internal/service/apprunner/observability_configuration.go
@@ -151,9 +151,10 @@ func resourceObservabilityConfigurationDelete(ctx context.Context, d *schema.Res
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
 
 	log.Printf("[INFO] Deleting App Runner Observability Configuration: %s", d.Id())
-	_, err := conn.DeleteObservabilityConfiguration(ctx, &apprunner.DeleteObservabilityConfigurationInput{
+	input := apprunner.DeleteObservabilityConfigurationInput{
 		ObservabilityConfigurationArn: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteObservabilityConfiguration(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -604,9 +604,10 @@ func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta int
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
 
 	log.Printf("[INFO] Deleting App Runner Service: %s", d.Id())
-	_, err := conn.DeleteService(ctx, &apprunner.DeleteServiceInput{
+	input := apprunner.DeleteServiceInput{
 		ServiceArn: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteService(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -144,9 +144,10 @@ func resourceVPCConnectorDelete(ctx context.Context, d *schema.ResourceData, met
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
 
 	log.Printf("[DEBUG] Deleting App Runner VPC Connector: %s", d.Id())
-	_, err := conn.DeleteVpcConnector(ctx, &apprunner.DeleteVpcConnectorInput{
+	input := apprunner.DeleteVpcConnectorInput{
 		VpcConnectorArn: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteVpcConnector(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/apprunner/vpc_ingress_connection.go
+++ b/internal/service/apprunner/vpc_ingress_connection.go
@@ -160,9 +160,10 @@ func resourceVPCIngressConnectionDelete(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
 
 	log.Printf("[INFO] Deleting App Runner VPC Ingress Connection: %s", d.Id())
-	_, err := conn.DeleteVpcIngressConnection(ctx, &apprunner.DeleteVpcIngressConnectionInput{
+	input := apprunner.DeleteVpcIngressConnectionInput{
 		VpcIngressConnectionArn: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteVpcIngressConnection(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appstream/directory_config.go
+++ b/internal/service/appstream/directory_config.go
@@ -103,7 +103,8 @@ func resourceDirectoryConfigRead(ctx context.Context, d *schema.ResourceData, me
 
 	conn := meta.(*conns.AWSClient).AppStreamClient(ctx)
 
-	resp, err := conn.DescribeDirectoryConfigs(ctx, &appstream.DescribeDirectoryConfigsInput{DirectoryNames: []string{d.Id()}})
+	input := appstream.DescribeDirectoryConfigsInput{DirectoryNames: []string{d.Id()}}
+	resp, err := conn.DescribeDirectoryConfigs(ctx, &input)
 
 	if !d.IsNewResource() && errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		log.Printf("[WARN] AppStream Directory Config (%s) not found, removing from state", d.Id())
@@ -166,9 +167,10 @@ func resourceDirectoryConfigDelete(ctx context.Context, d *schema.ResourceData, 
 	conn := meta.(*conns.AWSClient).AppStreamClient(ctx)
 
 	log.Printf("[DEBUG] Deleting AppStream Directory Config: (%s)", d.Id())
-	_, err := conn.DeleteDirectoryConfig(ctx, &appstream.DeleteDirectoryConfigInput{
+	input := appstream.DeleteDirectoryConfigInput{
 		DirectoryName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteDirectoryConfig(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appstream/directory_config_test.go
+++ b/internal/service/appstream/directory_config_test.go
@@ -162,7 +162,8 @@ func testAccCheckDirectoryConfigExists(ctx context.Context, resourceName string,
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppStreamClient(ctx)
-		resp, err := conn.DescribeDirectoryConfigs(ctx, &appstream.DescribeDirectoryConfigsInput{DirectoryNames: []string{rs.Primary.ID}})
+		input := appstream.DescribeDirectoryConfigsInput{DirectoryNames: []string{rs.Primary.ID}}
+		resp, err := conn.DescribeDirectoryConfigs(ctx, &input)
 
 		if err != nil {
 			return err
@@ -187,7 +188,8 @@ func testAccCheckDirectoryConfigDestroy(ctx context.Context) resource.TestCheckF
 				continue
 			}
 
-			resp, err := conn.DescribeDirectoryConfigs(ctx, &appstream.DescribeDirectoryConfigsInput{DirectoryNames: []string{rs.Primary.ID}})
+			input := appstream.DescribeDirectoryConfigsInput{DirectoryNames: []string{rs.Primary.ID}}
+			resp, err := conn.DescribeDirectoryConfigs(ctx, &input)
 
 			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 				continue

--- a/internal/service/appstream/fleet.go
+++ b/internal/service/appstream/fleet.go
@@ -320,9 +320,10 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	d.SetId(aws.ToString(output.Fleet.Name))
 
 	// Start fleet workflow
-	_, err = conn.StartFleet(ctx, &appstream.StartFleetInput{
+	startFleetInput := appstream.StartFleetInput{
 		Name: aws.String(d.Id()),
-	})
+	}
+	_, err = conn.StartFleet(ctx, &startFleetInput)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "starting Appstream Fleet (%s): %s", d.Id(), err)
 	}
@@ -339,7 +340,8 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	conn := meta.(*conns.AWSClient).AppStreamClient(ctx)
 
-	resp, err := conn.DescribeFleets(ctx, &appstream.DescribeFleetsInput{Names: []string{d.Id()}})
+	input := appstream.DescribeFleetsInput{Names: []string{d.Id()}}
+	resp, err := conn.DescribeFleets(ctx, &input)
 
 	if !d.IsNewResource() && errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		log.Printf("[WARN] Appstream Fleet (%s) not found, removing from state", d.Id())
@@ -423,9 +425,10 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// Stop fleet workflow if needed
 	if shouldStop {
-		_, err := conn.StopFleet(ctx, &appstream.StopFleetInput{
+		input := appstream.StopFleetInput{
 			Name: aws.String(d.Id()),
-		})
+		}
+		_, err := conn.StopFleet(ctx, &input)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "stopping Appstream Fleet (%s): %s", d.Id(), err)
 		}
@@ -501,9 +504,10 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// Start fleet workflow if stopped
 	if shouldStop {
-		_, err = conn.StartFleet(ctx, &appstream.StartFleetInput{
+		input := appstream.StartFleetInput{
 			Name: aws.String(d.Id()),
-		})
+		}
+		_, err = conn.StartFleet(ctx, &input)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "starting Appstream Fleet (%s): %s", d.Id(), err)
 		}
@@ -523,9 +527,10 @@ func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta inter
 
 	// Stop fleet workflow
 	log.Printf("[DEBUG] Stopping AppStream Fleet: (%s)", d.Id())
-	_, err := conn.StopFleet(ctx, &appstream.StopFleetInput{
+	stopFleetInput := appstream.StopFleetInput{
 		Name: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.StopFleet(ctx, &stopFleetInput)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags
@@ -540,9 +545,10 @@ func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[DEBUG] Deleting AppStream Fleet: (%s)", d.Id())
-	_, err = conn.DeleteFleet(ctx, &appstream.DeleteFleetInput{
+	deleteFleetInput := appstream.DeleteFleetInput{
 		Name: aws.String(d.Id()),
-	})
+	}
+	_, err = conn.DeleteFleet(ctx, &deleteFleetInput)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appstream/fleet_stack_association.go
+++ b/internal/service/appstream/fleet_stack_association.go
@@ -117,10 +117,11 @@ func resourceFleetStackAssociationDelete(ctx context.Context, d *schema.Resource
 		return sdkdiag.AppendErrorf(diags, "decoding AppStream Fleet Stack Association ID (%s): %s", d.Id(), err)
 	}
 
-	_, err = conn.DisassociateFleet(ctx, &appstream.DisassociateFleetInput{
+	input := appstream.DisassociateFleetInput{
 		StackName: aws.String(stackName),
 		FleetName: aws.String(fleetName),
-	})
+	}
+	_, err = conn.DisassociateFleet(ctx, &input)
 
 	if err != nil {
 		if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/appstream/fleet_test.go
+++ b/internal/service/appstream/fleet_test.go
@@ -367,7 +367,8 @@ func testAccCheckFleetExists(ctx context.Context, resourceName string, appStream
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppStreamClient(ctx)
-		resp, err := conn.DescribeFleets(ctx, &appstream.DescribeFleetsInput{Names: []string{rs.Primary.ID}})
+		input := appstream.DescribeFleetsInput{Names: []string{rs.Primary.ID}}
+		resp, err := conn.DescribeFleets(ctx, &input)
 
 		if err != nil {
 			return err
@@ -392,7 +393,8 @@ func testAccCheckFleetDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			resp, err := conn.DescribeFleets(ctx, &appstream.DescribeFleetsInput{Names: []string{rs.Primary.ID}})
+			input := appstream.DescribeFleetsInput{Names: []string{rs.Primary.ID}}
+			resp, err := conn.DescribeFleets(ctx, &input)
 
 			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 				continue

--- a/internal/service/appstream/fleet_test.go
+++ b/internal/service/appstream/fleet_test.go
@@ -591,7 +591,7 @@ resource "aws_subnet" "test" {
 }
 
 data "aws_appstream_image" "test" {
-  name_regex  = "^AppStream-WinServer.*$"
+  name_regex  = "^AppStream-WinServer2022.*$"
   type        = "PUBLIC"
   most_recent = true
 }

--- a/internal/service/appstream/image_builder.go
+++ b/internal/service/appstream/image_builder.go
@@ -311,9 +311,10 @@ func resourceImageBuilderDelete(ctx context.Context, d *schema.ResourceData, met
 	conn := meta.(*conns.AWSClient).AppStreamClient(ctx)
 
 	log.Printf("[DEBUG] Deleting AppStream ImageBuilder: %s", d.Id())
-	_, err := conn.DeleteImageBuilder(ctx, &appstream.DeleteImageBuilderInput{
+	input := appstream.DeleteImageBuilderInput{
 		Name: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteImageBuilder(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -422,9 +422,10 @@ func resourceStackDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	conn := meta.(*conns.AWSClient).AppStreamClient(ctx)
 
 	log.Printf("[DEBUG] Deleting AppStream Stack: (%s)", d.Id())
-	_, err := conn.DeleteStack(ctx, &appstream.DeleteStackInput{
+	input := appstream.DeleteStackInput{
 		Name: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteStack(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/appstream/stack_test.go
+++ b/internal/service/appstream/stack_test.go
@@ -507,6 +507,10 @@ resource "aws_appstream_stack" "test" {
   }
 
   user_settings {
+    action     = "AUTO_TIME_ZONE_REDIRECTION"
+    permission = "DISABLED"
+  }
+  user_settings {
     action     = "CLIPBOARD_COPY_FROM_LOCAL_DEVICE"
     permission = "ENABLED"
   }

--- a/internal/service/appstream/user.go
+++ b/internal/service/appstream/user.go
@@ -215,10 +215,11 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 		return sdkdiag.AppendErrorf(diags, "decoding AppStream User ID (%s): %s", d.Id(), err)
 	}
 
-	_, err = conn.DeleteUser(ctx, &appstream.DeleteUserInput{
+	input := appstream.DeleteUserInput{
 		AuthenticationType: awstypes.AuthenticationType(authType),
 		UserName:           aws.String(userName),
-	})
+	}
+	_, err = conn.DeleteUser(ctx, &input)
 
 	if err != nil {
 		if errs.IsA[*awstypes.ResourceNotFoundException](err) {

--- a/internal/service/appstream/user_stack_association_test.go
+++ b/internal/service/appstream/user_stack_association_test.go
@@ -135,11 +135,12 @@ func testAccCheckUserStackAssociationExists(ctx context.Context, resourceName st
 			return fmt.Errorf("error decoding AppStream User Stack Association ID (%s): %w", rs.Primary.ID, err)
 		}
 
-		resp, err := conn.DescribeUserStackAssociations(ctx, &appstream.DescribeUserStackAssociationsInput{
+		input := appstream.DescribeUserStackAssociationsInput{
 			AuthenticationType: awstypes.AuthenticationType(authType),
 			StackName:          aws.String(stackName),
 			UserName:           aws.String(userName),
-		})
+		}
+		resp, err := conn.DescribeUserStackAssociations(ctx, &input)
 
 		if err != nil {
 			return err
@@ -167,11 +168,12 @@ func testAccCheckUserStackAssociationDestroy(ctx context.Context) resource.TestC
 				return fmt.Errorf("error decoding AppStream User Stack Association ID (%s): %w", rs.Primary.ID, err)
 			}
 
-			resp, err := conn.DescribeUserStackAssociations(ctx, &appstream.DescribeUserStackAssociationsInput{
+			input := appstream.DescribeUserStackAssociationsInput{
 				AuthenticationType: awstypes.AuthenticationType(authType),
 				StackName:          aws.String(stackName),
 				UserName:           aws.String(userName),
-			})
+			}
+			resp, err := conn.DescribeUserStackAssociations(ctx, &input)
 
 			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 				continue

--- a/internal/service/appstream/user_test.go
+++ b/internal/service/appstream/user_test.go
@@ -185,7 +185,8 @@ func testAccCheckUserDestroy(ctx context.Context) resource.TestCheckFunc {
 				return err
 			}
 
-			resp, err := conn.DescribeUsers(ctx, &appstream.DescribeUsersInput{AuthenticationType: awstypes.AuthenticationType(authType)})
+			input := appstream.DescribeUsersInput{AuthenticationType: awstypes.AuthenticationType(authType)}
+			resp, err := conn.DescribeUsers(ctx, &input)
 
 			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 				continue

--- a/internal/service/appsync/api_cache.go
+++ b/internal/service/appsync/api_cache.go
@@ -166,9 +166,10 @@ func resourceAPICacheDelete(ctx context.Context, d *schema.ResourceData, meta in
 	conn := meta.(*conns.AWSClient).AppSyncClient(ctx)
 
 	log.Printf("[INFO] Deleting Appsync API Cache: %s", d.Id())
-	_, err := conn.DeleteApiCache(ctx, &appsync.DeleteApiCacheInput{
+	input := appsync.DeleteApiCacheInput{
 		ApiId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteApiCache(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/appsync/api_key.go
+++ b/internal/service/appsync/api_key.go
@@ -170,10 +170,11 @@ func resourceAPIKeyDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[INFO] Deleting Appsync API Key: %s", d.Id())
-	_, err = conn.DeleteApiKey(ctx, &appsync.DeleteApiKeyInput{
+	input := appsync.DeleteApiKeyInput{
 		ApiId: aws.String(apiID),
 		Id:    aws.String(keyID),
-	})
+	}
+	_, err = conn.DeleteApiKey(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/appsync/datasource.go
+++ b/internal/service/appsync/datasource.go
@@ -461,10 +461,11 @@ func resourceDataSourceDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	log.Printf("[INFO] Deleting Appsync Data Source: %s", d.Id())
-	_, err = conn.DeleteDataSource(ctx, &appsync.DeleteDataSourceInput{
+	input := appsync.DeleteDataSourceInput{
 		ApiId: aws.String(apiID),
 		Name:  aws.String(name),
-	})
+	}
+	_, err = conn.DeleteDataSource(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/appsync/domain_name_api_association.go
+++ b/internal/service/appsync/domain_name_api_association.go
@@ -123,9 +123,10 @@ func resourceDomainNameAPIAssociationDelete(ctx context.Context, d *schema.Resou
 	conn := meta.(*conns.AWSClient).AppSyncClient(ctx)
 
 	log.Printf("[INFO] Deleting Appsync Domain Name API Association: %s", d.Id())
-	_, err := conn.DisassociateApi(ctx, &appsync.DisassociateApiInput{
+	input := appsync.DisassociateApiInput{
 		DomainName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DisassociateApi(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/appsync/function.go
+++ b/internal/service/appsync/function.go
@@ -311,10 +311,11 @@ func resourceFunctionDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[INFO] Deleting Appsync Function: %s", d.Id())
-	_, err = conn.DeleteFunction(ctx, &appsync.DeleteFunctionInput{
+	input := appsync.DeleteFunctionInput{
 		ApiId:      aws.String(apiID),
 		FunctionId: aws.String(functionID),
-	})
+	}
+	_, err = conn.DeleteFunction(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/appsync/graphql_api.go
+++ b/internal/service/appsync/graphql_api.go
@@ -534,9 +534,10 @@ func resourceGraphQLAPIDelete(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).AppSyncClient(ctx)
 
 	log.Printf("[DEBUG] Deleting AppSync GraphQL API: %s", d.Id())
-	_, err := conn.DeleteGraphqlApi(ctx, &appsync.DeleteGraphqlApiInput{
+	input := appsync.DeleteGraphqlApiInput{
 		ApiId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteGraphqlApi(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/appsync/type.go
+++ b/internal/service/appsync/type.go
@@ -154,10 +154,11 @@ func resourceTypeDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	log.Printf("[INFO] Deleting Appsync Type: %s", d.Id())
-	_, err = conn.DeleteType(ctx, &appsync.DeleteTypeInput{
+	input := appsync.DeleteTypeInput{
 		ApiId:    aws.String(apiID),
 		TypeName: aws.String(name),
-	})
+	}
+	_, err = conn.DeleteType(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags

--- a/internal/service/athena/data_catalog.go
+++ b/internal/service/athena/data_catalog.go
@@ -193,9 +193,10 @@ func resourceDataCatalogDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Athena Data Catalog (%s)", d.Id())
-	_, err := conn.DeleteDataCatalog(ctx, &athena.DeleteDataCatalogInput{
+	input := athena.DeleteDataCatalogInput{
 		Name: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteDataCatalog(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/athena/named_query.go
+++ b/internal/service/athena/named_query.go
@@ -122,9 +122,10 @@ func resourceNamedQueryDelete(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).AthenaClient(ctx)
 
 	log.Printf("[INFO] Deleting Athena Named Query: %s", d.Id())
-	_, err := conn.DeleteNamedQuery(ctx, &athena.DeleteNamedQueryInput{
+	input := athena.DeleteNamedQueryInput{
 		NamedQueryId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteNamedQuery(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Athena Named Query (%s): %s", d.Id(), err)

--- a/internal/service/athena/prepared_statement.go
+++ b/internal/service/athena/prepared_statement.go
@@ -167,10 +167,11 @@ func resourcePreparedStatementDelete(ctx context.Context, d *schema.ResourceData
 	}
 
 	log.Printf("[INFO] Deleting Athena Prepared Statement: %s", d.Id())
-	_, err = conn.DeletePreparedStatement(ctx, &athena.DeletePreparedStatementInput{
+	input := athena.DeletePreparedStatementInput{
 		StatementName: aws.String(statementName),
 		WorkGroup:     aws.String(workGroupName),
-	})
+	}
+	_, err = conn.DeletePreparedStatement(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -4280,9 +4280,10 @@ func testAccCheckALBTargetGroupHealthy(ctx context.Context, v *elasticloadbalanc
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).ELBV2Client(ctx)
 
-		output, err := conn.DescribeTargetHealth(ctx, &elasticloadbalancingv2.DescribeTargetHealthInput{
+		input := elasticloadbalancingv2.DescribeTargetHealthInput{
 			TargetGroupArn: v.TargetGroupArn,
-		})
+		}
+		output, err := conn.DescribeTargetHealth(ctx, &input)
 
 		if err != nil {
 			return err

--- a/internal/service/autoscaling/lifecycle_hook.go
+++ b/internal/service/autoscaling/lifecycle_hook.go
@@ -169,10 +169,11 @@ func resourceLifecycleHookDelete(ctx context.Context, d *schema.ResourceData, me
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
 	log.Printf("[INFO] Deleting Auto Scaling Lifecycle Hook: %s", d.Id())
-	_, err := conn.DeleteLifecycleHook(ctx, &autoscaling.DeleteLifecycleHookInput{
+	input := autoscaling.DeleteLifecycleHookInput{
 		AutoScalingGroupName: aws.String(d.Get("autoscaling_group_name").(string)),
 		LifecycleHookName:    aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteLifecycleHook(ctx, &input)
 
 	if tfawserr.ErrMessageContains(err, errCodeValidationError, "No Lifecycle Hook found") {
 		return diags

--- a/internal/service/autoscaling/policy.go
+++ b/internal/service/autoscaling/policy.go
@@ -589,10 +589,11 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
 	log.Printf("[INFO] Deleting Auto Scaling Policy: %s", d.Id())
-	_, err := conn.DeletePolicy(ctx, &autoscaling.DeletePolicyInput{
+	input := autoscaling.DeletePolicyInput{
 		AutoScalingGroupName: aws.String(d.Get("autoscaling_group_name").(string)),
 		PolicyName:           aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeletePolicy(ctx, &input)
 
 	if tfawserr.ErrMessageContains(err, errCodeValidationError, "not found") {
 		return diags

--- a/internal/service/autoscaling/schedule.go
+++ b/internal/service/autoscaling/schedule.go
@@ -205,10 +205,11 @@ func resourceScheduleDelete(ctx context.Context, d *schema.ResourceData, meta in
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
 	log.Printf("[INFO] Deleting Auto Scaling Scheduled Action: %s", d.Id())
-	_, err := conn.DeleteScheduledAction(ctx, &autoscaling.DeleteScheduledActionInput{
+	input := autoscaling.DeleteScheduledActionInput{
 		AutoScalingGroupName: aws.String(d.Get("autoscaling_group_name").(string)),
 		ScheduledActionName:  aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteScheduledAction(ctx, &input)
 
 	if tfawserr.ErrMessageContains(err, errCodeValidationError, "not found") {
 		return diags

--- a/internal/service/autoscaling/traffic_source_attachment.go
+++ b/internal/service/autoscaling/traffic_source_attachment.go
@@ -134,10 +134,11 @@ func resourceTrafficSourceAttachmentDelete(ctx context.Context, d *schema.Resour
 	trafficSource := expandTrafficSourceIdentifier(d.Get("traffic_source").([]interface{})[0].(map[string]interface{}))
 
 	log.Printf("[INFO] Deleting Auto Scaling Traffic Source Attachment: %s", d.Id())
-	_, err = conn.DetachTrafficSources(ctx, &autoscaling.DetachTrafficSourcesInput{
+	input := autoscaling.DetachTrafficSourcesInput{
 		AutoScalingGroupName: aws.String(asgName),
 		TrafficSources:       []awstypes.TrafficSourceIdentifier{trafficSource},
-	})
+	}
+	_, err = conn.DetachTrafficSources(ctx, &input)
 
 	if tfawserr.ErrMessageContains(err, errCodeValidationError, "not found") {
 		return diags

--- a/internal/service/autoscalingplans/scaling_plan.go
+++ b/internal/service/autoscalingplans/scaling_plan.go
@@ -437,10 +437,11 @@ func resourceScalingPlanDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	log.Printf("[DEBUG] Deleting Auto Scaling Scaling Plan: %s", d.Id())
-	_, err = conn.DeleteScalingPlan(ctx, &autoscalingplans.DeleteScalingPlanInput{
+	input := autoscalingplans.DeleteScalingPlanInput{
 		ScalingPlanName:    aws.String(scalingPlanName),
 		ScalingPlanVersion: aws.Int64(int64(scalingPlanVersion)),
-	})
+	}
+	_, err = conn.DeleteScalingPlan(ctx, &input)
 
 	if errs.IsA[*awstypes.ObjectNotFoundException](err) {
 		return diags

--- a/internal/service/wafregional/web_acl_association.go
+++ b/internal/service/wafregional/web_acl_association.go
@@ -116,9 +116,10 @@ func resourceWebACLAssociationDelete(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	_, err = conn.DisassociateWebACL(ctx, &wafregional.DisassociateWebACLInput{
+	input := wafregional.DisassociateWebACLInput{
 		ResourceArn: aws.String(resourceARN),
-	})
+	}
+	_, err = conn.DisassociateWebACL(ctx, &input)
 
 	if errs.IsA[*awstypes.WAFNonexistentItemException](err) {
 		return diags

--- a/internal/service/wafv2/ip_set_data_source.go
+++ b/internal/service/wafv2/ip_set_data_source.go
@@ -62,13 +62,13 @@ func dataSourceIPSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	name := d.Get(names.AttrName).(string)
 
 	var foundIpSet awstypes.IPSetSummary
-	input := &wafv2.ListIPSetsInput{
+	listInput := wafv2.ListIPSetsInput{
 		Scope: awstypes.Scope(d.Get(names.AttrScope).(string)),
 		Limit: aws.Int32(100),
 	}
 
 	for {
-		resp, err := conn.ListIPSets(ctx, input)
+		resp, err := conn.ListIPSets(ctx, &listInput)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "reading WAFv2 IPSets: %s", err)
 		}
@@ -87,18 +87,19 @@ func dataSourceIPSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 		if resp.NextMarker == nil {
 			break
 		}
-		input.NextMarker = resp.NextMarker
+		listInput.NextMarker = resp.NextMarker
 	}
 
 	if foundIpSet.Id == nil {
 		return sdkdiag.AppendErrorf(diags, "WAFv2 IPSet not found for name: %s", name)
 	}
 
-	resp, err := conn.GetIPSet(ctx, &wafv2.GetIPSetInput{
+	getInput := wafv2.GetIPSetInput{
 		Id:    foundIpSet.Id,
 		Name:  foundIpSet.Name,
 		Scope: awstypes.Scope(d.Get(names.AttrScope).(string)),
-	})
+	}
+	resp, err := conn.GetIPSet(ctx, &getInput)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading WAFv2 IPSet: %s", err)

--- a/internal/service/wafv2/regex_pattern_set_data_source.go
+++ b/internal/service/wafv2/regex_pattern_set_data_source.go
@@ -64,13 +64,13 @@ func dataSourceRegexPatternSetRead(ctx context.Context, d *schema.ResourceData, 
 	name := d.Get(names.AttrName).(string)
 
 	var foundRegexPatternSet awstypes.RegexPatternSetSummary
-	input := &wafv2.ListRegexPatternSetsInput{
+	listInput := wafv2.ListRegexPatternSetsInput{
 		Scope: awstypes.Scope(d.Get(names.AttrScope).(string)),
 		Limit: aws.Int32(100),
 	}
 
 	for {
-		resp, err := conn.ListRegexPatternSets(ctx, input)
+		resp, err := conn.ListRegexPatternSets(ctx, &listInput)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "reading WAFv2 RegexPatternSets: %s", err)
 		}
@@ -89,18 +89,19 @@ func dataSourceRegexPatternSetRead(ctx context.Context, d *schema.ResourceData, 
 		if resp.NextMarker == nil {
 			break
 		}
-		input.NextMarker = resp.NextMarker
+		listInput.NextMarker = resp.NextMarker
 	}
 
 	if foundRegexPatternSet.Id == nil {
 		return sdkdiag.AppendErrorf(diags, "WAFv2 RegexPatternSet not found for name: %s", name)
 	}
 
-	resp, err := conn.GetRegexPatternSet(ctx, &wafv2.GetRegexPatternSetInput{
+	getInput := wafv2.GetRegexPatternSetInput{
 		Id:    foundRegexPatternSet.Id,
 		Name:  foundRegexPatternSet.Name,
 		Scope: awstypes.Scope(d.Get(names.AttrScope).(string)),
-	})
+	}
+	resp, err := conn.GetRegexPatternSet(ctx, &getInput)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading WAFv2 RegexPatternSet: %s", err)

--- a/internal/service/wafv2/web_acl_association.go
+++ b/internal/service/wafv2/web_acl_association.go
@@ -128,9 +128,10 @@ func resourceWebACLAssociationDelete(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[INFO] Deleting WAFv2 WebACL Association: %s", d.Id())
 	resourceARN := parts[1]
-	_, err = conn.DisassociateWebACL(ctx, &wafv2.DisassociateWebACLInput{
+	input := wafv2.DisassociateWebACLInput{
 		ResourceArn: aws.String(resourceARN),
-	})
+	}
+	_, err = conn.DisassociateWebACL(ctx, &input)
 
 	if errs.IsA[*awstypes.WAFNonexistentItemException](err) {
 		return diags

--- a/internal/service/wafv2/web_acl_logging_configuration.go
+++ b/internal/service/wafv2/web_acl_logging_configuration.go
@@ -247,9 +247,10 @@ func resourceWebACLLoggingConfigurationDelete(ctx context.Context, d *schema.Res
 	conn := meta.(*conns.AWSClient).WAFV2Client(ctx)
 
 	log.Printf("[INFO] Deleting WAFv2 WebACL Logging Configuration: %s", d.Id())
-	_, err := conn.DeleteLoggingConfiguration(ctx, &wafv2.DeleteLoggingConfigurationInput{
+	input := wafv2.DeleteLoggingConfigurationInput{
 		ResourceArn: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteLoggingConfiguration(ctx, &input)
 
 	if errs.IsA[*awstypes.WAFNonexistentItemException](err) {
 		return diags

--- a/internal/service/worklink/fleet.go
+++ b/internal/service/worklink/fleet.go
@@ -204,17 +204,19 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if output.LastUpdatedTime != nil {
 		d.Set(names.AttrLastUpdatedTime, output.LastUpdatedTime.Format(time.RFC3339))
 	}
-	auditStreamConfigurationResp, err := conn.DescribeAuditStreamConfiguration(ctx, &worklink.DescribeAuditStreamConfigurationInput{
+	describeAuditStreamInput := worklink.DescribeAuditStreamConfigurationInput{
 		FleetArn: aws.String(d.Id()),
-	})
+	}
+	auditStreamConfigurationResp, err := conn.DescribeAuditStreamConfiguration(ctx, &describeAuditStreamInput)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "describing WorkLink Fleet (%s) audit stream configuration: %s", d.Id(), err)
 	}
 	d.Set("audit_stream_arn", auditStreamConfigurationResp.AuditStreamArn)
 
-	companyNetworkConfigurationResp, err := conn.DescribeCompanyNetworkConfiguration(ctx, &worklink.DescribeCompanyNetworkConfigurationInput{
+	describeCompanyNetworkInput := worklink.DescribeCompanyNetworkConfigurationInput{
 		FleetArn: aws.String(d.Id()),
-	})
+	}
+	companyNetworkConfigurationResp, err := conn.DescribeCompanyNetworkConfiguration(ctx, &describeCompanyNetworkInput)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "describing WorkLink Fleet (%s) company network configuration: %s", d.Id(), err)
 	}
@@ -222,9 +224,10 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return sdkdiag.AppendErrorf(diags, "setting network: %s", err)
 	}
 
-	identityProviderConfigurationResp, err := conn.DescribeIdentityProviderConfiguration(ctx, &worklink.DescribeIdentityProviderConfigurationInput{
+	describeIdentityProviderInput := worklink.DescribeIdentityProviderConfigurationInput{
 		FleetArn: aws.String(d.Id()),
-	})
+	}
+	identityProviderConfigurationResp, err := conn.DescribeIdentityProviderConfiguration(ctx, &describeIdentityProviderInput)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "describing WorkLink Fleet (%s) identity provider configuration: %s", d.Id(), err)
 	}
@@ -232,9 +235,10 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return sdkdiag.AppendErrorf(diags, "setting identity_provider: %s", err)
 	}
 
-	devicePolicyConfigurationResp, err := conn.DescribeDevicePolicyConfiguration(ctx, &worklink.DescribeDevicePolicyConfigurationInput{
+	describeDevicePolicyInput := worklink.DescribeDevicePolicyConfigurationInput{
 		FleetArn: aws.String(d.Id()),
-	})
+	}
+	devicePolicyConfigurationResp, err := conn.DescribeDevicePolicyConfiguration(ctx, &describeDevicePolicyInput)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "describing WorkLink Fleet (%s) device policy configuration: %s", d.Id(), err)
 	}
@@ -349,9 +353,10 @@ func fleetStateRefresh(ctx context.Context, conn *worklink.Client, arn string) r
 	return func() (interface{}, string, error) {
 		emptyResp := &worklink.DescribeFleetMetadataOutput{}
 
-		resp, err := conn.DescribeFleetMetadata(ctx, &worklink.DescribeFleetMetadataInput{
+		input := worklink.DescribeFleetMetadataInput{
 			FleetArn: aws.String(arn),
-		})
+		}
+		resp, err := conn.DescribeFleetMetadata(ctx, &input)
 		if err != nil {
 			if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 				return emptyResp, "DELETED", nil

--- a/internal/service/worklink/website_certificate_authority_association.go
+++ b/internal/service/worklink/website_certificate_authority_association.go
@@ -180,10 +180,11 @@ func websiteCertificateAuthorityAssociationStateRefresh(ctx context.Context, con
 	return func() (interface{}, string, error) {
 		emptyResp := &worklink.DescribeWebsiteCertificateAuthorityOutput{}
 
-		resp, err := conn.DescribeWebsiteCertificateAuthority(ctx, &worklink.DescribeWebsiteCertificateAuthorityInput{
+		input := worklink.DescribeWebsiteCertificateAuthorityInput{
 			FleetArn:    aws.String(arn),
 			WebsiteCaId: aws.String(websiteCaID),
-		})
+		}
+		resp, err := conn.DescribeWebsiteCertificateAuthority(ctx, &input)
 		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 			return emptyResp, "DELETED", nil
 		}

--- a/internal/service/workspaces/connection_alias.go
+++ b/internal/service/workspaces/connection_alias.go
@@ -166,9 +166,10 @@ func (r *connectionAliasResource) Delete(ctx context.Context, request resource.D
 
 	conn := r.Meta().WorkSpacesClient(ctx)
 
-	_, err := conn.DeleteConnectionAlias(ctx, &workspaces.DeleteConnectionAliasInput{
+	input := workspaces.DeleteConnectionAliasInput{
 		AliasId: data.ID.ValueStringPointer(),
-	})
+	}
+	_, err := conn.DeleteConnectionAlias(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/workspaces/image_data_source_test.go
+++ b/internal/service/workspaces/image_data_source_test.go
@@ -70,9 +70,10 @@ func testAccCheckImageExists(ctx context.Context, n string, image *types.Workspa
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).WorkSpacesClient(ctx)
-		resp, err := conn.DescribeWorkspaceImages(ctx, &workspaces.DescribeWorkspaceImagesInput{
+		input := workspaces.DescribeWorkspaceImagesInput{
 			ImageIds: []string{rs.Primary.ID},
-		})
+		}
+		resp, err := conn.DescribeWorkspaceImages(ctx, &input)
 		if err != nil {
 			return fmt.Errorf("Failed describe workspaces images: %w", err)
 		}

--- a/internal/service/workspaces/ip_group.go
+++ b/internal/service/workspaces/ip_group.go
@@ -143,8 +143,8 @@ func resourceIPGroupDelete(ctx context.Context, d *schema.ResourceData, meta int
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WorkSpacesClient(ctx)
 
-	input := &workspaces.DescribeWorkspaceDirectoriesInput{}
-	directories, err := findDirectories(ctx, conn, input)
+	describeInput := &workspaces.DescribeWorkspaceDirectoriesInput{}
+	directories, err := findDirectories(ctx, conn, describeInput)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading WorkSpaces Directories: %s", err)
@@ -169,9 +169,10 @@ func resourceIPGroupDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	log.Printf("[DEBUG] Deleting WorkSpaces IP Group (%s)", d.Id())
-	_, err = conn.DeleteIpGroup(ctx, &workspaces.DeleteIpGroupInput{
+	deleteInput := workspaces.DeleteIpGroupInput{
 		GroupId: aws.String(d.Id()),
-	})
+	}
+	_, err = conn.DeleteIpGroup(ctx, &deleteInput)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/workspaces/workspace.go
+++ b/internal/service/workspaces/workspace.go
@@ -159,7 +159,7 @@ func resourceWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta i
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WorkSpacesClient(ctx)
 
-	input := types.WorkspaceRequest{
+	req := types.WorkspaceRequest{
 		BundleId:                    aws.String(d.Get("bundle_id").(string)),
 		DirectoryId:                 aws.String(d.Get("directory_id").(string)),
 		RootVolumeEncryptionEnabled: aws.Bool(d.Get("root_volume_encryption_enabled").(bool)),
@@ -170,12 +170,13 @@ func resourceWorkspaceCreate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if v, ok := d.GetOk("volume_encryption_key"); ok {
-		input.VolumeEncryptionKey = aws.String(v.(string))
+		req.VolumeEncryptionKey = aws.String(v.(string))
 	}
 
-	output, err := conn.CreateWorkspaces(ctx, &workspaces.CreateWorkspacesInput{
-		Workspaces: []types.WorkspaceRequest{input},
-	})
+	input := workspaces.CreateWorkspacesInput{
+		Workspaces: []types.WorkspaceRequest{req},
+	}
+	output, err := conn.CreateWorkspaces(ctx, &input)
 
 	if err == nil && len(output.FailedRequests) > 0 {
 		v := output.FailedRequests[0]
@@ -273,11 +274,12 @@ func resourceWorkspaceDelete(ctx context.Context, d *schema.ResourceData, meta i
 	conn := meta.(*conns.AWSClient).WorkSpacesClient(ctx)
 
 	log.Printf("[DEBUG] Deleting WorkSpaces Workspace: %s", d.Id())
-	output, err := conn.TerminateWorkspaces(ctx, &workspaces.TerminateWorkspacesInput{
+	input := workspaces.TerminateWorkspacesInput{
 		TerminateWorkspaceRequests: []types.TerminateRequest{{
 			WorkspaceId: aws.String(d.Id()),
 		}},
-	})
+	}
+	output, err := conn.TerminateWorkspaces(ctx, &input)
 
 	if err == nil && len(output.FailedRequests) > 0 {
 		v := output.FailedRequests[0]


### PR DESCRIPTION
### Description

Adds autofix for inputs allocated on heap declared inline to the operation.

Allocates inputs on stack for those declared inline to the operation for remaining `a` services and `w` services.

Also fixes errors in:

* `TestAccAppStreamStack_withTags`
* `TestAccAppStreamFleet_multiSession`