### PR TITLE
Fixes `appstream` test errors

### DIFF
--- a/internal/service/appstream/fleet_test.go
+++ b/internal/service/appstream/fleet_test.go
@@ -591,7 +591,7 @@ resource "aws_subnet" "test" {
 }
 
 data "aws_appstream_image" "test" {
-  name_regex  = "^AppStream-WinServer.*$"
+  name_regex  = "^AppStream-WinServer2022.*$"
   type        = "PUBLIC"
   most_recent = true
 }

--- a/internal/service/appstream/stack_test.go
+++ b/internal/service/appstream/stack_test.go
@@ -507,6 +507,10 @@ resource "aws_appstream_stack" "test" {
   }
 
   user_settings {
+    action     = "AUTO_TIME_ZONE_REDIRECTION"
+    permission = "DISABLED"
+  }
+  user_settings {
     action     = "CLIPBOARD_COPY_FROM_LOCAL_DEVICE"
     permission = "ENABLED"
   }


### PR DESCRIPTION
### Description

Fixes `TestAccAppStreamStack_withTags`

Fixes `TestAccAppStreamFleet_multiSession`

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=appstream TESTS='TestAccAppStreamStack_withTags|TestAccAppStreamFleet_multiSession'

--- PASS: TestAccAppStreamStack_withTags (38.95s)
--- PASS: TestAccAppStreamFleet_multiSession (779.75s)
```
