### PR TITLE
r/aws_internet_gateway: continue to deletion when attachment not found

### DIFF
--- a/.changelog/41346.txt
+++ b/.changelog/41346.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_internet_gateway: Fix to continue deletion when attachment is not found
+```

--- a/internal/service/ec2/vpc_internet_gateway.go
+++ b/internal/service/ec2/vpc_internet_gateway.go
@@ -166,10 +166,7 @@ func resourceInternetGatewayDelete(ctx context.Context, d *schema.ResourceData, 
 	if v, ok := d.GetOk(names.AttrVPCID); ok {
 		err := detachInternetGateway(ctx, conn, d.Id(), v.(string), d.Timeout(schema.TimeoutDelete))
 
-		switch {
-		case tfresource.NotFound(err):
-			return diags
-		case err != nil:
+		if err != nil && !tfresource.NotFound(err) {
 			return sdkdiag.AppendErrorf(diags, "deleting EC2 Internet Gateway (%s): %s", d.Id(), err)
 		}
 	}


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This fixes a regression introduced in `v5.83.0` which caused destruction of the `aws_internet_gateway` resource to exit early if an attempt to detach the internet gateway returned a not found error. Rather than exit early, the operation should just proceed after `NotFound` errors to allow the internet gateway to be deleted.

Also updates the `_Disappears_attachment` acceptance test to delete a standalone attachment out-of-band, rather than the entire internet gateway.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41327
Relates #40790

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS=TestAccVPCInternetGateway_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCInternetGateway_'  -timeout 360m -vet=off
2025/02/11 16:45:34 Initializing Terraform AWS Provider...

--- PASS: TestAccVPCInternetGateway_disappears (13.68s)
--- PASS: TestAccVPCInternetGateway_basic (15.96s)
--- PASS: TestAccVPCInternetGateway_Disappears_attachment (18.03s)
--- PASS: TestAccVPCInternetGateway_attachment (30.32s)
--- PASS: TestAccVPCInternetGateway_tags (32.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        39.413s
```
