### PR TITLE
Move inputs off heap with autofix: `b`, `t`, and `v` services

### DIFF
--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -66,7 +66,8 @@ rules:
         - "internal/service/q*"
         - "internal/service/r*"
         - "internal/service/s*"
-        - "internal/service/t*"
+        - "internal/service/transcribe"
+        - "internal/service/transfer"
     patterns:
       - pattern-either:
           - pattern: |

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -67,7 +67,6 @@ rules:
         - "internal/service/r*"
         - "internal/service/s*"
         - "internal/service/t*"
-        - "internal/service/v*"
     patterns:
       - pattern-either:
           - pattern: |

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -51,7 +51,9 @@ rules:
     paths:
       exclude:
         - "internal/service/auditmanager"
-        - "internal/service/b*"
+        - "internal/service/bedrock"
+        - "internal/service/bedrockagent"
+        - "internal/service/budgets"
         - "internal/service/c*"
         - "internal/service/d*"
         - "internal/service/e*"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -52,7 +52,6 @@ rules:
       exclude:
         - "internal/service/auditmanager"
         - "internal/service/bedrock"
-        - "internal/service/bedrockagent"
         - "internal/service/budgets"
         - "internal/service/c*"
         - "internal/service/d*"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -51,8 +51,6 @@ rules:
     paths:
       exclude:
         - "internal/service/auditmanager"
-        - "internal/service/bedrock"
-        - "internal/service/budgets"
         - "internal/service/c*"
         - "internal/service/d*"
         - "internal/service/e*"

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -66,7 +66,6 @@ rules:
         - "internal/service/q*"
         - "internal/service/r*"
         - "internal/service/s*"
-        - "internal/service/transfer"
     patterns:
       - pattern-either:
           - pattern: |

--- a/.ci/semgrep/aws/input-on-heap.yml
+++ b/.ci/semgrep/aws/input-on-heap.yml
@@ -66,7 +66,6 @@ rules:
         - "internal/service/q*"
         - "internal/service/r*"
         - "internal/service/s*"
-        - "internal/service/transcribe"
         - "internal/service/transfer"
     patterns:
       - pattern-either:

--- a/.teamcity/components/generated/services_all.kt
+++ b/.teamcity/components/generated/services_all.kt
@@ -245,7 +245,7 @@ val services = mapOf(
     "verifiedaccess" to ServiceSpec("Verified Access", vpcLock = true, patternOverride = "TestAccVerifiedAccess", splitPackageRealPackage = "ec2"),
     "verifiedpermissions" to ServiceSpec("Verified Permissions"),
     "vpc" to ServiceSpec("VPC (Virtual Private Cloud)", vpcLock = true, patternOverride = "TestAccVPC", splitPackageRealPackage = "ec2"),
-    "vpclattice" to ServiceSpec("VPC Lattice"),
+    "vpclattice" to ServiceSpec("VPC Lattice", vpcLock = true, parallelismOverride = 10),
     "vpnclient" to ServiceSpec("VPN (Client)", vpcLock = true, patternOverride = "TestAccClientVPN", splitPackageRealPackage = "ec2"),
     "vpnsite" to ServiceSpec("VPN (Site-to-Site)", vpcLock = true, patternOverride = "TestAccSiteVPN", splitPackageRealPackage = "ec2"),
     "waf" to ServiceSpec("WAF Classic", regionOverride = "us-east-1"),

--- a/internal/generate/teamcity/acctest_services.hcl
+++ b/internal/generate/teamcity/acctest_services.hcl
@@ -283,6 +283,11 @@ service "vpc" {
   split_package_real_package = "ec2"
 }
 
+service "vpclattice" {
+  vpc_lock    = true
+  parallelism = 10
+}
+
 service "vpnclient" {
   vpc_lock                   = true
   pattern_override           = "TestAccClientVPN"

--- a/internal/service/backup/framework_test.go
+++ b/internal/service/backup/framework_test.go
@@ -397,7 +397,8 @@ func testAccFramework_disappears(t *testing.T) {
 func testAccFrameworkPreCheck(ctx context.Context, t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupClient(ctx)
 
-	_, err := conn.ListFrameworks(ctx, &backup.ListFrameworksInput{})
+	input := backup.ListFrameworksInput{}
+	_, err := conn.ListFrameworks(ctx, &input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/backup/logically_air_gapped_vault.go
+++ b/internal/service/backup/logically_air_gapped_vault.go
@@ -182,9 +182,10 @@ func (r *logicallyAirGappedVaultResource) Delete(ctx context.Context, request re
 
 	conn := r.Meta().BackupClient(ctx)
 
-	_, err := conn.DeleteBackupVault(ctx, &backup.DeleteBackupVaultInput{
+	input := backup.DeleteBackupVaultInput{
 		BackupVaultName: fwflex.StringFromFramework(ctx, data.ID),
-	})
+	}
+	_, err := conn.DeleteBackupVault(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) || tfawserr.ErrCodeEquals(err, errCodeAccessDeniedException) {
 		return

--- a/internal/service/backup/report_plan.go
+++ b/internal/service/backup/report_plan.go
@@ -241,9 +241,10 @@ func resourceReportPlanDelete(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Backup Report Plan: %s", d.Id())
-	_, err := conn.DeleteReportPlan(ctx, &backup.DeleteReportPlanInput{
+	input := backup.DeleteReportPlanInput{
 		ReportPlanName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteReportPlan(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/backup/report_plan_test.go
+++ b/internal/service/backup/report_plan_test.go
@@ -235,7 +235,8 @@ func TestAccBackupReportPlan_disappears(t *testing.T) {
 func testAccReportPlanPreCheck(ctx context.Context, t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).BackupClient(ctx)
 
-	_, err := conn.ListReportPlans(ctx, &backup.ListReportPlansInput{})
+	input := backup.ListReportPlansInput{}
+	_, err := conn.ListReportPlans(ctx, &input)
 
 	if acctest.PreCheckSkipError(err) {
 		t.Skipf("skipping acceptance testing: %s", err)

--- a/internal/service/backup/restore_testing_plan.go
+++ b/internal/service/backup/restore_testing_plan.go
@@ -285,9 +285,10 @@ func (r *restoreTestingPlanResource) Delete(ctx context.Context, request resourc
 	conn := r.Meta().BackupClient(ctx)
 
 	name := data.RestoreTestingPlanName.ValueString()
-	_, err := conn.DeleteRestoreTestingPlan(ctx, &backup.DeleteRestoreTestingPlanInput{
+	input := backup.DeleteRestoreTestingPlanInput{
 		RestoreTestingPlanName: aws.String(name),
-	})
+	}
+	_, err := conn.DeleteRestoreTestingPlan(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/backup/restore_testing_selection.go
+++ b/internal/service/backup/restore_testing_selection.go
@@ -329,10 +329,11 @@ func (r *restoreTestingSelectionResource) Delete(ctx context.Context, request re
 
 	restoreTestingPlanName := data.RestoreTestingPlanName.ValueString()
 	name := data.RestoreTestingSelectionName.ValueString()
-	_, err := conn.DeleteRestoreTestingSelection(ctx, &backup.DeleteRestoreTestingSelectionInput{
+	input := backup.DeleteRestoreTestingSelectionInput{
 		RestoreTestingPlanName:      aws.String(restoreTestingPlanName),
 		RestoreTestingSelectionName: aws.String(name),
-	})
+	}
+	_, err := conn.DeleteRestoreTestingSelection(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/backup/selection.go
+++ b/internal/service/backup/selection.go
@@ -303,10 +303,11 @@ func resourceSelectionDelete(ctx context.Context, d *schema.ResourceData, meta i
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Backup Selection: %s", d.Id())
-	_, err := conn.DeleteBackupSelection(ctx, &backup.DeleteBackupSelectionInput{
+	input := backup.DeleteBackupSelectionInput{
 		BackupPlanId: aws.String(d.Get("plan_id").(string)),
 		SelectionId:  aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteBackupSelection(ctx, &input)
 
 	if errs.IsA[*awstypes.InvalidParameterValueException](err) {
 		return diags

--- a/internal/service/backup/vault.go
+++ b/internal/service/backup/vault.go
@@ -169,10 +169,11 @@ func resourceVaultDelete(ctx context.Context, d *schema.ResourceData, meta inter
 				recoveryPointARN := aws.ToString(v.RecoveryPointArn)
 
 				log.Printf("[DEBUG] Deleting Backup Vault recovery point: %s", recoveryPointARN)
-				_, err := conn.DeleteRecoveryPoint(ctx, &backup.DeleteRecoveryPointInput{
+				input := backup.DeleteRecoveryPointInput{
 					BackupVaultName:  aws.String(d.Id()),
 					RecoveryPointArn: aws.String(recoveryPointARN),
-				})
+				}
+				_, err := conn.DeleteRecoveryPoint(ctx, &input)
 
 				if err != nil {
 					errs = append(errs, fmt.Errorf("deleting Backup Vault recovery point (%s): %w", recoveryPointARN, err))
@@ -188,9 +189,10 @@ func resourceVaultDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[DEBUG] Deleting Backup Vault: %s", d.Id())
-	_, err := conn.DeleteBackupVault(ctx, &backup.DeleteBackupVaultInput{
+	input := backup.DeleteBackupVaultInput{
 		BackupVaultName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteBackupVault(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) || tfawserr.ErrCodeEquals(err, errCodeAccessDeniedException) {
 		return diags

--- a/internal/service/backup/vault_lock_configuration.go
+++ b/internal/service/backup/vault_lock_configuration.go
@@ -123,9 +123,10 @@ func resourceVaultLockConfigurationDelete(ctx context.Context, d *schema.Resourc
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Backup Vault Lock Configuration: %s", d.Id())
-	_, err := conn.DeleteBackupVaultLockConfiguration(ctx, &backup.DeleteBackupVaultLockConfigurationInput{
+	input := backup.DeleteBackupVaultLockConfigurationInput{
 		BackupVaultName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteBackupVaultLockConfiguration(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/backup/vault_notifications.go
+++ b/internal/service/backup/vault_notifications.go
@@ -118,9 +118,10 @@ func resourceVaultNotificationsDelete(ctx context.Context, d *schema.ResourceDat
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Backup Vault Notifications: %s", d.Id())
-	_, err := conn.DeleteBackupVaultNotifications(ctx, &backup.DeleteBackupVaultNotificationsInput{
+	input := backup.DeleteBackupVaultNotificationsInput{
 		BackupVaultName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteBackupVaultNotifications(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/backup/vault_policy.go
+++ b/internal/service/backup/vault_policy.go
@@ -131,9 +131,10 @@ func resourceVaultPolicyDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Backup Vault Policy (%s)", d.Id())
-	_, err := conn.DeleteBackupVaultAccessPolicy(ctx, &backup.DeleteBackupVaultAccessPolicyInput{
+	input := backup.DeleteBackupVaultAccessPolicyInput{
 		BackupVaultName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteBackupVaultAccessPolicy(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) || tfawserr.ErrCodeEquals(err, errCodeAccessDeniedException) {
 		return diags

--- a/internal/service/backup/vault_test.go
+++ b/internal/service/backup/vault_test.go
@@ -243,11 +243,12 @@ func testAccCheckRunDynamoDBTableBackupJob(ctx context.Context, rName string) re
 			AccountID: client.AccountID(ctx),
 			Resource:  fmt.Sprintf("table/%s", rName),
 		}.String()
-		output, err := conn.StartBackupJob(ctx, &backup.StartBackupJobInput{
+		input := backup.StartBackupJobInput{
 			BackupVaultName: aws.String(rName),
 			IamRoleArn:      aws.String(iamRoleARN),
 			ResourceArn:     aws.String(resourceARN),
-		})
+		}
+		output, err := conn.StartBackupJob(ctx, &input)
 
 		if err != nil {
 			return fmt.Errorf("error starting Backup Job: %w", err)

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -531,10 +531,11 @@ func resourceComputeEnvironmentDelete(ctx context.Context, d *schema.ResourceDat
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
 	log.Printf("[DEBUG] Disabling Batch Compute Environment: %s", d.Id())
-	_, err := conn.UpdateComputeEnvironment(ctx, &batch.UpdateComputeEnvironmentInput{
+	updateInput := batch.UpdateComputeEnvironmentInput{
 		ComputeEnvironment: aws.String(d.Id()),
 		State:              awstypes.CEStateDisabled,
-	})
+	}
+	_, err := conn.UpdateComputeEnvironment(ctx, &updateInput)
 
 	if errs.IsAErrorMessageContains[*awstypes.ClientException](err, "does not exist") {
 		return diags
@@ -549,9 +550,10 @@ func resourceComputeEnvironmentDelete(ctx context.Context, d *schema.ResourceDat
 	}
 
 	log.Printf("[DEBUG] Deleting Batch Compute Environment: %s", d.Id())
-	_, err = conn.DeleteComputeEnvironment(ctx, &batch.DeleteComputeEnvironmentInput{
+	deleteInput := batch.DeleteComputeEnvironmentInput{
 		ComputeEnvironment: aws.String(d.Id()),
-	})
+	}
+	_, err = conn.DeleteComputeEnvironment(ctx, &deleteInput)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Batch Compute Environment (%s): %s", d.Id(), err)

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -997,9 +997,10 @@ func resourceJobDefinitionUpdate(ctx context.Context, d *schema.ResourceData, me
 
 		if v := d.Get("deregister_on_new_revision"); v == true {
 			log.Printf("[DEBUG] Deleting previous Batch Job Definition: %s", currentARN)
-			_, err := conn.DeregisterJobDefinition(ctx, &batch.DeregisterJobDefinitionInput{
+			input := batch.DeregisterJobDefinitionInput{
 				JobDefinition: aws.String(currentARN),
-			})
+			}
+			_, err := conn.DeregisterJobDefinition(ctx, &input)
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "deleting Batch Job Definition (%s): %s", currentARN, err)
@@ -1030,9 +1031,10 @@ func resourceJobDefinitionDelete(ctx context.Context, d *schema.ResourceData, me
 		arn := aws.ToString(jds[i].JobDefinitionArn)
 
 		log.Printf("[DEBUG] Deregistering Batch Job Definition: %s", arn)
-		_, err := conn.DeregisterJobDefinition(ctx, &batch.DeregisterJobDefinitionInput{
+		input := batch.DeregisterJobDefinitionInput{
 			JobDefinition: aws.String(arn),
-		})
+		}
+		_, err := conn.DeregisterJobDefinition(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "deregistering Batch Job Definition (%s): %s", arn, err)

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -348,10 +348,11 @@ func (r *jobQueueResource) Delete(ctx context.Context, request resource.DeleteRe
 
 	conn := r.Meta().BatchClient(ctx)
 
-	_, err := conn.UpdateJobQueue(ctx, &batch.UpdateJobQueueInput{
+	updateInput := batch.UpdateJobQueueInput{
 		JobQueue: fwflex.StringFromFramework(ctx, data.ID),
 		State:    awstypes.JQStateDisabled,
-	})
+	}
+	_, err := conn.UpdateJobQueue(ctx, &updateInput)
 
 	// "An error occurred (ClientException) when calling the UpdateJobQueue operation: ... does not exist".
 	if errs.IsAErrorMessageContains[*awstypes.ClientException](err, "does not exist") {
@@ -371,9 +372,10 @@ func (r *jobQueueResource) Delete(ctx context.Context, request resource.DeleteRe
 		return
 	}
 
-	_, err = conn.DeleteJobQueue(ctx, &batch.DeleteJobQueueInput{
+	deleteInput := batch.DeleteJobQueueInput{
 		JobQueue: fwflex.StringFromFramework(ctx, data.ID),
-	})
+	}
+	_, err = conn.DeleteJobQueue(ctx, &deleteInput)
 
 	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("deleting Batch Job Queue (%s)", data.ID.ValueString()), err.Error())

--- a/internal/service/batch/scheduling_policy.go
+++ b/internal/service/batch/scheduling_policy.go
@@ -168,9 +168,10 @@ func resourceSchedulingPolicyDelete(ctx context.Context, d *schema.ResourceData,
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Batch Scheduling Policy: %s", d.Id())
-	_, err := conn.DeleteSchedulingPolicy(ctx, &batch.DeleteSchedulingPolicyInput{
+	input := batch.DeleteSchedulingPolicyInput{
 		Arn: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteSchedulingPolicy(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting Batch Scheduling Policy (%s): %s", d.Id(), err)

--- a/internal/service/bedrock/custom_model.go
+++ b/internal/service/bedrock/custom_model.go
@@ -459,9 +459,10 @@ func (r *customModelResource) Delete(ctx context.Context, request resource.Delet
 	}
 
 	if !data.CustomModelARN.IsNull() {
-		_, err := conn.DeleteCustomModel(ctx, &bedrock.DeleteCustomModelInput{
+		input := bedrock.DeleteCustomModelInput{
 			ModelIdentifier: fwflex.StringFromFramework(ctx, data.CustomModelARN),
-		})
+		}
+		_, err := conn.DeleteCustomModel(ctx, &input)
 
 		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 			return

--- a/internal/service/bedrock/guardrail_version.go
+++ b/internal/service/bedrock/guardrail_version.go
@@ -165,10 +165,11 @@ func (r *guardrailVersionResource) Delete(ctx context.Context, request resource.
 		return
 	}
 
-	_, err := conn.DeleteGuardrail(ctx, &bedrock.DeleteGuardrailInput{
+	input := bedrock.DeleteGuardrailInput{
 		GuardrailIdentifier: data.GuardrailARN.ValueStringPointer(),
 		GuardrailVersion:    data.Version.ValueStringPointer(),
-	})
+	}
+	_, err := conn.DeleteGuardrail(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/bedrock/inference_profile_test.go
+++ b/internal/service/bedrock/inference_profile_test.go
@@ -203,9 +203,10 @@ func testAccCheckInferenceProfileExists(ctx context.Context, name string, infere
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).BedrockClient(ctx)
 
-		resp, err := conn.GetInferenceProfile(ctx, &bedrock.GetInferenceProfileInput{
+		input := bedrock.GetInferenceProfileInput{
 			InferenceProfileIdentifier: aws.String(rs.Primary.ID),
-		})
+		}
+		resp, err := conn.GetInferenceProfile(ctx, &input)
 		if err != nil {
 			return create.Error(names.Bedrock, create.ErrActionCheckingExistence, tfbedrock.ResNameInferenceProfile, rs.Primary.ID, err)
 		}

--- a/internal/service/bedrock/model_invocation_logging_configuration.go
+++ b/internal/service/bedrock/model_invocation_logging_configuration.go
@@ -179,7 +179,8 @@ func (r *resourceModelInvocationLoggingConfiguration) Delete(ctx context.Context
 
 	conn := r.Meta().BedrockClient(ctx)
 
-	_, err := conn.DeleteModelInvocationLoggingConfiguration(ctx, &bedrock.DeleteModelInvocationLoggingConfigurationInput{})
+	input := bedrock.DeleteModelInvocationLoggingConfigurationInput{}
+	_, err := conn.DeleteModelInvocationLoggingConfiguration(ctx, &input)
 
 	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("deleting Bedrock Model Invocation Logging Configuration (%s)", data.ID.ValueString()), err.Error())

--- a/internal/service/bedrock/provisioned_model_throughput.go
+++ b/internal/service/bedrock/provisioned_model_throughput.go
@@ -185,9 +185,10 @@ func (r *resourceProvisionedModelThroughput) Delete(ctx context.Context, request
 
 	conn := r.Meta().BedrockClient(ctx)
 
-	_, err := conn.DeleteProvisionedModelThroughput(ctx, &bedrock.DeleteProvisionedModelThroughputInput{
+	input := bedrock.DeleteProvisionedModelThroughputInput{
 		ProvisionedModelId: fwflex.StringFromFramework(ctx, data.ID),
-	})
+	}
+	_, err := conn.DeleteProvisionedModelThroughput(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -388,10 +388,11 @@ func (r *agentResource) Delete(ctx context.Context, request resource.DeleteReque
 	conn := r.Meta().BedrockAgentClient(ctx)
 
 	agentID := data.ID.ValueString()
-	_, err := conn.DeleteAgent(ctx, &bedrockagent.DeleteAgentInput{
+	input := bedrockagent.DeleteAgentInput{
 		AgentId:                aws.String(agentID),
 		SkipResourceInUseCheck: fwflex.BoolValueFromFramework(ctx, data.SkipResourceInUseCheck),
-	})
+	}
+	_, err := conn.DeleteAgent(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/bedrockagent/agent_action_group.go
+++ b/internal/service/bedrockagent/agent_action_group.go
@@ -386,12 +386,13 @@ func (r *agentActionGroupResource) Delete(ctx context.Context, request resource.
 
 	conn := r.Meta().BedrockAgentClient(ctx)
 
-	_, err := conn.DeleteAgentActionGroup(ctx, &bedrockagent.DeleteAgentActionGroupInput{
+	input := bedrockagent.DeleteAgentActionGroupInput{
 		ActionGroupId:          fwflex.StringFromFramework(ctx, data.ActionGroupID),
 		AgentId:                fwflex.StringFromFramework(ctx, data.AgentID),
 		AgentVersion:           fwflex.StringFromFramework(ctx, data.AgentVersion),
 		SkipResourceInUseCheck: data.SkipResourceInUseCheck.ValueBool(),
-	})
+	}
+	_, err := conn.DeleteAgentActionGroup(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/bedrockagent/agent_alias.go
+++ b/internal/service/bedrockagent/agent_alias.go
@@ -254,10 +254,11 @@ func (r *agentAliasResource) Delete(ctx context.Context, request resource.Delete
 
 	conn := r.Meta().BedrockAgentClient(ctx)
 
-	_, err := conn.DeleteAgentAlias(ctx, &bedrockagent.DeleteAgentAliasInput{
+	input := bedrockagent.DeleteAgentAliasInput{
 		AgentAliasId: fwflex.StringFromFramework(ctx, data.AgentAliasID),
 		AgentId:      fwflex.StringFromFramework(ctx, data.AgentID),
-	})
+	}
+	_, err := conn.DeleteAgentAlias(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/bedrockagent/agent_collaborator.go
+++ b/internal/service/bedrockagent/agent_collaborator.go
@@ -272,11 +272,12 @@ func (r *agentCollaboratorResource) Delete(ctx context.Context, request resource
 
 	conn := r.Meta().BedrockAgentClient(ctx)
 
-	_, err := conn.DisassociateAgentCollaborator(ctx, &bedrockagent.DisassociateAgentCollaboratorInput{
+	input := bedrockagent.DisassociateAgentCollaboratorInput{
 		AgentId:        data.AgentID.ValueStringPointer(),
 		AgentVersion:   data.AgentVersion.ValueStringPointer(),
 		CollaboratorId: data.CollaboratorID.ValueStringPointer(),
-	})
+	}
+	_, err := conn.DisassociateAgentCollaborator(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/bedrockagent/agent_knowledge_base_association.go
+++ b/internal/service/bedrockagent/agent_knowledge_base_association.go
@@ -221,11 +221,12 @@ func (r *agentKnowledgeBaseAssociationResource) Delete(ctx context.Context, requ
 
 	conn := r.Meta().BedrockAgentClient(ctx)
 
-	_, err := conn.DisassociateAgentKnowledgeBase(ctx, &bedrockagent.DisassociateAgentKnowledgeBaseInput{
+	input := bedrockagent.DisassociateAgentKnowledgeBaseInput{
 		AgentId:         fwflex.StringFromFramework(ctx, data.AgentID),
 		AgentVersion:    fwflex.StringFromFramework(ctx, data.AgentVersion),
 		KnowledgeBaseId: fwflex.StringFromFramework(ctx, data.KnowledgeBaseID),
-	})
+	}
+	_, err := conn.DisassociateAgentKnowledgeBase(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/bedrockagent/data_source.go
+++ b/internal/service/bedrockagent/data_source.go
@@ -924,10 +924,11 @@ func (r *dataSourceResource) Delete(ctx context.Context, request resource.Delete
 
 	conn := r.Meta().BedrockAgentClient(ctx)
 
-	_, err := conn.DeleteDataSource(ctx, &bedrockagent.DeleteDataSourceInput{
+	input := bedrockagent.DeleteDataSourceInput{
 		DataSourceId:    data.DataSourceID.ValueStringPointer(),
 		KnowledgeBaseId: data.KnowledgeBaseID.ValueStringPointer(),
-	})
+	}
+	_, err := conn.DeleteDataSource(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/bedrockagent/knowledge_base.go
+++ b/internal/service/bedrockagent/knowledge_base.go
@@ -669,9 +669,10 @@ func (r *knowledgeBaseResource) Delete(ctx context.Context, request resource.Del
 
 	conn := r.Meta().BedrockAgentClient(ctx)
 
-	_, err := conn.DeleteKnowledgeBase(ctx, &bedrockagent.DeleteKnowledgeBaseInput{
+	input := bedrockagent.DeleteKnowledgeBaseInput{
 		KnowledgeBaseId: data.KnowledgeBaseID.ValueStringPointer(),
-	})
+	}
+	_, err := conn.DeleteKnowledgeBase(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/budgets/budget.go
+++ b/internal/service/budgets/budget.go
@@ -318,11 +318,12 @@ func resourceBudgetCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		accountID = meta.(*conns.AWSClient).AccountID(ctx)
 	}
 
-	_, err = conn.CreateBudget(ctx, &budgets.CreateBudgetInput{
+	input := budgets.CreateBudgetInput{
 		AccountId:    aws.String(accountID),
 		Budget:       budget,
 		ResourceTags: getTagsIn(ctx),
-	})
+	}
+	_, err = conn.CreateBudget(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Budget (%s): %s", name, err)
@@ -487,10 +488,11 @@ func resourceBudgetUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "expandBudgetUnmarshal: %s", err)
 	}
 
-	_, err = conn.UpdateBudget(ctx, &budgets.UpdateBudgetInput{
+	input := budgets.UpdateBudgetInput{
 		AccountId: aws.String(accountID),
 		NewBudget: budget,
-	})
+	}
+	_, err = conn.UpdateBudget(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Budget (%s): %s", d.Id(), err)
@@ -517,10 +519,11 @@ func resourceBudgetDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[DEBUG] Deleting Budget: %s", d.Id())
-	_, err = conn.DeleteBudget(ctx, &budgets.DeleteBudgetInput{
+	input := budgets.DeleteBudgetInput{
 		AccountId:  aws.String(accountID),
 		BudgetName: aws.String(budgetName),
-	})
+	}
+	_, err = conn.DeleteBudget(ctx, &input)
 
 	if errs.IsA[*awstypes.NotFoundException](err) {
 		return diags
@@ -663,12 +666,13 @@ func createBudgetNotifications(ctx context.Context, conn *budgets.Client, notifi
 			return errors.New("Budget notification must have at least one subscriber")
 		}
 
-		_, err := conn.CreateNotification(ctx, &budgets.CreateNotificationInput{
+		input := budgets.CreateNotificationInput{
 			AccountId:    aws.String(accountID),
 			BudgetName:   aws.String(budgetName),
 			Notification: notification,
 			Subscribers:  subscribers,
-		})
+		}
+		_, err := conn.CreateNotification(ctx, &input)
 
 		if err != nil {
 			return err

--- a/internal/service/timestreamwrite/database.go
+++ b/internal/service/timestreamwrite/database.go
@@ -147,9 +147,10 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 	conn := meta.(*conns.AWSClient).TimestreamWriteClient(ctx)
 
 	log.Printf("[INFO] Deleting Timestream Database: %s", d.Id())
-	_, err := conn.DeleteDatabase(ctx, &timestreamwrite.DeleteDatabaseInput{
+	input := timestreamwrite.DeleteDatabaseInput{
 		DatabaseName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteDatabase(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/timestreamwrite/table.go
+++ b/internal/service/timestreamwrite/table.go
@@ -306,10 +306,11 @@ func resourceTableDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	log.Printf("[INFO] Deleting Timestream Table: %s", d.Id())
-	_, err = conn.DeleteTable(ctx, &timestreamwrite.DeleteTableInput{
+	input := timestreamwrite.DeleteTableInput{
 		DatabaseName: aws.String(databaseName),
 		TableName:    aws.String(tableName),
-	})
+	}
+	_, err = conn.DeleteTable(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/transcribe/language_model.go
+++ b/internal/service/transcribe/language_model.go
@@ -196,9 +196,10 @@ func resourceLanguageModelDelete(ctx context.Context, d *schema.ResourceData, me
 
 	log.Printf("[INFO] Deleting Transcribe LanguageModel %s", d.Id())
 
-	_, err := conn.DeleteLanguageModel(ctx, &transcribe.DeleteLanguageModelInput{
+	input := transcribe.DeleteLanguageModelInput{
 		ModelName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteLanguageModel(ctx, &input)
 
 	var resourceNotFoundException *types.NotFoundException
 	if errors.As(err, &resourceNotFoundException) {

--- a/internal/service/transcribe/medical_vocabulary.go
+++ b/internal/service/transcribe/medical_vocabulary.go
@@ -175,9 +175,10 @@ func resourceMedicalVocabularyDelete(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[INFO] Deleting Transcribe MedicalVocabulary %s", d.Id())
 
-	_, err := conn.DeleteMedicalVocabulary(ctx, &transcribe.DeleteMedicalVocabularyInput{
+	input := transcribe.DeleteMedicalVocabularyInput{
 		VocabularyName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteMedicalVocabulary(ctx, &input)
 
 	var badRequestException *types.BadRequestException
 	if errors.As(err, &badRequestException) {

--- a/internal/service/transcribe/vocabulary.go
+++ b/internal/service/transcribe/vocabulary.go
@@ -198,9 +198,10 @@ func resourceVocabularyDelete(ctx context.Context, d *schema.ResourceData, meta 
 
 	log.Printf("[INFO] Deleting Transcribe Vocabulary %s", d.Id())
 
-	_, err := conn.DeleteVocabulary(ctx, &transcribe.DeleteVocabularyInput{
+	input := transcribe.DeleteVocabularyInput{
 		VocabularyName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteVocabulary(ctx, &input)
 
 	var badRequestException *types.BadRequestException
 	if errors.As(err, &badRequestException) {

--- a/internal/service/transcribe/vocabulary_filter.go
+++ b/internal/service/transcribe/vocabulary_filter.go
@@ -197,9 +197,10 @@ func resourceVocabularyFilterDelete(ctx context.Context, d *schema.ResourceData,
 
 	log.Printf("[INFO] Deleting Transcribe VocabularyFilter %s", d.Id())
 
-	_, err := conn.DeleteVocabularyFilter(ctx, &transcribe.DeleteVocabularyFilterInput{
+	input := transcribe.DeleteVocabularyFilterInput{
 		VocabularyFilterName: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteVocabularyFilter(ctx, &input)
 
 	if err != nil {
 		var bre *types.BadRequestException

--- a/internal/service/transfer/access.go
+++ b/internal/service/transfer/access.go
@@ -280,10 +280,11 @@ func resourceAccessDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[DEBUG] Deleting Transfer Access: %s", d.Id())
-	_, err = conn.DeleteAccess(ctx, &transfer.DeleteAccessInput{
+	input := transfer.DeleteAccessInput{
 		ExternalId: aws.String(externalID),
 		ServerId:   aws.String(serverID),
-	})
+	}
+	_, err = conn.DeleteAccess(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/transfer/agreement.go
+++ b/internal/service/transfer/agreement.go
@@ -202,10 +202,11 @@ func resourceAgreementDelete(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	log.Printf("[DEBUG] Deleting Transfer Agreement: %s", d.Id())
-	_, err = conn.DeleteAgreement(ctx, &transfer.DeleteAgreementInput{
+	input := transfer.DeleteAgreementInput{
 		AgreementId: aws.String(agreementID),
 		ServerId:    aws.String(serverID),
-	})
+	}
+	_, err = conn.DeleteAgreement(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/transfer/certificate.go
+++ b/internal/service/transfer/certificate.go
@@ -184,9 +184,10 @@ func resourceCertificateDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).TransferClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Transfer Certificate: %s", d.Id())
-	_, err := conn.DeleteCertificate(ctx, &transfer.DeleteCertificateInput{
+	input := transfer.DeleteCertificateInput{
 		CertificateId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteCertificate(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/transfer/connector.go
+++ b/internal/service/transfer/connector.go
@@ -266,9 +266,10 @@ func resourceConnectorDelete(ctx context.Context, d *schema.ResourceData, meta i
 	conn := meta.(*conns.AWSClient).TransferClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Transfer Connector: %s", d.Id())
-	_, err := conn.DeleteConnector(ctx, &transfer.DeleteConnectorInput{
+	input := transfer.DeleteConnectorInput{
 		ConnectorId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteConnector(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/transfer/profile.go
+++ b/internal/service/transfer/profile.go
@@ -150,9 +150,10 @@ func resourceProfileDelete(ctx context.Context, d *schema.ResourceData, meta int
 	conn := meta.(*conns.AWSClient).TransferClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Transfer Profile: %s", d.Id())
-	_, err := conn.DeleteProfile(ctx, &transfer.DeleteProfileInput{
+	input := transfer.DeleteProfileInput{
 		ProfileId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteProfile(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/transfer/ssh_key.go
+++ b/internal/service/transfer/ssh_key.go
@@ -126,11 +126,12 @@ func resourceSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[DEBUG] Deleting Transfer SSH Key: %s", d.Id())
-	_, err = conn.DeleteSshPublicKey(ctx, &transfer.DeleteSshPublicKeyInput{
+	input := transfer.DeleteSshPublicKeyInput{
 		UserName:       aws.String(userName),
 		ServerId:       aws.String(serverID),
 		SshPublicKeyId: aws.String(sshKeyID),
-	})
+	}
+	_, err = conn.DeleteSshPublicKey(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/transfer/workflow.go
+++ b/internal/service/transfer/workflow.go
@@ -757,9 +757,10 @@ func resourceWorkflowDelete(ctx context.Context, d *schema.ResourceData, meta in
 	conn := meta.(*conns.AWSClient).TransferClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Transfer Workflow: %s", d.Id())
-	_, err := conn.DeleteWorkflow(ctx, &transfer.DeleteWorkflowInput{
+	input := transfer.DeleteWorkflowInput{
 		WorkflowId: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteWorkflow(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/vpclattice/access_log_subscription.go
+++ b/internal/service/vpclattice/access_log_subscription.go
@@ -141,9 +141,10 @@ func resourceAccessLogSubscriptionDelete(ctx context.Context, d *schema.Resource
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VPCLattice AccessLogSubscription %s", d.Id())
-	_, err := conn.DeleteAccessLogSubscription(ctx, &vpclattice.DeleteAccessLogSubscriptionInput{
+	input := vpclattice.DeleteAccessLogSubscriptionInput{
 		AccessLogSubscriptionIdentifier: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteAccessLogSubscription(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/vpclattice/auth_policy.go
+++ b/internal/service/vpclattice/auth_policy.go
@@ -137,9 +137,10 @@ func resourceAuthPolicyDelete(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VPCLattice AuthPolicy: %s", d.Id())
-	_, err := conn.DeleteAuthPolicy(ctx, &vpclattice.DeleteAuthPolicyInput{
+	input := vpclattice.DeleteAuthPolicyInput{
 		ResourceIdentifier: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteAuthPolicy(ctx, &input)
 
 	if err != nil {
 		var nfe *types.ResourceNotFoundException

--- a/internal/service/vpclattice/auth_policy_test.go
+++ b/internal/service/vpclattice/auth_policy_test.go
@@ -95,9 +95,10 @@ func testAccCheckAuthPolicyDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			policy, err := conn.GetAuthPolicy(ctx, &vpclattice.GetAuthPolicyInput{
+			input := vpclattice.GetAuthPolicyInput{
 				ResourceIdentifier: aws.String(rs.Primary.ID),
-			})
+			}
+			policy, err := conn.GetAuthPolicy(ctx, &input)
 			if err != nil {
 				var nfe *types.ResourceNotFoundException
 				if errors.As(err, &nfe) {
@@ -127,9 +128,10 @@ func testAccCheckAuthPolicyExists(ctx context.Context, name string, authpolicy *
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		resp, err := conn.GetAuthPolicy(ctx, &vpclattice.GetAuthPolicyInput{
+		input := vpclattice.GetAuthPolicyInput{
 			ResourceIdentifier: aws.String(rs.Primary.ID),
-		})
+		}
+		resp, err := conn.GetAuthPolicy(ctx, &input)
 
 		if err != nil {
 			//return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameAuthPolicy, rs.Primary.ID, err)

--- a/internal/service/vpclattice/listener.go
+++ b/internal/service/vpclattice/listener.go
@@ -288,10 +288,11 @@ func resourceListenerDelete(ctx context.Context, d *schema.ResourceData, meta in
 	listenerId := d.Get("listener_id").(string)
 
 	log.Printf("[INFO] Deleting VPCLattice Listener %s", d.Id())
-	_, err := conn.DeleteListener(ctx, &vpclattice.DeleteListenerInput{
+	input := vpclattice.DeleteListenerInput{
 		ListenerIdentifier: aws.String(listenerId),
 		ServiceIdentifier:  aws.String(serviceId),
-	})
+	}
+	_, err := conn.DeleteListener(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/vpclattice/listener_rule.go
+++ b/internal/service/vpclattice/listener_rule.go
@@ -375,11 +375,12 @@ func resourceListenerRuleDelete(ctx context.Context, d *schema.ResourceData, met
 	ruleId := d.Get("rule_id").(string)
 
 	log.Printf("[INFO] Deleting VpcLattice Listening Rule: %s", d.Id())
-	_, err := conn.DeleteRule(ctx, &vpclattice.DeleteRuleInput{
+	input := vpclattice.DeleteRuleInput{
 		ListenerIdentifier: aws.String(listenerId),
 		RuleIdentifier:     aws.String(ruleId),
 		ServiceIdentifier:  aws.String(serviceId),
-	})
+	}
+	_, err := conn.DeleteRule(ctx, &input)
 
 	if err != nil {
 		var nfe *types.ResourceNotFoundException

--- a/internal/service/vpclattice/listener_rule_test.go
+++ b/internal/service/vpclattice/listener_rule_test.go
@@ -172,11 +172,12 @@ func testAccCheckListenerRuleExists(ctx context.Context, name string, rule *vpcl
 		listenerIdentifier := rs.Primary.Attributes["listener_identifier"]
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		resp, err := conn.GetRule(ctx, &vpclattice.GetRuleInput{
+		input := vpclattice.GetRuleInput{
 			RuleIdentifier:     aws.String(rs.Primary.Attributes[names.AttrARN]),
 			ListenerIdentifier: aws.String(listenerIdentifier),
 			ServiceIdentifier:  aws.String(serviceIdentifier),
-		})
+		}
+		resp, err := conn.GetRule(ctx, &input)
 
 		if err != nil {
 			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameListenerRule, rs.Primary.ID, err)
@@ -200,11 +201,12 @@ func testAccChecklistenerRuleDestroy(ctx context.Context) resource.TestCheckFunc
 			listenerIdentifier := rs.Primary.Attributes["listener_identifier"]
 			serviceIdentifier := rs.Primary.Attributes["service_identifier"]
 
-			_, err := conn.GetRule(ctx, &vpclattice.GetRuleInput{
+			input := vpclattice.GetRuleInput{
 				RuleIdentifier:     aws.String(rs.Primary.Attributes[names.AttrARN]),
 				ListenerIdentifier: aws.String(listenerIdentifier),
 				ServiceIdentifier:  aws.String(serviceIdentifier),
-			})
+			}
+			_, err := conn.GetRule(ctx, &input)
 			if err != nil {
 				var nfe *types.ResourceNotFoundException
 				if errors.As(err, &nfe) {

--- a/internal/service/vpclattice/resource_gateway.go
+++ b/internal/service/vpclattice/resource_gateway.go
@@ -258,9 +258,10 @@ func (r *resourceGatewayResource) Delete(ctx context.Context, request resource.D
 
 	conn := r.Meta().VPCLatticeClient(ctx)
 
-	_, err := conn.DeleteResourceGateway(ctx, &vpclattice.DeleteResourceGatewayInput{
+	input := vpclattice.DeleteResourceGatewayInput{
 		ResourceGatewayIdentifier: fwflex.StringFromFramework(ctx, data.ID),
-	})
+	}
+	_, err := conn.DeleteResourceGateway(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/vpclattice/resource_policy.go
+++ b/internal/service/vpclattice/resource_policy.go
@@ -129,9 +129,10 @@ func resourceResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VPCLattice ResourcePolicy: %s", d.Id())
-	_, err := conn.DeleteResourcePolicy(ctx, &vpclattice.DeleteResourcePolicyInput{
+	input := vpclattice.DeleteResourcePolicyInput{
 		ResourceArn: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteResourcePolicy(ctx, &input)
 
 	if err != nil {
 		var nfe *types.ResourceNotFoundException

--- a/internal/service/vpclattice/resource_policy_test.go
+++ b/internal/service/vpclattice/resource_policy_test.go
@@ -95,9 +95,10 @@ func testAccCheckResourcePolicyDestroy(ctx context.Context) resource.TestCheckFu
 				continue
 			}
 
-			policy, err := conn.GetResourcePolicy(ctx, &vpclattice.GetResourcePolicyInput{
+			input := vpclattice.GetResourcePolicyInput{
 				ResourceArn: aws.String(rs.Primary.ID),
-			})
+			}
+			policy, err := conn.GetResourcePolicy(ctx, &input)
 			if err != nil {
 				var nfe *types.ResourceNotFoundException
 				if errors.As(err, &nfe) {
@@ -127,9 +128,10 @@ func testAccCheckResourcePolicyExists(ctx context.Context, name string, resource
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		resp, err := conn.GetResourcePolicy(ctx, &vpclattice.GetResourcePolicyInput{
+		input := vpclattice.GetResourcePolicyInput{
 			ResourceArn: aws.String(rs.Primary.ID),
-		})
+		}
+		resp, err := conn.GetResourcePolicy(ctx, &input)
 
 		if err != nil {
 			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameResourcePolicy, rs.Primary.ID, err)

--- a/internal/service/vpclattice/service.go
+++ b/internal/service/vpclattice/service.go
@@ -210,9 +210,10 @@ func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta int
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VPC Lattice Service: %s", d.Id())
-	_, err := conn.DeleteService(ctx, &vpclattice.DeleteServiceInput{
+	input := vpclattice.DeleteServiceInput{
 		ServiceIdentifier: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteService(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/vpclattice/service_network.go
+++ b/internal/service/vpclattice/service_network.go
@@ -145,9 +145,10 @@ func resourceServiceNetworkDelete(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VPC Lattice Service Network: %s", d.Id())
-	_, err := conn.DeleteServiceNetwork(ctx, &vpclattice.DeleteServiceNetworkInput{
+	input := vpclattice.DeleteServiceNetworkInput{
 		ServiceNetworkIdentifier: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteServiceNetwork(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/vpclattice/service_network_resource_association.go
+++ b/internal/service/vpclattice/service_network_resource_association.go
@@ -176,9 +176,10 @@ func (r *serviceNetworkResourceAssociationResource) Delete(ctx context.Context, 
 
 	conn := r.Meta().VPCLatticeClient(ctx)
 
-	_, err := conn.DeleteServiceNetworkResourceAssociation(ctx, &vpclattice.DeleteServiceNetworkResourceAssociationInput{
+	input := vpclattice.DeleteServiceNetworkResourceAssociationInput{
 		ServiceNetworkResourceAssociationIdentifier: data.ID.ValueStringPointer(),
-	})
+	}
+	_, err := conn.DeleteServiceNetworkResourceAssociation(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return

--- a/internal/service/vpclattice/service_network_service_association.go
+++ b/internal/service/vpclattice/service_network_service_association.go
@@ -177,9 +177,10 @@ func resourceServiceNetworkServiceAssociationDelete(ctx context.Context, d *sche
 
 	log.Printf("[INFO] Deleting VPCLattice Service Network Association %s", d.Id())
 
-	_, err := conn.DeleteServiceNetworkServiceAssociation(ctx, &vpclattice.DeleteServiceNetworkServiceAssociationInput{
+	input := vpclattice.DeleteServiceNetworkServiceAssociationInput{
 		ServiceNetworkServiceAssociationIdentifier: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteServiceNetworkServiceAssociation(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/vpclattice/service_network_vpc_association.go
+++ b/internal/service/vpclattice/service_network_vpc_association.go
@@ -176,9 +176,10 @@ func resourceServiceNetworkVPCAssociationDelete(ctx context.Context, d *schema.R
 
 	log.Printf("[INFO] Deleting VPCLattice Service Network VPC Association %s", d.Id())
 
-	_, err := conn.DeleteServiceNetworkVpcAssociation(ctx, &vpclattice.DeleteServiceNetworkVpcAssociationInput{
+	input := vpclattice.DeleteServiceNetworkVpcAssociationInput{
 		ServiceNetworkVpcAssociationIdentifier: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteServiceNetworkVpcAssociation(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/vpclattice/target_group.go
+++ b/internal/service/vpclattice/target_group.go
@@ -317,9 +317,10 @@ func resourceTargetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	log.Printf("[INFO] Deleting VpcLattice TargetGroup: %s", d.Id())
-	_, err := conn.DeleteTargetGroup(ctx, &vpclattice.DeleteTargetGroupInput{
+	input := vpclattice.DeleteTargetGroupInput{
 		TargetGroupIdentifier: aws.String(d.Id()),
-	})
+	}
+	_, err := conn.DeleteTargetGroup(ctx, &input)
 
 	if err != nil {
 		var nfe *types.ResourceNotFoundException

--- a/internal/service/vpclattice/target_group_attachment.go
+++ b/internal/service/vpclattice/target_group_attachment.go
@@ -141,10 +141,11 @@ func resourceTargetGroupAttachmentDelete(ctx context.Context, d *schema.Resource
 	targetPort := int(aws.ToInt32(target.Port))
 
 	log.Printf("[INFO] Deleting VPC Lattice Target Group Attachment: %s", d.Id())
-	_, err := conn.DeregisterTargets(ctx, &vpclattice.DeregisterTargetsInput{
+	input := vpclattice.DeregisterTargetsInput{
 		TargetGroupIdentifier: aws.String(targetGroupID),
 		Targets:               []types.Target{target},
-	})
+	}
+	_, err := conn.DeregisterTargets(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags

--- a/internal/service/vpclattice/target_group_test.go
+++ b/internal/service/vpclattice/target_group_test.go
@@ -357,9 +357,10 @@ func testAccCheckTargetGroupDestroy(ctx context.Context) resource.TestCheckFunc 
 				continue
 			}
 
-			_, err := conn.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+			input := vpclattice.GetTargetGroupInput{
 				TargetGroupIdentifier: aws.String(rs.Primary.ID),
-			})
+			}
+			_, err := conn.GetTargetGroup(ctx, &input)
 			if err != nil {
 				var nfe *types.ResourceNotFoundException
 				if errors.As(err, &nfe) {
@@ -387,9 +388,10 @@ func testAccCheckTargetGroupExists(ctx context.Context, name string, targetGroup
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		resp, err := conn.GetTargetGroup(ctx, &vpclattice.GetTargetGroupInput{
+		input := vpclattice.GetTargetGroupInput{
 			TargetGroupIdentifier: aws.String(rs.Primary.ID),
-		})
+		}
+		resp, err := conn.GetTargetGroup(ctx, &input)
 
 		if err != nil {
 			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameService, rs.Primary.ID, err)


### PR DESCRIPTION
### Description

Allocates inputs on stack for those declared inline to the operation for `b`, `t`, and `v` services.
