### PR TITLE
fix: Add missing on_demand_throughput attrs for aws_dynamodb_table data source

### DIFF
--- a/.changelog/41350.txt
+++ b/.changelog/41350.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_dynamodb_table: Add missing `on_demand_throughput` and `global_secondary_index.*.on_demand_throughput` attributes to resolve read error
+```

--- a/internal/service/dynamodb/table_data_source.go
+++ b/internal/service/dynamodb/table_data_source.go
@@ -70,6 +70,22 @@ func dataSourceTable() *schema.Resource {
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"on_demand_throughput": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"max_read_request_units": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"max_write_request_units": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
 						"projection_type": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -121,6 +137,22 @@ func dataSourceTable() *schema.Resource {
 			names.AttrName: {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"on_demand_throughput": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_read_request_units": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"max_write_request_units": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"point_in_time_recovery": {
 				Type:     schema.TypeList,
@@ -267,6 +299,10 @@ func dataSourceTableRead(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if err := d.Set("global_secondary_index", flattenTableGlobalSecondaryIndex(table.GlobalSecondaryIndexes)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting global_secondary_index: %s", err)
+	}
+
+	if err := d.Set("on_demand_throughput", flattenOnDemandThroughput(table.OnDemandThroughput)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting on_demand_throughput: %s", err)
 	}
 
 	if table.StreamSpecification != nil {

--- a/internal/service/dynamodb/table_data_source_test.go
+++ b/internal/service/dynamodb/table_data_source_test.go
@@ -49,6 +49,44 @@ func TestAccDynamoDBTableDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccDynamoDBTableDataSource_onDemandThroughput(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_dynamodb_table.test"
+	resourceName := "aws_dynamodb_table.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTableDataSourceConfig_onDemandThroughput(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(datasourceName, "hash_key", resourceName, "hash_key"),
+					resource.TestCheckResourceAttrPair(datasourceName, "range_key", resourceName, "range_key"),
+					resource.TestCheckResourceAttrPair(datasourceName, "attribute.#", resourceName, "attribute.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "global_secondary_index.#", resourceName, "global_secondary_index.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "global_secondary_index.0.on_demand_throughput.0.max_read_request_units", resourceName, "global_secondary_index.0.on_demand_throughput.0.max_read_request_units"),
+					resource.TestCheckResourceAttrPair(datasourceName, "global_secondary_index.0.on_demand_throughput.0.max_write_request_units", resourceName, "global_secondary_index.0.on_demand_throughput.0.max_write_request_units"),
+					resource.TestCheckResourceAttrPair(datasourceName, "on_demand_throughput.0.max_read_request_units", resourceName, "on_demand_throughput.0.max_read_request_units"),
+					resource.TestCheckResourceAttrPair(datasourceName, "on_demand_throughput.0.max_write_request_units", resourceName, "on_demand_throughput.0.max_write_request_units"),
+					resource.TestCheckResourceAttrPair(datasourceName, "ttl.#", resourceName, "ttl.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.Name", resourceName, "tags.Name"),
+					resource.TestCheckResourceAttrPair(datasourceName, "tags.Environment", resourceName, "tags.Environment"),
+					resource.TestCheckResourceAttrPair(datasourceName, "server_side_encryption.#", resourceName, "server_side_encryption.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "billing_mode", resourceName, "billing_mode"),
+					resource.TestCheckResourceAttrPair(datasourceName, "point_in_time_recovery.#", resourceName, "point_in_time_recovery.#"),
+					resource.TestCheckResourceAttrPair(datasourceName, "point_in_time_recovery.0.enabled", resourceName, "point_in_time_recovery.0.enabled"),
+					resource.TestCheckResourceAttrPair(datasourceName, "table_class", resourceName, "table_class"),
+				),
+			},
+		},
+	})
+}
+
 func testAccTableDataSourceConfig_basic(tableName string) string {
 	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "test" {
@@ -81,6 +119,59 @@ resource "aws_dynamodb_table" "test" {
     read_capacity      = 10
     projection_type    = "INCLUDE"
     non_key_attributes = ["UserId"]
+  }
+
+  tags = {
+    Name        = "dynamodb-table-1"
+    Environment = "test"
+  }
+}
+
+data "aws_dynamodb_table" "test" {
+  name = aws_dynamodb_table.test.name
+}
+`, tableName)
+}
+
+func testAccTableDataSourceConfig_onDemandThroughput(tableName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name         = %[1]q
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "UserId"
+  range_key    = "GameTitle"
+
+  attribute {
+    name = "UserId"
+    type = "S"
+  }
+
+  attribute {
+    name = "GameTitle"
+    type = "S"
+  }
+
+  attribute {
+    name = "TopScore"
+    type = "N"
+  }
+
+  global_secondary_index {
+    name               = "GameTitleIndex"
+    hash_key           = "GameTitle"
+    range_key          = "TopScore"
+    projection_type    = "INCLUDE"
+    non_key_attributes = ["UserId"]
+
+    on_demand_throughput {
+      max_read_request_units  = 10
+      max_write_request_units = 10
+    }
+  }
+
+  on_demand_throughput {
+    max_read_request_units  = 10
+    max_write_request_units = 10
   }
 
   tags = {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the missing `on_demand_throughput` configuration block to the resource root and the `global_secondary_index` configuration block in the `aws_dynamodb_table` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41343
Relates #37799

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
n/a

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccDynamoDBTableDataSource_ PKG=dynamodb
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTableDataSource_'  -timeout 360m -vet=off
2025/02/11 23:25:48 Initializing Terraform AWS Provider...
=== RUN   TestAccDynamoDBTableDataSource_tags
=== PAUSE TestAccDynamoDBTableDataSource_tags
=== RUN   TestAccDynamoDBTableDataSource_tags_NullMap
=== PAUSE TestAccDynamoDBTableDataSource_tags_NullMap
=== RUN   TestAccDynamoDBTableDataSource_tags_EmptyMap
=== PAUSE TestAccDynamoDBTableDataSource_tags_EmptyMap
=== RUN   TestAccDynamoDBTableDataSource_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccDynamoDBTableDataSource_tags_DefaultTags_nonOverlapping
=== RUN   TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccDynamoDBTableDataSource_basic
=== PAUSE TestAccDynamoDBTableDataSource_basic
=== RUN   TestAccDynamoDBTableDataSource_onDemandThroughput
=== PAUSE TestAccDynamoDBTableDataSource_onDemandThroughput
=== CONT  TestAccDynamoDBTableDataSource_tags
=== CONT  TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_DefaultTag
=== CONT  TestAccDynamoDBTableDataSource_tags_NullMap
=== CONT  TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccDynamoDBTableDataSource_tags_DefaultTags_nonOverlapping
=== CONT  TestAccDynamoDBTableDataSource_basic
=== CONT  TestAccDynamoDBTableDataSource_onDemandThroughput
=== CONT  TestAccDynamoDBTableDataSource_tags_EmptyMap
--- PASS: TestAccDynamoDBTableDataSource_tags_NullMap (28.21s)
--- PASS: TestAccDynamoDBTableDataSource_tags_EmptyMap (28.26s)
--- PASS: TestAccDynamoDBTableDataSource_tags (29.94s)
--- PASS: TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_DefaultTag (30.33s)
--- PASS: TestAccDynamoDBTableDataSource_tags_DefaultTags_nonOverlapping (30.38s)
--- PASS: TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_ResourceTag (34.82s)
--- PASS: TestAccDynamoDBTableDataSource_basic (35.70s)
--- PASS: TestAccDynamoDBTableDataSource_onDemandThroughput (44.05s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb   44.286s

$
```
