### PR TITLE
AWS RDS - Adding support for performance Insights mode

### DIFF
--- a/internal/acctest/consts_gen.go
+++ b/internal/acctest/consts_gen.go
@@ -42,6 +42,4 @@ const (
 	CtValue1                = "value1"
 	CtValue1Updated         = "value1updated"
 	CtValue2                = "value2"
-	CtStandart              = "standart"
-	CtAdvanced              = "advanced"
 )

--- a/internal/acctest/consts_gen.go
+++ b/internal/acctest/consts_gen.go
@@ -42,4 +42,6 @@ const (
 	CtValue1                = "value1"
 	CtValue1Updated         = "value1updated"
 	CtValue2                = "value2"
+	CtStandart              = "standart"
+	CtAdvanced              = "advanced"
 )

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -384,7 +384,7 @@ func resourceCluster() *schema.Resource {
 			"performance_insights_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "standard",
+				Default:      performanceInsightsModeStandard,
 				ValidateFunc: validation.StringInSlice(performanceInsightsMode_Values(), false),
 			},
 			"performance_insights_kms_key_id": {

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -381,6 +381,12 @@ func resourceCluster() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"performance_insights_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "standard",
+				ValidateFunc: validation.StringInSlice(performanceInsightsMode_Values(), false),
+			},
 			"performance_insights_kms_key_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -1265,6 +1271,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			input.EnablePerformanceInsights = aws.Bool(v.(bool))
 		}
 
+		if v, ok := d.GetOk("performance_insights_mode"); ok {
+			input.DatabaseInsightsMode = types.DatabaseInsightsMode(v.(string))
+		}
+
 		if v, ok := d.GetOk("performance_insights_kms_key_id"); ok {
 			input.PerformanceInsightsKMSKeyId = aws.String(v.(string))
 		}
@@ -1444,6 +1454,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("monitoring_role_arn", dbc.MonitoringRoleArn)
 	d.Set("network_type", dbc.NetworkType)
 	d.Set("performance_insights_enabled", dbc.PerformanceInsightsEnabled)
+	d.Set("performance_insights_mode", dbc.DatabaseInsightsMode)
 	d.Set("performance_insights_kms_key_id", dbc.PerformanceInsightsKMSKeyId)
 	d.Set("performance_insights_retention_period", dbc.PerformanceInsightsRetentionPeriod)
 	d.Set(names.AttrPort, dbc.Port)
@@ -1673,6 +1684,10 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		if d.HasChange("performance_insights_enabled") {
 			input.EnablePerformanceInsights = aws.Bool(d.Get("performance_insights_enabled").(bool))
+		}
+
+		if v, ok := d.GetOk("performance_insights_mode"); ok {
+			input.DatabaseInsightsMode = types.DatabaseInsightsMode(v.(string))
 		}
 
 		if d.HasChange("performance_insights_kms_key_id") {

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -3121,7 +3121,7 @@ func TestAccRDSCluster_performanceInsightsEnabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", acctest.CtTrue),
-					resource.TestCheckResourceAttr(resourceName, "performance_insights_mode", acctest.CtStandart), // default
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_mode", "standard"), // default
 				),
 			},
 			{
@@ -3129,23 +3129,23 @@ func TestAccRDSCluster_performanceInsightsEnabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", acctest.CtFalse),
-					resource.TestCheckResourceAttr(resourceName, "performance_insights_mode", acctest.CtStandart), // default
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_mode", "standard"), // default
 				),
 			},
 			{
-				Config: testAccClusterConfig_performanceInsightsEnabledWithAdvancedMode(rName, false, acctest.CtStandart),
+				Config: testAccClusterConfig_performanceInsightsEnabledWithAdvancedMode(rName, false, "standard"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", acctest.CtFalse),
-					resource.TestCheckResourceAttr(resourceName, "performance_insights_mode", acctest.CtStandart),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_mode", "standard"),
 				),
 			},
 			{
-				Config: testAccClusterConfig_performanceInsightsEnabledWithAdvancedMode(rName, false, acctest.CtAdvanced),
+				Config: testAccClusterConfig_performanceInsightsEnabledWithAdvancedMode(rName, false, "advanced"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
 					resource.TestCheckResourceAttr(resourceName, "performance_insights_enabled", acctest.CtFalse),
-					resource.TestCheckResourceAttr(resourceName, "performance_insights_mode", acctest.CtAdvanced),
+					resource.TestCheckResourceAttr(resourceName, "performance_insights_mode", "advanced"),
 				),
 			},
 		},

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -286,8 +286,6 @@ const (
 )
 
 const (
-	PerformanceInsightsModeStandard = "standard"
-
 	performanceInsightsModeStandard = "standard"
 	performanceInsightsModeAdvanced = "advanced"
 )

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -54,12 +54,9 @@ const (
 )
 
 const (
-	storageTypeStandard    = "standard"
-	storageTypeGP2         = "gp2"
-	storageTypeGP3         = "gp3"
-	storageTypeIO1         = "io1"
-	storageTypeIO2         = "io2"
-	storageTypeAuroraIOPT1 = "aurora-iopt1"
+	storageTypeGP3 = "gp3"
+	storageTypeIO1 = "io1"
+	storageTypeIO2 = "io2"
 )
 
 const (
@@ -287,6 +284,20 @@ const (
 	timeoutActionForceApplyCapacityChange = "ForceApplyCapacityChange"
 	timeoutActionRollbackCapacityChange   = "RollbackCapacityChange"
 )
+
+const (
+	PerformanceInsightsModeStandard = "standard"
+
+	performanceInsightsModeStandard = "standard"
+	performanceInsightsModeAdvanced = "advanced"
+)
+
+func performanceInsightsMode_Values() []string {
+	return []string{
+		performanceInsightsModeStandard,
+		performanceInsightsModeAdvanced,
+	}
+}
 
 func timeoutAction_Values() []string {
 	return []string{

--- a/website/docs/cdktf/python/r/rds_cluster.html.markdown
+++ b/website/docs/cdktf/python/r/rds_cluster.html.markdown
@@ -344,6 +344,7 @@ This resource supports the following arguments:
 * `monitoring_role_arn` - (Optional) ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. You can find more information on the [AWS Documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.html#USER_Monitoring.OS.IAMRole.html) what IAM permissions are needed to allow Enhanced Monitoring for RDS Clusters.
 * `network_type` - (Optional) Network type of the cluster. Valid values: `IPV4`, `DUAL`.
 * `performance_insights_enabled` - (Optional) Enables Performance Insights.
+* `performance_insights_mode` - (Optional) The Performance Insights mode for analyzing database performance. Valid values: `standard`, `advanced`. Setting to `advanced` enables lock contention diagnostics for Aurora PostgreSQL. Default: `standard`.
 * `performance_insights_kms_key_id` - (Optional) Specifies the KMS Key ID to encrypt Performance Insights data. If not specified, the default RDS KMS key will be used (`aws/rds`).
 * `performance_insights_retention_period` - (Optional) Specifies the amount of time to retain performance insights data for. Defaults to 7 days if Performance Insights are enabled. Valid values are `7`, `month * 31` (where month is a number of months from 1-23), and `731`. See [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.cost.html) for more information on retention periods.
 * `port` - (Optional) Port on which the DB accepts connections.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

AWS announces the general availability of Amazon CloudWatch Database Insights with support for Amazon Aurora PostgreSQL and Amazon Aurora MySQL. Database Insights is a database observability solution that provides a curated experience designed for DevOps engineers, application developers, and database administrators (DBAs) to expedite database troubleshooting and gain a holistic view into their database fleet health.

[Announcement](https://aws.amazon.com/about-aws/whats-new/2024/12/amazon-cloudwatch-database-insights/)
[AWS CLI Attribute Flag](https://awscli.amazonaws.com/v2/documentation/api/2.22.8/reference/rds/modify-db-cluster.html#:~:text=DB%20clusters%20only-,%2D%2Ddatabase%2Dinsights%2Dmode,-(string))
[Documentation To Enable Advanced Insights](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_DatabaseInsights.TurningOnAdvanced.html)


* `performance_insights_mode` - (Optional) The Performance Insights mode for analyzing database performance. Valid values: `standard`, `advanced`. Setting to `advanced` enables lock contention diagnostics for Aurora PostgreSQL. Default: `standard`.

Usage:
```
resource "aws_rds_cluster" "rds_example" {
  cluster_identifier           = "rds_example"
  performance_insights_enabled = true
  ...
  performance_insights_mode = "advanced"
}

```

### Relations

Closes #40393