### PR TITLE
Add support for `ena_srd_specification` in ec2_launch_template

### DIFF
--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -1382,6 +1382,41 @@ func TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount(t *testing.T) {
 	})
 }
 
+func TestAccEC2LaunchTemplate_NetworkInterface_enaSrd(t *testing.T) {
+	ctx := acctest.Context(t)
+	var template awstypes.LaunchTemplate
+	resourceName := "aws_launch_template.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLaunchTemplateConfig_networkInterfaceEnaSrd(rName, true, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLaunchTemplateExists(ctx, resourceName, &template),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ena_srd_specification.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_interfaces.0.ena_srd_specification.0.ena_srd_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccLaunchTemplateConfig_networkInterfaceEnaSrd(rName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"network_interfaces.0.ena_srd_specification.0.ena_srd_udp_specification.0.ena_srd_udp_enabled", // <-- Nested path
+						"true",
+					),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEC2LaunchTemplate_instanceMarketOptions(t *testing.T) {
 	ctx := acctest.Context(t)
 	var template awstypes.LaunchTemplate
@@ -3509,6 +3544,41 @@ resource "aws_launch_template" "test" {
   }
 }
 `, rName, deleteOnTermination)
+}
+
+func testAccLaunchTemplateConfig_networkInterfaceEnaSrd(rName string, enaSrdEnabled, enaSrdUdpEnabled bool) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "10.1.0.0/16"
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.1.0.0/24"
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_launch_template" "test" {
+  name = %[1]q
+
+  network_interfaces {
+    device_index = 0
+    subnet_id    = aws_subnet.test.id
+
+    ena_srd_specification {
+      ena_srd_enabled      = %[2]t
+	  ena_srd_udp_specification {
+      	ena_srd_udp_enabled  = %[3]t
+	  }
+    }
+  }
+}
+`, rName, enaSrdEnabled, enaSrdUdpEnabled)
 }
 
 func testAccLaunchTemplateConfig_ebsOptimized(rName, ebsOptimized string) string {

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -458,7 +458,20 @@ Each `network_interfaces` block supports the following:
 * `ipv4_addresses` - (Optional) One or more private IPv4 addresses to associate. Conflicts with `ipv4_address_count`
 * `security_groups` - (Optional) A list of security group IDs to associate.
 * `subnet_id` - (Optional) The VPC Subnet ID to associate.
+* `ena_srd_specification` - (Optional) Configuration for Elastic Network Adapter (ENA) Express settings. Applies to network interfaces that use the [ena Express](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena-express.html) feature. See details below.
 * `connection_tracking_specification` - (Optional) The Connection Tracking Configuration for the network interface. See [Amazon EC2 security group connection tracking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-connection-tracking.html#connection-tracking-timeouts)
+
+
+The `ena_srd_specification` block supports the following:
+
+* `ena_srd_enabled` - (Optional) Whether to enable ENA Express. ENA Express uses AWS Scalable Reliable Datagram (SRD) technology to improve the performance of TCP traffic.
+* `ena_srd_udp_specification` - (Optional) Configuration for ENA Express UDP optimization. See details below.
+
+The `ena_srd_udp_specification` block supports the following:
+
+* `ena_srd_udp_enabled` - (Optional) Whether to enable UDP traffic optimization through ENA Express. Requires `ena_srd_enabled` to be `true`.
+
+NOTE: ENA Express requires [specific instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena-express.html#ena-express-requirements) and minimum bandwidth of 25 Gbps.
 
 The `connection_tracking_specification` block supports the following:
 


### PR DESCRIPTION
### Description
Adds support for `ena_srd_specification` configuration block in `aws_launch_template` network interfaces, enabling ENA Express settings for enhanced networking performance.

### Acceptance Tests
```
➜  make testacc TESTARGS='-run=TestAccEC2LaunchTemplate_NetworkInterface_enaSrd' PKG=ec2

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccEC2LaunchTemplate_NetworkInterface_enaSrd -timeout 360m -vet=off
2025/02/12 10:26:56 Initializing Terraform AWS Provider...
=== RUN   TestAccEC2LaunchTemplate_NetworkInterface_enaSrd
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterface_enaSrd
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_enaSrd
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_enaSrd (46.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	54.135s
```


### Release Notes
```release-note:enhancement
resource/aws_launch_template: Add `ena_srd_specification` support to `network_interfaces` configuration block
```