### PR TITLE
resource/aws_sagemaker_endpoint_configuration: Prevents panic when `data_capture_config.capture_content_type_header` empty

### DIFF
--- a/internal/errs/diag.go
+++ b/internal/errs/diag.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 )
 
 const (
@@ -112,6 +113,16 @@ func NewAttributeRequiredWhenError(neededPath, otherPath cty.Path, value string)
 			PathString(otherPath),
 			value,
 		),
+	)
+}
+
+// NewAtLeastOneOfChildrenError returns an error diagnostic indicating that at least on of the named children of
+// parentPath is required.
+func NewAtLeastOneOfChildrenError(parentPath cty.Path, paths ...cty.Path) diag.Diagnostic {
+	return NewAttributeErrorDiagnostic(
+		parentPath,
+		"Invalid Attribute Combination",
+		fmt.Sprintf("At least one attribute out of [%s] must be specified", strings.Join(tfslices.ApplyToAll(paths, PathString), ", ")),
 	)
 }
 

--- a/internal/errs/sdkdiag/diags.go
+++ b/internal/errs/sdkdiag/diags.go
@@ -56,7 +56,7 @@ func DiagnosticString(d diag.Diagnostic) string {
 		fmt.Fprintf(&buf, "\n\n%s", d.Detail)
 	}
 	if len(d.AttributePath) > 0 {
-		fmt.Fprintf(&buf, "\n%s", pathString(d.AttributePath))
+		fmt.Fprintf(&buf, "\n\nPath: %s", pathString(d.AttributePath))
 	}
 
 	return buf.String()

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -10,7 +10,10 @@ import (
 
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfsagemaker "github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker"
@@ -448,9 +451,17 @@ func TestAccSageMakerEndpointConfiguration_dataCapture(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.destination_s3_uri", fmt.Sprintf("s3://%s/", rName)),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_options.0.capture_mode", "Input"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_options.1.capture_mode", "Output"),
-					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_content_type_header.0.json_content_types.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "data_capture_config.0.capture_content_type_header.0.json_content_types.*", "application/json"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("data_capture_config").AtSliceIndex(0).AtMapKey("capture_content_type_header"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"csv_content_types": knownvalue.Null(),
+							"json_content_types": knownvalue.SetExact([]knownvalue.Check{
+								knownvalue.StringExact("application/json"),
+							}),
+						}),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -481,9 +492,17 @@ func TestAccSageMakerEndpointConfiguration_dataCapture_inputAndOutput(t *testing
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.initial_sampling_percentage", "50"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.destination_s3_uri", fmt.Sprintf("s3://%s/", rName)),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_options.0.capture_mode", "InputAndOutput"),
-					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.capture_content_type_header.0.json_content_types.#", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "data_capture_config.0.capture_content_type_header.0.json_content_types.*", "application/json"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("data_capture_config").AtSliceIndex(0).AtMapKey("capture_content_type_header"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"csv_content_types": knownvalue.Null(),
+							"json_content_types": knownvalue.SetExact([]knownvalue.Check{
+								knownvalue.StringExact("application/json"),
+							}),
+						}),
+					})),
+				},
 			},
 			{
 				ResourceName:      resourceName,

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -1356,7 +1356,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     capture_options {
       capture_mode = "Output"
     }
-	
+
     capture_content_type_header {
     }
   }
@@ -1394,11 +1394,11 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
     capture_options {
       capture_mode = "Output"
     }
-	
+
     capture_content_type_header {
-		csv_content_types = ["text/csv"]
-       json_content_types = ["application/json"]
-   }
+      csv_content_types  = ["text/csv"]
+      json_content_types = ["application/json"]
+    }
   }
 }
 `, rName))

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -38,6 +38,7 @@ func TestAccSageMakerEndpointConfiguration_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "sagemaker", "endpoint-config/{name}"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.variant_name", "variant-1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.model_name", rName),
@@ -78,6 +79,7 @@ func TestAccSageMakerEndpointConfiguration_nameGenerated(t *testing.T) {
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					acctest.CheckResourceAttrNameGenerated(resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, "terraform-"),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "sagemaker", "endpoint-config/{name}"),
 				),
 			},
 			{
@@ -106,6 +108,7 @@ func TestAccSageMakerEndpointConfiguration_namePrefix(t *testing.T) {
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, rName),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "sagemaker", "endpoint-config/{name}"),
 				),
 			},
 			{
@@ -561,7 +564,8 @@ func TestAccSageMakerEndpointConfiguration_dataCapture_EmptyHeaders(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccEndpointConfigurationConfig_dataCapture_emptyHeaders(rName),
-				ExpectError: regexache.MustCompile(`At least one attribute out of \[csv_content_types, json_content_types\] must be specified`)},
+				ExpectError: regexache.MustCompile(`At least one attribute out of \[csv_content_types, json_content_types\] must be specified`),
+			},
 		},
 	})
 }

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -31,7 +31,7 @@ func TestAccSageMakerEndpointConfiguration_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
@@ -70,7 +70,7 @@ func TestAccSageMakerEndpointConfiguration_nameGenerated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_nameGenerated(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					acctest.CheckResourceAttrNameGenerated(resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, "terraform-"),
@@ -98,7 +98,7 @@ func TestAccSageMakerEndpointConfiguration_namePrefix(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_namePrefix(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, rName),
@@ -126,7 +126,7 @@ func TestAccSageMakerEndpointConfiguration_shadowProductionVariants(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_shadowProductionVariants(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
@@ -167,7 +167,7 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_routing(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_routing(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.routing_config.#", "1"),
@@ -196,7 +196,7 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_serverless(t *test
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_serverless(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.serverless_config.#", "1"),
@@ -227,7 +227,7 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_ami(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_ami(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.inference_ami_version", "al2-ami-sagemaker-inference-gpu-2"), //lintignore:AWSAT002
@@ -255,7 +255,7 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_serverlessProvisio
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_serverlessProvisionedConcurrency(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.serverless_config.#", "1"),
@@ -286,7 +286,7 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeig
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_productionVariantsInitialVariantWeight(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(
 						resourceName, "production_variants.1.initial_variant_weight", "0.5"),
@@ -314,7 +314,7 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType(t 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_productionVariantAcceleratorType(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "production_variants.0.accelerator_type", "ml.eia1.medium"),
 				),
@@ -341,7 +341,7 @@ func TestAccSageMakerEndpointConfiguration_ProductionVariants_variantNameGenerat
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_productionVariantVariantNameGenerated(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "production_variants.0.variant_name"),
 				),
@@ -368,7 +368,7 @@ func TestAccSageMakerEndpointConfiguration_kmsKeyID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_kmsKeyID(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrKMSKeyARN, "aws_kms_key.test", names.AttrARN),
 				),
@@ -395,7 +395,7 @@ func TestAccSageMakerEndpointConfiguration_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
@@ -408,7 +408,7 @@ func TestAccSageMakerEndpointConfiguration_tags(t *testing.T) {
 			},
 			{
 				Config: testAccEndpointConfigurationConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
@@ -417,7 +417,7 @@ func TestAccSageMakerEndpointConfiguration_tags(t *testing.T) {
 			},
 			{
 				Config: testAccEndpointConfigurationConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -440,7 +440,7 @@ func TestAccSageMakerEndpointConfiguration_dataCapture(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_dataCapture(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.enable_capture", acctest.CtTrue),
@@ -474,7 +474,7 @@ func TestAccSageMakerEndpointConfiguration_dataCapture_inputAndOutput(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_dataCapture_inputAndOutput(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "data_capture_config.0.enable_capture", acctest.CtTrue),
@@ -507,7 +507,7 @@ func TestAccSageMakerEndpointConfiguration_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfsagemaker.ResourceEndpointConfiguration(), resourceName),
 				),
@@ -530,7 +530,7 @@ func TestAccSageMakerEndpointConfiguration_async(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_async(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "1"),
@@ -563,7 +563,7 @@ func TestAccSageMakerEndpointConfiguration_async_includeInference(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_asyncNotifInferenceIn(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "1"),
@@ -598,7 +598,7 @@ func TestAccSageMakerEndpointConfiguration_async_kms(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_asyncKMS(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "1"),
@@ -631,7 +631,7 @@ func TestAccSageMakerEndpointConfiguration_Async_notif(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_asyncNotif(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "1"),
@@ -665,7 +665,7 @@ func TestAccSageMakerEndpointConfiguration_Async_client(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_asyncClient(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "1"),
@@ -697,7 +697,7 @@ func TestAccSageMakerEndpointConfiguration_Async_client_failurePath(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEndpointConfigurationConfig_asyncClientFailure(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckEndpointConfigurationExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "async_inference_config.#", "1"),

--- a/website/docs/r/sagemaker_endpoint_configuration.html.markdown
+++ b/website/docs/r/sagemaker_endpoint_configuration.html.markdown
@@ -90,7 +90,8 @@ This resource supports the following arguments:
 * `capture_options` - (Required) Specifies what data to capture. Fields are documented below.
 * `kms_key_id` - (Optional) Amazon Resource Name (ARN) of a AWS Key Management Service key that Amazon SageMaker uses to encrypt the captured data on Amazon S3.
 * `enable_capture` - (Optional) Flag to enable data capture. Defaults to `false`.
-* `capture_content_type_header` - (Optional) The content type headers to capture. Fields are documented below.
+* `capture_content_type_header` - (Optional) The content type headers to capture.
+  See [`capture_content_type_header`](#capture_content_type_header) below.
 
 #### capture_options
 
@@ -99,7 +100,9 @@ This resource supports the following arguments:
 #### capture_content_type_header
 
 * `csv_content_types` - (Optional) The CSV content type headers to capture.
+  One of `csv_content_types` or `json_content_types` is required.
 * `json_content_types` - (Optional) The JSON content type headers to capture.
+  One of `json_content_types` or `csv_content_types` is required.
 
 ### async_inference_config
 


### PR DESCRIPTION
### Description

In `aws_sagemaker_endpoint_configuration` an empty `data_capture_config.capture_content_type_header`, either by not setting any values or setting them all to `nil`, would cause a panic. Adds validation to require at least one of `csv_content_types` or `json_content_types`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=sagemaker TESTS=TestAccSageMakerEndpointConfiguration_

--- PASS: TestAccSageMakerEndpointConfiguration_dataCapture_EmptyHeaders (5.99s)
--- PASS: TestAccSageMakerEndpointConfiguration_kmsKeyID (36.65s)
--- PASS: TestAccSageMakerEndpointConfiguration_disappears (41.72s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_routing (51.72s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_client_failurePath (58.50s)
--- PASS: TestAccSageMakerEndpointConfiguration_async (61.10s)
--- PASS: TestAccSageMakerEndpointConfiguration_namePrefix (68.30s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_acceleratorType (62.44s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_serverless (69.33s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_ami (69.73s)
--- PASS: TestAccSageMakerEndpointConfiguration_productionVariantsManagedInstanceScalingZero (75.26s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_serverlessProvisionedConcurrency (78.24s)
--- PASS: TestAccSageMakerEndpointConfiguration_dataCapture_inputAndOutput (80.60s)
--- PASS: TestAccSageMakerEndpointConfiguration_async_includeInference (80.78s)
--- PASS: TestAccSageMakerEndpointConfiguration_upgradeToEnableSSMAccess (82.10s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_variantNameGenerated (46.97s)
--- PASS: TestAccSageMakerEndpointConfiguration_nameGenerated (51.83s)
--- PASS: TestAccSageMakerEndpointConfiguration_productionVariantsManagedInstanceScaling (94.63s)
--- PASS: TestAccSageMakerEndpointConfiguration_shadowProductionVariants (99.58s)
--- PASS: TestAccSageMakerEndpointConfiguration_async_kms (100.02s)
--- PASS: TestAccSageMakerEndpointConfiguration_ProductionVariants_initialVariantWeight (51.17s)
--- PASS: TestAccSageMakerEndpointConfiguration_dataCapture (103.26s)
--- PASS: TestAccSageMakerEndpointConfiguration_basic (103.49s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_client (45.49s)
--- PASS: TestAccSageMakerEndpointConfiguration_Async_notif (45.67s)
--- PASS: TestAccSageMakerEndpointConfiguration_dataCapture_NoHeaders (42.95s)
--- PASS: TestAccSageMakerEndpointConfiguration_dataCapture_BothHeaders (43.88s)
--- PASS: TestAccSageMakerEndpointConfiguration_tags (113.95s)
```
