### PR TITLE
Support defining period in custom metrics for target tracking policies

### DIFF
--- a/.changelog/41385.txt
+++ b/.changelog/41385.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_autoscaling_policy: Add `target_tracking_configuration.customized_metric_specification.period` argument to support [high-resolution metrics](https://docs.aws.amazon.com/autoscaling/ec2/userguide/policy-creating-high-resolution-metrics.html)
+```

--- a/internal/service/autoscaling/policy.go
+++ b/internal/service/autoscaling/policy.go
@@ -457,6 +457,11 @@ func resourcePolicy() *schema.Resource {
 											Optional:      true,
 											ConflictsWith: []string{"target_tracking_configuration.0.customized_metric_specification.0.metrics"},
 										},
+										"period": {
+											Type:         schema.TypeInt,
+											Optional:     true,
+											ValidateFunc: validation.IntInSlice([]int{10, 30, 60}),
+										},
 										"statistic": {
 											Type:          schema.TypeString,
 											Optional:      true,
@@ -799,6 +804,7 @@ func expandTargetTrackingConfiguration(tfList []interface{}) *awstypes.TargetTra
 			}
 			customizedMetricSpecification.MetricName = aws.String(tfMap[names.AttrMetricName].(string))
 			customizedMetricSpecification.Namespace = aws.String(tfMap[names.AttrNamespace].(string))
+			customizedMetricSpecification.Period = awstypes.Int32(tfMap["period"].(int32))
 			customizedMetricSpecification.Statistic = awstypes.MetricStatistic(tfMap["statistic"].(string))
 			if v, ok := tfMap[names.AttrUnit]; ok && len(v.(string)) > 0 {
 				customizedMetricSpecification.Unit = aws.String(v.(string))
@@ -1109,6 +1115,7 @@ func flattenTargetTrackingConfiguration(apiObject *awstypes.TargetTrackingConfig
 			}
 			tfMapCustomizedMetricSpecification[names.AttrMetricName] = aws.ToString(apiObject.MetricName)
 			tfMapCustomizedMetricSpecification[names.AttrNamespace] = aws.ToString(apiObject.Namespace)
+			tfMapCustomizedMetricSpecification["period"] = apiObject.Period
 			tfMapCustomizedMetricSpecification["statistic"] = apiObject.Statistic
 			if v := apiObject.Unit; v != nil {
 				tfMapCustomizedMetricSpecification[names.AttrUnit] = aws.ToString(v)

--- a/internal/service/autoscaling/policy.go
+++ b/internal/service/autoscaling/policy.go
@@ -804,7 +804,7 @@ func expandTargetTrackingConfiguration(tfList []interface{}) *awstypes.TargetTra
 			}
 			customizedMetricSpecification.MetricName = aws.String(tfMap[names.AttrMetricName].(string))
 			customizedMetricSpecification.Namespace = aws.String(tfMap[names.AttrNamespace].(string))
-			customizedMetricSpecification.Period = aws.Int32(tfMap["period"].(int32))
+			customizedMetricSpecification.Period = aws.Int32(int32(tfMap["period"].(int)))
 			customizedMetricSpecification.Statistic = awstypes.MetricStatistic(tfMap["statistic"].(string))
 			if v, ok := tfMap[names.AttrUnit]; ok && len(v.(string)) > 0 {
 				customizedMetricSpecification.Unit = aws.String(v.(string))
@@ -1115,7 +1115,7 @@ func flattenTargetTrackingConfiguration(apiObject *awstypes.TargetTrackingConfig
 			}
 			tfMapCustomizedMetricSpecification[names.AttrMetricName] = aws.ToString(apiObject.MetricName)
 			tfMapCustomizedMetricSpecification[names.AttrNamespace] = aws.ToString(apiObject.Namespace)
-			tfMapCustomizedMetricSpecification["period"] = apiObject.Period
+			tfMapCustomizedMetricSpecification["period"] = aws.ToInt32(apiObject.Period)
 			tfMapCustomizedMetricSpecification["statistic"] = apiObject.Statistic
 			if v := apiObject.Unit; v != nil {
 				tfMapCustomizedMetricSpecification[names.AttrUnit] = aws.ToString(v)

--- a/internal/service/autoscaling/policy.go
+++ b/internal/service/autoscaling/policy.go
@@ -804,7 +804,7 @@ func expandTargetTrackingConfiguration(tfList []interface{}) *awstypes.TargetTra
 			}
 			customizedMetricSpecification.MetricName = aws.String(tfMap[names.AttrMetricName].(string))
 			customizedMetricSpecification.Namespace = aws.String(tfMap[names.AttrNamespace].(string))
-			customizedMetricSpecification.Period = awstypes.Int32(tfMap["period"].(int32))
+			customizedMetricSpecification.Period = aws.Int32(tfMap["period"].(int32))
 			customizedMetricSpecification.Statistic = awstypes.MetricStatistic(tfMap["statistic"].(string))
 			if v, ok := tfMap[names.AttrUnit]; ok && len(v.(string)) > 0 {
 				customizedMetricSpecification.Unit = aws.String(v.(string))

--- a/internal/service/autoscaling/policy.go
+++ b/internal/service/autoscaling/policy.go
@@ -804,7 +804,9 @@ func expandTargetTrackingConfiguration(tfList []interface{}) *awstypes.TargetTra
 			}
 			customizedMetricSpecification.MetricName = aws.String(tfMap[names.AttrMetricName].(string))
 			customizedMetricSpecification.Namespace = aws.String(tfMap[names.AttrNamespace].(string))
-			customizedMetricSpecification.Period = aws.Int32(int32(tfMap["period"].(int)))
+			if v, ok := tfMap["period"].(int); ok && v != 0 {
+				customizedMetricSpecification.Period = aws.Int32(int32(v))
+			}
 			customizedMetricSpecification.Statistic = awstypes.MetricStatistic(tfMap["statistic"].(string))
 			if v, ok := tfMap[names.AttrUnit]; ok && len(v.(string)) > 0 {
 				customizedMetricSpecification.Unit = aws.String(v.(string))
@@ -1115,7 +1117,9 @@ func flattenTargetTrackingConfiguration(apiObject *awstypes.TargetTrackingConfig
 			}
 			tfMapCustomizedMetricSpecification[names.AttrMetricName] = aws.ToString(apiObject.MetricName)
 			tfMapCustomizedMetricSpecification[names.AttrNamespace] = aws.ToString(apiObject.Namespace)
-			tfMapCustomizedMetricSpecification["period"] = aws.ToInt32(apiObject.Period)
+			if v := apiObject.Period; v != nil {
+				tfMapCustomizedMetricSpecification["period"] = aws.ToInt32(v)
+			}
 			tfMapCustomizedMetricSpecification["statistic"] = apiObject.Statistic
 			if v := apiObject.Unit; v != nil {
 				tfMapCustomizedMetricSpecification[names.AttrUnit] = aws.ToString(v)

--- a/internal/service/autoscaling/policy_test.go
+++ b/internal/service/autoscaling/policy_test.go
@@ -952,6 +952,7 @@ resource "aws_autoscaling_policy" "test" {
 
       metric_name = "hoge"
       namespace   = "hoge"
+      period      = 10
       statistic   = "Average"
     }
 

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -271,6 +271,7 @@ This configuration block supports the following arguments:
 * `metric_dimension` - (Optional) Dimensions of the metric.
 * `metric_name` - (Optional) Name of the metric.
 * `namespace` - (Optional) Namespace of the metric.
+* `period` - (Optional) The period of the metric in seconds.
 * `statistic` - (Optional) Statistic of the metric.
 * `unit` - (Optional) Unit of the metric.
 * `metrics` - (Optional) Metrics to include, as a metric data query.


### PR DESCRIPTION
### Description
Following up from #41066, this patch adds the `period` field to the `customized_metric_specification` to allow overriding the period the metric is observed.

### Relations
Relates #41066 

### References
- https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_CustomizedMetricSpecification.html


### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccAutoScalingPolicy PKG=autoscaling
...
```

My accounts don't support launch configuration so I can't test. It's the [same reason as in the previous PR I opened before](https://github.com/hashicorp/terraform-provider-aws/pull/41066#issuecomment-2612831833).
