### PR TITLE
docs: fix typo in `config_configuration_recorder`

### DIFF
--- a/website/docs/r/config_configuration_recorder.html.markdown
+++ b/website/docs/r/config_configuration_recorder.html.markdown
@@ -114,7 +114,7 @@ This resource supports the following arguments:
 
 ### recording_mode Configuration Block
 
-* `recording_frequency` - (Required) Default reecording frequency. `CONTINUOUS` or `DAILY`.
+* `recording_frequency` - (Required) Default recording frequency. `CONTINUOUS` or `DAILY`.
 * `recording_mode_override` - (Optional) Recording mode overrides. Detailed below.
 
 #### recording_mode_override Configuration Block


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fix typo in `config_configuration_recorder`: Change `reecording` to `recording`


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_recorder#recording_mode-configuration-block


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Not applicable. Only documentation is updated.
