### PR TITLE
resource/aws_cloudformation_stack_set_instance: Prevents conflicting creation retries

### DIFF
--- a/.teamcity/components/generated/service_orgacct.kt
+++ b/.teamcity/components/generated/service_orgacct.kt
@@ -1,10 +1,7 @@
 val orgacctServices = mapOf(
     "accessanalyzer" to ServiceSpec("IAM Access Analyzer"),
     "backup" to ServiceSpec("Backup", "TestAccBackupGlobalSettings_basic"),
-    "cloudformation" to ServiceSpec(
-        "CloudFormation",
-        "TestAccCloudFormationStackSet_PermissionModel_serviceManaged|TestAccCloudFormationStackSetInstance_deploymentTargets"
-    ),
+    "cloudformation" to ServiceSpec("CloudFormation"),
     "cloudtrail" to ServiceSpec("CloudTrail"),
     "config" to ServiceSpec("Config" /*"TestAccConfig_serial|TestAccConfigConfigurationAggregator_"*/),
     "detective" to ServiceSpec("Detective"),

--- a/internal/service/cloudformation/errors.go
+++ b/internal/service/cloudformation/errors.go
@@ -3,6 +3,48 @@
 
 package cloudformation
 
+import (
+	"strings"
+)
+
 const (
 	errCodeValidationError = "ValidationError"
 )
+
+func isRetryableIAMPropagationErr(err error) (bool, error) {
+	if err == nil {
+		return false, nil
+	}
+
+	message := err.Error()
+
+	// IAM eventual consistency
+	if strings.Contains(message, "AccountGate check failed") {
+		return true, err
+	}
+
+	// IAM eventual consistency
+	// User: XXX is not authorized to perform: cloudformation:CreateStack on resource: YYY
+	if strings.Contains(message, "is not authorized") {
+		return true, err
+	}
+
+	// IAM eventual consistency
+	// XXX role has insufficient YYY permissions
+	if strings.Contains(message, "role has insufficient") {
+		return true, err
+	}
+
+	// IAM eventual consistency
+	// Account XXX should have YYY role with trust relationship to Role ZZZ
+	if strings.Contains(message, "role with trust relationship") {
+		return true, err
+	}
+
+	// IAM eventual consistency
+	if strings.Contains(message, "The security token included in the request is invalid") {
+		return true, err
+	}
+
+	return false, err
+}

--- a/internal/service/cloudformation/stack_instances.go
+++ b/internal/service/cloudformation/stack_instances.go
@@ -315,43 +315,7 @@ func resourceStackInstancesCreate(ctx context.Context, d *schema.ResourceData, m
 
 			return operation, nil
 		},
-		func(err error) (bool, error) {
-			if err == nil {
-				return false, nil
-			}
-
-			message := err.Error()
-
-			// IAM eventual consistency
-			if strings.Contains(message, "AccountGate check failed") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			// User: XXX is not authorized to perform: cloudformation:CreateStack on resource: YYY
-			if strings.Contains(message, "is not authorized") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			// XXX role has insufficient YYY permissions
-			if strings.Contains(message, "role has insufficient") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			// Account XXX should have YYY role with trust relationship to Role ZZZ
-			if strings.Contains(message, "role with trust relationship") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			if strings.Contains(message, "The security token included in the request is invalid") {
-				return true, err
-			}
-
-			return false, err
-		},
+		isRetryableIAMPropagationErr,
 	)
 
 	if err != nil {

--- a/internal/service/cloudformation/stack_set.go
+++ b/internal/service/cloudformation/stack_set.go
@@ -288,43 +288,7 @@ func resourceStackSetCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 			return operation, nil
 		},
-		func(err error) (bool, error) {
-			if err == nil {
-				return false, nil
-			}
-
-			message := err.Error()
-
-			// IAM eventual consistency
-			if strings.Contains(message, "AccountGate check failed") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			// User: XXX is not authorized to perform: cloudformation:CreateStack on resource: YYY
-			if strings.Contains(message, "is not authorized") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			// XXX role has insufficient YYY permissions
-			if strings.Contains(message, "role has insufficient") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			// Account XXX should have YYY role with trust relationship to Role ZZZ
-			if strings.Contains(message, "role with trust relationship") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			if strings.Contains(message, "The security token included in the request is invalid") {
-				return true, err
-			}
-
-			return false, err
-		},
+		isRetryableIAMPropagationErr,
 	)
 
 	if err != nil {

--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -299,35 +299,7 @@ func resourceStackSetInstanceCreate(ctx context.Context, d *schema.ResourceData,
 
 			return operation, nil
 		},
-		func(err error) (bool, error) {
-			if err == nil {
-				return false, nil
-			}
-
-			message := err.Error()
-
-			// IAM eventual consistency
-			if strings.Contains(message, "AccountGate check failed") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			// User: XXX is not authorized to perform: cloudformation:CreateStack on resource: YYY
-			if strings.Contains(message, "is not authorized") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			// XXX role has insufficient YYY permissions
-			if strings.Contains(message, "role has insufficient") {
-				return true, err
-			}
-
-			// IAM eventual consistency
-			// Account XXX should have YYY role with trust relationship to Role ZZZ
-			if strings.Contains(message, "role with trust relationship") {
-				return true, err
-			}
+		isRetryableIAMPropagationErr,
 
 			// IAM eventual consistency
 			if strings.Contains(message, "The security token included in the request is invalid") {


### PR DESCRIPTION
### Description

The resource `aws_cloudformation_stack_set_instance` was incorrectly retrying creation operations that were already in progress. This was due to a combination of using the `tfresource.RetryWhen` function with a wait for completion in the nested function as well as a `Retryer` on the AWS service client itself.

The function `tfresource.RetryWhen` calls `retry.StateChangeConf`, which makes its calls based on a timer _even if the previous call is still running_. This led to subsequent calls returning an `OperationInProgress` error.

However, the AWS service client has a `Retryer` handler for `OperationInProgress` errors, which retries _internally to the AWS client_. If the CloudFormation stack takes a long time to complete, this could lead to these internally handled `OperationInProgress` errors to exceed the internal retry limit, leading to an error such as

> Instance: operation error CloudFormation: CreateStackInstances, exceeded maximum number of attempts, 25

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #28675

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

In non-Organization account

```console
% make testacc PKG=cloudformation TESTS=TestAccCloudFormationStackSetInstance_

--- PASS: TestAccCloudFormationStackSetInstance_Disappears_stackSet (83.88s)
--- PASS: TestAccCloudFormationStackSetInstance_basic (88.40s)
--- PASS: TestAccCloudFormationStackSetInstance_disappears (93.07s)
--- PASS: TestAccCloudFormationStackSetInstance_parameterOverrides (155.97s)
```

In Organization management account


```console
% make testacc PKG=cloudformation TESTS=TestAccCloudFormationStackSetInstance_

--- PASS: TestAccCloudFormationStackSetInstance_Disappears_stackSet (76.12s)
--- PASS: TestAccCloudFormationStackSetInstance_basic (80.80s)
--- PASS: TestAccCloudFormationStackSetInstance_disappears (99.88s)
--- PASS: TestAccCloudFormationStackSetInstance_parameterOverrides (151.49s)
--- PASS: TestAccCloudFormationStackSetInstance_deploymentTargets (179.48s)
--- PASS: TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU (214.29s)
--- PASS: TestAccCloudFormationStackSetInstance_concurrencyMode (241.26s)
--- PASS: TestAccCloudFormationStackSetInstance_operationPreferences (337.12s)
```
