### PR TITLE
Fix diff on ECS container definition when firelensConfiguration is defined

### DIFF
--- a/internal/service/ecs/container_definitions.go
+++ b/internal/service/ecs/container_definitions.go
@@ -75,6 +75,12 @@ func (cd containerDefinitions) reduce(isAWSVPC bool) {
 			}
 		}
 
+		if def.FirelensConfiguration != nil {
+			if def.User == nil {
+				cd[i].User = aws.String("0")
+			}
+		}
+
 		for j, pm := range def.PortMappings {
 			if pm.Protocol == awstypes.TransportProtocolTcp {
 				cd[i].PortMappings[j].Protocol = ""

--- a/internal/service/ecs/container_definitions_test.go
+++ b/internal/service/ecs/container_definitions_test.go
@@ -727,3 +727,46 @@ func TestExpandContainerDefinitions_InvalidVersionConsistency(t *testing.T) {
 		t.Fatalf("Expected message '%[1]s', got '%[2]s'", expectedErr, err.Error())
 	}
 }
+
+func TestContainerDefinitionsAreEquivalent_FirelensConfiguration(t *testing.T) {
+	t.Parallel()
+
+	cfgRepresentation := `
+[
+    {
+        "name": "log-router",
+        "image": "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
+        "essential": true,
+        "firelensConfiguration": {
+            "type": "fluentbit"
+        }
+    }
+]`
+
+	apiRepresentation := `
+[
+    {
+        "name": "log-router",
+        "image": "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
+        "cpu": 0,
+        "portMappings": [],
+        "essential": true,
+        "environment": [],
+        "mountPoints": [],
+        "volumesFrom": [],
+        "user": "0",
+        "systemControls": [],
+        "firelensConfiguration": {
+            "type": "fluentbit"
+        }
+    }
+]`
+
+	equal, err := containerDefinitionsAreEquivalent(cfgRepresentation, apiRepresentation, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equal {
+		t.Fatal("Expected definitions to be equal.")
+	}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

The ECS API is mutating the container definition in the background whenever the `firelensConfiguration` block is defined by setting the `user` attribute to `"0"`.

This is causing Terraform to always detect diffs during plans / applies, which forces the replacement of the `aws_ecs_task_definition` resource.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.ecs_service.aws_ecs_task_definition.this must be replaced
-/+ resource "aws_ecs_task_definition" "this" {
      ~ arn                      = "arn:aws:ecs:us-east-1:<REDACTED>:task-definition/example:53" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:<REDACTED>:task-definition/example" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [                
              ~ {
                    name                  = "log-router"
                  - user                  = "0"
                    # (8 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ id                       = "example" -> (known after apply)
      ~ revision                 = 53 -> (known after apply)      
        # (12 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```


### References
The [AWS examples](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/firelens-taskdef.html) also set `user = "0"` attribute, which means they are enforcing any container with `firelensConfiguration` defined to run as `root`.

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestContainerDefinitionsAreEquivalent_FirelensConfiguration PKG=ecs
make: go1.23.5 not found
make: installing go1.23.5...
make: if you get an error, see https://go.dev/doc/manage-install to locally install various Go versions
go: downloading golang.org/dl v0.0.0-20250211172903-ae3823a6a0a3
Downloaded   0.0% (   16384 / 71649277 bytes) ...
Downloaded  22.3% (15990704 / 71649277 bytes) ...
Downloaded  67.6% (48414384 / 71649277 bytes) ...
Downloaded 100.0% (71649277 / 71649277 bytes)
Unpacking /Users/daniel.santos/sdk/go1.23.5/go1.23.5.darwin-arm64.tar.gz ...
Success. You may now run 'go1.23.5'
make: go1.23.5 ready
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/ecs/... -v -count 1 -parallel 20 -run='TestContainerDefinitionsAreEquivalent_FirelensConfiguration'  -timeout 360m -vet=off
2025/02/13 15:25:36 Initializing Terraform AWS Provider...
=== RUN   TestContainerDefinitionsAreEquivalent_FirelensConfiguration
=== PAUSE TestContainerDefinitionsAreEquivalent_FirelensConfiguration
=== CONT  TestContainerDefinitionsAreEquivalent_FirelensConfiguration
--- PASS: TestContainerDefinitionsAreEquivalent_FirelensConfiguration (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	4.155s

...
```
