### PR TITLE
docs: fix invalid name in example

### DIFF
--- a/website/docs/r/cloudfront_vpc_origin.html.markdown
+++ b/website/docs/r/cloudfront_vpc_origin.html.markdown
@@ -22,7 +22,7 @@ The following example below creates a CloudFront VPC origin for a Application Lo
 ```terraform
 resource "aws_cloudfront_vpc_origin" "alb" {
   vpc_origin_endpoint_config {
-    name                   = "Example VPC Origin"
+    name                   = "example-vpc-origin"
     arn                    = aws_lb.this.arn
     http_port              = 8080
     https_port             = 8443


### PR DESCRIPTION
### Description
In #41392 it is mentioned that the example provided in the documentation for resource `aws_cloudfront_vpc_origin` is containing an invalid value: The value `Example VPC Origin` for the attribute `name` is not allowed. 

When specifying this value, the API call made to the endpoint fails with

>  InvalidArgument: The parameter Name contains characters other than alphanumericals, dashes, and underscores.

This pull request updates the value by replacing blanks and moving to lower-case.

I had a look into the [AWS SDK Go v2 docs](https://github.com/aws/aws-sdk-go-v2/blob/5c34f50a752430b2cda9b64d1a6206ce0cc18f79/service/cloudfront/types/types.go#L5860), there is also no hint on the restrictions for the name.

### Relations

Closes #41392 

### References

### Output from Acceptance Testing

Not applicable. Only documentation is updated.