### PR TITLE
fix(rds): instance enabled_cloudwatch_logs_exports doesn't allow iam-db-auth-error

### DIFF
--- a/.changelog/41408.txt
+++ b/.changelog/41408.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rds_instance: Support `iam-db-auth-error` as a valid value for `enabled_cloudwatch_logs_exports`
+```

--- a/internal/service/rds/consts.go
+++ b/internal/service/rds/consts.go
@@ -249,6 +249,7 @@ func instanceExportableLogType_Values() []string {
 		exportableLogTypeDiagLog,
 		exportableLogTypeError,
 		exportableLogTypeGeneral,
+		exportableLogTypeIAMDBAuthError,
 		exportableLogTypeListener,
 		exportableLogTypeNotifyLog,
 		exportableLogTypeOEMAgent,


### PR DESCRIPTION
There is a new instance value for aurora-postgresql that is accepted in the `enabled_cloudwatch_logs_exports` field. It looks like this is currently being rolled out and is only available in some regions (can be tested in `us-west-2`).

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relation

Closes https://github.com/hashicorp/terraform-provider-aws/issues/41407

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccRDSInstance_CloudWatchLogsExport_postgresql PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_CloudWatchLogsExport_postgresql'  -timeout 360m -vet=off
2025/02/14 16:33:21 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSInstance_CloudWatchLogsExport_postgresql
=== PAUSE TestAccRDSInstance_CloudWatchLogsExport_postgresql
=== RUN   TestAccRDSInstance_CloudWatchLogsExport_postgresql_iam_db_auth
=== PAUSE TestAccRDSInstance_CloudWatchLogsExport_postgresql_iam_db_auth
=== CONT  TestAccRDSInstance_CloudWatchLogsExport_postgresql
=== CONT  TestAccRDSInstance_CloudWatchLogsExport_postgresql_iam_db_auth
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_postgresql (464.52s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_postgresql_iam_db_auth (602.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        607.762s
```
