### PR TITLE
docs: add admin_password_secret_arn attribute to Redshift Serverless namespace

### DIFF
--- a/website/docs/r/redshiftserverless_namespace.html.markdown
+++ b/website/docs/r/redshiftserverless_namespace.html.markdown
@@ -44,6 +44,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `id` - The Redshift Namespace Name.
 * `namespace_id` - The Redshift Namespace ID.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `admin_password_secret_arn` - Amazon Resource Name (ARN) of namespace's admin user credentials secret.
 
 ## Import
 

--- a/website/docs/r/redshiftserverless_namespace.html.markdown
+++ b/website/docs/r/redshiftserverless_namespace.html.markdown
@@ -40,11 +40,11 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `admin_password_secret_arn` - Amazon Resource Name (ARN) of namespace's admin user credentials secret.
 * `arn` - Amazon Resource Name (ARN) of the Redshift Serverless Namespace.
 * `id` - The Redshift Namespace Name.
 * `namespace_id` - The Redshift Namespace ID.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
-* `admin_password_secret_arn` - Amazon Resource Name (ARN) of namespace's admin user credentials secret.
 
 ## Import
 


### PR DESCRIPTION
### Description

PR #41224: Added the missing reference to the admin_password_secret_arn attribute in the Redshift Serverless Namespace documentation

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41224

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Not applicable, Updated the Docs.
