### PR TITLE
r/redshift_cluster: add `master_password_wo` write-only attribute

### DIFF
--- a/.changelog/41411.txt
+++ b/.changelog/41411.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_redshift_cluster: Add `master_password_wo` write-only attribute
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -522,7 +522,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk(names.AttrEncrypted); ok {
-		inputC.Encrypted = aws.Bool(v.(bool))
+		inputC.Encrypted = aws.Bool(v.(bool)) // encryption is true by default
 		inputR.Encrypted = aws.Bool(v.(bool))
 	}
 
@@ -614,7 +614,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 		d.SetId(aws.ToString(output.Cluster.ClusterIdentifier))
 	} else {
-		if _, ok := d.GetOk("master_password"); !ok || masterPasswordWO == "" {
+		if _, ok := d.GetOk("master_password"); !ok && masterPasswordWO == "" {
 			if _, ok := d.GetOk("manage_master_password"); !ok {
 				return sdkdiag.AppendErrorf(diags, `provider.aws: aws_redshift_cluster: %s: one of "manage_master_password" or "master_password" is required`, d.Get(names.AttrClusterIdentifier).(string))
 			}

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	"github.com/hashicorp/go-version"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfredshift "github.com/hashicorp/terraform-provider-aws/internal/service/redshift"
@@ -923,8 +925,11 @@ func TestAccRedshiftCluster_passwordWriteOnly(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		PreCheck:   func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck: acctest.ErrorCheck(t, names.RedshiftServiceID),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -1082,6 +1082,7 @@ resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
   availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
+  encrypted                           = true
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
   multi_az                            = false

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -58,7 +58,7 @@ This resource supports the following arguments:
 * `node_type` - (Required) The node type to be provisioned for the cluster.
 * `cluster_type` - (Optional) The cluster type to use. Either `single-node` or `multi-node`.
 * `manage_master_password` - (Optional) Whether to use AWS SecretsManager to manage the cluster admin credentials.
-  Conflicts with `master_password`.
+  Conflicts with `master_password` and `master_password_wo`.
   One of `master_password` or `manage_master_password` is required unless `snapshot_identifier` is provided.
 * `master_password` - (Optional) Password for the master DB user.
   Conflicts with `manage_master_password` and `master_password_wo`.
@@ -68,7 +68,7 @@ This resource supports the following arguments:
 * `master_password_wo` - (Optional, Write-Only) Password for the master DB user.
   Conflicts with `manage_master_password` and `master_password`.
   One of `master_password_wo`, `master_password` or `manage_master_password` is required unless `snapshot_identifier` is provided.
-  Note that this may show up in logs, and it will be stored in the state file.
+  Note that this may show up in logs.
   Password must contain at least 8 characters and contain at least one uppercase letter, one lowercase letter, and one number.
 * `master_password_wo_version` - (Optional) Used together with `master_password_wo` to trigger an update. Increment this value when an update to the `master_password_wo` is required.
 * `master_password_secret_kms_key_id` - (Optional) ID of the KMS key used to encrypt the cluster admin credentials secret.

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -61,10 +61,16 @@ This resource supports the following arguments:
   Conflicts with `master_password`.
   One of `master_password` or `manage_master_password` is required unless `snapshot_identifier` is provided.
 * `master_password` - (Optional) Password for the master DB user.
-  Conflicts with `manage_master_password`.
-  One of `master_password` or `manage_master_password` is required unless `snapshot_identifier` is provided.
+  Conflicts with `manage_master_password` and `master_password_wo`.
+  One of `master_password`, `master_password_wo` or `manage_master_password` is required unless `snapshot_identifier` is provided.
   Note that this may show up in logs, and it will be stored in the state file.
   Password must contain at least 8 characters and contain at least one uppercase letter, one lowercase letter, and one number.
+* `master_password_wo` - (Optional, Write-Only) Password for the master DB user.
+  Conflicts with `manage_master_password` and `master_password`.
+  One of `master_password_wo`, `master_password` or `manage_master_password` is required unless `snapshot_identifier` is provided.
+  Note that this may show up in logs, and it will be stored in the state file.
+  Password must contain at least 8 characters and contain at least one uppercase letter, one lowercase letter, and one number.
+* `master_password_wo_version` - (Optional) Used together with `master_password_wo` to trigger an update. Increment this value when an update to the `master_password_wo` is required.
 * `master_password_secret_kms_key_id` - (Optional) ID of the KMS key used to encrypt the cluster admin credentials secret.
 * `master_username` - (Required unless a `snapshot_identifier` is provided) Username for the master DB user.
 * `multi_az` - (Optional) Specifies if the Redshift cluster is multi-AZ.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

add `master_password_wo` write-only attribute

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccRedshiftCluster_basic\|TestAccRedshiftCluster_disappears\|TestAccRedshiftCluster_passwordWriteOnly" PKG=redshift

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/redshift/... -v -count 1 -parallel 20  -run=TestAccRedshiftCluster_basic\|TestAccRedshiftCluster_disappears\|TestAccRedshiftCluster_passwordWriteOnly -timeout 360m -vet=off
2025/02/15 12:29:05 Initializing Terraform AWS Provider...
=== RUN   TestAccRedshiftCluster_basic
=== PAUSE TestAccRedshiftCluster_basic
=== RUN   TestAccRedshiftCluster_disappears
=== PAUSE TestAccRedshiftCluster_disappears
=== RUN   TestAccRedshiftCluster_passwordWriteOnly
=== PAUSE TestAccRedshiftCluster_passwordWriteOnly
=== CONT  TestAccRedshiftCluster_basic
=== CONT  TestAccRedshiftCluster_passwordWriteOnly
=== CONT  TestAccRedshiftCluster_disappears
--- PASS: TestAccRedshiftCluster_disappears (154.30s)
--- PASS: TestAccRedshiftCluster_basic (168.86s)
--- PASS: TestAccRedshiftCluster_passwordWriteOnly (410.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	417.283s
```

