### PR TITLE
r/redshiftserverless_namespace: add `admin_user_password_wo` write-only attribute

### DIFF
--- a/.changelog/41412.txt
+++ b/.changelog/41412.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_redshiftserverless_namespace: Add `admin_user_password_wo` write-only attribute
+```

--- a/internal/service/redshiftserverless/namespace.go
+++ b/internal/service/redshiftserverless/namespace.go
@@ -14,9 +14,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/redshiftserverless/types"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -41,6 +43,10 @@ func resourceNamespace() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
+			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("admin_user_password"), cty.GetAttrPath("admin_user_password_wo")),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"admin_password_secret_arn": {
 				Type:     schema.TypeString,
@@ -56,7 +62,18 @@ func resourceNamespace() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Sensitive:     true,
-				ConflictsWith: []string{"manage_admin_password"},
+				ConflictsWith: []string{"manage_admin_password", "admin_user_password_wo"},
+			},
+			"admin_user_password_wo": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				WriteOnly:     true,
+				ConflictsWith: []string{"admin_user_password", "manage_admin_password"},
+			},
+			"admin_user_password_wo_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"admin_user_password_wo"},
 			},
 			"admin_username": {
 				Type:      schema.TypeString,
@@ -105,7 +122,7 @@ func resourceNamespace() *schema.Resource {
 			"manage_admin_password": {
 				Type:          schema.TypeBool,
 				Optional:      true,
-				ConflictsWith: []string{"admin_user_password"},
+				ConflictsWith: []string{"admin_user_password", "admin_user_password_wo"},
 			},
 			"namespace_id": {
 				Type:     schema.TypeString,
@@ -134,12 +151,22 @@ func resourceNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta i
 		Tags:          getTagsIn(ctx),
 	}
 
+	adminUserPasswordWO, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("admin_user_password_wo"))
+	diags = append(diags, di...)
+	if diags.HasError() {
+		return diags
+	}
+
 	if v, ok := d.GetOk("admin_password_secret_kms_key_id"); ok {
 		input.AdminPasswordSecretKmsKeyId = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("admin_user_password"); ok {
 		input.AdminUserPassword = aws.String(v.(string))
+	}
+
+	if adminUserPasswordWO != "" {
+		input.AdminUserPassword = aws.String(adminUserPasswordWO)
 	}
 
 	if v, ok := d.GetOk("admin_username"); ok {
@@ -225,9 +252,22 @@ func resourceNamespaceUpdate(ctx context.Context, d *schema.ResourceData, meta i
 			input.AdminPasswordSecretKmsKeyId = aws.String(d.Get("admin_password_secret_kms_key_id").(string))
 		}
 
-		if d.HasChanges("admin_username", "admin_user_password") {
+		if d.HasChanges("admin_username", "admin_user_password", "admin_user_password_wo_version") {
 			input.AdminUsername = aws.String(d.Get("admin_username").(string))
-			input.AdminUserPassword = aws.String(d.Get("admin_user_password").(string))
+
+			if v, ok := d.Get("admin_user_password").(string); ok {
+				input.AdminUserPassword = aws.String(v)
+			}
+
+			adminUserPasswordWO, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("admin_user_password_wo"))
+			diags = append(diags, di...)
+			if diags.HasError() {
+				return diags
+			}
+
+			if adminUserPasswordWO != "" {
+				input.AdminUserPassword = aws.String(adminUserPasswordWO)
+			}
 		}
 
 		if d.HasChange("default_iam_role_arn") {

--- a/internal/service/redshiftserverless/namespace_test.go
+++ b/internal/service/redshiftserverless/namespace_test.go
@@ -9,9 +9,11 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/go-version"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfredshiftserverless "github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless"
@@ -132,8 +134,11 @@ func TestAccRedshiftServerlessNamespace_userPasswordWriteOnly(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServerlessServiceID),
+		PreCheck:   func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck: acctest.ErrorCheck(t, names.RedshiftServerlessServiceID),
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNamespaceDestroy(ctx),
 		Steps: []resource.TestStep{

--- a/internal/service/redshiftserverless/namespace_test.go
+++ b/internal/service/redshiftserverless/namespace_test.go
@@ -126,6 +126,33 @@ func TestAccRedshiftServerlessNamespace_user(t *testing.T) {
 	})
 }
 
+func TestAccRedshiftServerlessNamespace_userPasswordWriteOnly(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_redshiftserverless_namespace.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServerlessServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNamespaceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNamespaceConfig_userPasswordWriteOnly(rName, "Password123", 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNamespaceExists(ctx, resourceName),
+				),
+			},
+			{
+				Config: testAccNamespaceConfig_userPasswordWriteOnly(rName, "Password123updated", 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNamespaceExists(ctx, resourceName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRedshiftServerlessNamespace_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_redshiftserverless_namespace.test"
@@ -342,6 +369,17 @@ resource "aws_redshiftserverless_namespace" "test" {
   admin_user_password = "Password123"
 }
 `, rName)
+}
+
+func testAccNamespaceConfig_userPasswordWriteOnly(rName, password string, passwordVersion int) string {
+	return fmt.Sprintf(`
+resource "aws_redshiftserverless_namespace" "test" {
+  namespace_name                 = %[1]q
+  admin_username                 = "admin"
+  admin_user_password_wo         = %[2]q
+  admin_user_password_wo_version = %[3]d
+}
+`, rName, password, passwordVersion)
 }
 
 func testAccNamespaceConfig_updated(rName string) string {

--- a/website/docs/r/redshiftserverless_namespace.html.markdown
+++ b/website/docs/r/redshiftserverless_namespace.html.markdown
@@ -25,7 +25,7 @@ This resource supports the following arguments:
 * `admin_password_secret_kms_key_id` - (Optional) ID of the KMS key used to encrypt the namespace's admin credentials secret.
 * `admin_user_password` - (Optional) The password of the administrator for the first database created in the namespace.
   Conflicts with `manage_admin_password` and `admin_user_password_wo`.
-* `admin_user_password_wo` - (Optional) The password of the administrator for the first database created in the namespace.
+* `admin_user_password_wo` - (Optional, Write-Only) The password of the administrator for the first database created in the namespace.
   Conflicts with `manage_admin_password` and `admin_user_password`.
 * `admin_user_password_wo_version` - (Optional) Used together with `admin_user_password_wo` to trigger an update. Increment this value when an update to the `admin_user_password_wo` is required
 * `admin_username` - (Optional) The username of the administrator for the first database created in the namespace.

--- a/website/docs/r/redshiftserverless_namespace.html.markdown
+++ b/website/docs/r/redshiftserverless_namespace.html.markdown
@@ -36,7 +36,7 @@ This resource supports the following arguments:
 * `log_exports` - (Optional) The types of logs the namespace can export. Available export types are `userlog`, `connectionlog`, and `useractivitylog`.
 * `namespace_name` - (Required) The name of the namespace.
 * `manage_admin_password` - (Optional) Whether to use AWS SecretManager to manage namespace's admin credentials.
-  Conflicts with `admin_user_password`.
+  Conflicts with `admin_user_password` and `admin_user_password_wo`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference

--- a/website/docs/r/redshiftserverless_namespace.html.markdown
+++ b/website/docs/r/redshiftserverless_namespace.html.markdown
@@ -24,7 +24,10 @@ This resource supports the following arguments:
 
 * `admin_password_secret_kms_key_id` - (Optional) ID of the KMS key used to encrypt the namespace's admin credentials secret.
 * `admin_user_password` - (Optional) The password of the administrator for the first database created in the namespace.
-  Conflicts with `manage_admin_password`.
+  Conflicts with `manage_admin_password` and `admin_user_password_wo`.
+* `admin_user_password_wo` - (Optional) The password of the administrator for the first database created in the namespace.
+  Conflicts with `manage_admin_password` and `admin_user_password`.
+* `admin_user_password_wo_version` - (Optional) Used together with `admin_user_password_wo` to trigger an update. Increment this value when an update to the `admin_user_password_wo` is required
 * `admin_username` - (Optional) The username of the administrator for the first database created in the namespace.
 * `db_name` - (Optional) The name of the first database created in the namespace.
 * `default_iam_role_arn` - (Optional) The Amazon Resource Name (ARN) of the IAM role to set as a default in the namespace. When specifying `default_iam_role_arn`, it also must be part of `iam_roles`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

add `admin_user_password_wo` write-only attribute

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccRedshiftServerlessNamespace_basic\|TestAccRedshiftServerlessNamespace_user\|TestAccRedshiftServerlessNamespace_diappears\|TestAccRedshiftServerlessNamespace_userPasswordWriteOnly" PKG=redshiftserverless

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/redshiftserverless/... -v -count 1 -parallel 20  -run=TestAccRedshiftServerlessNamespace_basic\|TestAccRedshiftServerlessNamespace_user\|TestAccRedshiftServerlessNamespace_diappears\|TestAccRedshiftServerlessNamespace_userPasswordWriteOnly -timeout 360m -vet=off
2025/02/15 12:38:23 Initializing Terraform AWS Provider...
=== RUN   TestAccRedshiftServerlessNamespace_basic
=== PAUSE TestAccRedshiftServerlessNamespace_basic
=== RUN   TestAccRedshiftServerlessNamespace_user
=== PAUSE TestAccRedshiftServerlessNamespace_user
=== RUN   TestAccRedshiftServerlessNamespace_userPasswordWriteOnly
=== PAUSE TestAccRedshiftServerlessNamespace_userPasswordWriteOnly
=== CONT  TestAccRedshiftServerlessNamespace_basic
=== CONT  TestAccRedshiftServerlessNamespace_userPasswordWriteOnly
=== CONT  TestAccRedshiftServerlessNamespace_user
--- PASS: TestAccRedshiftServerlessNamespace_userPasswordWriteOnly (20.11s)
--- PASS: TestAccRedshiftServerlessNamespace_user (22.97s)
--- PASS: TestAccRedshiftServerlessNamespace_basic (24.07s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless	30.732s
```
