### PR TITLE
Removing duplicate documentation entry from R53 resolver resource

### DIFF
--- a/website/docs/cdktf/python/r/route53_resolver_endpoint.html.markdown
+++ b/website/docs/cdktf/python/r/route53_resolver_endpoint.html.markdown
@@ -59,7 +59,6 @@ to your network (for outbound endpoints) or on the way from your network to your
 * `security_group_ids` - (Required) ID of one or more security groups that you want to use to control access to this VPC.
 * `name` - (Optional) Friendly name of the Route 53 Resolver endpoint.
 * `protocols` - (Optional) Protocols you want to use for the Route 53 Resolver endpoint. Valid values: `DoH`, `Do53`, `DoH-FIPS`.
-* `resolver_endpoint_type` - (Optional) Route 53 Resolver endpoint IP address type. Valid values: `IPV4`, `IPV6`, `DUALSTACK`.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The `ip_address` object supports the following:

--- a/website/docs/cdktf/typescript/r/route53_resolver_endpoint.html.markdown
+++ b/website/docs/cdktf/typescript/r/route53_resolver_endpoint.html.markdown
@@ -64,7 +64,6 @@ to your network (for outbound endpoints) or on the way from your network to your
 * `securityGroupIds` - (Required) ID of one or more security groups that you want to use to control access to this VPC.
 * `name` - (Optional) Friendly name of the Route 53 Resolver endpoint.
 * `protocols` - (Optional) Protocols you want to use for the Route 53 Resolver endpoint. Valid values: `DoH`, `Do53`, `DoH-FIPS`.
-* `resolverEndpointType` - (Optional) Route 53 Resolver endpoint IP address type. Valid values: `IPV4`, `IPV6`, `DUALSTACK`.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`defaultTags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The `ipAddress` object supports the following:

--- a/website/docs/r/route53_resolver_endpoint.html.markdown
+++ b/website/docs/r/route53_resolver_endpoint.html.markdown
@@ -54,7 +54,6 @@ to your network (for outbound endpoints) or on the way from your network to your
 * `security_group_ids` - (Required) ID of one or more security groups that you want to use to control access to this VPC.
 * `name` - (Optional) Friendly name of the Route 53 Resolver endpoint.
 * `protocols` - (Optional) Protocols you want to use for the Route 53 Resolver endpoint. Valid values: `DoH`, `Do53`, `DoH-FIPS`.
-* `resolver_endpoint_type` - (Optional) Route 53 Resolver endpoint IP address type. Valid values: `IPV4`, `IPV6`, `DUALSTACK`.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 The `ip_address` object supports the following:


### PR DESCRIPTION
### Description
Removed duplicate argument in aws_route53_resolver_endpoint documentation

### Relations
N/A

### References
N/A

### Output from Acceptance Testing
N/A

