### PR TITLE
Fix document `remote_network_config` attribute `aws_eks_cluster`(#41421)

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -210,11 +210,11 @@ resource "aws_eks_cluster" "example" {
   role_arn = aws_iam_role.cluster.arn
   version  = "1.31"
 
-  cluster_remote_network_config = {
-    remote_node_networks = {
+  remote_network_config {
+    remote_node_networks {
       cidrs = ["172.16.0.0/18"]
     }
-    remote_pod_networks = {
+    remote_pod_networks {
       cidrs = ["172.16.64.0/18"]
     }
   }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
With this document of resource aws_eks_cluster, The [example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#eks-cluster-with-eks-hybrid-nodes) here is written like below

```hcl
resource "aws_eks_cluster" "example" {
  name = "example"
  cluster_remote_network_config = {
    remote_node_networks = {
      cidrs = ["172.16.0.0/18"]
    }
    remote_pod_networks = {
      cidrs = ["172.16.64.0/18"]
    }
  }
}
```

The `cluster_remote_network_config` block has to be rewritten like below.

```hcl
resource "aws_eks_cluster" "example" {
  name = "example"
  remote_network_config {
    remote_node_networks {
      cidrs = ["172.16.0.0/18"]
    }
    remote_pod_networks {
      cidrs = ["172.16.64.0/18"]
    }
  }
```
### Relations
Closes #41421 

### References



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
