### PR TITLE
r/aws_glue_partition - storage_descriptor.additional_locations

### DIFF
--- a/.changelog/41434.txt
+++ b/.changelog/41434.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_glue_partition: Add `additional_locations` argument in `storage_descriptor`
+resource/aws_glue_partition: Add `storage_descriptor.additional_locations` argument
 ```

--- a/.changelog/41434.txt
+++ b/.changelog/41434.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_glue_partition: Add `additional_locations` argument in `storage_descriptor`
+```

--- a/internal/service/glue/partition.go
+++ b/internal/service/glue/partition.go
@@ -66,6 +66,11 @@ func ResourcePartition() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"additional_locations": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 						"bucket_columns": {
 							Type:     schema.TypeList,
 							Optional: true,

--- a/internal/service/glue/partition_test.go
+++ b/internal/service/glue/partition_test.go
@@ -189,6 +189,63 @@ func TestAccGluePartition_storageDescriptorBasic(t *testing.T) {
 	})
 }
 
+func TestAccGluePartition_storageDescriptorAdditionalLocations(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	parValue := sdkacctest.RandString(10)
+	parValue2 := sdkacctest.RandString(10)
+	parValue3 := sdkacctest.RandString(10)
+	resourceName := "aws_glue_partition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPartitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPartitionConfig_storageDescriptorAdditionalLocationsSingle(rName, parValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPartitionExists(ctx, resourceName),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrCatalogID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, rName),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.additional_locations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.additional_locations.0", parValue),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPartitionConfig_storageDescriptorAdditionalLocationsDouble(rName, parValue, parValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPartitionExists(ctx, resourceName),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrCatalogID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, rName),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.additional_locations.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.additional_locations.0", parValue),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.additional_locations.1", parValue2),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
+				),
+			},
+			{
+				Config: testAccPartitionConfig_storageDescriptorAdditionalLocationsSingle(rName, parValue3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPartitionExists(ctx, resourceName),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrCatalogID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, rName),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.additional_locations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.additional_locations.0", parValue3),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGluePartition_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -513,4 +570,64 @@ resource "aws_glue_partition" "test" {
   }
 }
 `, parValue)
+}
+
+func testAccPartitionConfig_storageDescriptorAdditionalLocationsSingle(rName, additionalLocation1 string) string {
+	return testAccPartitionConfigBase(rName) +
+		fmt.Sprintf(`
+resource "aws_glue_partition" "test" {
+  database_name    = aws_glue_catalog_database.test.name
+  table_name       = aws_glue_catalog_table.test.name
+  partition_values = ["2025"]
+
+  storage_descriptor {
+    additional_locations = [%[1]q]
+    location             = "my_location"
+    input_format         = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format        = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+    compressed           = false
+    number_of_buckets    = 1
+
+    ser_de_info {
+      name = "ser_de_name"
+
+      parameters = {
+        "example" = "test"
+      }
+
+      serialization_library = "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
+    }
+  }
+}
+`, additionalLocation1)
+}
+
+func testAccPartitionConfig_storageDescriptorAdditionalLocationsDouble(rName, additionalLocation1, additionalLocation2 string) string {
+	return testAccPartitionConfigBase(rName) +
+		fmt.Sprintf(`
+resource "aws_glue_partition" "test" {
+  database_name    = aws_glue_catalog_database.test.name
+  table_name       = aws_glue_catalog_table.test.name
+  partition_values = ["2025"]
+
+  storage_descriptor {
+    additional_locations = [%[1]q, %[2]q]
+    location             = "my_location"
+    input_format         = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format        = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+    compressed           = false
+    number_of_buckets    = 1
+
+    ser_de_info {
+      name = "ser_de_name"
+
+      parameters = {
+        "example" = "test"
+      }
+
+      serialization_library = "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
+    }
+  }
+}
+`, additionalLocation1, additionalLocation2)
 }

--- a/internal/service/glue/partition_test.go
+++ b/internal/service/glue/partition_test.go
@@ -129,6 +129,66 @@ func TestAccGluePartition_parameters(t *testing.T) {
 	})
 }
 
+func TestAccGluePartition_storageDescriptorBasic(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	parValue := sdkacctest.RandString(10)
+	parValue2 := sdkacctest.RandString(10)
+	resourceName := "aws_glue_partition.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.GlueServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPartitionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPartitionConfig_storageDescriptorBasic(rName, parValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPartitionExists(ctx, resourceName),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrCatalogID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, rName),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.location", "my_location"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.input_format", "org.apache.hadoop.mapred.TextInputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.output_format", "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.compressed", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.number_of_buckets", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.parameters.example", parValue),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPartitionConfig_storageDescriptorBasic(rName, parValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPartitionExists(ctx, resourceName),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrCatalogID),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDatabaseName, rName),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.location", "my_location"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.input_format", "org.apache.hadoop.mapred.TextInputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.output_format", "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.compressed", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.number_of_buckets", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.name", "ser_de_name"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.parameters.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.parameters.example", parValue2),
+					resource.TestCheckResourceAttr(resourceName, "storage_descriptor.0.ser_de_info.0.serialization_library", "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreationTime),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGluePartition_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -424,4 +484,33 @@ resource "aws_glue_partition" "test" {
   partition_values = ["%[2]s", "%[3]s"]
 }
 `, rName, parValue, parValue2)
+}
+
+func testAccPartitionConfig_storageDescriptorBasic(rName, parValue string) string {
+	return testAccPartitionConfigBase(rName) +
+		fmt.Sprintf(`
+resource "aws_glue_partition" "test" {
+  database_name    = aws_glue_catalog_database.test.name
+  table_name       = aws_glue_catalog_table.test.name
+  partition_values = ["2025"]
+
+  storage_descriptor {
+    location          = "my_location"
+    input_format      = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format     = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+    compressed        = false
+    number_of_buckets = 1
+
+    ser_de_info {
+      name = "ser_de_name"
+
+      parameters = {
+        "example" = %[1]q
+      }
+
+      serialization_library = "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe"
+    }
+  }
+}
+`, parValue)
 }

--- a/website/docs/r/glue_partition.html.markdown
+++ b/website/docs/r/glue_partition.html.markdown
@@ -32,6 +32,7 @@ This resource supports the following arguments:
 
 ##### storage_descriptor
 
+* `additional_locations` - (Optional) List of locations that point to the path where a Delta table is located.
 * `columns` - (Optional) A list of the [Columns](#column) in the table.
 * `location` - (Optional) The physical location of the table. By default this takes the form of the warehouse location, followed by the database location in the warehouse, followed by the table name.
 * `input_format` - (Optional) The input format: SequenceFileInputFormat (binary), or TextInputFormat, or a custom format.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Support `storage_descriptor.additional_locations` for Glue Partition.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38925
Relates #37891

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- [API_CreatePartition](https://docs.aws.amazon.com/glue/latest/webapi/API_CreatePartition.html)

    - Supports [StorageDescriptor-AdditionalLocations](https://docs.aws.amazon.com/glue/latest/webapi/API_StorageDescriptor.html#Glue-Type-StorageDescriptor-AdditionalLocations)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccGluePartition' PKG=glue
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/glue/... -v -count 1 -parallel 20  -run=TestAccGluePartition -timeout 360m -vet=off
2025/02/18 06:17:53 Initializing Terraform AWS Provider...
=== RUN   TestAccGluePartitionIndex_basic
=== PAUSE TestAccGluePartitionIndex_basic
=== RUN   TestAccGluePartitionIndex_disappears
=== PAUSE TestAccGluePartitionIndex_disappears
=== RUN   TestAccGluePartitionIndex_Disappears_table
=== PAUSE TestAccGluePartitionIndex_Disappears_table
=== RUN   TestAccGluePartitionIndex_Disappears_database
=== PAUSE TestAccGluePartitionIndex_Disappears_database
=== RUN   TestAccGluePartition_basic
=== PAUSE TestAccGluePartition_basic
=== RUN   TestAccGluePartition_multipleValues
=== PAUSE TestAccGluePartition_multipleValues
=== RUN   TestAccGluePartition_parameters
=== PAUSE TestAccGluePartition_parameters
=== RUN   TestAccGluePartition_storageDescriptorBasic
=== PAUSE TestAccGluePartition_storageDescriptorBasic
=== RUN   TestAccGluePartition_storageDescriptorAdditionalLocations
=== PAUSE TestAccGluePartition_storageDescriptorAdditionalLocations
=== RUN   TestAccGluePartition_disappears
=== PAUSE TestAccGluePartition_disappears
=== RUN   TestAccGluePartition_Disappears_table
=== PAUSE TestAccGluePartition_Disappears_table
=== CONT  TestAccGluePartitionIndex_basic
=== CONT  TestAccGluePartition_parameters
=== CONT  TestAccGluePartition_basic
=== CONT  TestAccGluePartitionIndex_Disappears_table
=== CONT  TestAccGluePartition_Disappears_table
=== CONT  TestAccGluePartition_disappears
=== CONT  TestAccGluePartition_storageDescriptorAdditionalLocations
=== CONT  TestAccGluePartition_storageDescriptorBasic
=== CONT  TestAccGluePartition_multipleValues
=== CONT  TestAccGluePartitionIndex_disappears
=== CONT  TestAccGluePartitionIndex_Disappears_database
--- PASS: TestAccGluePartition_Disappears_table (25.52s)
--- PASS: TestAccGluePartition_disappears (25.74s)
--- PASS: TestAccGluePartition_multipleValues (28.95s)
--- PASS: TestAccGluePartition_basic (29.10s)
--- PASS: TestAccGluePartition_storageDescriptorBasic (45.16s)
--- PASS: TestAccGluePartitionIndex_Disappears_database (48.82s)
--- PASS: TestAccGluePartitionIndex_Disappears_table (49.24s)
--- PASS: TestAccGluePartition_parameters (60.61s)
--- PASS: TestAccGluePartition_storageDescriptorAdditionalLocations (62.29s)
--- PASS: TestAccGluePartitionIndex_disappears (74.21s)
--- PASS: TestAccGluePartitionIndex_basic (77.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       77.658s

...
```
