### PR TITLE
data-source/aws_s3_object: add `application/yaml` to the list of `Content-Type` that return a body.

### DIFF
--- a/.changelog/41443.txt
+++ b/.changelog/41443.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_s3_object: Add `application/yaml` to the list of `Content-Type` that return a body.
+```

--- a/.changelog/41443.txt
+++ b/.changelog/41443.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-data-source/aws_s3_object: Add `application/yaml` to the list of `Content-Type` that return a body.
+data-source/aws_s3_object: Add `application/yaml` to the list of `Content-Type`s that return a body
+```
+
+```release-note:enhancement
+data-source/aws_s3_bucket_object: Add `application/yaml` to the list of `Content-Type`s that return a body
 ```

--- a/internal/service/s3/object_data_source.go
+++ b/internal/service/s3/object_data_source.go
@@ -288,6 +288,7 @@ func isContentTypeAllowed(contentType *string) bool {
 		regexache.MustCompile(`^application/xhtml\+xml$`),
 		regexache.MustCompile(`^application/xml$`),
 		regexache.MustCompile(`^application/x-sql$`),
+		regexache.MustCompile(`^application/yaml$`),
 		regexache.MustCompile(`^text/.+`),
 	}
 	for _, r := range allowedContentTypes {

--- a/website/docs/d/s3_object.html.markdown
+++ b/website/docs/d/s3_object.html.markdown
@@ -23,6 +23,7 @@ _optionally_ (see below) content of an object stored inside S3 bucket.
 * `application/xml`
 * `application/atom+xml`
 * `application/x-sql`
+* `application/yaml`
 
 This is to prevent printing unsafe characters and potentially downloading large amount of data which would be thrown away in favor of metadata.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The YAML media type has been standardized last year to `application/yaml`. This pull requests updates the `aws_s3_object` data source so that it will return a body for objects using the `application/yaml` Content-Type.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://datatracker.ietf.org/doc/html/rfc9512

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

The `aws_s3_object` datasource's tests do not test each content-type individually so no tests have been added.
