### PR TITLE
[Docs]: `target_ip.ip` is optional in Route 53 Resolver rule

### DIFF
--- a/website/docs/r/route53_resolver_rule.html.markdown
+++ b/website/docs/r/route53_resolver_rule.html.markdown
@@ -74,7 +74,7 @@ This argument should only be specified for `FORWARD` type rules.
 
 The `target_ip` object supports the following:
 
-* `ip` - (Required) One IP address that you want to forward DNS queries to. You can specify only IPv4 addresses.
+* `ip` - (Optional) One IPv4 address that you want to forward DNS queries to.
 * `ipv6` - (Optional) One IPv6 address that you want to forward DNS queries to.
 * `port` - (Optional) Port at `ip` that you want to forward DNS queries to. Default value is `53`.
 * `protocol` - (Optional) Protocol for the resolver endpoint. Valid values can be found in the [AWS documentation](https://docs.aws.amazon.com/Route53/latest/APIReference/API_route53resolver_TargetAddress.html). Default value is `Do53`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
The documentation currently claims that the IPv4 address parameter is mandatory. This doesn’t make sense, as the API Reference specifies that you can specify IPv4 or IPv6 addresses but not both in the same rule, and checking the actual code, sure enough, it’s optional.

### Relations
N/A

### References
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/route53resolver/rule.go#L95


### Output from Acceptance Testing
N/A — minor documentation fix only