### PR TITLE
r/aws_s3tables_table[_bucket](doc): tidy headings, add documentation links

### DIFF
--- a/website/docs/r/s3tables_table.html.markdown
+++ b/website/docs/r/s3tables_table.html.markdown
@@ -41,6 +41,7 @@ The following arguments are required:
 * `name` - (Required) Name of the table.
   Must be between 1 and 255 characters in length.
   Can consist of lowercase letters, numbers, and underscores, and must begin and end with a lowercase letter or number.
+  A full list of table naming rules can be found in the [S3 Tables documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-buckets-naming.html#naming-rules-table).
 * `namespace` - (Required) Name of the namespace for this table.
   Must be between 1 and 255 characters in length.
   Can consist of lowercase letters, numbers, and underscores, and must begin and end with a lowercase letter or number.
@@ -49,23 +50,23 @@ The following arguments are required:
 The following argument is optional:
 
 * `maintenance_configuration` - (Optional) A single table bucket maintenance configuration block.
-  [See `maintenance_configuration` below](#maintenance_configuration)
+  [See `maintenance_configuration` below](#maintenance_configuration).
 
-### maintenance_configuration
+### `maintenance_configuration`
 
 The `maintenance_configuration` configuration block supports the following arguments:
 
 * `iceberg_compaction` - (Required) A single Iceberg compaction settings block.
-  [See `iceberg_compaction` below](#iceberg_compaction)
+  [See `iceberg_compaction` below](#iceberg_compaction).
 * `iceberg_snapshot_management` - (Required) A single Iceberg snapshot management settings block.
-  [See `iceberg_snapshot_management` below](#iceberg_snapshot_management)
+  [See `iceberg_snapshot_management` below](#iceberg_snapshot_management).
 
 ### `iceberg_compaction`
 
 The `iceberg_compaction` configuration block supports the following arguments:
 
 * `settings` - (Required) Settings for compaction.
-  [See `iceberg_compaction.settings` below](#iceberg_compactionsettings)
+  [See `iceberg_compaction.settings` below](#iceberg_compactionsettings).
 * `status` - (Required) Whether the configuration is enabled.
   Valid values are `enabled` and `disabled`.
 
@@ -81,7 +82,7 @@ The `iceberg_compaction.settings` configuration block supports the following arg
 The `iceberg_snapshot_management` configuration block supports the following arguments:
 
 * `settings` - (Required) Settings for snapshot management.
-  [See `iceberg_snapshot_management.settings` below](#iceberg_snapshot_managementsettings)
+  [See `iceberg_snapshot_management.settings` below](#iceberg_snapshot_managementsettings).
 * `status` - (Required) Whether the configuration is enabled.
   Valid values are `enabled` and `disabled`.
 

--- a/website/docs/r/s3tables_table_bucket.html.markdown
+++ b/website/docs/r/s3tables_table_bucket.html.markdown
@@ -27,26 +27,26 @@ The following argument is required:
 * `name` - (Required, Forces new resource) Name of the table bucket.
   Must be between 3 and 63 characters in length.
   Can consist of lowercase letters, numbers, and hyphens, and must begin and end with a lowercase letter or number.
-  A full list of bucket naming rules may be found in [S3 Tables documentation](???).
+  A full list of bucket naming rules can be found in the [S3 Tables documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-buckets-naming.html#table-buckets-naming-rules).
 
 The following argument is optional:
 
 * `maintenance_configuration` - (Optional) A single table bucket maintenance configuration block.
-  [See `maintenance_configuration` below](#maintenance_configuration)
+  [See `maintenance_configuration` below](#maintenance_configuration).
 
-### maintenance_configuration
+### `maintenance_configuration`
 
 The `maintenance_configuration` configuration block supports the following argument:
 
 * `iceberg_unreferenced_file_removal` - (Required) A single Iceberg unreferenced file removal settings block.
-  [See `iceberg_unreferenced_file_removal` below](#iceberg_unreferenced_file_removal)
+  [See `iceberg_unreferenced_file_removal` below](#iceberg_unreferenced_file_removal).
 
 ### `iceberg_unreferenced_file_removal`
 
 The `iceberg_unreferenced_file_removal` configuration block supports the following arguments:
 
 * `settings` - (Required) Settings for unreferenced file removal.
-  [See `iceberg_unreferenced_file_removal.settings` below](#iceberg_unreferenced_file_removalsettings)
+  [See `iceberg_unreferenced_file_removal.settings` below](#iceberg_unreferenced_file_removalsettings).
 * `status` - (Required) Whether the configuration is enabled.
   Valid values are `enabled` and `disabled`.
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Formats argument sub-headings consistently across the table and table bucket registry documentation. Also adds missing links to the S3 tables documentation on naming requirements and missing punctuation.


