### PR TITLE
docs: add docs for aws_backup_selection

### DIFF
--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -150,10 +150,10 @@ The `selection_tag` configuration block supports the following attributes:
 
 The `condition` configuration block supports the following attributes:
 
-* `string_equals` - (Optional) Filters resources that exactly match. See [below](#string_equals-configuration-block) for details.
-* `string_not_equals` - (Optional) Filters resources that do not exactly match. See [below](#string_not_equals-configuration-block) for details.
-* `string_like` - (Optional) Filters resources that match a pattern. See [below](#string_like-configuration-block) for details.
-* `string_not_like` - (Optional) Filters resources that do not match a pattern. See [below](#string_not_like-configuration-block) for details.
+* `string_equals` - (Optional) Filters the values of your tagged resources for only those resources that you tagged with the same value. Also called "exact matching". See [below](#string_equals-configuration-block) for details.
+* `string_not_equals` - (Optional) Filters the values of your tagged resources for only those resources that you tagged that do not have the same value. Also called "negated matching". See [below](#string_not_equals-configuration-block) for details.
+* `string_like` - (Optional) Filters the values of your tagged resources for matching tag values with the use of a wildcard character (`*`) anywhere in the string. For example, `prod*` or `*rod*` matches the tag value `production`. See [below](#string_like-configuration-block) for details.
+* `string_not_like` - (Optional) Filters the values of your tagged resources for non-matching tag values with the use of a wildcard character (`*`) anywhere in the string. See [below](#string_not_like-configuration-block) for details.
 
 ### string_equals Configuration Block
 

--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -133,16 +133,55 @@ This resource supports the following arguments:
 * `name` - (Required) The display name of a resource selection document.
 * `plan_id` - (Required) The backup plan ID to be associated with the selection of resources.
 * `iam_role_arn` - (Required) The ARN of the IAM role that AWS Backup uses to authenticate when restoring and backing up the target resource. See the [AWS Backup Developer Guide](https://docs.aws.amazon.com/aws-backup/latest/devguide/access-control.html#managed-policies) for additional information about using AWS managed policies or creating custom policies attached to the IAM role.
-* `selection_tag` - (Optional) Tag-based conditions used to specify a set of resources to assign to a backup plan.
-* `condition` - (Optional) A list of conditions that you define to assign resources to your backup plans using tags.
+* `selection_tag` - (Optional) Tag-based conditions used to specify a set of resources to assign to a backup plan. See [below](#selection_tag-configuration-block) for details.
+* `condition` - (Optional) Condition-based filters used to specify sets of resources for a backup plan. See [below](#condition-configuration-block) for details.
 * `resources` - (Optional) An array of strings that either contain Amazon Resource Names (ARNs) or match patterns of resources to assign to a backup plan.
 * `not_resources` - (Optional) An array of strings that either contain Amazon Resource Names (ARNs) or match patterns of resources to exclude from a backup plan.
 
-Tag conditions (`selection_tag`) support the following:
+### selection_tag Configuration Block
 
-* `type` - (Required) An operation, such as `STRINGEQUALS`, that is applied to a key-value pair used to filter resources in a selection.
-* `key` - (Required) The key in a key-value pair.
-* `value` - (Required) The value in a key-value pair.
+The `selection_tag` configuration block supports the following attributes:
+
+* `type` - (Required) An operation, such as `STRINGEQUALS`, that is applied to the key-value pair used to filter resources in a selection.
+* `key` - (Required) Key for the filter.
+* `value` - (Required) Value for the filter.
+
+### condition Configuration Block
+
+The `condition` configuration block supports the following attributes:
+
+* `string_equals` - (Optional) Filters resources that exactly match. See [below](#string_equals-configuration-block) for details.
+* `string_not_equals` - (Optional) Filters resources that do not exactly match. See [below](#string_not_equals-configuration-block) for details.
+* `string_like` - (Optional) Filters resources that match a pattern. See [below](#string_like-configuration-block) for details.
+* `string_not_like` - (Optional) Filters resources that do not match a pattern. See [below](#string_not_like-configuration-block) for details.
+
+### string_equals Configuration Block
+
+The `string_equals` configuration block supports the following attributes:
+
+* `key` - (Required) Key for the filter.
+* `value` - (Required) Value for the filter.
+
+### string_not_equals Configuration Block
+
+The `string_not_equals` configuration block supports the following attributes:
+
+* `key` - (Required) Key for the filter.
+* `value` - (Required) Value for the filter.
+
+### string_like Configuration Block
+
+The `string_like` configuration block supports the following attributes:
+
+* `key` - (Required) Key for the filter.
+* `value` - (Required) Value for the filter.
+
+### string_not_like Configuration Block
+
+The `string_not_like` configuration block supports the following attributes:
+
+* `key` - (Required) Key for the filter.
+* `value` - (Required)  Value for the filter.
 
 ## Attribute Reference
 

--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -133,8 +133,8 @@ This resource supports the following arguments:
 * `name` - (Required) The display name of a resource selection document.
 * `plan_id` - (Required) The backup plan ID to be associated with the selection of resources.
 * `iam_role_arn` - (Required) The ARN of the IAM role that AWS Backup uses to authenticate when restoring and backing up the target resource. See the [AWS Backup Developer Guide](https://docs.aws.amazon.com/aws-backup/latest/devguide/access-control.html#managed-policies) for additional information about using AWS managed policies or creating custom policies attached to the IAM role.
-* `selection_tag` - (Optional) Tag-based conditions used to specify a set of resources to assign to a backup plan. See [below](#selection_tag-configuration-block) for details.
-* `condition` - (Optional) Condition-based filters used to specify sets of resources for a backup plan. See [below](#condition-configuration-block) for details.
+* `selection_tag` - (Optional) Tag-based conditions used to specify a set of resources to assign to a backup plan. See [below](#selection_tag) for details.
+* `condition` - (Optional) Condition-based filters used to specify sets of resources for a backup plan. See [below](#condition) for details.
 * `resources` - (Optional) An array of strings that either contain Amazon Resource Names (ARNs) or match patterns of resources to assign to a backup plan.
 * `not_resources` - (Optional) An array of strings that either contain Amazon Resource Names (ARNs) or match patterns of resources to exclude from a backup plan.
 
@@ -150,10 +150,10 @@ The `selection_tag` configuration block supports the following attributes:
 
 The `condition` configuration block supports the following attributes:
 
-* `string_equals` - (Optional) Filters the values of your tagged resources for only those resources that you tagged with the same value. Also called "exact matching". See [below](#string_equals-configuration-block) for details.
-* `string_not_equals` - (Optional) Filters the values of your tagged resources for only those resources that you tagged that do not have the same value. Also called "negated matching". See [below](#string_not_equals-configuration-block) for details.
-* `string_like` - (Optional) Filters the values of your tagged resources for matching tag values with the use of a wildcard character (`*`) anywhere in the string. For example, `prod*` or `*rod*` matches the tag value `production`. See [below](#string_like-configuration-block) for details.
-* `string_not_like` - (Optional) Filters the values of your tagged resources for non-matching tag values with the use of a wildcard character (`*`) anywhere in the string. See [below](#string_not_like-configuration-block) for details.
+* `string_equals` - (Optional) Filters the values of your tagged resources for only those resources that you tagged with the same value. Also called "exact matching". See [below](#string_equals) for details.
+* `string_not_equals` - (Optional) Filters the values of your tagged resources for only those resources that you tagged that do not have the same value. Also called "negated matching". See [below](#string_not_equals) for details.
+* `string_like` - (Optional) Filters the values of your tagged resources for matching tag values with the use of a wildcard character (`*`) anywhere in the string. For example, `prod*` or `*rod*` matches the tag value `production`. See [below](#string_like) for details.
+* `string_not_like` - (Optional) Filters the values of your tagged resources for non-matching tag values with the use of a wildcard character (`*`) anywhere in the string. See [below](#string_not_like) for details.
 
 ### string_equals
 

--- a/website/docs/r/backup_selection.html.markdown
+++ b/website/docs/r/backup_selection.html.markdown
@@ -138,7 +138,7 @@ This resource supports the following arguments:
 * `resources` - (Optional) An array of strings that either contain Amazon Resource Names (ARNs) or match patterns of resources to assign to a backup plan.
 * `not_resources` - (Optional) An array of strings that either contain Amazon Resource Names (ARNs) or match patterns of resources to exclude from a backup plan.
 
-### selection_tag Configuration Block
+### selection_tag
 
 The `selection_tag` configuration block supports the following attributes:
 
@@ -146,7 +146,7 @@ The `selection_tag` configuration block supports the following attributes:
 * `key` - (Required) Key for the filter.
 * `value` - (Required) Value for the filter.
 
-### condition Configuration Block
+### condition
 
 The `condition` configuration block supports the following attributes:
 
@@ -155,28 +155,28 @@ The `condition` configuration block supports the following attributes:
 * `string_like` - (Optional) Filters the values of your tagged resources for matching tag values with the use of a wildcard character (`*`) anywhere in the string. For example, `prod*` or `*rod*` matches the tag value `production`. See [below](#string_like-configuration-block) for details.
 * `string_not_like` - (Optional) Filters the values of your tagged resources for non-matching tag values with the use of a wildcard character (`*`) anywhere in the string. See [below](#string_not_like-configuration-block) for details.
 
-### string_equals Configuration Block
+### string_equals
 
 The `string_equals` configuration block supports the following attributes:
 
 * `key` - (Required) Key for the filter.
 * `value` - (Required) Value for the filter.
 
-### string_not_equals Configuration Block
+### string_not_equals
 
 The `string_not_equals` configuration block supports the following attributes:
 
 * `key` - (Required) Key for the filter.
 * `value` - (Required) Value for the filter.
 
-### string_like Configuration Block
+### string_like
 
 The `string_like` configuration block supports the following attributes:
 
 * `key` - (Required) Key for the filter.
 * `value` - (Required) Value for the filter.
 
-### string_not_like Configuration Block
+### string_not_like
 
 The `string_not_like` configuration block supports the following attributes:
 


### PR DESCRIPTION
### Description

The documentation for the resource [`aws_backup_selection`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_selection) is missing details for the two configuration blocks
- [`selection_tag`](https://github.com/hashicorp/terraform-provider-aws/blob/d205660dcd528f389d3e5190d0f0df30a2021066/internal/service/backup/selection.go#L155)
- [`condition`](https://github.com/hashicorp/terraform-provider-aws/blob/d205660dcd528f389d3e5190d0f0df30a2021066/internal/service/backup/selection.go#L51)

The pull request adds basic details for both configuration blocks.

### Relations

- Relates #41191 
- Relates #41274 

### References

- [AWS Backup API Docs Conditions](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_Conditions.html)
- [AWS Backup API Docs BackupSelection](https://docs.aws.amazon.com/aws-backup/latest/devguide/API_BackupSelection.html)

### Output from Acceptance Testing

Not required. Only documentation is updated.
