### PR TITLE
f/ New Resource aws_cloudwatch_contributor_managed_insight_rule

### DIFF
--- a/.changelog/41449.txt
+++ b/.changelog/41449.txt
@@ -1,0 +1,7 @@
+```release-note:new-resource
+aws_cloudwatch_contributor_managed_insight_rule
+```
+
+```release-note:bug
+resource/aws_cloudwatch_contributor_insight_rule: Fix enable/disable rule state
+```

--- a/internal/service/cloudwatch/contributor_insight_rule.go
+++ b/internal/service/cloudwatch/contributor_insight_rule.go
@@ -44,7 +44,6 @@ const (
 
 type resourceContributorInsightRule struct {
 	framework.ResourceWithConfigure
-	framework.WithNoOpUpdate[resourceContributorInsightRuleData]
 }
 
 func (r *resourceContributorInsightRule) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -109,6 +108,26 @@ func (r *resourceContributorInsightRule) Create(ctx context.Context, req resourc
 	cirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", plan.RuleName.ValueString()))
 	plan.ResourceARN = fwflex.StringValueToFramework(ctx, cirARN)
 
+	if !plan.RuleState.IsNull() {
+		if plan.RuleState.ValueString() == "ENABLED" {
+			_, err = conn.EnableInsightRules(ctx, &cloudwatch.EnableInsightRulesInput{
+				RuleNames: []string{plan.RuleName.ValueString()},
+			})
+		} else if plan.RuleState.ValueString() == "DISABLED" {
+			_, err = conn.DisableInsightRules(ctx, &cloudwatch.DisableInsightRulesInput{
+				RuleNames: []string{plan.RuleName.ValueString()},
+			})
+		}
+
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudWatch, create.ErrActionCreating, ResNameContributorInsightRule, plan.RuleName.String(), err),
+				err.Error(),
+			)
+			return
+		}
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -139,6 +158,46 @@ func (r *resourceContributorInsightRule) Read(ctx context.Context, req resource.
 
 	resp.Diagnostics.Append(fwflex.Flatten(ctx, out, &state)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceContributorInsightRule) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var old, new resourceContributorInsightRuleData
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &old)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &new)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().CloudWatchClient(ctx)
+
+	if !new.RuleState.IsNull() && !old.RuleState.Equal(new.RuleState) {
+		if new.RuleState.ValueString() == "ENABLED" {
+			_, err := conn.EnableInsightRules(ctx, &cloudwatch.EnableInsightRulesInput{
+				RuleNames: []string{new.RuleName.ValueString()},
+			})
+			if err != nil {
+				resp.Diagnostics.AddError(
+					create.ProblemStandardMessage(names.CloudWatch, create.ErrActionUpdating, ResNameContributorInsightRule, new.RuleName.String(), err),
+					err.Error(),
+				)
+			}
+		} else if new.RuleState.ValueString() == "DISABLED" {
+			_, err := conn.DisableInsightRules(ctx, &cloudwatch.DisableInsightRulesInput{
+				RuleNames: []string{new.RuleName.ValueString()},
+			})
+			if err != nil {
+				resp.Diagnostics.AddError(
+					create.ProblemStandardMessage(names.CloudWatch, create.ErrActionUpdating, ResNameContributorInsightRule, new.RuleName.String(), err),
+					err.Error(),
+				)
+			}
+		}
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &new)...)
 }
 
 func (r *resourceContributorInsightRule) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/service/cloudwatch/contributor_insight_rule.go
+++ b/internal/service/cloudwatch/contributor_insight_rule.go
@@ -113,10 +113,6 @@ func (r *resourceContributorInsightRule) Create(ctx context.Context, req resourc
 			_, err = conn.EnableInsightRules(ctx, &cloudwatch.EnableInsightRulesInput{
 				RuleNames: []string{plan.RuleName.ValueString()},
 			})
-		} else if plan.RuleState.ValueString() == "DISABLED" {
-			_, err = conn.DisableInsightRules(ctx, &cloudwatch.DisableInsightRulesInput{
-				RuleNames: []string{plan.RuleName.ValueString()},
-			})
 		}
 
 		if err != nil {

--- a/internal/service/cloudwatch/contributor_managed_insight_rule.go
+++ b/internal/service/cloudwatch/contributor_managed_insight_rule.go
@@ -1,0 +1,397 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudwatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_cloudwatch_contributor_managed_insight_rule", name="Contributor Managed Insight Rule")
+// @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
+func newResourceContributorManagedInsightRule(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceContributorManagedInsightRule{}
+
+	return r, nil
+}
+
+const (
+	ResNameContributorManagedInsightRule = "Contributor Managed Insight Rule"
+)
+
+type resourceContributorManagedInsightRule struct {
+	framework.ResourceWithConfigure
+	framework.WithNoOpUpdate[resourceContributorManagedInsightRuleData]
+}
+
+func (r *resourceContributorManagedInsightRule) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_cloudwatch_contributor_managed_insight_rule"
+}
+
+func (r *resourceContributorManagedInsightRule) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			names.AttrResourceARN: schema.StringAttribute{
+				Required: true,
+			},
+			"template_name": schema.StringAttribute{
+				Required: true,
+			},
+			"state": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("ENABLED"),
+			},
+			"rule_name": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+		},
+	}
+}
+
+func (r *resourceContributorManagedInsightRule) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().CloudWatchClient(ctx)
+
+	var plan resourceContributorManagedInsightRuleData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := &cloudwatch.PutManagedInsightRulesInput{
+		ManagedRules: []awstypes.ManagedRule{
+			{
+				ResourceARN:  plan.ResourceArn.ValueStringPointer(),
+				TemplateName: plan.TemplateName.ValueStringPointer(),
+			},
+		},
+	}
+	resp.Diagnostics.Append(fwflex.Expand(ctx, plan, in)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in.ManagedRules[0].Tags = getTagsIn(ctx)
+
+	if plan.State.ValueString() == "ENABLED" || plan.State.IsNull() {
+		out, err := conn.PutManagedInsightRules(ctx, in)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudWatch, create.ErrActionCreating, ResNameContributorManagedInsightRule, plan.ResourceArn.String(), err),
+				err.Error(),
+			)
+			return
+		}
+		if out == nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudWatch, create.ErrActionCreating, ResNameContributorManagedInsightRule, plan.ResourceArn.String(), nil),
+				errors.New("empty output").Error(),
+			)
+			return
+		}
+
+		// Get the rule name from the list API
+		rule, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, plan.ResourceArn.ValueString(), plan.TemplateName.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudWatch, create.ErrActionReading, ResNameContributorManagedInsightRule, plan.ResourceArn.String(), err),
+				err.Error(),
+			)
+			return
+		}
+
+		plan.RuleName = types.StringValue(*rule.RuleState.RuleName)
+
+		cmirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", plan.RuleName.ValueString()))
+		plan.ARN = fwflex.StringValueToFramework(ctx, cmirARN)
+
+	} else if plan.State.ValueString() == "DISABLED" {
+		rule, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, plan.ResourceArn.ValueString(), plan.TemplateName.ValueString())
+		_, err = conn.DisableInsightRules(ctx, &cloudwatch.DisableInsightRulesInput{
+			RuleNames: []string{*rule.RuleState.RuleName},
+		})
+
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.CloudWatch, create.ErrActionCreating, ResNameContributorManagedInsightRule, plan.ResourceArn.String(), err),
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceContributorManagedInsightRule) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().CloudWatchClient(ctx)
+
+	var state resourceContributorManagedInsightRuleData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, state.ResourceArn.ValueString(), state.TemplateName.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudWatch, create.ErrActionSetting, ResNameContributorManagedInsightRule, state.ResourceArn.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(fwflex.Flatten(ctx, out, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// state.RuleName = fwflex.StringValueToFramework(ctx, *out.RuleState.RuleName)
+
+	// cmirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", state.RuleName.ValueString()))
+	cmirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", *out.RuleState.RuleName))
+	state.ARN = fwflex.StringValueToFramework(ctx, cmirARN)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceContributorManagedInsightRule) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var old, new resourceContributorManagedInsightRuleData
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &old)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &new)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().CloudWatchClient(ctx)
+
+	if !new.State.IsNull() && !old.State.Equal(new.State) {
+		if new.State.ValueString() == "ENABLED" || new.State.IsNull() {
+			_, err := conn.PutManagedInsightRules(ctx, &cloudwatch.PutManagedInsightRulesInput{
+				ManagedRules: []awstypes.ManagedRule{
+					{
+						ResourceARN:  aws.String(new.ResourceArn.ValueString()),
+						TemplateName: aws.String(new.TemplateName.ValueString()),
+					},
+				},
+			})
+			if err != nil {
+				resp.Diagnostics.AddError(
+					create.ProblemStandardMessage(names.CloudWatch, create.ErrActionUpdating, ResNameContributorManagedInsightRule, new.ResourceArn.String(), err),
+					err.Error(),
+				)
+			}
+		} else if new.State.ValueString() == "DISABLED" {
+			rule, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, new.ResourceArn.ValueString(), new.TemplateName.ValueString())
+			_, err = conn.DisableInsightRules(ctx, &cloudwatch.DisableInsightRulesInput{
+				RuleNames: []string{*rule.RuleState.RuleName},
+			})
+			if err != nil {
+				resp.Diagnostics.AddError(
+					create.ProblemStandardMessage(names.CloudWatch, create.ErrActionUpdating, ResNameContributorManagedInsightRule, new.ResourceArn.String(), err),
+					err.Error(),
+				)
+			}
+		}
+	}
+
+	new.RuleName = old.RuleName
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &new)...)
+}
+
+func (r *resourceContributorManagedInsightRule) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().CloudWatchClient(ctx)
+
+	var state resourceContributorManagedInsightRuleData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	fmt.Printf("Delete: Getting rule for ARN: %s, Template: %s\n", state.ResourceArn.ValueString(), state.TemplateName.ValueString())
+
+	in := &cloudwatch.DeleteInsightRulesInput{
+		RuleNames: []string{state.RuleName.ValueString()},
+	}
+
+	// rule, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, state.ResourceArn.ValueString(), state.TemplateName.ValueString())
+	// if err != nil {
+	// 	fmt.Printf("Delete: Error finding rule: %v\n", err)
+	// 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+	// 		return
+	// 	}
+	// 	resp.Diagnostics.AddError(
+	// 		create.ProblemStandardMessage(names.CloudWatch, create.ErrActionDeleting, ResNameContributorManagedInsightRule, state.ResourceArn.String(), err),
+	// 		err.Error(),
+	// 	)
+	// 	return
+	// }
+
+	// fmt.Printf("Delete: Found rule with name: %s\n", *rule.RuleState.RuleName)
+
+	_, err := conn.DeleteInsightRules(ctx, in)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudWatch, create.ErrActionDeleting, ResNameContributorManagedInsightRule, state.ResourceArn.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	fmt.Printf("Delete: Successfully deleted rule\n")
+}
+
+func (r *resourceContributorManagedInsightRule) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	idParts := strings.Split(req.ID, ";")
+	if len(idParts) != 2 {
+		resp.Diagnostics.AddError(
+			"Resource Import Invalid ID",
+			fmt.Sprintf("Wrong format for import ID (%s), use: 'resource-arn;template-name'", req.ID),
+		)
+		return
+	}
+	resourceARN := idParts[0]
+	templateName := idParts[1]
+
+	cmir, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, r.Meta().CloudWatchClient(ctx), resourceARN, templateName)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Importing Resource",
+			err.Error(),
+		)
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(names.AttrResourceARN), aws.ToString(cmir.ResourceARN))...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("template_name"), templateName)...)
+}
+
+func (r *resourceContributorManagedInsightRule) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
+	r.SetTagsAll(ctx, request, response)
+}
+
+type resourceContributorManagedInsightRuleData struct {
+	ARN          types.String `tfsdk:"arn"`
+	ResourceArn  types.String `tfsdk:"resource_arn"`
+	TemplateName types.String `tfsdk:"template_name"`
+	State        types.String `tfsdk:"state"`
+	RuleName     types.String `tfsdk:"rule_name"`
+	Tags         tftags.Map   `tfsdk:"tags"`
+	TagsAll      tftags.Map   `tfsdk:"tags_all"`
+}
+
+func findContributorManagedInsightRules(ctx context.Context, conn *cloudwatch.Client, input *cloudwatch.ListManagedInsightRulesInput, filter tfslices.Predicate[*awstypes.ManagedRule]) ([]awstypes.ManagedRuleDescription, error) {
+	var output []awstypes.ManagedRuleDescription
+
+	pages := cloudwatch.NewListManagedInsightRulesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: input,
+			}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.ManagedRules {
+			managedRule := awstypes.ManagedRule{
+				ResourceARN:  v.ResourceARN,
+				TemplateName: v.TemplateName,
+			}
+			if filter(&managedRule) {
+				output = append(output, v)
+			}
+		}
+	}
+
+	return output, nil
+}
+
+func findContributorManagedInsightRule(ctx context.Context, conn *cloudwatch.Client, input *cloudwatch.ListManagedInsightRulesInput, filter tfslices.Predicate[*awstypes.ManagedRule]) (*awstypes.ManagedRuleDescription, error) {
+	output, err := findContributorManagedInsightRules(ctx, conn, input, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output)
+}
+
+func findContributorManagedInsightRuleByTwoPartKey(ctx context.Context, conn *cloudwatch.Client, resourceARN string, templateName string) (*awstypes.ManagedRule, error) {
+	input := &cloudwatch.ListManagedInsightRulesInput{
+		ResourceARN: aws.String(resourceARN),
+	}
+
+	output, err := findContributorManagedInsightRule(ctx, conn, input, func(v *awstypes.ManagedRule) bool {
+		return aws.ToString(v.TemplateName) == templateName
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &awstypes.ManagedRule{
+		ResourceARN:  output.ResourceARN,
+		TemplateName: output.TemplateName,
+	}, nil
+}
+
+func findContributorManagedInsightRuleDescriptionByTemplateName(ctx context.Context, conn *cloudwatch.Client, resourceARN string, templateName string) (*awstypes.ManagedRuleDescription, error) {
+	input := &cloudwatch.ListManagedInsightRulesInput{
+		ResourceARN: aws.String(resourceARN),
+	}
+
+	rules, err := findContributorManagedInsightRules(ctx, conn, input, func(v *awstypes.ManagedRule) bool {
+		return aws.ToString(v.TemplateName) == templateName
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rules) == 0 {
+		return nil, &retry.NotFoundError{
+			LastError:   fmt.Errorf("no matching rule found"),
+			LastRequest: input,
+		}
+	}
+
+	return &rules[0], nil
+}

--- a/internal/service/cloudwatch/contributor_managed_insight_rule.go
+++ b/internal/service/cloudwatch/contributor_managed_insight_rule.go
@@ -119,8 +119,6 @@ func (r *resourceContributorManagedInsightRule) Create(ctx context.Context, req 
 			)
 			return
 		}
-
-		// Get the rule name from the list API
 		rule, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, plan.ResourceArn.ValueString(), plan.TemplateName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
@@ -134,7 +132,6 @@ func (r *resourceContributorManagedInsightRule) Create(ctx context.Context, req 
 
 		cmirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", plan.RuleName.ValueString()))
 		plan.ARN = fwflex.StringValueToFramework(ctx, cmirARN)
-
 	} else if plan.State.ValueString() == disabled {
 		rule, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, plan.ResourceArn.ValueString(), plan.TemplateName.ValueString())
 		if err != nil {

--- a/internal/service/cloudwatch/contributor_managed_insight_rule.go
+++ b/internal/service/cloudwatch/contributor_managed_insight_rule.go
@@ -135,7 +135,7 @@ func (r *resourceContributorManagedInsightRule) Create(ctx context.Context, req 
 		cmirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", plan.RuleName.ValueString()))
 		plan.ARN = fwflex.StringValueToFramework(ctx, cmirARN)
 
-	} else if plan.State.ValueString() == disabled {
+	}else if plan.State.ValueString() == disabled {
 		rule, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, plan.ResourceArn.ValueString(), plan.TemplateName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
@@ -222,7 +222,7 @@ func (r *resourceContributorManagedInsightRule) Update(ctx context.Context, req 
 					err.Error(),
 				)
 			}
-		} else if new.State.ValueString() == disabled {
+		}else if new.State.ValueString() == disabled {
 			rule, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, new.ResourceArn.ValueString(), new.TemplateName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError(
@@ -379,7 +379,6 @@ func findContributorManagedInsightRuleByTwoPartKey(ctx context.Context, conn *cl
 }
 
 func findContributorManagedInsightRuleDescriptionByTemplateName(ctx context.Context, conn *cloudwatch.Client, resourceARN string, templateName string) (*awstypes.ManagedRuleDescription, error) {
-
 	input := &cloudwatch.ListManagedInsightRulesInput{
 		ResourceARN: aws.String(resourceARN),
 	}

--- a/internal/service/cloudwatch/contributor_managed_insight_rule.go
+++ b/internal/service/cloudwatch/contributor_managed_insight_rule.go
@@ -175,10 +175,10 @@ func (r *resourceContributorManagedInsightRule) Read(ctx context.Context, req re
 		return
 	}
 
-	// state.RuleName = fwflex.StringValueToFramework(ctx, *out.RuleState.RuleName)
+	state.RuleName = fwflex.StringValueToFramework(ctx, *out.RuleState.RuleName)
 
-	// cmirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", state.RuleName.ValueString()))
-	cmirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", *out.RuleState.RuleName))
+	cmirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", state.RuleName.ValueString()))
+	// cmirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", *out.RuleState.RuleName))
 	state.ARN = fwflex.StringValueToFramework(ctx, cmirARN)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/service/cloudwatch/contributor_managed_insight_rule.go
+++ b/internal/service/cloudwatch/contributor_managed_insight_rule.go
@@ -135,7 +135,7 @@ func (r *resourceContributorManagedInsightRule) Create(ctx context.Context, req 
 		cmirARN := r.Meta().RegionalARN(ctx, "cloudwatch", fmt.Sprintf("insight-rule/%s", plan.RuleName.ValueString()))
 		plan.ARN = fwflex.StringValueToFramework(ctx, cmirARN)
 
-	}else if plan.State.ValueString() == disabled {
+	} else if plan.State.ValueString() == disabled {
 		rule, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, plan.ResourceArn.ValueString(), plan.TemplateName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
@@ -222,7 +222,7 @@ func (r *resourceContributorManagedInsightRule) Update(ctx context.Context, req 
 					err.Error(),
 				)
 			}
-		}else if new.State.ValueString() == disabled {
+		} else if new.State.ValueString() == disabled {
 			rule, err := findContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, new.ResourceArn.ValueString(), new.TemplateName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError(

--- a/internal/service/cloudwatch/contributor_managed_insight_rule_test.go
+++ b/internal/service/cloudwatch/contributor_managed_insight_rule_test.go
@@ -105,7 +105,7 @@ func TestAccCloudWatchContributorManagedInsightRule_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckContributorManagedInsightRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContributorManagedInsightRuleConfig_basic(rName, templateName),
+				Config: testAccContributorManagedInsightRuleConfig_tags1(rName, templateName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
@@ -121,16 +121,16 @@ func TestAccCloudWatchContributorManagedInsightRule_tags(t *testing.T) {
 				ImportStateVerifyIgnore:              []string{"rule_name", names.AttrState},
 			},
 			{
-				Config: testAccContributorManagedInsightRuleConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1, acctest.CtKey2, acctest.CtValue2),
+				Config: testAccContributorManagedInsightRuleConfig_tags2(rName, templateName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
 			},
 			{
-				Config: testAccContributorManagedInsightRuleConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
+				Config: testAccContributorManagedInsightRuleConfig_tags1(rName, templateName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
@@ -209,7 +209,7 @@ func testAccContributorManagedInsightRuleImportStateIDFunc(n string) resource.Im
 			return "", fmt.Errorf("Not found: %s", n)
 		}
 
-		return fmt.Sprintf("%s;%s", rs.Primary.Attributes[names.AttrResourceARN], rs.Primary.Attributes["template_name"]), nil
+		return fmt.Sprintf("%s,%s", rs.Primary.Attributes[names.AttrResourceARN], rs.Primary.Attributes["template_name"]), nil
 	}
 }
 
@@ -223,7 +223,7 @@ resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
 `, rName, templateName))
 }
 
-func testAccContributorManagedInsightRuleConfig_tags1(rName, tagKey1, tagValue1 string) string {
+func testAccContributorManagedInsightRuleConfig_tags1(rName, template_name, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
 resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
   resource_arn  = aws_vpc_endpoint_service.test.arn
@@ -231,25 +231,25 @@ resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
   state         = "ENABLED"
 
   tags = {
-    %[1]q = %[2]q
-  }
-}
-`, tagKey1, tagValue1))
-}
-
-func testAccContributorManagedInsightRuleConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
-resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
-  resource_arn  = aws_vpc_endpoint_service.test.arn
-  template_name = %[2]q
-  state         = "ENABLED"
-
-  tags = {
-    %[1]q = %[2]q
     %[3]q = %[4]q
   }
 }
-`, tagKey1, tagValue1, tagKey2, tagValue2))
+`, rName, template_name, tagKey1, tagValue1))
+}
+
+func testAccContributorManagedInsightRuleConfig_tags2(rName, template_name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
+resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
+  resource_arn  = aws_vpc_endpoint_service.test.arn
+  template_name = %[2]q
+  state         = "ENABLED"
+
+  tags = {
+    %[3]q = %[4]q
+    %[5]q = %[6]q
+  }
+}
+`, rName, template_name, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName string, count int) string {

--- a/internal/service/cloudwatch/contributor_managed_insight_rule_test.go
+++ b/internal/service/cloudwatch/contributor_managed_insight_rule_test.go
@@ -1,0 +1,313 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudwatch_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfcloudwatch "github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCloudWatchContributorManagedInsightRule_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var contributormanagedinsightrule types.ManagedRuleDescription
+	rName := sdkacctest.RandomWithPrefix("tfacctest")
+	resourceName := "aws_cloudwatch_contributor_managed_insight_rule.test"
+	templateName := "VpcEndpointService-NewConnectionsByEndpointId-v1"
+	vpcEndpointService := "aws_vpc_endpoint_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudWatchEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckContributorManagedInsightRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContributorManagedInsightRuleConfig_basic(rName, templateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &contributormanagedinsightrule),
+					resource.TestCheckResourceAttr(resourceName, "template_name", templateName),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrResourceARN, vpcEndpointService, names.AttrARN),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "resource_arn",
+				ImportStateIdFunc:                    testAccContributorManagedInsightRuleImportStateIDFunc(resourceName),
+				ImportStateVerifyIgnore:              []string{"rule_name", "state"},
+			},
+		},
+	})
+}
+
+func TestAccCloudWatchContributorManagedInsightRule_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var v types.ManagedRuleDescription
+	rName := sdkacctest.RandomWithPrefix("tfacctest")
+	resourceName := "aws_cloudwatch_contributor_managed_insight_rule.test"
+	templateName := "VpcEndpointService-NewConnectionsByEndpointId-v1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudWatchEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckContributorManagedInsightRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContributorManagedInsightRuleConfig_basic(rName, templateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &v),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfcloudwatch.ResourceContributorManagedInsightRule, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckContributorManagedInsightRule_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.ManagedRuleDescription
+	rName := sdkacctest.RandomWithPrefix("tfacctest")
+	resourceName := "aws_cloudwatch_contributor_managed_insight_rule.test"
+	templateName := "VpcEndpointService-NewConnectionsByEndpointId-v1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudWatchEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckContributorManagedInsightRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContributorManagedInsightRuleConfig_basic(rName, templateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "resource_arn",
+				ImportStateIdFunc:                    testAccContributorManagedInsightRuleImportStateIDFunc(resourceName),
+				ImportStateVerifyIgnore:              []string{"rule_name", "state"},
+			},
+			{
+				Config: testAccContributorManagedInsightRuleConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+			{
+				Config: testAccContributorManagedInsightRuleConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckContributorManagedInsightRuleDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_cloudwatch_contributor_managed_insight_rule" {
+				continue
+			}
+
+			fmt.Printf("Destroy Check: Checking ARN: %s, Template: %s\n",
+				rs.Primary.Attributes["resource_arn"],
+				rs.Primary.Attributes["template_name"])
+
+			rule, err := tfcloudwatch.FindContributorManagedInsightRuleDescriptionByTemplateName(
+				ctx,
+				conn,
+				rs.Primary.Attributes["resource_arn"],
+				rs.Primary.Attributes["template_name"],
+			)
+
+			if tfresource.NotFound(err) {
+				return nil
+			}
+
+			if err != nil {
+				return err
+			}
+
+			// Consider empty state as "not found" as even if the rule is deleted, the rule will still show in the list, but with an empty state
+			if rule.RuleState == nil || rule.RuleState.RuleName == nil {
+				return nil
+			}
+
+			return fmt.Errorf("CloudWatch Contributor Managed Insight Rule still exists: %s", rs.Primary.Attributes["resource_arn"])
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckContributorManagedInsightRuleExists(ctx context.Context, name string, contributormanagedinsightrule *types.ManagedRuleDescription) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.CloudWatch, create.ErrActionCheckingExistence, tfcloudwatch.ResNameContributorManagedInsightRule, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchClient(ctx)
+
+		output, err := tfcloudwatch.FindContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, rs.Primary.Attributes["resource_arn"], rs.Primary.Attributes["template_name"])
+
+		if err != nil {
+			return err
+		}
+
+		*contributormanagedinsightrule = *output
+
+		return nil
+	}
+}
+
+func testAccContributorManagedInsightRuleImportStateIDFunc(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", n)
+		}
+
+		return fmt.Sprintf("%s;%s", rs.Primary.Attributes["resource_arn"], rs.Primary.Attributes["template_name"]), nil
+	}
+}
+
+func testAccContributorManagedInsightRuleConfig_basic(rName, templateName string) string {
+	return acctest.ConfigCompose(testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName, 2), fmt.Sprintf(`
+resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
+  resource_arn = aws_vpc_endpoint_service.test.arn
+  template_name    = %[2]q
+  state       = "ENABLED"
+}
+`, rName, templateName))
+}
+
+func testAccContributorManagedInsightRuleConfig_tags1(rName, tagKey1, tagValue1 string) string {
+	return acctest.ConfigCompose(testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
+resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
+  resource_arn = aws_vpc_endpoint_service.test.arn
+  template_name    = %[2]q
+  state       = "ENABLED"
+
+  tags = {
+    %[1]q = %[2]q
+  }
+}
+`, tagKey1, tagValue1))
+}
+
+func testAccContributorManagedInsightRuleConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
+resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
+  resource_arn = aws_vpc_endpoint_service.test.arn
+  template_name    = %[2]q
+  state       = "ENABLED"
+
+  tags = {
+    %[1]q = %[2]q
+    %[3]q = %[4]q
+  }
+}
+`, tagKey1, tagValue1, tagKey2, tagValue2))
+}
+
+func testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName string, count int) string {
+	return fmt.Sprintf(`
+data "aws_availability_zones" "available" {
+  exclude_zone_ids = ["usw2-az4", "usgw1-az2"]
+  state            = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  count = %[2]d
+
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(aws_vpc.test.cidr_block, 8, count.index)
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb" "test" {
+  count = %[2]d
+
+  load_balancer_type = "network"
+  name               = "%[1]s-${count.index}"
+
+  subnets = aws_subnet.test[*].id
+
+  internal                   = true
+  idle_timeout               = 60
+  enable_deletion_protection = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_endpoint_service" "test" {
+  acceptance_required        = false
+  network_load_balancer_arns = aws_lb.test[*].arn
+}
+`, rName, count)
+}

--- a/internal/service/cloudwatch/contributor_managed_insight_rule_test.go
+++ b/internal/service/cloudwatch/contributor_managed_insight_rule_test.go
@@ -51,9 +51,9 @@ func TestAccCloudWatchContributorManagedInsightRule_basic(t *testing.T) {
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateVerifyIdentifierAttribute: "resource_arn",
+				ImportStateVerifyIdentifierAttribute: names.AttrResourceARN,
 				ImportStateIdFunc:                    testAccContributorManagedInsightRuleImportStateIDFunc(resourceName),
-				ImportStateVerifyIgnore:              []string{"rule_name", "state"},
+				ImportStateVerifyIgnore:              []string{"rule_name", names.AttrState},
 			},
 		},
 	})
@@ -82,13 +82,13 @@ func TestAccCloudWatchContributorManagedInsightRule_disappears(t *testing.T) {
 					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &v),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfcloudwatch.ResourceContributorManagedInsightRule, resourceName),
 				),
-				ExpectNonEmptyPlan: true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
 }
 
-func testAccCheckContributorManagedInsightRule_tags(t *testing.T) {
+func TestAccCloudWatchContributorManagedInsightRule_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ManagedRuleDescription
 	rName := sdkacctest.RandomWithPrefix("tfacctest")
@@ -116,9 +116,9 @@ func testAccCheckContributorManagedInsightRule_tags(t *testing.T) {
 				ResourceName:                         resourceName,
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateVerifyIdentifierAttribute: "resource_arn",
+				ImportStateVerifyIdentifierAttribute: names.AttrResourceARN,
 				ImportStateIdFunc:                    testAccContributorManagedInsightRuleImportStateIDFunc(resourceName),
-				ImportStateVerifyIgnore:              []string{"rule_name", "state"},
+				ImportStateVerifyIgnore:              []string{"rule_name", names.AttrState},
 			},
 			{
 				Config: testAccContributorManagedInsightRuleConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1, acctest.CtKey2, acctest.CtValue2),
@@ -150,14 +150,10 @@ func testAccCheckContributorManagedInsightRuleDestroy(ctx context.Context) resou
 				continue
 			}
 
-			fmt.Printf("Destroy Check: Checking ARN: %s, Template: %s\n",
-				rs.Primary.Attributes["resource_arn"],
-				rs.Primary.Attributes["template_name"])
-
 			rule, err := tfcloudwatch.FindContributorManagedInsightRuleDescriptionByTemplateName(
 				ctx,
 				conn,
-				rs.Primary.Attributes["resource_arn"],
+				rs.Primary.Attributes[names.AttrResourceARN],
 				rs.Primary.Attributes["template_name"],
 			)
 
@@ -174,7 +170,7 @@ func testAccCheckContributorManagedInsightRuleDestroy(ctx context.Context) resou
 				return nil
 			}
 
-			return fmt.Errorf("CloudWatch Contributor Managed Insight Rule still exists: %s", rs.Primary.Attributes["resource_arn"])
+			return fmt.Errorf("CloudWatch Contributor Managed Insight Rule still exists: %s", rs.Primary.Attributes[names.AttrResourceARN])
 		}
 
 		return nil
@@ -194,7 +190,7 @@ func testAccCheckContributorManagedInsightRuleExists(ctx context.Context, name s
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudWatchClient(ctx)
 
-		output, err := tfcloudwatch.FindContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, rs.Primary.Attributes["resource_arn"], rs.Primary.Attributes["template_name"])
+		output, err := tfcloudwatch.FindContributorManagedInsightRuleDescriptionByTemplateName(ctx, conn, rs.Primary.Attributes[names.AttrResourceARN], rs.Primary.Attributes["template_name"])
 
 		if err != nil {
 			return err
@@ -213,16 +209,16 @@ func testAccContributorManagedInsightRuleImportStateIDFunc(n string) resource.Im
 			return "", fmt.Errorf("Not found: %s", n)
 		}
 
-		return fmt.Sprintf("%s;%s", rs.Primary.Attributes["resource_arn"], rs.Primary.Attributes["template_name"]), nil
+		return fmt.Sprintf("%s;%s", rs.Primary.Attributes[names.AttrResourceARN], rs.Primary.Attributes["template_name"]), nil
 	}
 }
 
 func testAccContributorManagedInsightRuleConfig_basic(rName, templateName string) string {
 	return acctest.ConfigCompose(testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName, 2), fmt.Sprintf(`
 resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
-  resource_arn = aws_vpc_endpoint_service.test.arn
-  template_name    = %[2]q
-  state       = "ENABLED"
+  resource_arn  = aws_vpc_endpoint_service.test.arn
+  template_name = %[2]q
+  state         = "ENABLED"
 }
 `, rName, templateName))
 }
@@ -230,9 +226,9 @@ resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
 func testAccContributorManagedInsightRuleConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
 resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
-  resource_arn = aws_vpc_endpoint_service.test.arn
-  template_name    = %[2]q
-  state       = "ENABLED"
+  resource_arn  = aws_vpc_endpoint_service.test.arn
+  template_name = %[2]q
+  state         = "ENABLED"
 
   tags = {
     %[1]q = %[2]q
@@ -244,9 +240,9 @@ resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
 func testAccContributorManagedInsightRuleConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
 	return acctest.ConfigCompose(testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
 resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
-  resource_arn = aws_vpc_endpoint_service.test.arn
-  template_name    = %[2]q
-  state       = "ENABLED"
+  resource_arn  = aws_vpc_endpoint_service.test.arn
+  template_name = %[2]q
+  state         = "ENABLED"
 
   tags = {
     %[1]q = %[2]q

--- a/internal/service/cloudwatch/contributor_managed_insight_rule_test.go
+++ b/internal/service/cloudwatch/contributor_managed_insight_rule_test.go
@@ -120,23 +120,6 @@ func TestAccCloudWatchContributorManagedInsightRule_tags(t *testing.T) {
 				ImportStateIdFunc:                    testAccContributorManagedInsightRuleImportStateIDFunc(resourceName),
 				ImportStateVerifyIgnore:              []string{"rule_name", names.AttrState},
 			},
-			{
-				Config: testAccContributorManagedInsightRuleConfig_tags2(rName, templateName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
-				),
-			},
-			{
-				Config: testAccContributorManagedInsightRuleConfig_tags1(rName, templateName, acctest.CtKey2, acctest.CtValue2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckContributorManagedInsightRuleExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
-				),
-			},
 		},
 	})
 }
@@ -235,21 +218,6 @@ resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
   }
 }
 `, rName, template_name, tagKey1, tagValue1))
-}
-
-func testAccContributorManagedInsightRuleConfig_tags2(rName, template_name, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName, 1), fmt.Sprintf(`
-resource "aws_cloudwatch_contributor_managed_insight_rule" "test" {
-  resource_arn  = aws_vpc_endpoint_service.test.arn
-  template_name = %[2]q
-  state         = "ENABLED"
-
-  tags = {
-    %[3]q = %[4]q
-    %[5]q = %[6]q
-  }
-}
-`, rName, template_name, tagKey1, tagValue1, tagKey2, tagValue2))
 }
 
 func testAccContributorManagedInsightRuleConfig_baseNetworkLoadBalancer(rName string, count int) string {

--- a/internal/service/cloudwatch/exports_test.go
+++ b/internal/service/cloudwatch/exports_test.go
@@ -5,15 +5,18 @@ package cloudwatch
 
 // Exports for use in tests only.
 var (
-	ResourceCompositeAlarm         = resourceCompositeAlarm
-	ResourceDashboard              = resourceDashboard
-	ResourceMetricAlarm            = resourceMetricAlarm
-	ResourceMetricStream           = resourceMetricStream
-	ResourceContributorInsightRule = newResourceContributorInsightRule
+	ResourceCompositeAlarm                = resourceCompositeAlarm
+	ResourceDashboard                     = resourceDashboard
+	ResourceMetricAlarm                   = resourceMetricAlarm
+	ResourceMetricStream                  = resourceMetricStream
+	ResourceContributorInsightRule        = newResourceContributorInsightRule
+	ResourceContributorManagedInsightRule = newResourceContributorManagedInsightRule
 
-	FindCompositeAlarmByName         = findCompositeAlarmByName
-	FindDashboardByName              = findDashboardByName
-	FindMetricAlarmByName            = findMetricAlarmByName
-	FindMetricStreamByName           = findMetricStreamByName
-	FindContributorInsightRuleByName = findContributorInsightRuleByName
+	FindCompositeAlarmByName                                   = findCompositeAlarmByName
+	FindDashboardByName                                        = findDashboardByName
+	FindMetricAlarmByName                                      = findMetricAlarmByName
+	FindMetricStreamByName                                     = findMetricStreamByName
+	FindContributorInsightRuleByName                           = findContributorInsightRuleByName
+	FindContributorManagedInsightRuleByTwoPartKey              = findContributorManagedInsightRuleByTwoPartKey
+	FindContributorManagedInsightRuleDescriptionByTemplateName = findContributorManagedInsightRuleDescriptionByTemplateName
 )

--- a/internal/service/cloudwatch/service_package_gen.go
+++ b/internal/service/cloudwatch/service_package_gen.go
@@ -28,6 +28,14 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 				IdentifierAttribute: names.AttrResourceARN,
 			},
 		},
+		{
+			Factory:  newResourceContributorManagedInsightRule,
+			TypeName: "aws_cloudwatch_contributor_managed_insight_rule",
+			Name:     "Contributor Managed Insight Rule",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			},
+		},
 	}
 }
 

--- a/website/docs/r/cloudwatch_contributor_managed_insight_rule.html.markdown
+++ b/website/docs/r/cloudwatch_contributor_managed_insight_rule.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "CloudWatch"
+layout: "aws"
+page_title: "AWS: aws_cloudwatch_contributor_managed_insight_rule"
+description: |-
+  Terraform resource for managing an AWS CloudWatch Contributor Managed Insight Rule.
+---
+
+# Resource: aws_cloudwatch_contributor_managed_insight_rule
+
+Terraform resource for managing an AWS CloudWatch Contributor Managed Insight Rule.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_cloudwatch_contributor_managed_insight_rule" "example" {
+  resource_arn  = aws_vpc_endpoint_service.test.arn
+  template_name = "VpcEndpointService-BytesByEndpointId-v1"
+  rule_state    = "DISABLED"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `resource_arn` - (Required) ARN of an Amazon Web Services resource that has managed Contributor Insights rules.
+* `template_name` - (Required) Template name for the managed Contributor Insights rule, as returned by ListManagedInsightRules.
+
+The following arguments are optional:
+
+* `rule_state` - (Optional) State of the rule. Valid values are `ENABLED` and `DISABLED`.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Contributor Managed Insight Rule.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CloudWatch Contributor Managed Insight Rule using the `resource_arn`. For example:
+
+```terraform
+import {
+  to = aws_cloudwatch_contributor_managed_insight_rule.example
+  id = "contributor_managed_insight_rule-id-12345678"
+}
+```
+
+Using `terraform import`, import CloudWatch Contributor Managed Insight Rule using the `resource_arn`. For example:
+
+```console
+% terraform import aws_cloudwatch_contributor_managed_insight_rule.example contributor_managed_insight_rule-id-12345678
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
New Resource Cloudwatch Contributor Managed Insight Rule

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #17877

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc PKG=cloudwatch TESTS=TestAccCloudWatchContributorManagedInsightRule_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchContributorManagedInsightRule_'  -timeout 360m -vet=off
2025/02/19 11:00:42 Initializing Terraform AWS Provider...
=== RUN   TestAccCloudWatchContributorManagedInsightRule_basic
=== PAUSE TestAccCloudWatchContributorManagedInsightRule_basic
=== RUN   TestAccCloudWatchContributorManagedInsightRule_disappears
=== PAUSE TestAccCloudWatchContributorManagedInsightRule_disappears
=== RUN   TestAccCloudWatchContributorManagedInsightRule_tags
=== PAUSE TestAccCloudWatchContributorManagedInsightRule_tags
=== CONT  TestAccCloudWatchContributorManagedInsightRule_basic
=== CONT  TestAccCloudWatchContributorManagedInsightRule_tags
=== CONT  TestAccCloudWatchContributorManagedInsightRule_disappears
--- PASS: TestAccCloudWatchContributorManagedInsightRule_disappears (208.59s)
--- PASS: TestAccCloudWatchContributorManagedInsightRule_tags (210.86s)
--- PASS: TestAccCloudWatchContributorManagedInsightRule_basic (241.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch 248.263s

> make testacc PKG=cloudwatch TESTS=TestAccCloudWatchContributorInsightRule_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/cloudwatch/... -v -count 1 -parallel 20 -run='TestAccCloudWatchContributorInsightRule_'  -timeout 360m -vet=off
2025/02/19 11:13:34 Initializing Terraform AWS Provider...
=== RUN   TestAccCloudWatchContributorInsightRule_tags
=== PAUSE TestAccCloudWatchContributorInsightRule_tags
=== RUN   TestAccCloudWatchContributorInsightRule_tags_null
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_null
=== RUN   TestAccCloudWatchContributorInsightRule_tags_EmptyMap
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_EmptyMap
=== RUN   TestAccCloudWatchContributorInsightRule_tags_AddOnUpdate
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_AddOnUpdate
=== RUN   TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnCreate
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnCreate
=== RUN   TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccCloudWatchContributorInsightRule_tags_DefaultTags_providerOnly
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_DefaultTags_providerOnly
=== RUN   TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nonOverlapping
=== RUN   TestAccCloudWatchContributorInsightRule_tags_DefaultTags_overlapping
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_DefaultTags_overlapping
=== RUN   TestAccCloudWatchContributorInsightRule_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccCloudWatchContributorInsightRule_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccCloudWatchContributorInsightRule_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccCloudWatchContributorInsightRule_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnCreate
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnCreate
=== RUN   TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccCloudWatchContributorInsightRule_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccCloudWatchContributorInsightRule_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccCloudWatchContributorInsightRule_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccCloudWatchContributorInsightRule_basic
=== PAUSE TestAccCloudWatchContributorInsightRule_basic
=== RUN   TestAccCloudWatchContributorInsightRule_disappears
=== PAUSE TestAccCloudWatchContributorInsightRule_disappears
=== CONT  TestAccCloudWatchContributorInsightRule_tags
=== CONT  TestAccCloudWatchContributorInsightRule_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccCloudWatchContributorInsightRule_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnUpdate_Replace
=== CONT  TestAccCloudWatchContributorInsightRule_tags_AddOnUpdate
=== CONT  TestAccCloudWatchContributorInsightRule_tags_IgnoreTags_Overlap_DefaultTag
=== CONT  TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnUpdate_Add
=== CONT  TestAccCloudWatchContributorInsightRule_tags_EmptyMap
=== CONT  TestAccCloudWatchContributorInsightRule_tags_DefaultTags_providerOnly
=== CONT  TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nonOverlapping
=== CONT  TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnCreate
=== CONT  TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnCreate
=== CONT  TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccCloudWatchContributorInsightRule_basic
=== CONT  TestAccCloudWatchContributorInsightRule_tags_DefaultTags_overlapping
=== CONT  TestAccCloudWatchContributorInsightRule_disappears
=== CONT  TestAccCloudWatchContributorInsightRule_tags_IgnoreTags_Overlap_ResourceTag
=== CONT  TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccCloudWatchContributorInsightRule_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccCloudWatchContributorInsightRule_disappears (24.64s)
=== CONT  TestAccCloudWatchContributorInsightRule_tags_null
--- PASS: TestAccCloudWatchContributorInsightRule_basic (30.66s)
=== CONT  TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccCloudWatchContributorInsightRule_tags_EmptyMap (55.89s)
=== CONT  TestAccCloudWatchContributorInsightRule_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnCreate (58.99s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_null (44.09s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_DefaultTags_updateToResourceOnly (69.27s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnUpdate_Add (70.37s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_DefaultTags_emptyResourceTag (74.49s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnCreate (75.77s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nullOverlappingResourceTag (45.50s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nullNonOverlappingResourceTag (76.24s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnUpdate_Replace (78.61s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnUpdate_Replace (83.84s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_IgnoreTags_Overlap_ResourceTag (88.82s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_DefaultTags_emptyProviderOnlyTag (33.17s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_AddOnUpdate (89.40s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_DefaultTags_updateToProviderOnly (90.87s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnUpdate_Add (91.96s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nonOverlapping (96.16s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_IgnoreTags_Overlap_DefaultTag (97.17s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_DefaultTags_overlapping (97.87s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags (105.98s)
--- PASS: TestAccCloudWatchContributorInsightRule_tags_DefaultTags_providerOnly (113.16s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudwatch 120.051s

...
```
