### PR TITLE
r/aws_s3_bucket_lifecycle_configuration: remove `expired_object_delete_marker` plan modifier

### DIFF
--- a/.changelog/41462.txt
+++ b/.changelog/41462.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_service_thing: A warning diagnostic has been added for configurations where `rule.exipration.expired_object_delete_marker` is set with either `rule.exipration.date` or `rule.exipration.days`. While historically the provider allowed this invalid configuration, the migration of this resource to the Terraform Plugin Framework in `v5.86.0` resulted in this misconfiguration surfacing as a hard `inconsistent result after apply` error. This diagnostic aims to direct users how to resolve the issue at plan time. See [this issue comment](https://github.com/hashicorp/terraform-provider-aws/issues/41277#issuecomment-2654728812) for additional context.
+```

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -166,9 +165,6 @@ func (r *resourceBucketLifecycleConfiguration) Schema(ctx context.Context, reque
 									"expired_object_delete_marker": schema.BoolAttribute{
 										Optional: true,
 										Computed: true,
-										PlanModifiers: []planmodifier.Bool{
-											boolplanmodifier.UseStateForUnknown(),
-										},
 									},
 								},
 							},

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -165,6 +166,12 @@ func (r *resourceBucketLifecycleConfiguration) Schema(ctx context.Context, reque
 									"expired_object_delete_marker": schema.BoolAttribute{
 										Optional: true,
 										Computed: true,
+										Validators: []validator.Bool{
+											warnIfSetWith(
+												path.MatchRelative().AtParent().AtName("date"),
+												path.MatchRelative().AtParent().AtName("days"),
+											),
+										},
 									},
 								},
 							},
@@ -1066,4 +1073,79 @@ func (m transitionDefaultMinimumObjectSizeDefaultModifier) PlanModifyString(ctx 
 		return
 	}
 	resp.PlanValue = v
+}
+
+var (
+	_ validator.Bool = warnIfSetWithValidator{}
+)
+
+func warnIfSetWith(expressions ...path.Expression) validator.Bool {
+	return warnIfSetWithValidator{
+		PathExpressions: expressions,
+	}
+}
+
+type warnIfSetWithValidator struct {
+	PathExpressions path.Expressions
+}
+
+func (v warnIfSetWithValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v warnIfSetWithValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("Ensure that if an attribute is set, a warning is emitted if any of these are also set: %q", v.PathExpressions)
+}
+
+// Validation logic is adapted from the standard ConflictsWith validator
+// available for all types
+func (v warnIfSetWithValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	// If attribute configuration is null, it cannot conflict with others
+	// If attribute configuration is unknown, delay the validation until it is known.
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	expressions := req.PathExpression.MergeExpressions(v.PathExpressions...)
+
+	for _, expression := range expressions {
+		matchedPaths, diags := req.Config.PathMatches(ctx, expression)
+
+		resp.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(req.Path) {
+				continue
+			}
+
+			var mpVal attr.Value
+			diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+			resp.Diagnostics.Append(diags...)
+
+			// Collect all errors
+			if diags.HasError() {
+				continue
+			}
+
+			// Delay validation until all involved attribute have a known value
+			if mpVal.IsUnknown() {
+				return
+			}
+
+			if !mpVal.IsNull() {
+				resp.Diagnostics.Append(diag.NewAttributeWarningDiagnostic(
+					req.Path,
+					"Invalid Attribute Combination",
+					fmt.Sprintf("Attribute %q should not be specified when %q is also specified", req.Path, mp),
+				))
+			}
+		}
+	}
 }

--- a/internal/service/s3/bucket_lifecycle_configuration_migrate_v0_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_migrate_v0_test.go
@@ -125,13 +125,13 @@ func TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_basic(t *testing
 							}),
 						})),
 						// This is checking the change _after_ the state migration step happens
-						tfplancheck.ExpectKnownValueChange(resourceName, tfjsonpath.New(names.AttrRule).AtSliceIndex(0).AtMapKey(names.AttrFilter),
-							checkFilter_Prefix(""),
-							checkFilter_None(),
-						),
 						tfplancheck.ExpectKnownValueChange(resourceName, tfjsonpath.New(names.AttrRule).AtSliceIndex(0).AtMapKey("expiration"),
 							checkExpiration_Days(365),
 							checkExpiration_DaysAfterMigration(365),
+						),
+						tfplancheck.ExpectKnownValueChange(resourceName, tfjsonpath.New(names.AttrRule).AtSliceIndex(0).AtMapKey(names.AttrFilter),
+							checkFilter_Prefix(""),
+							checkFilter_None(),
 						),
 					},
 					PostApplyPreRefresh: []plancheck.PlanCheck{

--- a/internal/service/s3/bucket_lifecycle_configuration_migrate_v0_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_migrate_v0_test.go
@@ -116,20 +116,22 @@ func TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_basic(t *testing
 						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRule), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"abort_incomplete_multipart_upload": checkAbortIncompleteMultipartUpload_None(),
-								"expiration":                        checkExpiration_Days(365),
-								// names.AttrFilter:
-								names.AttrID:                    knownvalue.StringExact(rName),
-								"noncurrent_version_expiration": checkNoncurrentVersionExpiration_None(),
-								"noncurrent_version_transition": checkNoncurrentVersionTransitions(),
-								names.AttrPrefix:                knownvalue.StringExact(""),
-								names.AttrStatus:                knownvalue.StringExact(tfs3.LifecycleRuleStatusEnabled),
-								"transition":                    checkTransitions(),
+								names.AttrID:                        knownvalue.StringExact(rName),
+								"noncurrent_version_expiration":     checkNoncurrentVersionExpiration_None(),
+								"noncurrent_version_transition":     checkNoncurrentVersionTransitions(),
+								names.AttrPrefix:                    knownvalue.StringExact(""),
+								names.AttrStatus:                    knownvalue.StringExact(tfs3.LifecycleRuleStatusEnabled),
+								"transition":                        checkTransitions(),
 							}),
 						})),
 						// This is checking the change _after_ the state migration step happens
 						tfplancheck.ExpectKnownValueChange(resourceName, tfjsonpath.New(names.AttrRule).AtSliceIndex(0).AtMapKey(names.AttrFilter),
 							checkFilter_Prefix(""),
 							checkFilter_None(),
+						),
+						tfplancheck.ExpectKnownValueChange(resourceName, tfjsonpath.New(names.AttrRule).AtSliceIndex(0).AtMapKey("expiration"),
+							checkExpiration_Days(365),
+							checkExpiration_DaysAfterMigration(365),
 						),
 					},
 					PostApplyPreRefresh: []plancheck.PlanCheck{

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -1964,6 +1964,18 @@ func checkExpiration_Days(days int32) knownvalue.Check {
 	})
 }
 
+func checkExpiration_DaysAfterMigration(days int32) knownvalue.Check {
+	return knownvalue.ListExact([]knownvalue.Check{
+		knownvalue.ObjectExact(
+			map[string]knownvalue.Check{
+				"date": knownvalue.Null(),
+				"days": knownvalue.Int32Exact(days),
+				// "expired_object_delete_marker": knownvalue.Bool(false),
+			},
+		),
+	})
+}
+
 func checkExpiration_DeleteMarker(marker bool) knownvalue.Check {
 	checks := expirationDefaults()
 	maps.Copy(checks, map[string]knownvalue.Check{


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change should enable configurations with the `rule.exipration.expired_object_delete_maker` set alongside one of the other nested arguments (`date` or `days`) to remove the configured argument in order to resolve inconsistent result after apply errors. Previously, `expired_object_delete_marker` must have been explicitly set to `false` in order to resolve the issue.

Also introduces a warning diagnostic to provide additional context when arguments are provided together that may produce an `inconsistent result after apply` error. In practice the diagnostic will appear as follows.

```
│ Warning: Invalid Attribute Combination
│
│   with aws_s3_bucket_lifecycle_configuration.test,
│   on main.tf line 33, in resource "aws_s3_bucket_lifecycle_configuration" "test":
│   33:       expired_object_delete_marker = true
│
│ Attribute "rule[0].expiration[0].expired_object_delete_marker" should not be specified when "rule[0].expiration[0].days" is also specified
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #41126
Relates #41159
Relates #41277

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_LifecycleExpiration.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=s3 TESTS=TestAccS3BucketLifecycleConfiguration_ ACCTEST_PARALLELISM=10
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/s3/... -v -count 1 -parallel 10 -run='TestAccS3BucketLifecycleConfiguration_'  -timeout 360m -vet=off
2025/02/19 09:46:39 Initializing Terraform AWS Provider...

--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (45.32s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_expireMarkerOnly
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RulePrefix (98.53s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_And_Tags
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_nonCurrentVersionExpiration (107.94s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionDate
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionStorageClassOnly_intelligentTiering (110.64s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions_WithChange
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_FilterWithPrefix (117.73s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RulePrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_ruleAbortIncompleteMultipartUpload (126.12s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_emptyBlock
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_basic (126.67s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions_WithChange (136.66s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_Tag
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_nonCurrentVersionExpiration (136.81s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionStorageClassOnly_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions (147.88s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRange
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_expireMarkerOnly (107.25s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionZeroDays_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_And_Tags (71.87s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRangeAndPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions (74.22s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionDate (93.15s)
=== CONT  TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions_WithChange (96.42s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RulePrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionStorageClassOnly_intelligentTiering (77.10s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_basic
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_Tag (80.41s)
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_emptyBlock (92.54s)
=== CONT  TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRange (70.97s)
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RulePrefix (102.19s)
=== CONT  TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionZeroDays_intelligentTiering (71.37s)
=== CONT  TestAccS3BucketLifecycleConfiguration_directoryBucket
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRangeAndPrefix (69.08s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (41.24s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_RulePrefix (51.12s)
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_withChange
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (41.39s)
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_noChange
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (41.18s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules
--- PASS: TestAccS3BucketLifecycleConfiguration_directoryBucket (42.99s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (78.21s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disableRule
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (40.65s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_basic (69.08s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update (77.73s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove (79.19s)
=== CONT  TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (40.64s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_withChange (48.76s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_noChange (49.11s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (40.86s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRange
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (75.07s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionDate
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (43.37s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_Tag
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (42.70s)
=== CONT  TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (42.59s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_Tags
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (42.19s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (43.35s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (78.46s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRangeAndPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix (41.83s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionDate (69.40s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_expireMarkerOnly
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (41.97s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (42.92s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_emptyBlock
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (117.15s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRange (96.53s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_filterWithEmptyPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (129.69s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disappears
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_Tag (93.47s)
=== CONT  TestAccS3BucketLifecycleConfiguration_filterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (41.83s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_Tags (91.97s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_FilterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (39.17s)
=== CONT  TestAccS3BucketLifecycleConfiguration_basic
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_expireMarkerOnly (72.50s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_ruleAbortIncompleteMultipartUpload
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRangeAndPrefix (91.95s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_emptyBlock (74.66s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeGreaterThan (95.97s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionZeroDays_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (43.20s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeLessThan (100.62s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_filterWithEmptyPrefix (93.93s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (81.38s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (79.60s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_FilterWithPrefix (89.24s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_ruleAbortIncompleteMultipartUpload (68.55s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeLessThan (70.30s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeGreaterThan (74.09s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionZeroDays_intelligentTiering (87.45s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 581.313s
```