### PR TITLE
fix (sagemaker): increase mlflowTrackingServerTimeout

### DIFF
--- a/.changelog/41463.txt
+++ b/.changelog/41463.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sagemaker_mlflow_tracking_server: Increased the timeout from 30 to 45 minutes
+```

--- a/internal/service/sagemaker/wait.go
+++ b/internal/service/sagemaker/wait.go
@@ -42,7 +42,7 @@ const (
 	spaceInServiceTimeout              = 10 * time.Minute
 	monitoringScheduleScheduledTimeout = 2 * time.Minute
 	monitoringScheduleStoppedTimeout   = 2 * time.Minute
-	mlflowTrackingServerTimeout        = 30 * time.Minute
+	mlflowTrackingServerTimeout        = 45 * time.Minute
 	hubTimeout                         = 10 * time.Minute
 
 	notebookInstanceStatusNotFound = "NotFound"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

As mentioned in issue #41436 , the 30-minute timeout is not always sufficient for creating an MLflow tracking server.. This PR increases the timeout to 45 minutes. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41436

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
The `mlflowTrackingServerTimeout` is being used by the [`waitMlflowTrackingServerCreated`](waitMlflowTrackingServerCreated), [`waitMlflowTrackingServerUpdated`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/sagemaker/wait.go#L653) and [`waitMlflowTrackingServerDeleted`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/sagemaker/wait.go#L670C6-L670C37) functions. 

<!--
### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.


```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
-->