### PR TITLE
fix: update an attribute name aws_appflow_flow

### DIFF
--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -987,7 +987,7 @@ func resourceFlow() *schema.Resource {
 													MaxItems: 1,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
-															"max_page_size": {
+															"max_parallelism": {
 																Type:         schema.TypeInt,
 																Required:     true,
 																ValidateFunc: validation.IntBetween(1, 10),

--- a/website/docs/r/appflow_flow.html.markdown
+++ b/website/docs/r/appflow_flow.html.markdown
@@ -328,7 +328,7 @@ Amplitude, Datadog, Dynatrace, Google Analytics, Infor Nexus, Marketo, ServiceNo
 * `pagination_config` - (Optional) Sets the page size for each concurrent process that transfers OData records from your SAP instance.
     * `max_page_size` - (Optional) he maximum number of records that Amazon AppFlow receives in each page of the response from your SAP application.
 * `parallelism_config` - (Optional) Sets the number of concurrent processes that transfers OData records from your SAP instance.
-    * `max_parallelism` - (Optional) The maximum number of processes that Amazon AppFlow runs at the same time when it retrieves your data from your SAP application.
+    * `max_parallelism` - (Optional) The maximum number of processes that Amazon AppFlow runs at the same time when it retrieves your data from your SAP application. Valid range is `1` to `10`.
 
 ##### Veeva Source Properties
 


### PR DESCRIPTION
### Description

According to the [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appflow_flow#max_parallelism-2), the resource `aws_appflow_flow` contains under `source_flow_config` -> `source_connector_properties` -> `sapo_data` ->  `parallelism_config` the key `max_parallelism`.

Actually, in the [source code](https://github.com/hashicorp/terraform-provider-aws/blob/3388ab65edb92190f3db84ddb2a5b181dc8822b6/internal/service/appflow/flow.go#L990) the key is named `max_page_size`. 

The correct name of the key is `max_parallelism`

### Relations

Closes #41431 

### References

- [AWS Go SDK v2 reference](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/appflow@v1.45.17/types#SAPODataParallelismConfig)

### Output from Acceptance Testing

TODO