### PR TITLE
F AWS Q Business Index resource

### DIFF
--- a/internal/service/qbusiness/exports_test.go
+++ b/internal/service/qbusiness/exports_test.go
@@ -5,6 +5,8 @@ package qbusiness
 
 var (
 	ResourceApplication = newResourceApplication
+	ResourceIndex       = newResourceIndex
 
 	FindApplicationByID = findApplicationByID
+	FindIndexByID       = findIndexByID
 )

--- a/internal/service/qbusiness/index.go
+++ b/internal/service/qbusiness/index.go
@@ -1,0 +1,531 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package qbusiness
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/qbusiness"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/qbusiness/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_qbusiness_index", name="Index")
+// @Tags(identifierAttribute="arn")
+func newResourceIndex(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceIndex{}
+
+	r.SetDefaultCreateTimeout(30 * time.Minute)
+	r.SetDefaultDeleteTimeout(30 * time.Minute)
+	r.SetDefaultUpdateTimeout(30 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameIndex = "Index"
+)
+
+type resourceIndex struct {
+	framework.ResourceWithConfigure
+	framework.WithImportByID
+	framework.WithTimeouts
+}
+
+func (r *resourceIndex) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrApplicationID: schema.StringAttribute{
+				Description: "Identifier of the Amazon Q application associated with the index",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexache.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{35}$`), "must be a valid application ID"),
+				},
+			},
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			names.AttrDescription: schema.StringAttribute{
+				Description: "A description of the Amazon Q application.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(0, 1000),
+					stringvalidator.RegexMatches(regexache.MustCompile(`^\P{C}*$`), "must not contain control characters"),
+				},
+			},
+			names.AttrDisplayName: schema.StringAttribute{
+				Description: "The display name of the Amazon Q application.",
+				Required:    true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 1000),
+					stringvalidator.RegexMatches(regexache.MustCompile(`^\P{C}*$`), "must not contain control characters"),
+				},
+			},
+			names.AttrID: framework.IDAttribute(),
+			"index_id": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			"capacity_configuration": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[capacityConfigurationData](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+					listvalidator.IsRequired(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"units": schema.Int64Attribute{
+							Required:    true,
+							Description: "The number of additional storage units for the Amazon Q index.",
+							Validators: []validator.Int64{
+								int64validator.AtLeast(1),
+							},
+						},
+					},
+				},
+			},
+			"document_attribute_configuration": schema.SetNestedBlock{
+				CustomType: fwtypes.NewSetNestedObjectTypeOf[documentAttributeConfigurationData](ctx),
+				Validators: []validator.Set{
+					setvalidator.SizeAtMost(500),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrName: schema.StringAttribute{
+							Required:    true,
+							Description: "The name of the document attribute.",
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 2048),
+							},
+						},
+						"search": schema.StringAttribute{
+							Required:    true,
+							Description: "Information about whether the document attribute can be used by an end user to search for information on their web experience.",
+							Validators: []validator.String{
+								enum.FrameworkValidate[awstypes.Status](),
+							},
+						},
+						names.AttrType: schema.StringAttribute{
+							Required:    true,
+							Description: "The type of document attribute.",
+							Validators: []validator.String{
+								enum.FrameworkValidate[awstypes.AttributeType](),
+							},
+						},
+					},
+				},
+			},
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Delete: true,
+				Update: true,
+			}),
+		},
+	}
+}
+
+func (r *resourceIndex) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data resourceIndexData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().QBusinessClient(ctx)
+
+	input := &qbusiness.CreateIndexInput{}
+	resp.Diagnostics.Append(fwflex.Expand(ctx, data, input)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	input.Tags = getTagsIn(ctx)
+	input.ClientToken = aws.String(id.UniqueId())
+
+	out, err := conn.CreateIndex(ctx, input)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionCreating, ResNameIndex, data.DisplayName.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	data.IndexId = fwflex.StringToFramework(ctx, out.IndexId)
+	data.IndexArn = fwflex.StringToFramework(ctx, out.IndexArn)
+
+	resp.Diagnostics.Append(data.setID()...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.State.SetAttribute(ctx, path.Root(names.AttrID), data.ID.String())
+
+	if _, err := waitIndexActive(ctx, conn, data.ID.ValueString(), r.CreateTimeout(ctx, data.Timeouts)); err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionWaitingForCreation, ResNameIndex, data.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	update := &qbusiness.UpdateIndexInput{}
+
+	resp.Diagnostics.Append(fwflex.Expand(ctx, data, update)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if len(update.DocumentAttributeConfigurations) > 0 {
+		_, err = conn.UpdateIndex(ctx, update)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.QBusiness, create.ErrActionCreating, ResNameIndex, data.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+
+		if _, err := waitIndexActive(ctx, conn, data.ID.ValueString(), r.UpdateTimeout(ctx, data.Timeouts)); err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.QBusiness, create.ErrActionWaitingForCreation, ResNameIndex, data.ID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *resourceIndex) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data resourceIndexData
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().QBusinessClient(ctx)
+
+	if err := data.initFromID(); err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionDeleting, ResNameIndex, data.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	indexId := data.IndexId.ValueString()
+	appId := data.ApplicationId.ValueString()
+
+	input := &qbusiness.DeleteIndexInput{
+		IndexId:       aws.String(indexId),
+		ApplicationId: aws.String(appId),
+	}
+
+	_, err := conn.DeleteIndex(ctx, input)
+
+	if err != nil {
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionDeleting, ResNameIndex, data.IndexId.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	if _, err := waitIndexDeleted(ctx, conn, data.ID.ValueString(), r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionWaitingForDeletion, ResNameIndex, data.IndexId.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceIndex) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "aws_qbusiness_index"
+}
+
+func (r *resourceIndex) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data resourceIndexData
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().QBusinessClient(ctx)
+
+	out, err := findIndexByID(ctx, conn, data.ID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionReading, ResNameIndex, data.ID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	out.DocumentAttributeConfigurations = filterDefaultDocumentAttributeConfigurations(out.DocumentAttributeConfigurations)
+
+	resp.Diagnostics.Append(fwflex.Flatten(ctx, out, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *resourceIndex) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var state, plan resourceIndexData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := plan.initFromID(); err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionUpdating, ResNameIndex, plan.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	if !state.CapacityConfiguration.Equal(plan.CapacityConfiguration) ||
+		!state.DisplayName.Equal(plan.DisplayName) ||
+		!state.Description.Equal(plan.Description) ||
+		!state.DocumentAttributeConfigurations.Equal(plan.DocumentAttributeConfigurations) {
+		conn := r.Meta().QBusinessClient(ctx)
+
+		input := &qbusiness.UpdateIndexInput{}
+
+		resp.Diagnostics.Append(fwflex.Expand(ctx, plan, input)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		_, err := conn.UpdateIndex(ctx, input)
+
+		id := plan.ID.ValueString()
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.QBusiness, create.ErrActionUpdating, ResNameIndex, id, err),
+				err.Error(),
+			)
+			return
+		}
+
+		if _, err := waitIndexActive(ctx, conn, id, r.UpdateTimeout(ctx, plan.Timeouts)); err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.QBusiness, create.ErrActionWaitingForUpdate, ResNameIndex, id, err),
+				err.Error(),
+			)
+			return
+		}
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceIndex) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
+	r.SetTagsAll(ctx, request, response)
+}
+
+type resourceIndexData struct {
+	ApplicationId                   types.String                                                       `tfsdk:"application_id"`
+	CapacityConfiguration           fwtypes.ListNestedObjectValueOf[capacityConfigurationData]         `tfsdk:"capacity_configuration"`
+	Description                     types.String                                                       `tfsdk:"description"`
+	DisplayName                     types.String                                                       `tfsdk:"display_name"`
+	DocumentAttributeConfigurations fwtypes.SetNestedObjectValueOf[documentAttributeConfigurationData] `tfsdk:"document_attribute_configuration"`
+	ID                              types.String                                                       `tfsdk:"id"`
+	IndexArn                        types.String                                                       `tfsdk:"arn"`
+	IndexId                         types.String                                                       `tfsdk:"index_id"`
+	Tags                            tftags.Map                                                         `tfsdk:"tags"`
+	TagsAll                         tftags.Map                                                         `tfsdk:"tags_all"`
+	Timeouts                        timeouts.Value                                                     `tfsdk:"timeouts"`
+}
+
+type capacityConfigurationData struct {
+	Units types.Int64 `tfsdk:"units"`
+}
+
+type documentAttributeConfigurationData struct {
+	Name   types.String                               `tfsdk:"name"`
+	Search fwtypes.StringEnum[awstypes.Status]        `tfsdk:"search"`
+	Type   fwtypes.StringEnum[awstypes.AttributeType] `tfsdk:"type"`
+}
+
+const (
+	indexResourceIDPartCount = 2
+)
+
+func (data *resourceIndexData) setID() diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	id, err := flex.FlattenResourceId([]string{data.ApplicationId.ValueString(), data.IndexId.ValueString()}, indexResourceIDPartCount, false)
+	if err != nil {
+		diags.AddError(
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionFlatteningResourceId, ResNameIndex, id, err),
+			err.Error())
+		return diags
+	}
+	data.ID = types.StringValue(id)
+	return diags
+}
+
+func (data *resourceIndexData) initFromID() error {
+	parts, err := flex.ExpandResourceId(data.ID.ValueString(), indexResourceIDPartCount, false)
+	if err != nil {
+		return err
+	}
+
+	data.ApplicationId = types.StringValue(parts[0])
+	data.IndexId = types.StringValue(parts[1])
+	return nil
+}
+
+func findIndexByID(ctx context.Context, conn *qbusiness.Client, index_id string) (*qbusiness.GetIndexOutput, error) {
+	parts, err := flex.ExpandResourceId(index_id, indexResourceIDPartCount, false)
+
+	if err != nil {
+		return nil, err
+	}
+
+	input := &qbusiness.GetIndexInput{
+		ApplicationId: aws.String(parts[0]),
+		IndexId:       aws.String(parts[1]),
+	}
+
+	output, err := conn.GetIndex(ctx, input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
+func filterDefaultDocumentAttributeConfigurations(conf []awstypes.DocumentAttributeConfiguration) []awstypes.DocumentAttributeConfiguration {
+	var attributes []awstypes.DocumentAttributeConfiguration
+	for _, attribute := range conf {
+		filter := false
+		if strings.HasPrefix(aws.ToString(attribute.Name), "_") {
+			filter = true
+		}
+		if aws.ToString(attribute.Name) == "_document_title" && attribute.Search == awstypes.StatusDisabled {
+			filter = false
+		}
+		if filter {
+			continue
+		}
+		attributes = append(attributes, attribute)
+	}
+	return attributes
+}
+
+func statusIndex(ctx context.Context, conn *qbusiness.Client, index_id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		output, err := findIndexByID(ctx, conn, index_id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.Status), nil
+	}
+}
+
+func waitIndexActive(ctx context.Context, conn *qbusiness.Client, index_id string, timeout time.Duration) (*qbusiness.GetIndexOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:    enum.Slice(awstypes.IndexStatusCreating, awstypes.IndexStatusUpdating),
+		Target:     enum.Slice(awstypes.IndexStatusActive),
+		Refresh:    statusIndex(ctx, conn, index_id),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*qbusiness.GetIndexOutput); ok {
+		tfresource.SetLastError(err, errors.New(string(output.Status)))
+
+		return output, err
+	}
+	return nil, err
+}
+
+func waitIndexDeleted(ctx context.Context, conn *qbusiness.Client, index_id string, timeout time.Duration) (*qbusiness.GetIndexOutput, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending:    enum.Slice(awstypes.IndexStatusActive, awstypes.IndexStatusDeleting),
+		Target:     []string{},
+		Refresh:    statusIndex(ctx, conn, index_id),
+		Timeout:    timeout,
+		MinTimeout: 10 * time.Second,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*qbusiness.GetIndexOutput); ok {
+		tfresource.SetLastError(err, errors.New(string(output.Status)))
+
+		return output, err
+	}
+	return nil, err
+}

--- a/internal/service/qbusiness/index.go
+++ b/internal/service/qbusiness/index.go
@@ -266,7 +266,7 @@ func (r *resourceIndex) Delete(ctx context.Context, req resource.DeleteRequest, 
 			return
 		}
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.QBusiness, create.ErrActionDeleting, ResNameIndex, data.IndexId.ValueString(), err),
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionDeleting, ResNameIndex, data.IndexId.String(), err),
 			err.Error(),
 		)
 		return
@@ -274,7 +274,7 @@ func (r *resourceIndex) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 	if _, err := waitIndexDeleted(ctx, conn, data.ID.ValueString(), r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.QBusiness, create.ErrActionWaitingForDeletion, ResNameIndex, data.IndexId.ValueString(), err),
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionWaitingForDeletion, ResNameIndex, data.IndexId.String(), err),
 			err.Error(),
 		)
 		return
@@ -302,7 +302,7 @@ func (r *resourceIndex) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 	if err != nil {
 		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.QBusiness, create.ErrActionReading, ResNameIndex, data.ID.ValueString(), err),
+			create.ProblemStandardMessage(names.QBusiness, create.ErrActionReading, ResNameIndex, data.ID.String(), err),
 			err.Error(),
 		)
 		return
@@ -349,7 +349,7 @@ func (r *resourceIndex) Update(ctx context.Context, req resource.UpdateRequest, 
 
 		_, err := conn.UpdateIndex(ctx, input)
 
-		id := plan.ID.ValueString()
+		id := plan.ID.String()
 		if err != nil {
 			resp.Diagnostics.AddError(
 				create.ProblemStandardMessage(names.QBusiness, create.ErrActionUpdating, ResNameIndex, id, err),

--- a/internal/service/qbusiness/index_test.go
+++ b/internal/service/qbusiness/index_test.go
@@ -27,13 +27,17 @@ func TestAccQBusinessIndex_basic(t *testing.T) {
 	description := names.AttrDescription
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIndex(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, "qbusiness"),
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckIndex(ctx, t)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.QBusinessServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIndexDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIndexConfig_basic(rName),
+				Config: testAccIndexConfig_basic(rName, description),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIndexExists(ctx, resourceName, &index),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrApplicationID),
@@ -57,15 +61,20 @@ func TestAccQBusinessIndex_disappears(t *testing.T) {
 	var index qbusiness.GetIndexOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_qbusiness_index.test"
+	description := names.AttrDescription
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIndex(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, "qbusiness"),
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckIndex(ctx, t)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.QBusinessServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIndexDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIndexConfig_basic(rName),
+				Config: testAccIndexConfig_basic(rName, description),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIndexExists(ctx, resourceName, &index),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfqbusiness.ResourceIndex, resourceName),
@@ -83,26 +92,42 @@ func TestAccQBusinessIndex_tags(t *testing.T) {
 	resourceName := "aws_qbusiness_index.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIndex(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, "qbusiness"),
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckIndex(ctx, t)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.QBusinessServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIndexDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIndexConfig_tags(rName, acctest.CtKey1, acctest.CtValue1, acctest.CtKey2, acctest.CtValue2),
+				Config: testAccIndexConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckIndexExists(ctx, resourceName, &index),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccIndexConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIndexExists(ctx, resourceName, &index),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
 			},
 			{
-				Config: testAccIndexConfig_tags(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, "value2updated"),
-				Check: resource.ComposeAggregateTestCheckFunc(
+				Config: testAccIndexConfig_tags1(rName, acctest.CtKey2, "value2updated"),
+				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIndexExists(ctx, resourceName, &index),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, "value2updated"),
 				),
 			},
@@ -115,12 +140,16 @@ func TestAccQBusinessIndex_documentAttributeConfigurations(t *testing.T) {
 	var index qbusiness.GetIndexOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_qbusiness_index.test"
-	attr1 := "foo1"
-	attr2 := "foo2"
+	attr1 := "attr_name_1"
+	attr2 := "attr_name_2"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIndex(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, "qbusiness"),
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckIndex(ctx, t)
+			acctest.PreCheckSSOAdminInstances(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.QBusinessServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckIndexDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -130,6 +159,11 @@ func TestAccQBusinessIndex_documentAttributeConfigurations(t *testing.T) {
 					testAccCheckIndexExists(ctx, resourceName, &index),
 					resource.TestCheckResourceAttr(resourceName, "document_attribute_configuration.#", "2"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccIndexConfig_documentAttributeConfigurations(rName, attr2, attr1),
@@ -206,23 +240,23 @@ func testAccCheckIndexExists(ctx context.Context, n string, v *qbusiness.GetInde
 	}
 }
 
-func testAccIndexConfig_basic(rName string) string {
+func testAccIndexConfig_basic(rName, description string) string {
 	return acctest.ConfigCompose(testAccApplicationConfig_basic(rName), fmt.Sprintf(`
 resource "aws_qbusiness_index" "test" {
-  application_id = aws_qbusiness_app.test.id
+  application_id = aws_qbusiness_application.test.id
   display_name   = %[1]q
   capacity_configuration {
     units = 1
   }
-  description = "Index name"
+  description = %[2]q
 }
-`, rName))
+`, rName, description))
 }
 
 func testAccIndexConfig_documentAttributeConfigurations(rName, attr1, attr2 string) string {
 	return acctest.ConfigCompose(testAccApplicationConfig_basic(rName), fmt.Sprintf(`
 resource "aws_qbusiness_index" "test" {
-  application_id = aws_qbusiness_app.test.id
+  application_id = aws_qbusiness_application.test.id
   display_name   = %[1]q
   capacity_configuration {
     units = 1
@@ -242,10 +276,27 @@ resource "aws_qbusiness_index" "test" {
 `, rName, attr1, attr2))
 }
 
-func testAccIndexConfig_tags(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+func testAccIndexConfig_tags1(rName, tagKey1, tagValue1 string) string {
 	return acctest.ConfigCompose(testAccApplicationConfig_basic(rName), fmt.Sprintf(`
 resource "aws_qbusiness_index" "test" {
-  application_id = aws_qbusiness_app.test.id
+  application_id = aws_qbusiness_application.test.id
+  display_name   = %[1]q
+  capacity_configuration {
+    units = 1
+  }
+  description = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+  }
+}
+`, rName, tagKey1, tagValue1))
+}
+
+func testAccIndexConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccApplicationConfig_basic(rName), fmt.Sprintf(`
+resource "aws_qbusiness_index" "test" {
+  application_id = aws_qbusiness_application.test.id
   display_name   = %[1]q
   capacity_configuration {
     units = 1

--- a/internal/service/qbusiness/index_test.go
+++ b/internal/service/qbusiness/index_test.go
@@ -1,0 +1,261 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package qbusiness_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/qbusiness"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfqbusiness "github.com/hashicorp/terraform-provider-aws/internal/service/qbusiness"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccQBusinessIndex_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var index qbusiness.GetIndexOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_qbusiness_index.test"
+	description := names.AttrDescription
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIndex(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, "qbusiness"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIndexDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIndexConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIndexExists(ctx, resourceName, &index),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrApplicationID),
+					resource.TestCheckResourceAttrSet(resourceName, "index_id"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDisplayName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
+					resource.TestCheckResourceAttr(resourceName, "capacity_configuration.0.units", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccQBusinessIndex_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var index qbusiness.GetIndexOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_qbusiness_index.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIndex(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, "qbusiness"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIndexDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIndexConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIndexExists(ctx, resourceName, &index),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfqbusiness.ResourceIndex, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccQBusinessIndex_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	var index qbusiness.GetIndexOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_qbusiness_index.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIndex(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, "qbusiness"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIndexDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIndexConfig_tags(rName, acctest.CtKey1, acctest.CtValue1, acctest.CtKey2, acctest.CtValue2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIndexExists(ctx, resourceName, &index),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
+				),
+			},
+			{
+				Config: testAccIndexConfig_tags(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, "value2updated"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIndexExists(ctx, resourceName, &index),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, "value2updated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccQBusinessIndex_documentAttributeConfigurations(t *testing.T) {
+	ctx := acctest.Context(t)
+	var index qbusiness.GetIndexOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_qbusiness_index.test"
+	attr1 := "foo1"
+	attr2 := "foo2"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIndex(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, "qbusiness"),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckIndexDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIndexConfig_documentAttributeConfigurations(rName, attr1, attr2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIndexExists(ctx, resourceName, &index),
+					resource.TestCheckResourceAttr(resourceName, "document_attribute_configuration.#", "2"),
+				),
+			},
+			{
+				Config: testAccIndexConfig_documentAttributeConfigurations(rName, attr2, attr1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIndexExists(ctx, resourceName, &index),
+				),
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
+		},
+	})
+}
+
+func testAccPreCheckIndex(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).QBusinessClient(ctx)
+
+	input := &qbusiness.ListApplicationsInput{}
+
+	_, err := conn.ListApplications(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccCheckIndexDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QBusinessClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_qbusiness_index" {
+				continue
+			}
+
+			_, err := tfqbusiness.FindIndexByID(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Amazon Q Index %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIndexExists(ctx context.Context, n string, v *qbusiness.GetIndexOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QBusinessClient(ctx)
+
+		output, err := tfqbusiness.FindIndexByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccIndexConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccApplicationConfig_basic(rName), fmt.Sprintf(`
+resource "aws_qbusiness_index" "test" {
+  application_id = aws_qbusiness_app.test.id
+  display_name   = %[1]q
+  capacity_configuration {
+    units = 1
+  }
+  description = "Index name"
+}
+`, rName))
+}
+
+func testAccIndexConfig_documentAttributeConfigurations(rName, attr1, attr2 string) string {
+	return acctest.ConfigCompose(testAccApplicationConfig_basic(rName), fmt.Sprintf(`
+resource "aws_qbusiness_index" "test" {
+  application_id = aws_qbusiness_app.test.id
+  display_name   = %[1]q
+  capacity_configuration {
+    units = 1
+  }
+  description = %[1]q
+  document_attribute_configuration {
+    name   = %[2]q
+    search = "ENABLED"
+    type   = "STRING"
+  }
+  document_attribute_configuration {
+    name   = %[3]q
+    search = "ENABLED"
+    type   = "STRING"
+  }
+}
+`, rName, attr1, attr2))
+}
+
+func testAccIndexConfig_tags(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
+	return acctest.ConfigCompose(testAccApplicationConfig_basic(rName), fmt.Sprintf(`
+resource "aws_qbusiness_index" "test" {
+  application_id = aws_qbusiness_app.test.id
+  display_name   = %[1]q
+  capacity_configuration {
+    units = 1
+  }
+  description = %[1]q
+
+  tags = {
+    %[2]q = %[3]q
+    %[4]q = %[5]q
+  }
+}
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+}

--- a/internal/service/qbusiness/service_package_gen.go
+++ b/internal/service/qbusiness/service_package_gen.go
@@ -28,6 +28,14 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 				IdentifierAttribute: names.AttrARN,
 			},
 		},
+		{
+			Factory:  newResourceIndex,
+			TypeName: "aws_qbusiness_index",
+			Name:     "Index",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			},
+		},
 	}
 }
 

--- a/website/docs/r/qbusiness_index.html.markdown
+++ b/website/docs/r/qbusiness_index.html.markdown
@@ -1,0 +1,79 @@
+---
+subcategory: "Amazon Q Business"
+layout: "aws"
+page_title: "AWS: aws_qbusiness_index"
+description: |-
+  Provides a Q Business Index resource.
+---
+
+# Resource: aws_qbusiness_index
+
+Provides a Q Business Index resource.
+
+## Example Usage
+
+```terraform
+resource "aws_qbusiness_index" "example" {
+  application_id = "aws_qbusiness_application.test.application_id"
+  display_name   = "Index display name"
+  capacity_configuration {
+    units = 1
+  }
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `application_id` - (Required) Id of the Q Business application.
+* `display_name` - (Required) Index display name.
+* `capacity_configuration` - (Required) Number of additional storage units for the Amazon Q index.
+
+The following arguments are optional:
+
+* `description` - (Optional) Description for the Amazon Q index.
+* `document_attribute_configuration` - (Optional) Configuration information for document metadata or fields.
+
+`document_attribute_configuration` supports the following:
+
+* `name` - (Required) Name of the document attribute.
+* `search` - (Required) Information about whether the document attribute can be used by an end user to search for information on their web experience. Valid values are `ENABLED` and `DISABLED`
+* `type` - (Required) Type of document attribute. Valid values are `STRING`, `STRING_LIST`, `NUMBER` and `DATE`
+
+`capacity_configuration` supports the following:
+
+* `units` - (Required) Number of storage units configured for an Amazon Q index.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `index_id` - Id of the Q Business index.
+* `arn` - Amazon Resource Name (ARN) of the Q Business index.
+* `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `30m`)
+* `update` - (Default `30m`)
+* `delete` - (Default `30m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import a Q Business Index using the `id`. For example:
+
+```terraform
+import {
+  to = aws_qbusiness_index.example
+  id = "a5006afd-3f45-42bc-abf7-c5374014b72d,7242e08d-94be-4c4a-aa22-6347944738cb"
+}
+```
+
+Using `terraform import`, import a Q Business Index using the `id`. For example:
+
+```console
+% terraform import aws_qbusiness_index.example a5006afd-3f45-42bc-abf7-c5374014b72d,7242e08d-94be-4c4a-aa22-6347944738cb
+```


### PR DESCRIPTION
### AWS Q Business Index resource

This PR implements AWS Q Business index resource

### Output from Acceptance Testing

```console
% make testacc PKG=qbusiness TESTS=TestAccQBusinessIndex_
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/qbusiness/... -v -count 1 -parallel 20 -run='TestAccQBusinessIndex_'  -timeout 360m -vet=off
2025/02/19 22:33:19 Initializing Terraform AWS Provider...
=== RUN   TestAccQBusinessIndex_basic
=== PAUSE TestAccQBusinessIndex_basic
=== RUN   TestAccQBusinessIndex_disappears
=== PAUSE TestAccQBusinessIndex_disappears
=== RUN   TestAccQBusinessIndex_tags
=== PAUSE TestAccQBusinessIndex_tags
=== RUN   TestAccQBusinessIndex_documentAttributeConfigurations
=== PAUSE TestAccQBusinessIndex_documentAttributeConfigurations
=== CONT  TestAccQBusinessIndex_basic
=== CONT  TestAccQBusinessIndex_tags
=== CONT  TestAccQBusinessIndex_documentAttributeConfigurations
=== CONT  TestAccQBusinessIndex_disappears
--- PASS: TestAccQBusinessIndex_disappears (302.06s)
--- PASS: TestAccQBusinessIndex_basic (306.97s)
--- PASS: TestAccQBusinessIndex_documentAttributeConfigurations (320.61s)
--- PASS: TestAccQBusinessIndex_tags (332.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/qbusiness  332.559s
...
```
