### PR TITLE
docs/aws_vpclattice_resource_configuration: added missing protocol arguments to examples

### DIFF
--- a/website/docs/r/vpclattice_resource_configuration.html.markdown
+++ b/website/docs/r/vpclattice_resource_configuration.html.markdown
@@ -20,6 +20,7 @@ resource "aws_vpclattice_resource_configuration" "example" {
   resource_gateway_identifier = aws_vpclattice_resource_gateway.example.id
 
   port_ranges = ["80"]
+  protocol    = "TCP"
 
   resource_configuration_definition {
     dns_resource {
@@ -43,6 +44,7 @@ resource "aws_vpclattice_resource_configuration" "example" {
   resource_gateway_identifier = aws_vpclattice_resource_gateway.example.id
 
   port_ranges = ["80"]
+  protocol    = "TCP"
 
   resource_configuration_definition {
     ip_resource {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Just two line documentation addition for aws_vpclattice_resource_configuration examples as described in #41491 
The `protocol` argument was missing, leading to errors when plan/apply using these examples.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41491 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
