### PR TITLE
sweeper/memorydb: Adds support for multi-region clusters

### DIFF
--- a/internal/service/memorydb/acl.go
+++ b/internal/service/memorydb/acl.go
@@ -301,10 +301,12 @@ func waitACLDeleted(ctx context.Context, conn *memorydb.Client, name string) (*a
 		timeout = 5 * time.Minute
 	)
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{aclStatusDeleting},
-		Target:  []string{},
-		Refresh: statusACL(ctx, conn, name),
-		Timeout: timeout,
+		Pending:      []string{aclStatusDeleting},
+		Target:       []string{},
+		Refresh:      statusACL(ctx, conn, name),
+		Timeout:      timeout,
+		Delay:        30 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/memorydb/cluster.go
+++ b/internal/service/memorydb/cluster.go
@@ -294,7 +294,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	conn := meta.(*conns.AWSClient).MemoryDBClient(ctx)
 
 	name := create.Name(d.Get(names.AttrName).(string), d.Get(names.AttrNamePrefix).(string))
-	input := &memorydb.CreateClusterInput{
+	input := memorydb.CreateClusterInput{
 		ACLName:                 aws.String(d.Get("acl_name").(string)),
 		AutoMinorVersionUpgrade: aws.Bool(d.Get(names.AttrAutoMinorVersionUpgrade).(bool)),
 		ClusterName:             aws.String(name),
@@ -369,7 +369,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.SubnetGroupName = aws.String(v.(string))
 	}
 
-	_, err := conn.CreateCluster(ctx, input)
+	_, err := conn.CreateCluster(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating MemoryDB Cluster (%s): %s", name, err)
@@ -468,7 +468,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		waitParameterGroupInSync := false
 		waitSecurityGroupsActive := false
 
-		input := &memorydb.UpdateClusterInput{
+		input := memorydb.UpdateClusterInput{
 			ClusterName: aws.String(d.Id()),
 		}
 
@@ -546,7 +546,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			}
 		}
 
-		_, err := conn.UpdateCluster(ctx, input)
+		_, err := conn.UpdateCluster(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating MemoryDB Cluster (%s): %s", d.Id(), err)
@@ -576,7 +576,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).MemoryDBClient(ctx)
 
-	input := &memorydb.DeleteClusterInput{
+	input := memorydb.DeleteClusterInput{
 		ClusterName: aws.String(d.Get(names.AttrName).(string)),
 	}
 
@@ -589,7 +589,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	log.Printf("[DEBUG] Deleting MemoryDB Cluster: (%s)", d.Get(names.AttrName).(string))
-	_, err := conn.DeleteCluster(ctx, input)
+	_, err := conn.DeleteCluster(ctx, &input)
 
 	if errs.IsA[*awstypes.ClusterNotFoundFault](err) {
 		return diags
@@ -607,12 +607,12 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func findClusterByName(ctx context.Context, conn *memorydb.Client, name string) (*awstypes.Cluster, error) {
-	input := &memorydb.DescribeClustersInput{
+	input := memorydb.DescribeClustersInput{
 		ClusterName:      aws.String(name),
 		ShowShardDetails: aws.Bool(true),
 	}
 
-	return findCluster(ctx, conn, input)
+	return findCluster(ctx, conn, &input)
 }
 
 func findCluster(ctx context.Context, conn *memorydb.Client, input *memorydb.DescribeClustersInput) (*awstypes.Cluster, error) {

--- a/internal/service/memorydb/cluster.go
+++ b/internal/service/memorydb/cluster.go
@@ -724,10 +724,12 @@ func waitClusterAvailable(ctx context.Context, conn *memorydb.Client, name strin
 
 func waitClusterDeleted(ctx context.Context, conn *memorydb.Client, name string, timeout time.Duration) (*awstypes.Cluster, error) {
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{clusterStatusDeleting},
-		Target:  []string{},
-		Refresh: statusCluster(ctx, conn, name),
-		Timeout: timeout,
+		Pending:      []string{clusterStatusDeleting},
+		Target:       []string{},
+		Refresh:      statusCluster(ctx, conn, name),
+		Timeout:      timeout,
+		Delay:        5 * time.Minute,
+		PollInterval: 10 * time.Second,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)

--- a/internal/service/memorydb/cluster.go
+++ b/internal/service/memorydb/cluster.go
@@ -577,7 +577,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	conn := meta.(*conns.AWSClient).MemoryDBClient(ctx)
 
 	input := &memorydb.DeleteClusterInput{
-		ClusterName: aws.String(d.Id()),
+		ClusterName: aws.String(d.Get(names.AttrName).(string)),
 	}
 
 	if v := d.Get("multi_region_cluster_name"); v != nil && len(v.(string)) > 0 {
@@ -588,7 +588,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 		input.FinalSnapshotName = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Deleting MemoryDB Cluster: (%s)", d.Id())
+	log.Printf("[DEBUG] Deleting MemoryDB Cluster: (%s)", d.Get(names.AttrName).(string))
 	_, err := conn.DeleteCluster(ctx, input)
 
 	if errs.IsA[*awstypes.ClusterNotFoundFault](err) {
@@ -596,11 +596,11 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting MemoryDB Cluster (%s): %s", d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting MemoryDB Cluster (%s): %s", d.Get(names.AttrName).(string), err)
 	}
 
-	if _, err := waitClusterDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for MemoryDB Cluster (%s) delete: %s", d.Id(), err)
+	if _, err := waitClusterDeleted(ctx, conn, d.Get(names.AttrName).(string), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for MemoryDB Cluster (%s) delete: %s", d.Get(names.AttrName).(string), err)
 	}
 
 	return diags

--- a/internal/service/memorydb/cluster_test.go
+++ b/internal/service/memorydb/cluster_test.go
@@ -47,6 +47,7 @@ func TestAccMemoryDBCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrKMSKeyARN, ""),
 					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window"),
+					resource.TestCheckResourceAttr(resourceName, "multi_region_cluster_name", ""),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "db.t4g.small"),
 					resource.TestCheckResourceAttr(resourceName, "num_replicas_per_shard", "1"),

--- a/internal/service/memorydb/cluster_test.go
+++ b/internal/service/memorydb/cluster_test.go
@@ -69,8 +69,7 @@ func TestAccMemoryDBCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "snapshot_window"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrSNSTopicARN, ""),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_group_name", "aws_memorydb_subnet_group.test", names.AttrID),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Test", "test"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, "tls_enabled", acctest.CtTrue),
 				),
 			},
@@ -1106,8 +1105,7 @@ func TestAccMemoryDBCluster_valkeyEngine(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "snapshot_window"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrSNSTopicARN, ""),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "subnet_group_name", "aws_memorydb_subnet_group.test", names.AttrID),
-					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Test", "test"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, "tls_enabled", acctest.CtTrue),
 				),
 			},
@@ -1217,10 +1215,6 @@ func testAccClusterConfig_basic(rName string) string {
 resource "aws_security_group" "test" {
   name   = %[1]q
   vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
 }
 
 resource "aws_memorydb_cluster" "test" {
@@ -1232,10 +1226,6 @@ resource "aws_memorydb_cluster" "test" {
   security_group_ids         = [aws_security_group.test.id]
   snapshot_retention_limit   = 7
   subnet_group_name          = aws_memorydb_subnet_group.test.id
-
-  tags = {
-    Test = "test"
-  }
 }
 `, rName),
 	)
@@ -1249,10 +1239,6 @@ func testAccClusterConfig_engine(rName, engine, engineVersion string) string {
 resource "aws_security_group" "test" {
   name   = %[1]q
   vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
 }
 
 resource "aws_memorydb_cluster" "test" {
@@ -1266,10 +1252,6 @@ resource "aws_memorydb_cluster" "test" {
   security_group_ids         = [aws_security_group.test.id]
   snapshot_retention_limit   = 7
   subnet_group_name          = aws_memorydb_subnet_group.test.id
-
-  tags = {
-    Test = "test"
-  }
 }
 `, rName, engine, engineVersion),
 	)
@@ -1408,10 +1390,6 @@ func testAccClusterConfig_multiRegionClusterName(rName string) string {
 resource "aws_security_group" "test" {
   name   = %[1]q
   vpc_id = aws_vpc.test.id
-
-  tags = {
-    Name = %[1]q
-  }
 }
 
 resource "aws_memorydb_multi_region_cluster" "test" {
@@ -1577,10 +1555,6 @@ resource "aws_security_group" "test" {
 
   vpc_id = aws_vpc.test.id
   name   = "%[1]s-${count.index}"
-
-  tags = {
-    Name = %[1]q
-  }
 }
 
 resource "aws_memorydb_cluster" "test" {

--- a/internal/service/memorydb/cluster_test.go
+++ b/internal/service/memorydb/cluster_test.go
@@ -35,7 +35,7 @@ func TestAccMemoryDBCluster_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "acl_name", "aws_memorydb_acl.test", names.AttrID),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "memorydb", "cluster/"+rName),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "memorydb", "cluster/{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
 					resource.TestMatchResourceAttr(resourceName, "cluster_endpoint.0.address", regexache.MustCompile(`^clustercfg\..*?\.amazonaws\.com$`)),
 					resource.TestCheckResourceAttr(resourceName, "cluster_endpoint.0.port", "6379"),
@@ -44,6 +44,7 @@ func TestAccMemoryDBCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "engine_patch_version"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrEngineVersion),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrKMSKeyARN, ""),
 					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -98,7 +99,7 @@ func TestAccMemoryDBCluster_defaults(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "acl_name", "open-access"),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "memorydb", "cluster/"+rName),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "memorydb", "cluster/{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_endpoint.0.address"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_endpoint.0.port", "6379"),
@@ -1072,7 +1073,7 @@ func TestAccMemoryDBCluster_valkeyEngine(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "acl_name", "aws_memorydb_acl.test", names.AttrID),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "memorydb", "cluster/"+rName),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "memorydb", "cluster/{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
 					resource.TestMatchResourceAttr(resourceName, "cluster_endpoint.0.address", regexache.MustCompile(`^clustercfg\..*?\.amazonaws\.com$`)),
 					resource.TestCheckResourceAttr(resourceName, "cluster_endpoint.0.port", "6379"),

--- a/internal/service/memorydb/cluster_test.go
+++ b/internal/service/memorydb/cluster_test.go
@@ -32,7 +32,7 @@ func TestAccMemoryDBCluster_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "acl_name", "aws_memorydb_acl.test", names.AttrID),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "memorydb", "cluster/"+rName),
@@ -95,7 +95,7 @@ func TestAccMemoryDBCluster_defaults(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_defaults(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "acl_name", "open-access"),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "memorydb", "cluster/"+rName),
@@ -145,7 +145,7 @@ func TestAccMemoryDBCluster_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfmemorydb.ResourceCluster(), resourceName),
 				),
@@ -168,7 +168,7 @@ func TestAccMemoryDBCluster_nameGenerated(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_noName(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					acctest.CheckResourceAttrNameGenerated(resourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, "terraform-"),
@@ -191,7 +191,7 @@ func TestAccMemoryDBCluster_namePrefix(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_namePrefix(rName, "tftest-"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					acctest.CheckResourceAttrNameFromPrefix(resourceName, names.AttrName, "tftest-"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, "tftest-"),
@@ -216,7 +216,7 @@ func TestAccMemoryDBCluster_create_noTLS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_noTLS(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tls_enabled", acctest.CtFalse),
 				),
@@ -243,7 +243,7 @@ func TestAccMemoryDBCluster_create_withDataTiering(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_dataTiering(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "data_tiering", acctest.CtTrue),
 				),
@@ -271,7 +271,7 @@ func TestAccMemoryDBCluster_multiRegionClusterName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_multiRegionClusterName(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, "multi_region_cluster_name", multiRegionClusterResourceName, "multi_region_cluster_name"),
 				),
@@ -298,7 +298,7 @@ func TestAccMemoryDBCluster_create_withKMS(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_kms(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrKMSKeyARN, "aws_kms_key.test", names.AttrARN),
 				),
@@ -325,7 +325,7 @@ func TestAccMemoryDBCluster_create_withPort(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_port(rName, 9999),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "cluster_endpoint.0.port", "9999"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPort, "9999"),
@@ -353,7 +353,7 @@ func TestAccMemoryDBCluster_create_fromSnapshot(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_snapshotFrom(rName1, rName2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, "aws_memorydb_cluster.test1"),
 					testAccCheckClusterExists(ctx, "aws_memorydb_cluster.test2"),
 				),
@@ -375,7 +375,7 @@ func TestAccMemoryDBCluster_delete_withFinalSnapshot(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_finalSnapshotName(rName, rName+"-1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "final_snapshot_name", rName+"-1"),
 				),
@@ -388,7 +388,7 @@ func TestAccMemoryDBCluster_delete_withFinalSnapshot(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_finalSnapshotName(rName, rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "final_snapshot_name", rName),
 				),
@@ -401,7 +401,7 @@ func TestAccMemoryDBCluster_delete_withFinalSnapshot(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_baseNetwork(rName), // empty Config not supported
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSnapshotExistsByName(ctx, rName),
 				),
 			},
@@ -422,7 +422,7 @@ func TestAccMemoryDBCluster_Update_aclName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_aclName(rName, rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "acl_name", rName),
 				),
@@ -434,7 +434,7 @@ func TestAccMemoryDBCluster_Update_aclName(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_aclName(rName, "open-access"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "acl_name", "open-access"),
 				),
@@ -461,7 +461,7 @@ func TestAccMemoryDBCluster_Update_description(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_description(rName, "Test 1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Test 1"),
 				),
@@ -473,7 +473,7 @@ func TestAccMemoryDBCluster_Update_description(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_description(rName, "Test 2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Test 2"),
 				),
@@ -485,7 +485,7 @@ func TestAccMemoryDBCluster_Update_description(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_description(rName, ""),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 				),
@@ -513,7 +513,7 @@ func TestAccMemoryDBCluster_Update_engine(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_engine(rName, "redis", "7.1"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 				),
@@ -525,7 +525,7 @@ func TestAccMemoryDBCluster_Update_engine(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_engine(rName, "valkey", "7.2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "valkey"),
 				),
@@ -552,7 +552,7 @@ func TestAccMemoryDBCluster_Update_maintenanceWindow(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_maintenanceWindow(rName, "thu:09:00-thu:10:00"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window", "thu:09:00-thu:10:00"),
 				),
@@ -564,7 +564,7 @@ func TestAccMemoryDBCluster_Update_maintenanceWindow(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_maintenanceWindow(rName, "fri:09:00-fri:10:00"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window", "fri:09:00-fri:10:00"),
 				),
@@ -591,7 +591,7 @@ func TestAccMemoryDBCluster_Update_nodeType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_nodeType(rName, "db.t4g.small"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "db.t4g.small"),
 				),
@@ -603,7 +603,7 @@ func TestAccMemoryDBCluster_Update_nodeType(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_nodeType(rName, "db.t4g.medium"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "db.t4g.medium"),
 				),
@@ -633,7 +633,7 @@ func TestAccMemoryDBCluster_Update_numShards_scaleUp(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_numShards(rName, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_shards", "1"),
 				),
@@ -645,7 +645,7 @@ func TestAccMemoryDBCluster_Update_numShards_scaleUp(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_numShards(rName, 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_shards", "2"),
 				),
@@ -670,7 +670,7 @@ func TestAccMemoryDBCluster_Update_numShards_scaleDown(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_numShards(rName, 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_shards", "2"),
 				),
@@ -682,7 +682,7 @@ func TestAccMemoryDBCluster_Update_numShards_scaleDown(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_numShards(rName, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_shards", "1"),
 				),
@@ -707,7 +707,7 @@ func TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleUp(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_numReplicasPerShard(rName, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_replicas_per_shard", "1"),
 				),
@@ -719,7 +719,7 @@ func TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleUp(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_numReplicasPerShard(rName, 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_replicas_per_shard", "2"),
 				),
@@ -744,7 +744,7 @@ func TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleDown(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_numReplicasPerShard(rName, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_replicas_per_shard", "1"),
 				),
@@ -756,7 +756,7 @@ func TestAccMemoryDBCluster_Update_numReplicasPerShard_scaleDown(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_numReplicasPerShard(rName, 0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "num_replicas_per_shard", "0"),
 				),
@@ -778,7 +778,7 @@ func TestAccMemoryDBCluster_Update_parameterGroup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_parameterGroup(rName, "default.memorydb-redis7"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrParameterGroupName, "default.memorydb-redis7"),
 				),
@@ -790,14 +790,14 @@ func TestAccMemoryDBCluster_Update_parameterGroup(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_parameterGroup(rName, rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrParameterGroupName, rName),
 				),
 			},
 			{
 				Config: testAccClusterConfig_parameterGroup(rName, "default.memorydb-redis7"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrParameterGroupName, "default.memorydb-redis7"),
 				),
@@ -824,7 +824,7 @@ func TestAccMemoryDBCluster_Update_securityGroupIds(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_securityGroups(rName, 2, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "security_group_ids.*", "aws_security_group.test.0", names.AttrID),
@@ -837,7 +837,7 @@ func TestAccMemoryDBCluster_Update_securityGroupIds(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_securityGroups(rName, 2, 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "2"), // add one
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "security_group_ids.*", "aws_security_group.test.0", names.AttrID),
@@ -855,7 +855,7 @@ func TestAccMemoryDBCluster_Update_securityGroupIds(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_securityGroups(rName, 2, 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"), // remove one
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "security_group_ids.*", "aws_security_group.test.0", names.AttrID),
@@ -883,7 +883,7 @@ func TestAccMemoryDBCluster_Update_snapshotRetentionLimit(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_snapshotRetentionLimit(rName, 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_retention_limit", "2"),
 				),
@@ -895,7 +895,7 @@ func TestAccMemoryDBCluster_Update_snapshotRetentionLimit(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_snapshotRetentionLimit(rName, 35),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_retention_limit", "35"),
 				),
@@ -907,7 +907,7 @@ func TestAccMemoryDBCluster_Update_snapshotRetentionLimit(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_snapshotRetentionLimit(rName, 0),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_retention_limit", "0"),
 				),
@@ -934,7 +934,7 @@ func TestAccMemoryDBCluster_Update_snapshotWindow(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_snapshotWindow(rName, "00:30-01:30"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_window", "00:30-01:30"),
 				),
@@ -946,7 +946,7 @@ func TestAccMemoryDBCluster_Update_snapshotWindow(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_snapshotWindow(rName, "02:30-03:30"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_window", "02:30-03:30"),
 				),
@@ -973,7 +973,7 @@ func TestAccMemoryDBCluster_Update_snsTopicARN(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_snsTopic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrSNSTopicARN, "aws_sns_topic.test", names.AttrARN),
 				),
@@ -985,7 +985,7 @@ func TestAccMemoryDBCluster_Update_snsTopicARN(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_snsTopicNull(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrSNSTopicARN, ""),
 				),
@@ -997,7 +997,7 @@ func TestAccMemoryDBCluster_Update_snsTopicARN(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_snsTopic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrSNSTopicARN, "aws_sns_topic.test", names.AttrARN),
 				),
@@ -1024,7 +1024,7 @@ func TestAccMemoryDBCluster_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
@@ -1037,7 +1037,7 @@ func TestAccMemoryDBCluster_tags(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
@@ -1046,7 +1046,7 @@ func TestAccMemoryDBCluster_tags(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -1069,7 +1069,7 @@ func TestAccMemoryDBCluster_valkeyEngine(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_engine(rName, "valkey", "7.2"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "acl_name", "aws_memorydb_acl.test", names.AttrID),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "memorydb", "cluster/"+rName),

--- a/internal/service/memorydb/sweep.go
+++ b/internal/service/memorydb/sweep.go
@@ -70,10 +70,10 @@ func sweepACLs(region string) error {
 		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.MemoryDBClient(ctx)
-	input := &memorydb.DescribeACLsInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
+	input := memorydb.DescribeACLsInput{}
+	var sweepResources []sweep.Sweepable
 
-	pages := memorydb.NewDescribeACLsPaginator(conn, input)
+	pages := memorydb.NewDescribeACLsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
@@ -118,10 +118,10 @@ func sweepClusters(region string) error {
 		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.MemoryDBClient(ctx)
-	input := &memorydb.DescribeClustersInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
+	input := memorydb.DescribeClustersInput{}
+	var sweepResources []sweep.Sweepable
 
-	pages := memorydb.NewDescribeClustersPaginator(conn, input)
+	pages := memorydb.NewDescribeClustersPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
@@ -161,10 +161,10 @@ func sweepParameterGroups(region string) error {
 		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.MemoryDBClient(ctx)
-	input := &memorydb.DescribeParameterGroupsInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
+	input := memorydb.DescribeParameterGroupsInput{}
+	var sweepResources []sweep.Sweepable
 
-	pages := memorydb.NewDescribeParameterGroupsPaginator(conn, input)
+	pages := memorydb.NewDescribeParameterGroupsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
@@ -209,10 +209,10 @@ func sweepSnapshots(region string) error {
 		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.MemoryDBClient(ctx)
-	input := &memorydb.DescribeSnapshotsInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
+	input := memorydb.DescribeSnapshotsInput{}
+	var sweepResources []sweep.Sweepable
 
-	pages := memorydb.NewDescribeSnapshotsPaginator(conn, input)
+	pages := memorydb.NewDescribeSnapshotsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
@@ -250,10 +250,10 @@ func sweepSubnetGroups(region string) error {
 		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.MemoryDBClient(ctx)
-	input := &memorydb.DescribeSubnetGroupsInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
+	input := memorydb.DescribeSubnetGroupsInput{}
+	var sweepResources []sweep.Sweepable
 
-	pages := memorydb.NewDescribeSubnetGroupsPaginator(conn, input)
+	pages := memorydb.NewDescribeSubnetGroupsPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
@@ -298,10 +298,10 @@ func sweepUsers(region string) error {
 		return fmt.Errorf("error getting client: %w", err)
 	}
 	conn := client.MemoryDBClient(ctx)
-	input := &memorydb.DescribeUsersInput{}
-	sweepResources := make([]sweep.Sweepable, 0)
+	input := memorydb.DescribeUsersInput{}
+	var sweepResources []sweep.Sweepable
 
-	pages := memorydb.NewDescribeUsersPaginator(conn, input)
+	pages := memorydb.NewDescribeUsersPaginator(conn, &input)
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 

--- a/internal/service/memorydb/sweep.go
+++ b/internal/service/memorydb/sweep.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func RegisterSweepers() {
@@ -137,6 +138,8 @@ func sweepClusters(region string) error {
 			r := resourceCluster()
 			d := r.Data(nil)
 			d.SetId(aws.ToString(v.Name))
+			d.Set(names.AttrName, v.Name)
+			d.Set("multi_region_cluster_name", v.MultiRegionClusterName)
 
 			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
 		}


### PR DESCRIPTION
### Description

Updates `aws_memorydb_cluster` sweeper to set `multi_region_cluster_name` if present

Adds sweeper for `aws_memorydb_multi_region_cluster`
