### PR TITLE
r/cloudwatch_log_delivery: fix provider error on `s3_delivery_configuration.suffix_path`

### DIFF
--- a/.changelog/41497.txt
+++ b/.changelog/41497.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_log_delivery: Fix Provider produced inconsistent result error on `s3_delivery_configuration.suffix_path`
+```

--- a/internal/framework/resource_list_of_object.go
+++ b/internal/framework/resource_list_of_object.go
@@ -29,9 +29,9 @@ func ResourceComputedListOfObjectsAttribute[T any](ctx context.Context, planModi
 
 // ResourceOptionalComputedListOfObjectsAttribute returns a new schema.ListAttribute for objects of the specified type.
 // The list is Optional+Computed.
-func ResourceOptionalComputedListOfObjectsAttribute[T any](ctx context.Context, sizeAtMost int, planModifiers ...planmodifier.List) schema.ListAttribute {
+func ResourceOptionalComputedListOfObjectsAttribute[T any](ctx context.Context, sizeAtMost int, listNestedObjectOptions []fwtypes.ListNestedObjectOfOption[T], planModifiers ...planmodifier.List) schema.ListAttribute {
 	return schema.ListAttribute{
-		CustomType:    fwtypes.NewListNestedObjectTypeOf[T](ctx),
+		CustomType:    fwtypes.NewListNestedObjectTypeOf[T](ctx, listNestedObjectOptions...),
 		Optional:      true,
 		Computed:      true,
 		PlanModifiers: planModifiers,

--- a/internal/service/logs/delivery.go
+++ b/internal/service/logs/delivery.go
@@ -111,6 +111,9 @@ func s3DeliverySemanticEquality(ctx context.Context, oldValue fwtypes.ListNested
 
 	oldValPtr, di := oldValue.ToPtr(ctx)
 	diags = append(diags, di...)
+	if diags.HasError() {
+		return false, diags
+	}
 
 	newValPtr, di := newValue.ToPtr(ctx)
 	diags = append(diags, di...)

--- a/internal/service/logs/delivery.go
+++ b/internal/service/logs/delivery.go
@@ -340,7 +340,6 @@ func (r *deliveryResource) ModifyPlan(ctx context.Context, request resource.Modi
 				}
 			}
 		}
-
 	}
 	r.SetTagsAll(ctx, request, response)
 }

--- a/internal/service/logs/delivery.go
+++ b/internal/service/logs/delivery.go
@@ -106,7 +106,7 @@ var s3DeliveryConfigurationListOptions = []fwtypes.ListNestedObjectOfOption[s3De
 	fwtypes.WithSemanticEqualityFunc(s3DeliverySemanticEquality),
 }
 
-func s3DeliverySemanticEquality(ctx context.Context, oldValue fwtypes.ListNestedObjectValueOf[s3DeliveryConfigurationModel], newValue fwtypes.ListNestedObjectValueOf[s3DeliveryConfigurationModel]) (bool, diag.Diagnostics) {
+func s3DeliverySemanticEquality(ctx context.Context, oldValue, newValue fwtypes.ListNestedObjectValueOf[s3DeliveryConfigurationModel]) (bool, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	oldValPtr, di := oldValue.ToPtr(ctx)

--- a/internal/service/logs/delivery.go
+++ b/internal/service/logs/delivery.go
@@ -95,12 +95,15 @@ func (r *deliveryResource) Schema(ctx context.Context, request resource.SchemaRe
 					listplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"s3_delivery_configuration": framework.ResourceOptionalComputedListOfObjectsAttribute[s3DeliveryConfigurationModel](ctx, 1,
-				[]fwtypes.ListNestedObjectOfOption[s3DeliveryConfigurationModel]{fwtypes.WithSemanticEqualityFunc(s3DeliverySemanticEquality)}, listplanmodifier.UseStateForUnknown()),
-			names.AttrTags:    tftags.TagsAttribute(),
-			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+			"s3_delivery_configuration": framework.ResourceOptionalComputedListOfObjectsAttribute[s3DeliveryConfigurationModel](ctx, 1, s3DeliveryConfigurationListOptions, listplanmodifier.UseStateForUnknown()),
+			names.AttrTags:              tftags.TagsAttribute(),
+			names.AttrTagsAll:           tftags.TagsAttributeComputedOnly(),
 		},
 	}
+}
+
+var s3DeliveryConfigurationListOptions = []fwtypes.ListNestedObjectOfOption[s3DeliveryConfigurationModel]{
+	fwtypes.WithSemanticEqualityFunc(s3DeliverySemanticEquality),
 }
 
 func s3DeliverySemanticEquality(ctx context.Context, oldValue fwtypes.ListNestedObjectValueOf[s3DeliveryConfigurationModel], newValue fwtypes.ListNestedObjectValueOf[s3DeliveryConfigurationModel]) (bool, diag.Diagnostics) {

--- a/internal/service/route53domains/domain.go
+++ b/internal/service/route53domains/domain.go
@@ -84,7 +84,7 @@ func (r *domainResource) Schema(ctx context.Context, request resource.SchemaRequ
 				Computed: true,
 				Default:  booldefault.StaticBool(true),
 			},
-			"billing_contact": framework.ResourceOptionalComputedListOfObjectsAttribute[contactDetailModel](ctx, 1, fwplanmodifiers.ListDefaultValueFromPath[fwtypes.ListNestedObjectValueOf[contactDetailModel]](path.Root("registrant_contact"))),
+			"billing_contact": framework.ResourceOptionalComputedListOfObjectsAttribute[contactDetailModel](ctx, 1, nil, fwplanmodifiers.ListDefaultValueFromPath[fwtypes.ListNestedObjectValueOf[contactDetailModel]](path.Root("registrant_contact"))),
 			"billing_privacy": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,
@@ -122,7 +122,7 @@ func (r *domainResource) Schema(ctx context.Context, request resource.SchemaRequ
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"name_server": framework.ResourceOptionalComputedListOfObjectsAttribute[nameserverModel](ctx, 6, listplanmodifier.UseStateForUnknown()), //nolint:mnd // 6 is the maximum number of items
+			"name_server": framework.ResourceOptionalComputedListOfObjectsAttribute[nameserverModel](ctx, 6, nil, listplanmodifier.UseStateForUnknown()), //nolint:mnd // 6 is the maximum number of items
 			"registrant_privacy": schema.BoolAttribute{
 				Optional: true,
 				Computed: true,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Provider produces an error during create when `s3_delivery_configuration.suffix_path` is set to a value that is different than the config.

```console
% make testacc TESTARGS='-run=TestAccLogs_serial/Delivery/cloudFrontDistribution$' PKG=logs AWS_DEFAULT_REGION=us-east-1

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/logs/... -v -count 1 -parallel 20  -run=TestAccLogs_serial/Delivery/cloudFrontDistribution -timeout 360m -vet=off
2025/02/20 13:30:13 Initializing Terraform AWS Provider...
=== RUN   TestAccLogs_serial
=== PAUSE TestAccLogs_serial
=== CONT  TestAccLogs_serial
=== RUN   TestAccLogs_serial/Delivery
=== RUN   TestAccLogs_serial/Delivery/cloudFrontDistribution
    delivery_test.go:290: Step 1/1 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply

        When applying changes to aws_cloudwatch_log_delivery.test, provider
        "provider[\"registry.terraform.io/hashicorp/aws\"]" produced an unexpected
        new value: .s3_delivery_configuration[0].suffix_path: was
        cty.StringVal("/123456678910/{DistributionId}/{yyyy}/{MM}/{dd}/{HH}"), but
        now
        cty.StringVal("AWSLogs/{account-id}/CloudFront/123456678910/{DistributionId}/{yyyy}/{MM}/{dd}/{HH}").

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
=== RUN   TestAccLogs_serial/DeliverySource
--- FAIL: TestAccLogs_serial (463.21s)
    --- FAIL: TestAccLogs_serial/Delivery (463.21s)
        --- FAIL: TestAccLogs_serial/Delivery/cloudFrontDistribution (463.21s)
    --- PASS: TestAccLogs_serial/DeliverySource (0.00s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/logs	470.090s
FAIL
make: *** [testacc] Error 1
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:


--->

Closes #40885

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccLogs_serial/Delivery/cloudFrontDistribution$' PKG=logs AWS_DEFAULT_REGION=us-east-1

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/logs/... -v -count 1 -parallel 20  -run=TestAccLogs_serial/Delivery/cloudFrontDistribution -timeout 360m -vet=off
2025/02/20 13:46:00 Initializing Terraform AWS Provider...
=== RUN   TestAccLogs_serial
=== PAUSE TestAccLogs_serial
=== CONT  TestAccLogs_serial
=== RUN   TestAccLogs_serial/Delivery
=== RUN   TestAccLogs_serial/Delivery/cloudFrontDistribution
=== RUN   TestAccLogs_serial/DeliverySource
--- PASS: TestAccLogs_serial (314.58s)
    --- PASS: TestAccLogs_serial/Delivery (314.58s)
        --- PASS: TestAccLogs_serial/Delivery/cloudFrontDistribution (314.58s)
    --- PASS: TestAccLogs_serial/DeliverySource (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	321.366s
```

```console
make testacc TESTARGS='-run=TestAccLogs_serial/Delivery/' PKG=logs AWS_DEFAULT_REGION=us-east-1
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/logs/... -v -count 1 -parallel 20  -run=TestAccLogs_serial/Delivery/ -timeout 360m -vet=off
2025/02/20 17:17:08 Initializing Terraform AWS Provider...
=== RUN   TestAccLogs_serial
=== PAUSE TestAccLogs_serial
=== CONT  TestAccLogs_serial
=== RUN   TestAccLogs_serial/Delivery
=== RUN   TestAccLogs_serial/Delivery/cloudFrontDistribution
=== RUN   TestAccLogs_serial/Delivery/tags
=== RUN   TestAccLogs_serial/Delivery/update
=== RUN   TestAccLogs_serial/Delivery/basic
=== RUN   TestAccLogs_serial/Delivery/disappears
--- PASS: TestAccLogs_serial (6072.47s)
    --- PASS: TestAccLogs_serial/Delivery (6072.47s)
        --- PASS: TestAccLogs_serial/Delivery/cloudFrontDistribution (282.50s)
        --- PASS: TestAccLogs_serial/Delivery/tags (1420.89s)
        --- PASS: TestAccLogs_serial/Delivery/update (1453.04s)
        --- PASS: TestAccLogs_serial/Delivery/basic (1485.52s)
        --- PASS: TestAccLogs_serial/Delivery/disappears (1420.93s)
PASS
ok	github.com/hashicorp/terraform-provider-aws/internal/service/logs	6079.158s
```