### PR TITLE
docs: add details on exceptions and example code

### DIFF
--- a/website/docs/d/cloudfront_cache_policy.html.markdown
+++ b/website/docs/d/cloudfront_cache_policy.html.markdown
@@ -22,11 +22,15 @@ data "aws_cloudfront_cache_policy" "example" {
 
 ### AWS-Managed Policies
 
-AWS managed cache policy names are prefixed with `Managed-`:
+AWS managed cache policy names are prefixed with `Managed-`, except for `UseOriginCacheControlHeaders` and `UseOriginCacheControlHeaders-QueryStrings`:
 
 ```terraform
-data "aws_cloudfront_cache_policy" "example" {
+data "aws_cloudfront_cache_policy" "example_1" {
   name = "Managed-CachingOptimized"
+}
+
+data "aws_cloudfront_cache_policy" "example_2" {
+  name = "UseOriginCacheControlHeaders"
 }
 ```
 


### PR DESCRIPTION
### Description

The [documentation for data `aws_cloudfront_cache_policy`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy#aws-managed-policies) states

> AWS managed cache policy names are prefixed with `Managed-`:

which is not true for two of the policies: `UseOriginCacheControlHeaders` and `UseOriginCacheControlHeaders-QueryStrings`.

```shell
$ aws cloudfront list-cache-policies --query "CachePolicyList.Items[?Type=='managed']" | jq '.[] | .CachePolicy.CachePolicyConfig.Name'
"Managed-CachingOptimized"
"Managed-CachingDisabled"
"Managed-CachingOptimizedForUncompressedObjects"
"Managed-Elemental-MediaPackage"
"Managed-Amplify"
"Managed-Amplify-DefaultNoCookies"
"Managed-Amplify-DefaultNoCookies-V2"
"Managed-Amplify-Default"
"Managed-Amplify-Default-V2"
"Managed-Amplify-StaticContent"
"Managed-Amplify-StaticContent-V2"
"Managed-Amplify-ImageOptimization"
"Managed-Amplify-ImageOptimization-V2"
"UseOriginCacheControlHeaders"
"UseOriginCacheControlHeaders-QueryStrings"
```

The exceptions are now named explicitly in the documentation. Additionally, the  example usage is updated and shows the usage for one of the exceptions.

### Relations

Closes #41467 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

Not applicable. Only documentation is updated.