### PR TITLE
Replace `tenv` linter by `usetesting`

### DIFF
--- a/.ci/.golangci5.yml
+++ b/.ci/.golangci5.yml
@@ -14,15 +14,19 @@ linters:
   disable-all: true
   enable:
     # !! only add t-z linters here
-    - tenv
     - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
+    - usetesting
     - wastedassign
     - whitespace
+
+linters-settings:
+  usetesting:
+    os-setenv: true
 
 run:
   timeout: 75m

--- a/internal/provider/provider_config_test.go
+++ b/internal/provider/provider_config_test.go
@@ -150,7 +150,7 @@ sso_start_url = https://d-123456789a.awsapps.com/start#
 			maps.Copy(config, tc.Config)
 
 			if tc.SharedConfigurationFile != "" {
-				file, err := os.CreateTemp("", "aws-sdk-go-base-shared-configuration-file")
+				file, err := os.CreateTemp(t.TempDir(), "aws-sdk-go-base-shared-configuration-file")
 
 				if err != nil {
 					t.Fatalf("unexpected error creating temporary shared configuration file: %s", err)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -204,7 +204,7 @@ func TestEndpointEnvVarPrecedence(t *testing.T) { //nolint:paralleltest
 			defer popEnv(oldEnv)
 
 			for k, v := range testcase.envvars {
-				os.Setenv(k, v) //nolint:usetesting
+				os.Setenv(k, v) //nolint:usetesting // stashEnv & popEnv require os.Setenv
 			}
 
 			endpoints := make(map[string]interface{})
@@ -288,7 +288,7 @@ func TestExpandDefaultTags(t *testing.T) { //nolint:paralleltest
 			defer popEnv(oldEnv)
 
 			for k, v := range testcase.envvars {
-				os.Setenv(k, v) //nolint:usetesting
+				os.Setenv(k, v) //nolint:usetesting // stashEnv & popEnv require os.Setenv
 			}
 
 			results := expandDefaultTags(ctx, map[string]interface{}{
@@ -405,7 +405,7 @@ func TestExpandIgnoreTags(t *testing.T) { //nolint:paralleltest
 			defer popEnv(oldEnv)
 
 			for k, v := range testcase.envvars {
-				os.Setenv(k, v) //nolint:usetesting
+				os.Setenv(k, v) //nolint:usetesting // stashEnv & popEnv require os.Setenv
 			}
 
 			results := expandIgnoreTags(ctx, map[string]interface{}{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -204,7 +204,7 @@ func TestEndpointEnvVarPrecedence(t *testing.T) { //nolint:paralleltest
 			defer popEnv(oldEnv)
 
 			for k, v := range testcase.envvars {
-				os.Setenv(k, v)
+				os.Setenv(k, v) //nolint:usetesting
 			}
 
 			endpoints := make(map[string]interface{})
@@ -286,8 +286,9 @@ func TestExpandDefaultTags(t *testing.T) { //nolint:paralleltest
 		t.Run(name, func(t *testing.T) {
 			oldEnv := stashEnv()
 			defer popEnv(oldEnv)
+
 			for k, v := range testcase.envvars {
-				os.Setenv(k, v)
+				os.Setenv(k, v) //nolint:usetesting
 			}
 
 			results := expandDefaultTags(ctx, map[string]interface{}{
@@ -402,8 +403,9 @@ func TestExpandIgnoreTags(t *testing.T) { //nolint:paralleltest
 		t.Run(name, func(t *testing.T) {
 			oldEnv := stashEnv()
 			defer popEnv(oldEnv)
+
 			for k, v := range testcase.envvars {
-				os.Setenv(k, v)
+				os.Setenv(k, v) //nolint:usetesting
 			}
 
 			results := expandIgnoreTags(ctx, map[string]interface{}{

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -2236,7 +2236,7 @@ func testAccCheckObjectSSE(ctx context.Context, n, want string) resource.TestChe
 }
 
 func testAccObjectCreateTempFile(t *testing.T, data string) string {
-	tmpFile, err := os.CreateTemp("", "tf-acc-s3-obj")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "tf-acc-s3-obj")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Replaces `tenv` linter by `usetesting`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/41510.

### Output from Acceptance Testing

```console
% make testacc TESTARGS='-run=TestAccS3Object_source' PKG=s3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3Object_source -timeout 360m -vet=off
2025/02/21 16:15:25 Initializing Terraform AWS Provider...
=== RUN   TestAccS3Object_source
=== PAUSE TestAccS3Object_source
=== RUN   TestAccS3Object_sourceHashTrigger
=== PAUSE TestAccS3Object_sourceHashTrigger
=== CONT  TestAccS3Object_source
=== CONT  TestAccS3Object_sourceHashTrigger
--- PASS: TestAccS3Object_source (17.75s)
--- PASS: TestAccS3Object_sourceHashTrigger (29.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	35.219s
```