### PR TITLE
Sweepers: Fix US GovCloud failure

### DIFF
--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -86,6 +86,10 @@ func SkipSweepError(err error) bool {
 	if tfawserr.ErrMessageContains(err, "InvalidParameterValueException", "Access Denied to API Version") {
 		return true
 	}
+	// Example (GovCloud): InvalidParameterValueException: This API operation is currently unavailable
+	if tfawserr.ErrMessageContains(err, "InvalidParameterValueException", "This API operation is currently unavailable") {
+		return true
+	}
 	// For example from us-west-2 Route53 zone
 	if tfawserr.ErrMessageContains(err, "KeySigningKeyInParentDSRecord", "Due to DNS lookup failure") {
 		return true


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes

```
2025/02/24 07:45:43 [DEBUG] Running Sweeper (aws_memorydb_multi_region_cluster) in region (us-gov-west-1)
2025/02/24 07:45:43 [INFO]  sweeper: listing resources: tf_resource_type=aws_memorydb_multi_region_cluster sweeper_region=us-gov-west-1
2025/02/24 07:45:43 [DEBUG] Completed Sweeper (aws_memorydb_multi_region_cluster) in region (us-gov-west-1) in 333.339625ms
2025/02/24 07:45:43 [ERROR] Error running Sweeper (aws_memorydb_multi_region_cluster) in region (us-gov-west-1): listing "aws_memorydb_multi_region_cluster" (us-gov-west-1): operation error MemoryDB: DescribeMultiRegionClusters, https response error StatusCode: 400, RequestID: c6ddb2ae-22e3-47fe-90fe-b59e3ac6e694, InvalidParameterValueException: This API operation is currently unavailable.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/41494.