### PR TITLE
resource/aws_s3_bucket_lifecycle_configuration: Prevents sending 0 for `rule.and.object_size_less_than`

### DIFF
--- a/.changelog/41542.txt
+++ b/.changelog/41542.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Prevents `InvalidRequest` error when `rule.and.object_size_less_than` not set.
+```

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -111,7 +111,7 @@ func Int32FromFrameworkLegacy(_ context.Context, v types.Int32) *int32 {
 		return nil
 	}
 
-	return aws.Int32(int32(i))
+	return aws.Int32(i)
 }
 
 // Int32ValueFromFrameworkInt64 coverts a Framework Int64 value to an int32 value.

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -29,6 +29,19 @@ func Int64ValueFromFramework(ctx context.Context, v basetypes.Int64Valuable) int
 	return output
 }
 
+func Int64FromFrameworkLegacy(_ context.Context, v types.Int64) *int64 {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+
+	i := v.ValueInt64()
+	if i == 0 {
+		return nil
+	}
+
+	return aws.Int64(i)
+}
+
 // Int64ToFramework converts an int64 pointer to a Framework Int64 value.
 // A nil int64 pointer is converted to a null Int64.
 func Int64ToFramework(ctx context.Context, v *int64) types.Int64 {
@@ -86,6 +99,19 @@ func Int32FromFrameworkInt32(ctx context.Context, v basetypes.Int32Valuable) *in
 	must(Expand(ctx, v, &output))
 
 	return output
+}
+
+func Int32FromFrameworkLegacy(_ context.Context, v types.Int32) *int32 {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+
+	i := v.ValueInt32()
+	if i == 0 {
+		return nil
+	}
+
+	return aws.Int32(int32(i))
 }
 
 // Int32ValueFromFrameworkInt64 coverts a Framework Int64 value to an int32 value.

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -230,3 +230,42 @@ func TestInt32FromFramework(t *testing.T) {
 		})
 	}
 }
+
+func TestInt32FromFrameworkLegacy(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.Int32
+		expected *int32
+	}
+	tests := map[string]testCase{
+		"valid int32": {
+			input:    types.Int32Value(42),
+			expected: aws.Int32(42),
+		},
+		"zero int32": {
+			input:    types.Int32Value(0),
+			expected: nil,
+		},
+		"null int32": {
+			input:    types.Int32Null(),
+			expected: nil,
+		},
+		"unknown int32": {
+			input:    types.Int32Unknown(),
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.Int32FromFrameworkLegacy(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}

--- a/internal/framework/flex/string.go
+++ b/internal/framework/flex/string.go
@@ -90,6 +90,19 @@ func StringToFrameworkValuable[T basetypes.StringValuable](ctx context.Context, 
 	return output
 }
 
+func StringFromFrameworkLegacy(_ context.Context, v types.String) *string {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+
+	s := v.ValueString()
+	if s == "" {
+		return nil
+	}
+
+	return aws.String(s)
+}
+
 func EmptyStringAsNull(v types.String) types.String {
 	if v.IsNull() || v.IsUnknown() {
 		return v

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -991,9 +991,9 @@ var (
 )
 
 type lifecycleRuleAndOperatorModel struct {
-	ObjectSizeGreaterThan types.Int64  `tfsdk:"object_size_greater_than" autoflex:",legacy"`
-	ObjectSizeLessThan    types.Int64  `tfsdk:"object_size_less_than" autoflex:",legacy"`
-	Prefix                types.String `tfsdk:"prefix" autoflex:",legacy"`
+	ObjectSizeGreaterThan types.Int64  `tfsdk:"object_size_greater_than"`
+	ObjectSizeLessThan    types.Int64  `tfsdk:"object_size_less_than"`
+	Prefix                types.String `tfsdk:"prefix"`
 	Tags                  tftags.Map   `tfsdk:"tags"`
 }
 

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -1002,7 +1002,7 @@ func (m lifecycleRuleAndOperatorModel) Expand(ctx context.Context) (result any, 
 
 	r.ObjectSizeGreaterThan = fwflex.Int64FromFramework(ctx, m.ObjectSizeGreaterThan)
 
-	r.ObjectSizeLessThan = fwflex.Int64FromFramework(ctx, m.ObjectSizeLessThan)
+	r.ObjectSizeLessThan = fwflex.Int64FromFrameworkLegacy(ctx, m.ObjectSizeLessThan)
 
 	r.Prefix = fwflex.StringFromFramework(ctx, m.Prefix)
 


### PR DESCRIPTION
### Description

Prevents sending invalid 0 for `rule.and.object_size_less_than`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41521

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3BucketLifecycleConfiguration_

--- PASS: TestAccS3BucketLifecycleConfiguration_RulePrefix (52.63s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (52.64s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (52.64s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (53.08s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (53.10s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (54.82s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeLessThan (102.19s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionDate (112.21s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_expireMarkerOnly (117.40s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (65.93s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_ruleAbortIncompleteMultipartUpload (119.13s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (66.73s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRangeAndPrefix (130.14s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RulePrefix (130.76s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionZeroDays_intelligentTiering (132.70s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_And_Tags (136.56s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_FilterWithPrefix (136.66s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRange (143.17s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionStorageClassOnly_intelligentTiering (149.28s)
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (110.38s)
--- PASS: TestAccS3BucketLifecycleConfiguration_directoryBucket (50.79s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_nonCurrentVersionExpiration (173.32s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_withChange (58.70s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_emptyBlock (124.95s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_noChange (60.54s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (49.83s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_basic (125.68s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (50.01s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (52.99s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionStorageClassOnly_intelligentTiering (185.86s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix (50.85s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (51.41s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (48.71s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (46.43s)
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove (97.03s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (146.72s)
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update (92.57s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (86.38s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (48.71s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_basic (215.71s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (44.49s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (89.34s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (74.39s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions (102.43s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (96.92s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_Tag (123.76s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RulePrefix (125.83s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_nonCurrentVersionExpiration (123.25s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_ruleAbortIncompleteMultipartUpload (128.88s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_Tag (117.05s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeGreaterThan (128.87s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions (143.08s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionDate (155.88s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (55.11s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_emptyBlock (163.12s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions_WithChange (157.64s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_Tags (138.94s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_expireMarkerOnly (171.22s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionZeroDays_intelligentTiering (151.26s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions_WithChange (179.85s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeGreaterThan (129.10s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeLessThan (113.70s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (83.20s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_ZeroLessThan_ChangeOnUpdate (174.71s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_filterWithEmptyPrefix (97.89s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRangeAndPrefix (97.27s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_FilterWithPrefix (98.86s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRange (103.01s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (108.64s)
```
