### PR TITLE
Fix `Examples Checks / validate-terraform (0.12.31)` CI check

### DIFF
--- a/examples/sagemaker/main.tf
+++ b/examples/sagemaker/main.tf
@@ -3,6 +3,12 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    random = {
+      version = "~> 3.6"
+    }
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

https://github.com/hashicorp/terraform-provider-aws/actions/runs/13521816083/job/37782597956

```
===> Initializing Example: ./examples/sagemaker <===


Initializing the backend...

Initializing provider plugins...
- Checking for available provider plugins...

Provider "random" v3.7.0-alpha1 is not compatible with Terraform 0.12.31.

Provider version 2.2.1 is the latest compatible version. Select it with 
the following constraint:

    version = "~> 2.2"

Terraform checked all of the plugin versions matching the given constraint:
    (any version)

Consult the documentation for this provider for more information on
compatibility between provider and Terraform versions.

Alternatively, upgrade to the latest version of Terraform for compatibility with newer provider releases.


Error: incompatible provider version
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-random/issues/663.