### PR TITLE
Sweepers: Fix `panic: not implemented` for Framework resources

### DIFF
--- a/internal/sweep/framework/resource.go
+++ b/internal/sweep/framework/resource.go
@@ -55,9 +55,6 @@ func (sr *sweepResource) Delete(ctx context.Context, timeout time.Duration, optF
 		return err
 	}
 
-	metadata := resourceMetadata(ctx, resource)
-	ctx = tflog.SetField(ctx, "resource_type", metadata.TypeName)
-
 	resource.Configure(ctx, fwresource.ConfigureRequest{ProviderData: sr.meta}, &fwresource.ConfigureResponse{})
 
 	schemaResp := fwresource.SchemaResponse{}
@@ -123,11 +120,4 @@ func deleteResource(ctx context.Context, state tfsdk.State, resource fwresource.
 	resource.Delete(ctx, fwresource.DeleteRequest{State: state}, &response)
 
 	return fwdiag.DiagnosticsError(response.Diagnostics)
-}
-
-func resourceMetadata(ctx context.Context, resource fwresource.Resource) fwresource.MetadataResponse {
-	var response fwresource.MetadataResponse
-	resource.Metadata(ctx, fwresource.MetadataRequest{}, &response)
-
-	return response
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

```
2025/02/25 15:17:05 [DEBUG] Running Sweeper (aws_api_gateway_account) in region (us-east-2)
2025/02/25 15:17:05 [INFO]  sweeper: listing resources: sweeper_region=us-east-2 tf_resource_type=aws_api_gateway_account
panic: not implemented

goroutine 1904 [running]:
github.com/hashicorp/terraform-provider-aws/internal/framework.(*ResourceWithConfigure).Metadata(...)
	/Users/kewbank/altsrc.2/github.com/hashicorp/terraform-provider-aws/internal/framework/resource_with_configure.go:22
github.com/hashicorp/terraform-provider-aws/internal/sweep/framework.resourceMetadata(...)
	/Users/kewbank/altsrc.2/github.com/hashicorp/terraform-provider-aws/internal/sweep/framework/resource.go:130
github.com/hashicorp/terraform-provider-aws/internal/sweep/framework.(*sweepResource).Delete(0x14002ed3a40, {0x11ef74950, 0x14002ed3a10}, 0x8bb2c97000, {0x0, 0x0, 0x0?})
	/Users/kewbank/altsrc.2/github.com/hashicorp/terraform-provider-aws/internal/sweep/framework/resource.go:58 +0xcc
github.com/hashicorp/terraform-provider-aws/internal/sweep.SweepOrchestrator.func1()
	/Users/kewbank/altsrc.2/github.com/hashicorp/terraform-provider-aws/internal/sweep/sweep.go:118 +0x48
github.com/hashicorp/go-multierror.(*Group).Go.func1()
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/go-multierror@v1.1.1/group.go:23 +0x60
created by github.com/hashicorp/go-multierror.(*Group).Go in goroutine 1
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/go-multierror@v1.1.1/group.go:20 +0x84
FAIL	github.com/hashicorp/terraform-provider-aws/internal/sweep	98.575s
FAIL
make: *** [sweep] Error 1
```

`Metadata` is now implemented in wrappers, which aren't constructed in sweepers.
`log.WithResourceType` is called from `internal/sweep/awsv2/register.go`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/41141.