### PR TITLE
r/aws_cloudwatch_event_connection: Add `connectivity_parameters` argument

### DIFF
--- a/internal/service/events/connection.go
+++ b/internal/service/events/connection.go
@@ -166,6 +166,33 @@ func resourceConnection() *schema.Resource {
 								MaxItems: 1,
 								Elem:     connectionHttpParameters("auth_parameters.0.invocation_http_parameters"),
 							},
+							"connectivity_parameters": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"resource_parameters": {
+											Type:     schema.TypeList,
+											Required: true,
+											MaxItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"resource_association_arn": {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+													"resource_configuration_arn": {
+														Type:         schema.TypeString,
+														Required:     true,
+														ValidateFunc: verify.ValidARN,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 							"oauth": {
 								Type:     schema.TypeList,
 								Optional: true,
@@ -455,11 +482,11 @@ func statusConnectionState(ctx context.Context, conn *eventbridge.Client, name s
 
 func waitConnectionCreated(ctx context.Context, conn *eventbridge.Client, name string) (*eventbridge.DescribeConnectionOutput, error) {
 	const (
-		timeout = 2 * time.Minute
+		timeout = 10 * time.Minute
 	)
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(types.ConnectionStateCreating, types.ConnectionStateAuthorizing),
-		Target:  enum.Slice(types.ConnectionStateAuthorized, types.ConnectionStateDeauthorized),
+		Pending: enum.Slice(types.ConnectionStateCreating),
+		Target:  enum.Slice(types.ConnectionStateAuthorized, types.ConnectionStateDeauthorized, types.ConnectionStateAuthorizing, types.ConnectionStateActive),
 		Refresh: statusConnectionState(ctx, conn, name),
 		Timeout: timeout,
 	}
@@ -480,8 +507,8 @@ func waitConnectionUpdated(ctx context.Context, conn *eventbridge.Client, name s
 		timeout = 2 * time.Minute
 	)
 	stateConf := &retry.StateChangeConf{
-		Pending: enum.Slice(types.ConnectionStateUpdating, types.ConnectionStateAuthorizing, types.ConnectionStateDeauthorizing),
-		Target:  enum.Slice(types.ConnectionStateAuthorized, types.ConnectionStateDeauthorized),
+		Pending: enum.Slice(types.ConnectionStateUpdating, types.ConnectionStateDeauthorizing),
+		Target:  enum.Slice(types.ConnectionStateAuthorized, types.ConnectionStateDeauthorized, types.ConnectionStateAuthorizing, types.ConnectionStateActive),
 		Refresh: statusConnectionState(ctx, conn, name),
 		Timeout: timeout,
 	}
@@ -539,6 +566,9 @@ func expandCreateConnectionAuthRequestParameters(tfList []interface{}) *types.Cr
 		}
 		if v, ok := tfMap["invocation_http_parameters"].([]interface{}); ok && len(v) > 0 {
 			apiObject.InvocationHttpParameters = expandConnectionHTTPParameters(v)
+		}
+		if v, ok := tfMap["connectivity_parameters"].([]interface{}); ok && len(v) > 0 {
+			apiObject.ConnectivityParameters = expandConnectivityResourceParameters(v[0].(map[string]interface{}))
 		}
 	}
 
@@ -769,6 +799,10 @@ func flattenConnectionAuthParameters(apiObject *types.ConnectionAuthResponsePara
 		tfMap["invocation_http_parameters"] = flattenConnectionHTTPParameters(apiObject.InvocationHttpParameters, d, "auth_parameters.0.invocation_http_parameters")
 	}
 
+	if apiObject.ConnectivityParameters != nil {
+		tfMap["connectivity_parameters"] = []map[string]interface{}{flattenDescribeConnectionConnectivityParameters(apiObject.ConnectivityParameters)}
+	}
+
 	return []map[string]interface{}{tfMap}
 }
 
@@ -915,6 +949,9 @@ func expandUpdateConnectionAuthRequestParameters(tfList []interface{}) *types.Up
 		}
 		if v, ok := tfMap["invocation_http_parameters"].([]interface{}); ok && len(v) > 0 {
 			apiObject.InvocationHttpParameters = expandConnectionHTTPParameters(v)
+		}
+		if v, ok := tfMap["connectivity_parameters"].([]interface{}); ok && len(v) > 0 {
+			apiObject.ConnectivityParameters = expandConnectivityResourceParameters(v[0].(map[string]interface{}))
 		}
 	}
 

--- a/internal/service/events/connection_test.go
+++ b/internal/service/events/connection_test.go
@@ -375,6 +375,86 @@ func TestAccEventsConnection_oAuth(t *testing.T) {
 	})
 }
 
+func TestAccEventsConnection_connectivityParamters(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v eventbridge.DescribeConnectionOutput
+	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	oAuthorizationType := "OAUTH_CLIENT_CREDENTIALS"
+
+	description := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	// oauth
+	authorizationEndpoint := "https://example.com/auth"
+	httpMethod := "POST"
+
+	// client_parameters
+	clientID := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	clientSecret := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	// oauth_http_parameters
+	bodyKey := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bodyValue := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	bodyIsSecretValue := true
+
+	headerKey := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	headerValue := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	headerIsSecretValue := true
+
+	queryStringKey := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	queryStringValue := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	queryStringIsSecretValue := true
+
+	resourceName := "aws_cloudwatch_event_connection.oauth"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EventsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectionConfig_oauthConnectivityParameters(
+					name,
+					description,
+					oAuthorizationType,
+					authorizationEndpoint,
+					httpMethod,
+					clientID,
+					clientSecret,
+					bodyKey,
+					bodyValue,
+					bodyIsSecretValue,
+					headerKey,
+					headerValue,
+					headerIsSecretValue,
+					queryStringKey,
+					queryStringValue,
+					queryStringIsSecretValue,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckConnectionExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, name),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, description),
+					resource.TestCheckResourceAttr(resourceName, "authorization_type", oAuthorizationType),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.oauth.0.authorization_endpoint", authorizationEndpoint),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.oauth.0.http_method", httpMethod),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.oauth.0.client_parameters.0.client_id", clientID),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.oauth.0.oauth_http_parameters.0.body.0.key", bodyKey),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.oauth.0.oauth_http_parameters.0.body.0.is_value_secret", strconv.FormatBool(bodyIsSecretValue)),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.oauth.0.oauth_http_parameters.0.header.0.key", headerKey),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.oauth.0.oauth_http_parameters.0.header.0.is_value_secret", strconv.FormatBool(headerIsSecretValue)),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.oauth.0.oauth_http_parameters.0.query_string.0.key", queryStringKey),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.oauth.0.oauth_http_parameters.0.query_string.0.is_value_secret", strconv.FormatBool(queryStringIsSecretValue)),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.connectivity_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auth_parameters.0.connectivity_parameters.0.resource_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "invocation_connectivity_parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "invocation_connectivity_parameters.0.resource_parameters.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccEventsConnection_invocationHTTPParameters(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2, v3 eventbridge.DescribeConnectionOutput
@@ -908,6 +988,109 @@ resource "aws_cloudwatch_event_connection" "oauth" {
   }
 }
 `, name, description, authorizationType, authorizationEndpoint, httpMethod)
+}
+
+func testAccConnectionConfig_oauthConnectivityParameters(
+	name,
+	description,
+	authorizationType,
+	authorizationEndpoint,
+	httpMethod,
+	clientID,
+	clientSecret string,
+	bodyKey string,
+	bodyValue string,
+	bodyIsSecretValue bool,
+	headerKey string,
+	headerValue string,
+	headerIsSecretValue bool,
+	queryStringKey string,
+	queryStringValue string,
+	queryStringIsSecretValue bool) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(name, 1), fmt.Sprintf(`
+resource "aws_vpclattice_resource_gateway" "test" {
+  name       = %[1]q
+  vpc_id     = aws_vpc.test.id
+  subnet_ids = aws_subnet.test[*].id
+}
+
+resource "aws_vpclattice_resource_configuration" "test" {
+  name = %[1]q
+
+  resource_gateway_identifier = aws_vpclattice_resource_gateway.test.id
+
+  port_ranges = ["80"]
+  protocol    = "TCP"
+
+  resource_configuration_definition {
+    dns_resource {
+      domain_name     = "example.com"
+      ip_address_type = "IPV4"
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_connection" "oauth" {
+  name               = %[1]q
+  description        = %[2]q
+  authorization_type = %[3]q
+  invocation_connectivity_parameters {
+    resource_parameters {
+      resource_configuration_arn = aws_vpclattice_resource_configuration.test.arn
+    }
+  }
+  auth_parameters {
+    connectivity_parameters {
+      resource_parameters {
+        resource_configuration_arn = aws_vpclattice_resource_configuration.test.arn
+      }
+    }
+    oauth {
+      authorization_endpoint = %[4]q
+      http_method            = %[5]q
+      client_parameters {
+        client_id     = %[6]q
+        client_secret = %[7]q
+      }
+
+      oauth_http_parameters {
+        body {
+          key             = %[8]q
+          value           = %[9]q
+          is_value_secret = %[10]t
+        }
+
+        header {
+          key             = %[11]q
+          value           = %[12]q
+          is_value_secret = %[13]t
+        }
+
+        query_string {
+          key             = %[14]q
+          value           = %[15]q
+          is_value_secret = %[16]t
+        }
+      }
+    }
+  }
+}
+`, name,
+		description,
+		authorizationType,
+		authorizationEndpoint,
+		httpMethod,
+		clientID,
+		clientSecret,
+		bodyKey,
+		bodyValue,
+		bodyIsSecretValue,
+		headerKey,
+		headerValue,
+		headerIsSecretValue,
+		queryStringKey,
+		queryStringValue,
+		queryStringIsSecretValue))
 }
 
 func testAccConnectionConfig_invocationConnectivityParameters(rName string) string {

--- a/website/docs/r/cloudwatch_event_connection.html.markdown
+++ b/website/docs/r/cloudwatch_event_connection.html.markdown
@@ -145,6 +145,7 @@ This resource supports the following arguments:
 
 * `api_key` - (Optional) Parameters used for API_KEY authorization. An API key to include in the header for each authentication request. A maximum of 1 are allowed. Conflicts with `basic` and `oauth`. Documented below.
 * `basic` - (Optional) Parameters used for BASIC authorization. A maximum of 1 are allowed. Conflicts with `api_key` and `oauth`. Documented below.
+* `connectivity_parameters` - (Optional) Parameters used for `oauth` with private API. Documented below.
 * `invocation_http_parameters` - (Optional) Invocation Http Parameters are additional credentials used to sign each Invocation of the ApiDestination created from this Connection. If the ApiDestination Rule Target has additional HttpParameters, the values will be merged together, with the Connection Invocation Http Parameters taking precedence. Secret values are stored and managed by AWS Secrets Manager. A maximum of 1 are allowed. Documented below.
 * `oauth` - (Optional) Parameters used for OAUTH_CLIENT_CREDENTIALS authorization. A maximum of 1 are allowed. Conflicts with `basic` and `api_key`. Documented below.
 
@@ -187,6 +188,10 @@ This resource supports the following arguments:
 `invocation_connectivity_parameters` supports the following:
 
 * `resource_parameters` - (Required) The parameters for EventBridge to use when invoking the resource endpoint. Documented below.
+
+`connectivity_parameters` supports the following:
+
+* `resource_parameters` - (Required) The parameters for EventBridge to use when invoking the authentication endpoint. Documented below.
 
 `resource_parameters` supports the following:
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Adding `connectivity_parameters` to `aws_cloudwatch_event_connection` for supporting OAuth on private APIs.

Note: The creation of a connection with OAuth on a private API takes a little longer. I tested with different configurations, and got the following results. Creating a connection with OAuth on a private API might take up to 20 minutes before accessing a target state of `AUTHORIZED`, `DEAUTHORIZED` or `ACTIVE`. By accepting `AUTHORIZING` as a target state for a valid creation I could lower the timeout to 10 min (see `Output from Acceptance Testing`). I would go with this setup, otherwise we have to stay with a timeout of 20 min as it seems (see `Output from Acceptance Testing - Option 2` below).
More Information on connection states here [https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-target-connection-states.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-target-connection-states.html). As far as I understand this documentation `AUTHORIZING` is only used for private API OAuth, so there shouldnt be any conflicts.
Comment if you wish for the second implementation, then I will update this branch.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41220

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing - current implementation (10 min timeout & target states: AUTHORIZED, DEAUTHORIZED, ACTIVE, AUTHORIZING)
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=events TESTS=TestAccEventsConnection_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsConnection_'  -timeout 360m -vet=off
2025/02/25 21:05:14 Initializing Terraform AWS Provider...
=== RUN   TestAccEventsConnection_apiKey
=== PAUSE TestAccEventsConnection_apiKey
=== RUN   TestAccEventsConnection_basic
=== PAUSE TestAccEventsConnection_basic
=== RUN   TestAccEventsConnection_oAuth
=== PAUSE TestAccEventsConnection_oAuth
=== RUN   TestAccEventsConnection_connectivityParamters
=== PAUSE TestAccEventsConnection_connectivityParamters
=== RUN   TestAccEventsConnection_invocationHTTPParameters
=== PAUSE TestAccEventsConnection_invocationHTTPParameters
=== RUN   TestAccEventsConnection_disappears
=== PAUSE TestAccEventsConnection_disappears
=== RUN   TestAccEventsConnection_invocationConnectivityParameters
=== PAUSE TestAccEventsConnection_invocationConnectivityParameters
=== CONT  TestAccEventsConnection_apiKey
=== CONT  TestAccEventsConnection_invocationHTTPParameters
=== CONT  TestAccEventsConnection_invocationConnectivityParameters
=== CONT  TestAccEventsConnection_oAuth
=== CONT  TestAccEventsConnection_connectivityParamters
=== CONT  TestAccEventsConnection_basic
=== CONT  TestAccEventsConnection_disappears
--- PASS: TestAccEventsConnection_disappears (67.76s)
--- PASS: TestAccEventsConnection_basic (92.80s)
--- PASS: TestAccEventsConnection_invocationHTTPParameters (102.69s)
--- PASS: TestAccEventsConnection_apiKey (106.04s)
--- PASS: TestAccEventsConnection_oAuth (106.04s)
--- PASS: TestAccEventsConnection_invocationConnectivityParameters (151.34s)
--- PASS: TestAccEventsConnection_connectivityParamters (452.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     458.176s
```

### Output from Acceptance Testing - Option 2 (20 min timeout & target states: AUTHORIZED, DEAUTHORIZED, ACTIVE)
```console
% make testacc PKG=events TESTS=TestAccEventsConnection_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsConnection_'  -timeout 360m -vet=off
2025/02/25 20:45:48 Initializing Terraform AWS Provider...
=== RUN   TestAccEventsConnection_apiKey
=== PAUSE TestAccEventsConnection_apiKey
=== RUN   TestAccEventsConnection_basic
=== PAUSE TestAccEventsConnection_basic
=== RUN   TestAccEventsConnection_oAuth
=== PAUSE TestAccEventsConnection_oAuth
=== RUN   TestAccEventsConnection_connectivityParamters
=== PAUSE TestAccEventsConnection_connectivityParamters
=== RUN   TestAccEventsConnection_invocationHTTPParameters
=== PAUSE TestAccEventsConnection_invocationHTTPParameters
=== RUN   TestAccEventsConnection_disappears
=== PAUSE TestAccEventsConnection_disappears
=== RUN   TestAccEventsConnection_invocationConnectivityParameters
=== PAUSE TestAccEventsConnection_invocationConnectivityParameters
=== CONT  TestAccEventsConnection_apiKey
=== CONT  TestAccEventsConnection_invocationHTTPParameters
=== CONT  TestAccEventsConnection_invocationConnectivityParameters
=== CONT  TestAccEventsConnection_oAuth
=== CONT  TestAccEventsConnection_basic
=== CONT  TestAccEventsConnection_connectivityParamters
=== CONT  TestAccEventsConnection_disappears
--- PASS: TestAccEventsConnection_disappears (29.23s)
--- PASS: TestAccEventsConnection_basic (49.23s)
--- PASS: TestAccEventsConnection_invocationHTTPParameters (62.01s)
--- PASS: TestAccEventsConnection_apiKey (63.33s)
--- PASS: TestAccEventsConnection_oAuth (67.23s)
--- PASS: TestAccEventsConnection_invocationConnectivityParameters (112.36s)
--- PASS: TestAccEventsConnection_connectivityParamters (1031.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     1039.225s
```