### PR TITLE
validations: remove `PreferWriteOnlyAttribute` validations

### DIFF
--- a/.changelog/41562.txt
+++ b/.changelog/41562.txt
@@ -1,0 +1,27 @@
+```release-note:enhancement
+resource/aws_db_instance: Add `RequiredWith` validation `password_wo` and `password_wo_version`. Remove `PreferWriteOnlyAttribute` validation
+```
+
+```release-note:enhancement
+resource/aws_secretsmanager_secret_version: Add `RequiredWith` validation `secret_string_wo` and `secret_string_wo_version`. Remove `PreferWriteOnlyAttribute` validation
+```
+
+```release-note:enhancement
+resource/aws_rds_cluster: Add `RequiredWith` validation `master_password_wo` and `master_password_wo_version`. Remove `PreferWriteOnlyAttribute` validation
+```
+
+```release-note:enhancement
+resource/aws_redshift_cluster: Add `RequiredWith` validation `master_password_wo` and `master_password_wo_version`. Remove `PreferWriteOnlyAttribute` validation
+```
+
+```release-note:enhancement
+resource/aws_redshiftseverless_namespace: Add `RequiredWith` validation `admin_user_password_wo` and `admin_user_password_wo_version`. Remove `PreferWriteOnlyAttribute` validation
+```
+
+```release-note:enhancement
+resource/aws_docdb_cluster: Add `RequiredWith` validation `master_password_wo` and `master_password_wo_version`. Remove `PreferWriteOnlyAttribute` validation
+```
+
+```release-note:enhancement
+resource/aws_ssm_parameter: Remove `PreferWriteOnlyAttribute` validation
+```

--- a/internal/service/docdb/cluster.go
+++ b/internal/service/docdb/cluster.go
@@ -58,10 +58,6 @@ func resourceCluster() *schema.Resource {
 			Delete: schema.DefaultTimeout(120 * time.Minute),
 		},
 
-		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
-			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("master_password"), cty.GetAttrPath("master_password_wo")),
-		},
-
 		Schema: map[string]*schema.Schema{
 			names.AttrAllowMajorVersionUpgrade: {
 				Type:     schema.TypeBool,
@@ -201,6 +197,7 @@ func resourceCluster() *schema.Resource {
 				Optional:      true,
 				WriteOnly:     true,
 				ConflictsWith: []string{"master_password"},
+				RequiredWith:  []string{"master_password_wo_version"},
 			},
 			"master_password_wo_version": {
 				Type:         schema.TypeInt,

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -70,10 +70,6 @@ func resourceCluster() *schema.Resource {
 			},
 		},
 
-		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
-			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("master_password"), cty.GetAttrPath("master_password_wo")),
-		},
-
 		Schema: map[string]*schema.Schema{
 			names.AttrAllocatedStorage: {
 				Type:     schema.TypeInt,
@@ -368,6 +364,7 @@ func resourceCluster() *schema.Resource {
 				Sensitive:     true,
 				WriteOnly:     true,
 				ConflictsWith: []string{"manage_master_user_password", "master_password"},
+				RequiredWith:  []string{"master_password_wo_version"},
 			},
 			"master_password_wo_version": {
 				Type:         schema.TypeInt,

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -85,10 +85,6 @@ func resourceInstance() *schema.Resource {
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
-		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
-			validation.PreferWriteOnlyAttribute(cty.GetAttrPath(names.AttrPassword), cty.GetAttrPath("password_wo")),
-		},
-
 		Schema: map[string]*schema.Schema{
 			names.AttrAddress: {
 				Type:     schema.TypeString,
@@ -509,6 +505,7 @@ func resourceInstance() *schema.Resource {
 				WriteOnly:     true,
 				Sensitive:     true,
 				ConflictsWith: []string{"manage_master_user_password", names.AttrPassword},
+				RequiredWith:  []string{"password_wo_version"},
 			},
 			"password_wo_version": {
 				Type:         schema.TypeInt,

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -52,10 +52,6 @@ func resourceCluster() *schema.Resource {
 			Delete: schema.DefaultTimeout(40 * time.Minute),
 		},
 
-		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
-			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("master_password"), cty.GetAttrPath("master_password_wo")),
-		},
-
 		Schema: map[string]*schema.Schema{
 			"allow_version_upgrade": {
 				Type:     schema.TypeBool,
@@ -306,6 +302,7 @@ func resourceCluster() *schema.Resource {
 					validation.StringMatch(regexache.MustCompile(`^[^\@\/'" ]*$`), "cannot contain [/@\"' ]"),
 				),
 				ConflictsWith: []string{"manage_master_password", "master_password"},
+				RequiredWith:  []string{"master_password_wo_version"},
 			},
 			"master_password_wo_version": {
 				Type:         schema.TypeInt,

--- a/internal/service/redshiftserverless/namespace.go
+++ b/internal/service/redshiftserverless/namespace.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -43,10 +42,6 @@ func resourceNamespace() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
-			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("admin_user_password"), cty.GetAttrPath("admin_user_password_wo")),
-		},
-
 		Schema: map[string]*schema.Schema{
 			"admin_password_secret_arn": {
 				Type:     schema.TypeString,
@@ -69,6 +64,7 @@ func resourceNamespace() *schema.Resource {
 				Optional:      true,
 				WriteOnly:     true,
 				ConflictsWith: []string{"admin_user_password", "manage_admin_password"},
+				RequiredWith:  []string{"admin_user_password_wo_version"},
 			},
 			"admin_user_password_wo_version": {
 				Type:         schema.TypeInt,

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -46,10 +45,6 @@ func resourceSecretVersion() *schema.Resource {
 				d.Set("has_secret_string_wo", false)
 				return []*schema.ResourceData{d}, nil
 			},
-		},
-
-		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
-			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("secret_string"), cty.GetAttrPath("secret_string_wo")),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -87,6 +82,7 @@ func resourceSecretVersion() *schema.Resource {
 				WriteOnly:     true,
 				Sensitive:     true,
 				ConflictsWith: []string{"secret_binary", "secret_string"},
+				RequiredWith:  []string{"secret_string_wo_version"},
 			},
 			"secret_string_wo_version": {
 				Type:         schema.TypeInt,

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -46,9 +46,6 @@ func resourceParameter() *schema.Resource {
 			},
 		},
 
-		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
-			validation.PreferWriteOnlyAttribute(cty.GetAttrPath(names.AttrValue), cty.GetAttrPath("value_wo")),
-		},
 		Schema: map[string]*schema.Schema{
 			"allowed_pattern": {
 				Type:         schema.TypeString,

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -27,7 +27,7 @@ See the AWS Docs on [RDS Instance Maintenance][instance-maintenance] for more in
 ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 [Read more about sensitive data instate](https://www.terraform.io/docs/state/sensitive-data.html).
 
--> **Note:** Write-Only attribute `password_wo` is available to use in place of `password`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+-> **Note:** Write-Only argument `password_wo` is available to use in place of `password`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
 > **Hands-on:** Try the [Manage AWS RDS Instances](https://learn.hashicorp.com/tutorials/terraform/aws-rds) tutorial on HashiCorp Learn.
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -27,6 +27,8 @@ See the AWS Docs on [RDS Instance Maintenance][instance-maintenance] for more in
 ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 [Read more about sensitive data instate](https://www.terraform.io/docs/state/sensitive-data.html).
 
+-> **Note:** Write-Only attribute `password_wo` is available to use in place of `password`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+
 > **Hands-on:** Try the [Manage AWS RDS Instances](https://learn.hashicorp.com/tutorials/terraform/aws-rds) tutorial on HashiCorp Learn.
 
 ## RDS Instance Class Types

--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -21,7 +21,7 @@ phase because a modification has not yet taken place. You can use the
 ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
--> **Note:** Write-Only attribute `master_password_wo` is available to use in place of `master_password`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+-> **Note:** Write-Only argument `master_password_wo` is available to use in place of `master_password`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
 ## Example Usage
 

--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -21,6 +21,8 @@ phase because a modification has not yet taken place. You can use the
 ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
+-> **Note:** Write-Only attribute `master_password_wo` is available to use in place of `master_password`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -25,7 +25,7 @@ Changes to an RDS Cluster can occur when you manually change a parameter, such a
 
 ~> **NOTE on RDS Clusters and RDS Cluster Role Associations:** Terraform provides both a standalone [RDS Cluster Role Association](rds_cluster_role_association.html) - (an association between an RDS Cluster and a single IAM Role) and an RDS Cluster resource with `iam_roles` attributes. Use one resource or the other to associate IAM Roles and RDS Clusters. Not doing so will cause a conflict of associations and will result in the association being overwritten.
 
--> **Note:** Write-Only arguments `master_password_wo` is available to use in place of `master_password`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
+-> **Note:** Write-Only argument `master_password_wo` is available to use in place of `master_password`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
 ## Example Usage
 

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -25,7 +25,7 @@ Changes to an RDS Cluster can occur when you manually change a parameter, such a
 
 ~> **NOTE on RDS Clusters and RDS Cluster Role Associations:** Terraform provides both a standalone [RDS Cluster Role Association](rds_cluster_role_association.html) - (an association between an RDS Cluster and a single IAM Role) and an RDS Cluster resource with `iam_roles` attributes. Use one resource or the other to associate IAM Roles and RDS Clusters. Not doing so will cause a conflict of associations and will result in the association being overwritten.
 
--> **Note:** Write-Only attribute `master_password_wo` is available to use in place of `master_password`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+-> **Note:** Write-Only arguments `master_password_wo` is available to use in place of `master_password`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
 ## Example Usage
 

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -25,6 +25,8 @@ Changes to an RDS Cluster can occur when you manually change a parameter, such a
 
 ~> **NOTE on RDS Clusters and RDS Cluster Role Associations:** Terraform provides both a standalone [RDS Cluster Role Association](rds_cluster_role_association.html) - (an association between an RDS Cluster and a single IAM Role) and an RDS Cluster resource with `iam_roles` attributes. Use one resource or the other to associate IAM Roles and RDS Clusters. Not doing so will cause a conflict of associations and will result in the association being overwritten.
 
+-> **Note:** Write-Only attribute `master_password_wo` is available to use in place of `master_password`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+
 ## Example Usage
 
 ### Aurora MySQL 2.x (MySQL 5.7)

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -15,6 +15,8 @@ Provides a Redshift Cluster Resource.
 
 ~> **NOTE:** A Redshift cluster's default IAM role can be managed both by this resource's `default_iam_role_arn` argument and the [`aws_redshift_cluster_iam_roles`](redshift_cluster_iam_roles.html) resource's `default_iam_role_arn` argument. Do not configure different values for both arguments. Doing so will cause a conflict of default IAM roles.
 
+-> **Note:** Write-Only attribute `master_password_wo` is available to use in place of `master_password`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+
 ## Example Usage
 
 ### Basic Usage

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -15,7 +15,7 @@ Provides a Redshift Cluster Resource.
 
 ~> **NOTE:** A Redshift cluster's default IAM role can be managed both by this resource's `default_iam_role_arn` argument and the [`aws_redshift_cluster_iam_roles`](redshift_cluster_iam_roles.html) resource's `default_iam_role_arn` argument. Do not configure different values for both arguments. Doing so will cause a conflict of default IAM roles.
 
--> **Note:** Write-Only attribute `master_password_wo` is available to use in place of `master_password`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+-> **Note:** Write-Only argument `master_password_wo` is available to use in place of `master_password`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
 ## Example Usage
 

--- a/website/docs/r/redshiftserverless_namespace.html.markdown
+++ b/website/docs/r/redshiftserverless_namespace.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Creates a new Amazon Redshift Serverless Namespace.
 
--> **Note:** Write-Only attribute `admin_password_wo` is available to use in place of `admin_password`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+-> **Note:** Write-Only argument `admin_password_wo` is available to use in place of `admin_password`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
 ## Example Usage
 

--- a/website/docs/r/redshiftserverless_namespace.html.markdown
+++ b/website/docs/r/redshiftserverless_namespace.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Creates a new Amazon Redshift Serverless Namespace.
 
+-> **Note:** Write-Only attribute `admin_password_wo` is available to use in place of `admin_password`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -12,7 +12,7 @@ Provides a resource to manage AWS Secrets Manager secret version including its s
 
 ~> **NOTE:** If the `AWSCURRENT` staging label is present on this version during resource deletion, that label cannot be removed and will be skipped to prevent errors when fully deleting the secret. That label will leave this secret version active even after the resource is deleted from Terraform unless the secret itself is deleted. Move the `AWSCURRENT` staging label before or after deleting this resource from Terraform to fully trigger version deprecation if necessary.
 
--> **Note:** Write-Only attribute `secret_string_wo` is available to use in place of `secret_string`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+-> **Note:** Write-Only argument `secret_string_wo` is available to use in place of `secret_string`. Write-Only argumentss are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
 ## Example Usage
 

--- a/website/docs/r/secretsmanager_secret_version.html.markdown
+++ b/website/docs/r/secretsmanager_secret_version.html.markdown
@@ -12,6 +12,8 @@ Provides a resource to manage AWS Secrets Manager secret version including its s
 
 ~> **NOTE:** If the `AWSCURRENT` staging label is present on this version during resource deletion, that label cannot be removed and will be skipped to prevent errors when fully deleting the secret. That label will leave this secret version active even after the resource is deleted from Terraform unless the secret itself is deleted. Move the `AWSCURRENT` staging label before or after deleting this resource from Terraform to fully trigger version deprecation if necessary.
 
+-> **Note:** Write-Only attribute `secret_string_wo` is available to use in place of `secret_string`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+
 ## Example Usage
 
 ### Simple String Value

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -12,6 +12,8 @@ Provides an SSM Parameter resource.
 
 ~> **Note:** `overwrite` also makes it possible to overwrite an existing SSM Parameter that's not created by Terraform before. This argument has been deprecated and will be removed in v6.0.0 of the provider. For more information on how this affects the behavior of this resource, see [this issue comment](https://github.com/hashicorp/terraform-provider-aws/issues/25636#issuecomment-1623661159).
 
+-> **Note:** Write-Only attribute `value_wo` is available to use in place of `value`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+
 ## Example Usage
 
 ### Basic example

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -12,7 +12,7 @@ Provides an SSM Parameter resource.
 
 ~> **Note:** `overwrite` also makes it possible to overwrite an existing SSM Parameter that's not created by Terraform before. This argument has been deprecated and will be removed in v6.0.0 of the provider. For more information on how this affects the behavior of this resource, see [this issue comment](https://github.com/hashicorp/terraform-provider-aws/issues/25636#issuecomment-1623661159).
 
--> **Note:** Write-Only attribute `value_wo` is available to use in place of `value`. Write-Only attributes are supported in HashiCorp Terraform 1.11.0 and later.
+-> **Note:** Write-Only argument `value_wo` is available to use in place of `value`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
 ## Example Usage
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`PreferWriteOnlyAttribute` validation will be displayed as a `warning` when the following conditions are met:
- Using Terraform 1.11.0
- Not using a `write-only` attribute on a resource when one is available

This warning can be polarizing since there is nothing wrong with the configuration and the validation is simply a suggestion.

This PR also adds additional `RequiredWith` validation to `_wo` and `_wo_version` attributes

![image](https://github.com/user-attachments/assets/092af4c4-6687-44d3-b436-19eb88411159)

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
