### PR TITLE
Tech Debt: Improve memory behaviour of type-specific Flattener and Expander functions

### DIFF
--- a/internal/framework/flex/auto_expand_test.go
+++ b/internal/framework/flex/auto_expand_test.go
@@ -4627,9 +4627,6 @@ func TestExpandInterface(t *testing.T) {
 				infoExpanding(reflect.TypeFor[tfInterfaceFlexer](), reflect.TypeFor[*awsInterfaceInterface]()),
 				infoConverting(reflect.TypeFor[tfInterfaceFlexer](), reflect.TypeFor[awsInterfaceInterface]()),
 				infoSourceImplementsFlexExpander("", reflect.TypeFor[tfInterfaceFlexer](), "", reflect.TypeFor[awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceFlexer.Expand()
-				infoExpandingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[*string]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"top level return value does not implement target interface": {
@@ -4644,9 +4641,6 @@ func TestExpandInterface(t *testing.T) {
 				infoExpanding(reflect.TypeFor[tfInterfaceIncompatibleExpander](), reflect.TypeFor[*awsInterfaceInterface]()),
 				infoConverting(reflect.TypeFor[tfInterfaceIncompatibleExpander](), reflect.TypeFor[awsInterfaceInterface]()),
 				infoSourceImplementsFlexExpander("", reflect.TypeFor[tfInterfaceIncompatibleExpander](), "", reflect.TypeFor[awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceFlexer.Expand()
-				infoExpandingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[*string]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"single list Source and single interface Target": {
@@ -4669,9 +4663,6 @@ func TestExpandInterface(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfListNestedObject[tfInterfaceFlexer]](), "Field1", reflect.TypeFor[*awsInterfaceSingle]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfInterfaceFlexer]](), "Field1", reflect.TypeFor[awsInterfaceInterface]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfInterfaceFlexer](), "Field1", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()),                // TODO: fix path
 			},
 		},
 		"single list non-Expander Source and single interface Target": {
@@ -4724,9 +4715,6 @@ func TestExpandInterface(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfSetNestedObject[tfInterfaceFlexer]](), "Field1", reflect.TypeFor[*awsInterfaceSingle]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfInterfaceFlexer]](), "Field1", reflect.TypeFor[awsInterfaceInterface]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfInterfaceFlexer](), "Field1", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"empty list Source and empty interface Target": {
@@ -4774,13 +4762,7 @@ func TestExpandInterface(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfInterfaceFlexer]](), "Field1", reflect.TypeFor[[]awsInterfaceInterface]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfInterfaceFlexer]](), 2, "Field1", reflect.TypeFor[[]awsInterfaceInterface]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfInterfaceFlexer](), "Field1[0]", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexExpander("Field1[1]", reflect.TypeFor[tfInterfaceFlexer](), "Field1[1]", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceFlexer.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"empty set Source and empty interface Target": {
@@ -4828,13 +4810,7 @@ func TestExpandInterface(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfInterfaceFlexer]](), "Field1", reflect.TypeFor[[]awsInterfaceInterface]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfInterfaceFlexer]](), 2, "Field1", reflect.TypeFor[[]awsInterfaceInterface]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfInterfaceFlexer](), "Field1[0]", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexExpander("Field1[1]", reflect.TypeFor[tfInterfaceFlexer](), "Field1[1]", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceFlexer.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"object value Source and struct Target": {
@@ -4855,9 +4831,6 @@ func TestExpandInterface(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfObjectValue[tfInterfaceFlexer]](), "Field1", reflect.TypeFor[*awsInterfaceSingle]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ObjectValueOf[tfInterfaceFlexer]](), "Field1", reflect.TypeFor[awsInterfaceInterface]()),
 				infoSourceImplementsFlexExpander("Field1", reflect.TypeFor[tfInterfaceFlexer](), "Field1", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceFlexer.Expand()
-				infoExpandingWithPath("Field1", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 	}
@@ -4886,9 +4859,6 @@ func TestExpandExpander(t *testing.T) {
 				infoExpanding(reflect.TypeFor[tfFlexer](), reflect.TypeFor[*awsExpander]()),
 				infoConverting(reflect.TypeFor[tfFlexer](), reflect.TypeFor[*awsExpander]()),
 				infoSourceImplementsFlexExpander("", reflect.TypeFor[tfFlexer](), "", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"top level string Target": {
@@ -4901,9 +4871,6 @@ func TestExpandExpander(t *testing.T) {
 				infoExpanding(reflect.TypeFor[tfExpanderToString](), reflect.TypeFor[*string]()),
 				infoConverting(reflect.TypeFor[tfExpanderToString](), reflect.TypeFor[string]()),
 				infoSourceImplementsFlexExpander("", reflect.TypeFor[tfExpanderToString](), "", reflect.TypeFor[string]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"top level incompatible struct Target": {
@@ -4918,9 +4885,6 @@ func TestExpandExpander(t *testing.T) {
 				infoExpanding(reflect.TypeFor[tfFlexer](), reflect.TypeFor[*awsExpanderIncompatible]()),
 				infoConverting(reflect.TypeFor[tfFlexer](), reflect.TypeFor[*awsExpanderIncompatible]()),
 				infoSourceImplementsFlexExpander("", reflect.TypeFor[tfFlexer](), "", reflect.TypeFor[*awsExpanderIncompatible]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[*string]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"top level expands to nil": {
@@ -4949,9 +4913,6 @@ func TestExpandExpander(t *testing.T) {
 				infoExpanding(reflect.TypeFor[tfExpanderToString](), reflect.TypeFor[*int64]()),
 				infoConverting(reflect.TypeFor[tfExpanderToString](), reflect.TypeFor[int64]()),
 				infoSourceImplementsFlexExpander("", reflect.TypeFor[tfExpanderToString](), "", reflect.TypeFor[int64]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"single list Source and single struct Target": {
@@ -4974,9 +4935,6 @@ func TestExpandExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfExpanderListNestedObject](), "Field1", reflect.TypeFor[*awsExpanderSingleStruct]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]](), "Field1", reflect.TypeFor[awsExpander]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfFlexer](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"single set Source and single struct Target": {
@@ -4999,9 +4957,6 @@ func TestExpandExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfExpanderSetNestedObject](), "Field1", reflect.TypeFor[*awsExpanderSingleStruct]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]](), "Field1", reflect.TypeFor[awsExpander]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfFlexer](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"single list Source and single *struct Target": {
@@ -5024,9 +4979,6 @@ func TestExpandExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfExpanderListNestedObject](), "Field1", reflect.TypeFor[*awsExpanderSinglePtr]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]](), "Field1", reflect.TypeFor[*awsExpander]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfFlexer](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"single set Source and single *struct Target": {
@@ -5049,9 +5001,6 @@ func TestExpandExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfExpanderSetNestedObject](), "Field1", reflect.TypeFor[*awsExpanderSinglePtr]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]](), "Field1", reflect.TypeFor[*awsExpander]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfFlexer](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"empty list Source and empty struct Target": {
@@ -5099,13 +5048,7 @@ func TestExpandExpander(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]](), "Field1", reflect.TypeFor[[]awsExpander]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]](), 2, "Field1", reflect.TypeFor[[]awsExpander]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfFlexer](), "Field1[0]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexExpander("Field1[1]", reflect.TypeFor[tfFlexer](), "Field1[1]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"empty list Source and empty *struct Target": {
@@ -5153,13 +5096,7 @@ func TestExpandExpander(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]](), "Field1", reflect.TypeFor[[]*awsExpander]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]](), 2, "Field1", reflect.TypeFor[[]*awsExpander]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfFlexer](), "Field1[0]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexExpander("Field1[1]", reflect.TypeFor[tfFlexer](), "Field1[1]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"empty set Source and empty struct Target": {
@@ -5207,13 +5144,7 @@ func TestExpandExpander(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]](), "Field1", reflect.TypeFor[[]awsExpander]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]](), 2, "Field1", reflect.TypeFor[[]awsExpander]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfFlexer](), "Field1[0]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexExpander("Field1[1]", reflect.TypeFor[tfFlexer](), "Field1[1]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"empty set Source and empty *struct Target": {
@@ -5261,13 +5192,7 @@ func TestExpandExpander(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]](), "Field1", reflect.TypeFor[[]*awsExpander]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]](), 2, "Field1", reflect.TypeFor[[]*awsExpander]()),
 				infoSourceImplementsFlexExpander("Field1[0]", reflect.TypeFor[tfFlexer](), "Field1[0]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexExpander("Field1[1]", reflect.TypeFor[tfFlexer](), "Field1[1]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"object value Source and struct Target": {
@@ -5288,9 +5213,6 @@ func TestExpandExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfExpanderObjectValue](), "Field1", reflect.TypeFor[*awsExpanderSingleStruct]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ObjectValueOf[tfFlexer]](), "Field1", reflect.TypeFor[awsExpander]()),
 				infoSourceImplementsFlexExpander("Field1", reflect.TypeFor[tfFlexer](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"object value Source and *struct Target": {
@@ -5311,9 +5233,6 @@ func TestExpandExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfExpanderObjectValue](), "Field1", reflect.TypeFor[*awsExpanderSinglePtr]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ObjectValueOf[tfFlexer]](), "Field1", reflect.TypeFor[*awsExpander]()),
 				infoSourceImplementsFlexExpander("Field1", reflect.TypeFor[tfFlexer](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFFlexer.Expand()
-				infoExpandingWithPath("Field1", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 	}
@@ -5340,9 +5259,6 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 				infoExpanding(reflect.TypeFor[tfInterfaceTypedExpander](), reflect.TypeFor[*awsInterfaceInterface]()),
 				infoConverting(reflect.TypeFor[tfInterfaceTypedExpander](), reflect.TypeFor[awsInterfaceInterface]()),
 				infoSourceImplementsFlexTypedExpander("", reflect.TypeFor[tfInterfaceTypedExpander](), "", reflect.TypeFor[awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceTypedExpander.Expand()
-				infoExpandingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[*string]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"top level return value does not implement target interface": {
@@ -5357,9 +5273,6 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 				infoExpanding(reflect.TypeFor[tfInterfaceIncompatibleTypedExpander](), reflect.TypeFor[*awsInterfaceInterface]()),
 				infoConverting(reflect.TypeFor[tfInterfaceIncompatibleTypedExpander](), reflect.TypeFor[awsInterfaceInterface]()),
 				infoSourceImplementsFlexTypedExpander("", reflect.TypeFor[tfInterfaceIncompatibleTypedExpander](), "", reflect.TypeFor[awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceTypedExpander.Expand()
-				infoExpandingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[*string]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"single list Source and single interface Target": {
@@ -5382,9 +5295,6 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfListNestedObject[tfInterfaceTypedExpander]](), "Field1", reflect.TypeFor[*awsInterfaceSingle]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfInterfaceTypedExpander]](), "Field1", reflect.TypeFor[awsInterfaceInterface]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfInterfaceTypedExpander](), "Field1", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()),                // TODO: fix path
 			},
 		},
 		"single list non-Expander Source and single interface Target": {
@@ -5437,9 +5347,6 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfSetNestedObject[tfInterfaceTypedExpander]](), "Field1", reflect.TypeFor[*awsInterfaceSingle]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfInterfaceTypedExpander]](), "Field1", reflect.TypeFor[awsInterfaceInterface]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfInterfaceTypedExpander](), "Field1", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()),                // TODO: fix path
 			},
 		},
 		"empty list Source and empty interface Target": {
@@ -5487,13 +5394,7 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfInterfaceTypedExpander]](), "Field1", reflect.TypeFor[[]awsInterfaceInterface]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfInterfaceTypedExpander]](), 2, "Field1", reflect.TypeFor[[]awsInterfaceInterface]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfInterfaceTypedExpander](), "Field1[0]", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()),                   // TODO: fix path
 				infoSourceImplementsFlexTypedExpander("Field1[1]", reflect.TypeFor[tfInterfaceTypedExpander](), "Field1[1]", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceTypedExpander.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()),                   // TODO: fix path
 			},
 		},
 		"empty set Source and empty interface Target": {
@@ -5541,13 +5442,7 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfInterfaceTypedExpander]](), "Field1", reflect.TypeFor[[]awsInterfaceInterface]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfInterfaceTypedExpander]](), 2, "Field1", reflect.TypeFor[[]awsInterfaceInterface]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfInterfaceTypedExpander](), "Field1[0]", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexTypedExpander("Field1[1]", reflect.TypeFor[tfInterfaceTypedExpander](), "Field1[1]", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceTypedExpander.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"object value Source and struct Target": {
@@ -5568,9 +5463,6 @@ func TestExpandInterfaceTypedExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfObjectValue[tfInterfaceTypedExpander]](), "Field1", reflect.TypeFor[*awsInterfaceSingle]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ObjectValueOf[tfInterfaceTypedExpander]](), "Field1", reflect.TypeFor[awsInterfaceInterface]()),
 				infoSourceImplementsFlexTypedExpander("Field1", reflect.TypeFor[tfInterfaceTypedExpander](), "Field1", reflect.TypeFor[*awsInterfaceInterface]()),
-				// StringValueFromFramework in testFlexTFInterfaceTypedExpander.Expand()
-				infoExpandingWithPath("Field1", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 	}
@@ -5595,9 +5487,6 @@ func TestExpandTypedExpander(t *testing.T) {
 				infoExpanding(reflect.TypeFor[tfTypedExpander](), reflect.TypeFor[*awsExpander]()),
 				infoConverting(reflect.TypeFor[tfTypedExpander](), reflect.TypeFor[*awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("", reflect.TypeFor[tfTypedExpander](), "", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"top level incompatible struct Target": {
@@ -5612,9 +5501,6 @@ func TestExpandTypedExpander(t *testing.T) {
 				infoExpanding(reflect.TypeFor[tfTypedExpander](), reflect.TypeFor[*awsExpanderIncompatible]()),
 				infoConverting(reflect.TypeFor[tfTypedExpander](), reflect.TypeFor[*awsExpanderIncompatible]()),
 				infoSourceImplementsFlexTypedExpander("", reflect.TypeFor[tfTypedExpander](), "", reflect.TypeFor[*awsExpanderIncompatible]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"top level expands to nil": {
@@ -5651,9 +5537,6 @@ func TestExpandTypedExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfTypedExpanderListNestedObject](), "Field1", reflect.TypeFor[*awsExpanderSingleStruct]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfTypedExpander]](), "Field1", reflect.TypeFor[awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfTypedExpander](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"single set Source and single struct Target": {
@@ -5676,9 +5559,6 @@ func TestExpandTypedExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfSetNestedObject[tfTypedExpander]](), "Field1", reflect.TypeFor[*awsExpanderSingleStruct]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfTypedExpander]](), "Field1", reflect.TypeFor[awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfTypedExpander](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"single list Source and single *struct Target": {
@@ -5701,9 +5581,6 @@ func TestExpandTypedExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfTypedExpanderListNestedObject](), "Field1", reflect.TypeFor[*awsExpanderSinglePtr]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfTypedExpander]](), "Field1", reflect.TypeFor[*awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfTypedExpander](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"single set Source and single *struct Target": {
@@ -5726,9 +5603,6 @@ func TestExpandTypedExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfTypedExpanderSetNestedObject](), "Field1", reflect.TypeFor[*awsExpanderSinglePtr]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfTypedExpander]](), "Field1", reflect.TypeFor[*awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfTypedExpander](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"empty list Source and empty struct Target": {
@@ -5776,13 +5650,7 @@ func TestExpandTypedExpander(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfTypedExpander]](), "Field1", reflect.TypeFor[[]awsExpander]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfTypedExpander]](), 2, "Field1", reflect.TypeFor[[]awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfTypedExpander](), "Field1[0]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexTypedExpander("Field1[1]", reflect.TypeFor[tfTypedExpander](), "Field1[1]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"empty list Source and empty *struct Target": {
@@ -5830,13 +5698,7 @@ func TestExpandTypedExpander(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfTypedExpander]](), "Field1", reflect.TypeFor[[]*awsExpander]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfTypedExpander]](), 2, "Field1", reflect.TypeFor[[]*awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfTypedExpander](), "Field1[0]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexTypedExpander("Field1[1]", reflect.TypeFor[tfTypedExpander](), "Field1[1]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"empty set Source and empty struct Target": {
@@ -5884,13 +5746,7 @@ func TestExpandTypedExpander(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfTypedExpander]](), "Field1", reflect.TypeFor[[]awsExpander]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfTypedExpander]](), 2, "Field1", reflect.TypeFor[[]awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfTypedExpander](), "Field1[0]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexTypedExpander("Field1[1]", reflect.TypeFor[tfTypedExpander](), "Field1[1]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"empty set Source and empty *struct Target": {
@@ -5938,13 +5794,7 @@ func TestExpandTypedExpander(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfTypedExpander]](), "Field1", reflect.TypeFor[[]*awsExpander]()),
 				traceExpandingNestedObjectCollection("Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfTypedExpander]](), 2, "Field1", reflect.TypeFor[[]*awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("Field1[0]", reflect.TypeFor[tfTypedExpander](), "Field1[0]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[0]", reflect.TypeFor[types.String](), "Field1[0]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 				infoSourceImplementsFlexTypedExpander("Field1[1]", reflect.TypeFor[tfTypedExpander](), "Field1[1]", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1[1]", reflect.TypeFor[types.String](), "Field1[1]", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"object value Source and struct Target": {
@@ -5965,9 +5815,6 @@ func TestExpandTypedExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfTypedExpanderObjectValue](), "Field1", reflect.TypeFor[*awsExpanderSingleStruct]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ObjectValueOf[tfTypedExpander]](), "Field1", reflect.TypeFor[awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("Field1", reflect.TypeFor[tfTypedExpander](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 		"object value Source and *struct Target": {
@@ -5988,9 +5835,6 @@ func TestExpandTypedExpander(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[tfTypedExpanderObjectValue](), "Field1", reflect.TypeFor[*awsExpanderSinglePtr]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[fwtypes.ObjectValueOf[tfTypedExpander]](), "Field1", reflect.TypeFor[*awsExpander]()),
 				infoSourceImplementsFlexTypedExpander("Field1", reflect.TypeFor[tfTypedExpander](), "Field1", reflect.TypeFor[*awsExpander]()),
-				// StringValueFromFramework in testFlexTFTypedExpander.Expand()
-				infoExpandingWithPath("Field1", reflect.TypeFor[types.String](), "Field1", reflect.TypeFor[*string]()),
-				infoConvertingWithPath("", reflect.TypeFor[types.String](), "", reflect.TypeFor[string]()), // TODO: fix path
 			},
 		},
 	}

--- a/internal/framework/flex/auto_flatten_test.go
+++ b/internal/framework/flex/auto_flatten_test.go
@@ -4523,9 +4523,6 @@ func TestFlattenInterface(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[awsInterfaceSingle](), "Field1", reflect.TypeFor[*tfListNestedObject[tfInterfaceFlexer]]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[awsInterfaceInterface](), "Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfInterfaceFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1", reflect.TypeFor[awsInterfaceInterface](), "Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfInterfaceFlexer]]()),
-				// StringValueToFramework in testFlexTFInterfaceFlexer.Flatten()
-				infoFlatteningWithPath("Field1", reflect.TypeFor[string](), "Field1", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"nil interface Source and non-Flattener list Target": {
@@ -4613,9 +4610,6 @@ func TestFlattenInterface(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[awsInterfaceSingle](), "Field1", reflect.TypeFor[*tfSetNestedObject[tfInterfaceFlexer]]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[awsInterfaceInterface](), "Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfInterfaceFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1", reflect.TypeFor[awsInterfaceInterface](), "Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfInterfaceFlexer]]()),
-				// StringValueToFramework in testFlexTFInterfaceFlexer.Flatten()
-				infoFlatteningWithPath("Field1", reflect.TypeFor[string](), "Field1", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 
@@ -4680,13 +4674,7 @@ func TestFlattenInterface(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[[]awsInterfaceInterface](), "Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfInterfaceFlexer]]()),
 				traceFlatteningNestedObjectCollection("Field1", reflect.TypeFor[[]awsInterfaceInterface](), 2, "Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfInterfaceFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1[0]", reflect.TypeFor[awsInterfaceInterfaceImpl](), "Field1[0]", reflect.TypeFor[*tfInterfaceFlexer]()),
-				// StringValueToFramework in testFlexTFInterfaceFlexer.Flatten()
-				infoFlatteningWithPath("Field1[0]", reflect.TypeFor[string](), "Field1[0]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 				infoTargetImplementsFlexFlattener("Field1[1]", reflect.TypeFor[awsInterfaceInterfaceImpl](), "Field1[1]", reflect.TypeFor[*tfInterfaceFlexer]()),
-				// StringValueToFramework in testFlexTFInterfaceFlexer.Flatten()
-				infoFlatteningWithPath("Field1[1]", reflect.TypeFor[string](), "Field1[1]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 
@@ -4751,13 +4739,7 @@ func TestFlattenInterface(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[[]awsInterfaceInterface](), "Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfInterfaceFlexer]]()),
 				traceFlatteningNestedObjectCollection("Field1", reflect.TypeFor[[]awsInterfaceInterface](), 2, "Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfInterfaceFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1[0]", reflect.TypeFor[awsInterfaceInterfaceImpl](), "Field1[0]", reflect.TypeFor[*tfInterfaceFlexer]()),
-				// StringValueToFramework in testFlexTFInterfaceFlexer.Flatten()
-				infoFlatteningWithPath("Field1[0]", reflect.TypeFor[string](), "Field1[0]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 				infoTargetImplementsFlexFlattener("Field1[1]", reflect.TypeFor[awsInterfaceInterfaceImpl](), "Field1[1]", reflect.TypeFor[*tfInterfaceFlexer]()),
-				// StringValueToFramework in testFlexTFInterfaceFlexer.Flatten()
-				infoFlatteningWithPath("Field1[1]", reflect.TypeFor[string](), "Field1[1]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"nil interface Source and nested object Target": {
@@ -4793,9 +4775,6 @@ func TestFlattenInterface(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[awsInterfaceSingle](), "Field1", reflect.TypeFor[*tfObjectValue[tfInterfaceFlexer]]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[awsInterfaceInterface](), "Field1", reflect.TypeFor[fwtypes.ObjectValueOf[tfInterfaceFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1", reflect.TypeFor[awsInterfaceInterface](), "Field1", reflect.TypeFor[fwtypes.ObjectValueOf[tfInterfaceFlexer]]()),
-				// StringValueToFramework in testFlexTFInterfaceFlexer.Flatten()
-				infoFlatteningWithPath("Field1", reflect.TypeFor[string](), "Field1", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 	}
@@ -4820,9 +4799,6 @@ func TestFlattenFlattener(t *testing.T) {
 				infoFlattening(reflect.TypeFor[awsExpander](), reflect.TypeFor[*tfFlexer]()),
 				infoConverting(reflect.TypeFor[awsExpander](), reflect.TypeFor[*tfFlexer]()),
 				infoTargetImplementsFlexFlattener("", reflect.TypeFor[awsExpander](), "", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[*types.String]()), // TODO: fix path
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()),  // TODO: fix path
 			},
 		},
 		"top level incompatible struct Target": {
@@ -4859,9 +4835,6 @@ func TestFlattenFlattener(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[awsExpanderSingleStruct](), "Field1", reflect.TypeFor[*tfExpanderListNestedObject]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[awsExpander](), "Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1", reflect.TypeFor[awsExpander](), "Field1", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1", reflect.TypeFor[string](), "Field1", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"nil *struct Source and null list Target": {
@@ -4899,9 +4872,6 @@ func TestFlattenFlattener(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[awsExpanderSingleStruct](), "Field1", reflect.TypeFor[*tfExpanderSetNestedObject]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[awsExpander](), "Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1", reflect.TypeFor[awsExpander](), "Field1", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1", reflect.TypeFor[string](), "Field1", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"single *struct Source and single list Target": {
@@ -4924,9 +4894,6 @@ func TestFlattenFlattener(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[awsExpanderSinglePtr](), "Field1", reflect.TypeFor[*tfExpanderListNestedObject]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[*awsExpander](), "Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1", reflect.TypeFor[awsExpander](), "Field1", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1", reflect.TypeFor[string](), "Field1", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"single *struct Source and single set Target": {
@@ -4949,9 +4916,6 @@ func TestFlattenFlattener(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[awsExpanderSinglePtr](), "Field1", reflect.TypeFor[*tfExpanderSetNestedObject]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[*awsExpander](), "Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1", reflect.TypeFor[awsExpander](), "Field1", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1", reflect.TypeFor[string](), "Field1", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"nil *struct Source and null set Target": {
@@ -5015,13 +4979,7 @@ func TestFlattenFlattener(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[[]awsExpander](), "Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]]()),
 				traceFlatteningNestedObjectCollection("Field1", reflect.TypeFor[[]awsExpander](), 2, "Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1[0]", reflect.TypeFor[awsExpander](), "Field1[0]", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1[0]", reflect.TypeFor[string](), "Field1[0]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 				infoTargetImplementsFlexFlattener("Field1[1]", reflect.TypeFor[awsExpander](), "Field1[1]", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1[1]", reflect.TypeFor[string](), "Field1[1]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"empty *struct list Source and empty list Target": {
@@ -5069,13 +5027,7 @@ func TestFlattenFlattener(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[[]*awsExpander](), "Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]]()),
 				traceFlatteningNestedObjectCollection("Field1", reflect.TypeFor[[]*awsExpander](), 2, "Field1", reflect.TypeFor[fwtypes.ListNestedObjectValueOf[tfFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1[0]", reflect.TypeFor[awsExpander](), "Field1[0]", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1[0]", reflect.TypeFor[string](), "Field1[0]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 				infoTargetImplementsFlexFlattener("Field1[1]", reflect.TypeFor[awsExpander](), "Field1[1]", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1[1]", reflect.TypeFor[string](), "Field1[1]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"empty struct list Source and empty set Target": {
@@ -5123,13 +5075,7 @@ func TestFlattenFlattener(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[[]awsExpander](), "Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]]()),
 				traceFlatteningNestedObjectCollection("Field1", reflect.TypeFor[[]awsExpander](), 2, "Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1[0]", reflect.TypeFor[awsExpander](), "Field1[0]", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1[0]", reflect.TypeFor[string](), "Field1[0]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 				infoTargetImplementsFlexFlattener("Field1[1]", reflect.TypeFor[awsExpander](), "Field1[1]", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1[1]", reflect.TypeFor[string](), "Field1[1]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"empty *struct list Source and empty set Target": {
@@ -5177,13 +5123,7 @@ func TestFlattenFlattener(t *testing.T) {
 				infoConvertingWithPath("Field1", reflect.TypeFor[[]*awsExpander](), "Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]]()),
 				traceFlatteningNestedObjectCollection("Field1", reflect.TypeFor[[]*awsExpander](), 2, "Field1", reflect.TypeFor[fwtypes.SetNestedObjectValueOf[tfFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1[0]", reflect.TypeFor[awsExpander](), "Field1[0]", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1[0]", reflect.TypeFor[string](), "Field1[0]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 				infoTargetImplementsFlexFlattener("Field1[1]", reflect.TypeFor[awsExpander](), "Field1[1]", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1[1]", reflect.TypeFor[string](), "Field1[1]", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"struct Source and object value Target": {
@@ -5204,9 +5144,6 @@ func TestFlattenFlattener(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[awsExpanderSingleStruct](), "Field1", reflect.TypeFor[*tfExpanderObjectValue]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[awsExpander](), "Field1", reflect.TypeFor[fwtypes.ObjectValueOf[tfFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1", reflect.TypeFor[awsExpander](), "Field1", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1", reflect.TypeFor[string](), "Field1", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 		"*struct Source and object value Target": {
@@ -5227,9 +5164,6 @@ func TestFlattenFlattener(t *testing.T) {
 				traceMatchedFields("Field1", reflect.TypeFor[awsExpanderSinglePtr](), "Field1", reflect.TypeFor[*tfExpanderObjectValue]()),
 				infoConvertingWithPath("Field1", reflect.TypeFor[*awsExpander](), "Field1", reflect.TypeFor[fwtypes.ObjectValueOf[tfFlexer]]()),
 				infoTargetImplementsFlexFlattener("Field1", reflect.TypeFor[awsExpander](), "Field1", reflect.TypeFor[*tfFlexer]()),
-				// StringValueToFramework in testFlexTFFlexer.Flatten()
-				infoFlatteningWithPath("Field1", reflect.TypeFor[string](), "Field1", reflect.TypeFor[*types.String]()),
-				infoConvertingWithPath("", reflect.TypeFor[string](), "", reflect.TypeFor[types.String]()), // TODO: fix path
 			},
 		},
 	}

--- a/internal/framework/flex/bool.go
+++ b/internal/framework/flex/bool.go
@@ -23,11 +23,8 @@ func BoolFromFramework(ctx context.Context, v basetypes.BoolValuable) *bool {
 }
 
 func BoolValueFromFramework(ctx context.Context, v basetypes.BoolValuable) bool {
-	var output bool
-
-	must(Expand(ctx, v, &output))
-
-	return output
+	val := fwdiag.Must(v.ToBoolValue(ctx))
+	return val.ValueBool()
 }
 
 // BoolToFramework converts a bool pointer to a Framework Bool value.

--- a/internal/framework/flex/bool.go
+++ b/internal/framework/flex/bool.go
@@ -30,11 +30,7 @@ func BoolValueFromFramework(ctx context.Context, v basetypes.BoolValuable) bool 
 // BoolToFramework converts a bool pointer to a Framework Bool value.
 // A nil bool pointer is converted to a null Bool.
 func BoolToFramework(ctx context.Context, v *bool) types.Bool {
-	var output types.Bool
-
-	must(Flatten(ctx, v, &output))
-
-	return output
+	return types.BoolPointerValue(v)
 }
 
 // BoolToFrameworkLegacy converts a bool pointer to a Framework Bool value.

--- a/internal/framework/flex/bool.go
+++ b/internal/framework/flex/bool.go
@@ -9,16 +9,17 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 )
 
 // BoolFromFramework converts a Framework Bool value to a bool pointer.
 // A null Bool is converted to a nil bool pointer.
 func BoolFromFramework(ctx context.Context, v basetypes.BoolValuable) *bool {
-	var output *bool
-
-	must(Expand(ctx, v, &output))
-
-	return output
+	if v.IsUnknown() {
+		return nil
+	}
+	val := fwdiag.Must(v.ToBoolValue(ctx))
+	return val.ValueBoolPointer()
 }
 
 func BoolValueFromFramework(ctx context.Context, v basetypes.BoolValuable) bool {

--- a/internal/framework/flex/bool_test.go
+++ b/internal/framework/flex/bool_test.go
@@ -102,6 +102,17 @@ func TestBoolValueFromFramework(t *testing.T) {
 	}
 }
 
+func BenchmarkBoolValueFromFramework(b *testing.B) {
+	ctx := context.Background()
+	input := types.BoolValue(true)
+	for n := 0; n < b.N; n++ {
+		r := flex.BoolValueFromFramework(ctx, input)
+		if !r {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestBoolToFramework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/bool_test.go
+++ b/internal/framework/flex/bool_test.go
@@ -193,3 +193,14 @@ func TestBoolToFrameworkLegacy(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkBoolToFrameworkLegacy(b *testing.B) {
+	ctx := context.Background()
+	input := aws.Bool(true)
+	for n := 0; n < b.N; n++ {
+		r := flex.BoolToFrameworkLegacy(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}

--- a/internal/framework/flex/bool_test.go
+++ b/internal/framework/flex/bool_test.go
@@ -52,6 +52,17 @@ func TestBoolFromFramework(t *testing.T) {
 	}
 }
 
+func BenchmarkBoolFromFramework(b *testing.B) {
+	ctx := context.Background()
+	input := types.BoolValue(true)
+	for n := 0; n < b.N; n++ {
+		r := flex.BoolFromFramework(ctx, input)
+		if r == nil {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestBoolValueFromFramework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/bool_test.go
+++ b/internal/framework/flex/bool_test.go
@@ -148,6 +148,17 @@ func TestBoolToFramework(t *testing.T) {
 	}
 }
 
+func BenchmarkBoolToFramework(b *testing.B) {
+	ctx := context.Background()
+	input := aws.Bool(true)
+	for n := 0; n < b.N; n++ {
+		r := flex.BoolToFramework(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestBoolToFrameworkLegacy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/float.go
+++ b/internal/framework/flex/float.go
@@ -22,14 +22,13 @@ func Float64ToFrameworkLegacy(_ context.Context, v *float64) types.Float64 {
 	return types.Float64Value(aws.ToFloat64(v))
 }
 
-// Float32ToFramework converts a float32 pointer to a Framework Float64 value.
+// Float32ToFrameworkFloat64 converts a float32 pointer to a Framework Float64 value.
 // A nil float32 pointer is converted to a null Float64.
-func Float32ToFramework(ctx context.Context, v *float32) types.Float64 {
-	var output types.Float64
-
-	must(Flatten(ctx, v, &output))
-
-	return output
+func Float32ToFrameworkFloat64(_ context.Context, v *float32) types.Float64 {
+	if v == nil {
+		return types.Float64Null()
+	}
+	return types.Float64Value(float64(aws.ToFloat32(v)))
 }
 
 // Float32ToFrameworkLegacy converts a float32 pointer to a Framework Float64 value.

--- a/internal/framework/flex/float.go
+++ b/internal/framework/flex/float.go
@@ -31,8 +31,8 @@ func Float32ToFrameworkFloat64(_ context.Context, v *float32) types.Float64 {
 	return types.Float64Value(float64(aws.ToFloat32(v)))
 }
 
-// Float32ToFrameworkLegacy converts a float32 pointer to a Framework Float64 value.
+// Float32ToFrameworkFloat64Legacy converts a float32 pointer to a Framework Float64 value.
 // A nil float32 pointer is converted to a zero float64.
-func Float32ToFrameworkLegacy(_ context.Context, v *float32) types.Float64 {
+func Float32ToFrameworkFloat64Legacy(_ context.Context, v *float32) types.Float64 {
 	return types.Float64Value(float64(aws.ToFloat32(v)))
 }

--- a/internal/framework/flex/float.go
+++ b/internal/framework/flex/float.go
@@ -13,11 +13,7 @@ import (
 // Float64ToFramework converts a float64 pointer to a Framework Float64 value.
 // A nil float64 pointer is converted to a null Float64.
 func Float64ToFramework(ctx context.Context, v *float64) types.Float64 {
-	var output types.Float64
-
-	must(Flatten(ctx, v, &output))
-
-	return output
+	return types.Float64PointerValue(v)
 }
 
 // Float64ToFrameworkLegacy converts a float64 pointer to a Framework Float64 value.

--- a/internal/framework/flex/float_test.go
+++ b/internal/framework/flex/float_test.go
@@ -151,7 +151,7 @@ func BenchmarkFloat32ToFrameworkFloat64(b *testing.B) {
 	}
 }
 
-func TestFloat32ToFrameworkLegacy(t *testing.T) {
+func TestFloat32ToFrameworkFloat64Legacy(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -177,11 +177,22 @@ func TestFloat32ToFrameworkLegacy(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := flex.Float32ToFrameworkLegacy(context.Background(), test.input)
+			got := flex.Float32ToFrameworkFloat64Legacy(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 			}
 		})
+	}
+}
+
+func BenchmarkFloat32ToFrameworkFloat64Legacy(b *testing.B) {
+	ctx := context.Background()
+	input := aws.Float32(42.1)
+	for n := 0; n < b.N; n++ {
+		r := flex.Float32ToFrameworkFloat64Legacy(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
 	}
 }

--- a/internal/framework/flex/float_test.go
+++ b/internal/framework/flex/float_test.go
@@ -105,7 +105,7 @@ func BenchmarkFloat64ToFrameworkLegacy(b *testing.B) {
 	}
 }
 
-func TestFloat32ToFramework(t *testing.T) {
+func TestFloat32ToFrameworkFloat64(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -131,12 +131,23 @@ func TestFloat32ToFramework(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := flex.Float32ToFramework(context.Background(), test.input)
+			got := flex.Float32ToFrameworkFloat64(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 			}
 		})
+	}
+}
+
+func BenchmarkFloat32ToFrameworkFloat64(b *testing.B) {
+	ctx := context.Background()
+	input := aws.Float32(42.1)
+	for n := 0; n < b.N; n++ {
+		r := flex.Float32ToFrameworkFloat64(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
 	}
 }
 

--- a/internal/framework/flex/float_test.go
+++ b/internal/framework/flex/float_test.go
@@ -48,6 +48,17 @@ func TestFloat64ToFramework(t *testing.T) {
 	}
 }
 
+func BenchmarkFloat64ToFramework(b *testing.B) {
+	ctx := context.Background()
+	input := aws.Float64(42.1)
+	for n := 0; n < b.N; n++ {
+		r := flex.Float64ToFramework(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestFloat64ToFrameworkLegacy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/float_test.go
+++ b/internal/framework/flex/float_test.go
@@ -94,6 +94,17 @@ func TestFloat64ToFrameworkLegacy(t *testing.T) {
 	}
 }
 
+func BenchmarkFloat64ToFrameworkLegacy(b *testing.B) {
+	ctx := context.Background()
+	input := aws.Float64(42.1)
+	for n := 0; n < b.N; n++ {
+		r := flex.Float64ToFrameworkLegacy(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestFloat32ToFramework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -9,16 +9,17 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 )
 
 // Int64FromFramework converts a Framework Int64 value to an int64 pointer.
 // A null Int64 is converted to a nil int64 pointer.
 func Int64FromFramework(ctx context.Context, v basetypes.Int64Valuable) *int64 {
-	var output *int64
-
-	must(Expand(ctx, v, &output))
-
-	return output
+	if v.IsUnknown() {
+		return nil
+	}
+	val := fwdiag.Must(v.ToInt64Value(ctx))
+	return val.ValueInt64Pointer()
 }
 
 func Int64ValueFromFramework(ctx context.Context, v basetypes.Int64Valuable) int64 {

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -53,11 +53,10 @@ func Int64ToFrameworkLegacy(_ context.Context, v *int64) types.Int64 {
 }
 
 func Int32ToFrameworkInt64(ctx context.Context, v *int32) types.Int64 {
-	var output types.Int64
-
-	must(Flatten(ctx, v, &output))
-
-	return output
+	if v == nil {
+		return types.Int64Null()
+	}
+	return types.Int64Value(int64(aws.ToInt32(v)))
 }
 
 func Int32ValueToFrameworkInt64(ctx context.Context, v int32) types.Int64 {

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -94,11 +94,11 @@ func Int32ValueFromFrameworkInt64(ctx context.Context, v basetypes.Int64Valuable
 // Int32FromFramework coverts a Framework Int32 value to an int32 pointer.
 // A null Int32 is converted to a nil int32 pointer.
 func Int32FromFramework(ctx context.Context, v basetypes.Int32Valuable) *int32 {
-	var output *int32
-
-	must(Expand(ctx, v, &output))
-
-	return output
+	if v.IsUnknown() {
+		return nil
+	}
+	val := fwdiag.Must(v.ToInt32Value(ctx))
+	return val.ValueInt32Pointer()
 }
 
 func Int32FromFrameworkLegacy(_ context.Context, v types.Int32) *int32 {

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -43,11 +43,7 @@ func Int64FromFrameworkLegacy(_ context.Context, v types.Int64) *int64 {
 // Int64ToFramework converts an int64 pointer to a Framework Int64 value.
 // A nil int64 pointer is converted to a null Int64.
 func Int64ToFramework(ctx context.Context, v *int64) types.Int64 {
-	var output types.Int64
-
-	must(Flatten(ctx, v, &output))
-
-	return output
+	return types.Int64PointerValue(v)
 }
 
 // Int64ToFrameworkLegacy converts an int64 pointer to a Framework Int64 value.

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -83,6 +83,14 @@ func Int32FromFrameworkInt64(ctx context.Context, v basetypes.Int64Valuable) *in
 	return &i
 }
 
+// Int32ValueFromFrameworkInt64 coverts a Framework Int64 value to an int32 value.
+// A null Int64 is converted to a nil int32 pointer.
+func Int32ValueFromFrameworkInt64(ctx context.Context, v basetypes.Int64Valuable) int32 {
+	val := fwdiag.Must(v.ToInt64Value(ctx))
+	i := int32(val.ValueInt64())
+	return i
+}
+
 // Int32FromFramework coverts a Framework Int32 value to an int32 pointer.
 // A null Int32 is converted to a nil int32 pointer.
 func Int32FromFramework(ctx context.Context, v basetypes.Int32Valuable) *int32 {
@@ -104,16 +112,6 @@ func Int32FromFrameworkLegacy(_ context.Context, v types.Int32) *int32 {
 	}
 
 	return aws.Int32(i)
-}
-
-// Int32ValueFromFrameworkInt64 coverts a Framework Int64 value to an int32 value.
-// A null Int64 is converted to a nil int32 pointer.
-func Int32ValueFromFrameworkInt64(ctx context.Context, v basetypes.Int64Valuable) int32 {
-	var output int32
-
-	must(Expand(ctx, v, &output))
-
-	return output
 }
 
 func ZeroInt32AsNull(v types.Int32) types.Int32 {

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -60,11 +60,7 @@ func Int32ToFrameworkInt64(ctx context.Context, v *int32) types.Int64 {
 }
 
 func Int32ValueToFrameworkInt64(ctx context.Context, v int32) types.Int64 {
-	var output types.Int64
-
-	must(Flatten(ctx, v, &output))
-
-	return output
+	return types.Int64Value(int64(v))
 }
 
 // Int32ToFrameworkInt64Legacy converts an int32 pointer to a Framework Int64 value.

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -23,11 +23,8 @@ func Int64FromFramework(ctx context.Context, v basetypes.Int64Valuable) *int64 {
 }
 
 func Int64ValueFromFramework(ctx context.Context, v basetypes.Int64Valuable) int64 {
-	var output int64
-
-	must(Expand(ctx, v, &output))
-
-	return output
+	val := fwdiag.Must(v.ToInt64Value(ctx))
+	return val.ValueInt64()
 }
 
 func Int64FromFrameworkLegacy(_ context.Context, v types.Int64) *int64 {

--- a/internal/framework/flex/int.go
+++ b/internal/framework/flex/int.go
@@ -72,11 +72,15 @@ func Int32ToFrameworkInt64Legacy(_ context.Context, v *int32) types.Int64 {
 // Int32FromFrameworkInt64 coverts a Framework Int64 value to an int32 pointer.
 // A null Int64 is converted to a nil int32 pointer.
 func Int32FromFrameworkInt64(ctx context.Context, v basetypes.Int64Valuable) *int32 {
-	var output *int32
-
-	must(Expand(ctx, v, &output))
-
-	return output
+	if v.IsUnknown() {
+		return nil
+	}
+	if v.IsNull() {
+		return nil
+	}
+	val := fwdiag.Must(v.ToInt64Value(ctx))
+	i := int32(val.ValueInt64())
+	return &i
 }
 
 // Int32FromFramework coverts a Framework Int32 value to an int32 pointer.

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -427,3 +427,53 @@ func TestInt32FromFrameworkLegacy(t *testing.T) {
 		})
 	}
 }
+
+func TestInt32ValueFromFrameworkInt64(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.Int64
+		expected int32
+	}
+	tests := map[string]testCase{
+		"valid int64": {
+			input:    types.Int64Value(42),
+			expected: 42,
+		},
+		"zero int64": {
+			input:    types.Int64Value(0),
+			expected: 0,
+		},
+		"null int64": {
+			input:    types.Int64Null(),
+			expected: 0,
+		},
+		"unknown int64": {
+			input:    types.Int64Unknown(),
+			expected: 0,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.Int32ValueFromFrameworkInt64(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkInt32ValueFromFrameworkInt64(b *testing.B) {
+	ctx := context.Background()
+	input := types.Int64Value(42)
+	for n := 0; n < b.N; n++ {
+		r := flex.Int32ValueFromFrameworkInt64(ctx, input)
+		if r == 0 {
+			b.Fatal("should never see this")
+		}
+	}
+}

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -63,6 +63,56 @@ func BenchmarkInt64FromFramework(b *testing.B) {
 	}
 }
 
+func TestInt64ValueFromFramework(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.Int64
+		expected int64
+	}
+	tests := map[string]testCase{
+		"valid int64": {
+			input:    types.Int64Value(42),
+			expected: 42,
+		},
+		"zero int64": {
+			input:    types.Int64Value(0),
+			expected: 0,
+		},
+		"null int64": {
+			input:    types.Int64Null(),
+			expected: 0,
+		},
+		"unknown int64": {
+			input:    types.Int64Unknown(),
+			expected: 0,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.Int64ValueFromFramework(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkInt64ValueFromFramework(b *testing.B) {
+	ctx := context.Background()
+	input := types.Int64Value(42)
+	for n := 0; n < b.N; n++ {
+		r := flex.Int64ValueFromFramework(ctx, input)
+		if r == 0 {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestInt64ToFramework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -378,6 +378,17 @@ func TestInt32FromFrameworkInt64(t *testing.T) {
 	}
 }
 
+func BenchmarkInt32FromFrameworkInt64(b *testing.B) {
+	ctx := context.Background()
+	input := types.Int64Value(42)
+	for n := 0; n < b.N; n++ {
+		r := flex.Int32FromFrameworkInt64(ctx, input)
+		if r == nil {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestInt32FromFrameworkLegacy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -52,6 +52,17 @@ func TestInt64FromFramework(t *testing.T) {
 	}
 }
 
+func BenchmarkInt64FromFramework(b *testing.B) {
+	ctx := context.Background()
+	input := types.Int64Value(42)
+	for n := 0; n < b.N; n++ {
+		r := flex.Int64FromFramework(ctx, input)
+		if r == nil {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestInt64ToFramework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -251,6 +251,48 @@ func BenchmarkInt32ToFrameworkInt64(b *testing.B) {
 	}
 }
 
+func TestInt32ValueToFrameworkInt64(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    int32
+		expected types.Int64
+	}
+	tests := map[string]testCase{
+		"valid int64": {
+			input:    42,
+			expected: types.Int64Value(42),
+		},
+		"zero int64": {
+			input:    0,
+			expected: types.Int64Value(0),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.Int32ValueToFrameworkInt64(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkInt32ValueToFrameworkInt64(b *testing.B) {
+	ctx := context.Background()
+	input := int32(42)
+	for n := 0; n < b.N; n++ {
+		r := flex.Int32ValueToFrameworkInt64(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestInt32ToFrameworkInt64Legacy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -477,3 +477,53 @@ func BenchmarkInt32ValueFromFrameworkInt64(b *testing.B) {
 		}
 	}
 }
+
+func TestInt32FromFramework(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.Int32
+		expected *int32
+	}
+	tests := map[string]testCase{
+		"valid int64": {
+			input:    types.Int32Value(42),
+			expected: aws.Int32(42),
+		},
+		"zero int64": {
+			input:    types.Int32Value(0),
+			expected: aws.Int32(0),
+		},
+		"null int64": {
+			input:    types.Int32Null(),
+			expected: nil,
+		},
+		"unknown int64": {
+			input:    types.Int32Unknown(),
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.Int32FromFramework(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkInt32FromFramework(b *testing.B) {
+	ctx := context.Background()
+	input := types.Int32Value(42)
+	for n := 0; n < b.N; n++ {
+		r := flex.Int32FromFramework(ctx, input)
+		if r == nil {
+			b.Fatal("should never see this")
+		}
+	}
+}

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -148,6 +148,17 @@ func TestInt64ToFramework(t *testing.T) {
 	}
 }
 
+func BenchmarkInt64ToFramework(b *testing.B) {
+	ctx := context.Background()
+	input := aws.Int64(42)
+	for n := 0; n < b.N; n++ {
+		r := flex.Int64ToFramework(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestInt64ToFrameworkLegacy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -194,6 +194,17 @@ func TestInt64ToFrameworkLegacy(t *testing.T) {
 	}
 }
 
+func BenchmarkInt64ToFrameworkLegacy(b *testing.B) {
+	ctx := context.Background()
+	input := aws.Int64(42)
+	for n := 0; n < b.N; n++ {
+		r := flex.Int64ToFrameworkLegacy(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestInt32ToFrameworkInt64(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -240,6 +240,17 @@ func TestInt32ToFrameworkInt64(t *testing.T) {
 	}
 }
 
+func BenchmarkInt32ToFrameworkInt64(b *testing.B) {
+	ctx := context.Background()
+	input := aws.Int32(42)
+	for n := 0; n < b.N; n++ {
+		r := flex.Int32ToFrameworkInt64(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestInt32ToFrameworkInt64Legacy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/int_test.go
+++ b/internal/framework/flex/int_test.go
@@ -328,6 +328,17 @@ func TestInt32ToFrameworkInt64Legacy(t *testing.T) {
 	}
 }
 
+func BenchmarkInt32ValueToFrameworkInt64Legacy(b *testing.B) {
+	ctx := context.Background()
+	input := aws.Int32(42)
+	for n := 0; n < b.N; n++ {
+		r := flex.Int32ToFrameworkInt64Legacy(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestInt32FromFrameworkInt64(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/logging_test.go
+++ b/internal/framework/flex/logging_test.go
@@ -151,16 +151,8 @@ func infoExpanding(sourceType, targetType reflect.Type) map[string]any {
 	return infoLogLine("Expanding", sourceType, targetType)
 }
 
-func infoExpandingWithPath(sourcePath string, sourceType reflect.Type, targetPath string, targetType reflect.Type) map[string]any {
-	return infoWithPathLogLine("Expanding", sourcePath, sourceType, targetPath, targetType)
-}
-
 func infoFlattening(sourceType, targetType reflect.Type) map[string]any {
 	return infoLogLine("Flattening", sourceType, targetType)
-}
-
-func infoFlatteningWithPath(sourcePath string, sourceType reflect.Type, targetPath string, targetType reflect.Type) map[string]any {
-	return infoWithPathLogLine("Flattening", sourcePath, sourceType, targetPath, targetType)
 }
 
 func infoConverting(sourceType, targetType reflect.Type) map[string]any {
@@ -642,15 +634,6 @@ func infoLogLine(message string, sourceType, targetType reflect.Type) map[string
 	return logInfo(message, map[string]any{
 		logAttrKeySourceType: fullTypeName(sourceType),
 		logAttrKeyTargetType: fullTypeName(targetType),
-	})
-}
-
-func infoWithPathLogLine(message string, sourcePath string, sourceType reflect.Type, targetPath string, targetType reflect.Type) map[string]any {
-	return logInfo(message, map[string]any{
-		logAttrKeySourcePath: sourcePath,
-		logAttrKeySourceType: fullTypeName(sourceType),
-		logAttrKeyTargetType: fullTypeName(targetType),
-		logAttrKeyTargetPath: targetPath,
 	})
 }
 

--- a/internal/framework/flex/string.go
+++ b/internal/framework/flex/string.go
@@ -52,12 +52,7 @@ func StringValueToFramework[T ~string](ctx context.Context, v T) types.String {
 	if v == "" {
 		return types.StringNull()
 	}
-
-	var output types.String
-
-	must(Flatten(ctx, v, &output))
-
-	return output
+	return types.StringValue(string(v))
 }
 
 // StringValueToFrameworkLegacy converts a string value to a Framework String value.

--- a/internal/framework/flex/string.go
+++ b/internal/framework/flex/string.go
@@ -40,6 +40,12 @@ func StringSliceValueFromFramework(ctx context.Context, v basetypes.StringValuab
 	return []string{StringValueFromFramework(ctx, v)}
 }
 
+// StringToFramework converts a string pointer to a Framework String value.
+// A nil string pointer is converted to a null String.
+func StringToFramework(ctx context.Context, v *string) types.String {
+	return types.StringPointerValue(v)
+}
+
 // StringValueToFramework converts a string value to a Framework String value.
 // An empty string is converted to a null String.
 func StringValueToFramework[T ~string](ctx context.Context, v T) types.String {
@@ -58,12 +64,6 @@ func StringValueToFramework[T ~string](ctx context.Context, v T) types.String {
 // An empty string is left as an empty String.
 func StringValueToFrameworkLegacy[T ~string](_ context.Context, v T) types.String {
 	return types.StringValue(string(v))
-}
-
-// StringToFramework converts a string pointer to a Framework String value.
-// A nil string pointer is converted to a null String.
-func StringToFramework(ctx context.Context, v *string) types.String {
-	return StringToFrameworkValuable[types.String](ctx, v)
 }
 
 // StringToFrameworkLegacy converts a string pointer to a Framework String value.

--- a/internal/framework/flex/string.go
+++ b/internal/framework/flex/string.go
@@ -26,11 +26,8 @@ func StringFromFramework(ctx context.Context, v basetypes.StringValuable) *strin
 // StringValueFromFramework converts a Framework String value to a string.
 // A null String is converted to an empty string.
 func StringValueFromFramework(ctx context.Context, v basetypes.StringValuable) string {
-	var output string
-
-	must(Expand(ctx, v, &output))
-
-	return output
+	val := fwdiag.Must(v.ToStringValue(ctx))
+	return val.ValueString()
 }
 
 // StringSliceValueFromFramework converts a single Framework String value to a string slice.

--- a/internal/framework/flex/string.go
+++ b/internal/framework/flex/string.go
@@ -9,17 +9,18 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 )
 
 // StringFromFramework converts a Framework String value to a string pointer.
 // A null String is converted to a nil string pointer.
 func StringFromFramework(ctx context.Context, v basetypes.StringValuable) *string {
-	var output *string
-
-	must(Expand(ctx, v, &output))
-
-	return output
+	if v.IsUnknown() {
+		return nil
+	}
+	val := fwdiag.Must(v.ToStringValue(ctx))
+	return val.ValueStringPointer()
 }
 
 // StringValueFromFramework converts a Framework String value to a string.

--- a/internal/framework/flex/string.go
+++ b/internal/framework/flex/string.go
@@ -82,10 +82,11 @@ func StringToFrameworkARN(ctx context.Context, v *string) fwtypes.ARN {
 // A nil string pointer is converted to a null StringValuable.
 func StringToFrameworkValuable[T basetypes.StringValuable](ctx context.Context, v *string) T {
 	var output T
+	typ := output.Type(ctx)
+	styp := typ.(basetypes.StringTypable)
 
-	must(Flatten(ctx, v, &output))
-
-	return output
+	sv := fwdiag.Must(styp.ValueFromString(ctx, types.StringPointerValue(v)))
+	return sv.(T)
 }
 
 func StringFromFrameworkLegacy(_ context.Context, v types.String) *string {

--- a/internal/framework/flex/string_test.go
+++ b/internal/framework/flex/string_test.go
@@ -53,6 +53,17 @@ func TestStringFromFramework(t *testing.T) {
 	}
 }
 
+func BenchmarkStringFromFramework(b *testing.B) {
+	ctx := context.Background()
+	input := types.StringValue("TEST")
+	for n := 0; n < b.N; n++ {
+		r := flex.StringFromFramework(ctx, input)
+		if r == nil {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestStringToFramework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/string_test.go
+++ b/internal/framework/flex/string_test.go
@@ -197,6 +197,17 @@ func TestStringValueToFramework(t *testing.T) {
 	}
 }
 
+func BenchmarkStringValueToFramework(b *testing.B) {
+	ctx := context.Background()
+	input := "TEST"
+	for n := 0; n < b.N; n++ {
+		r := flex.StringValueToFramework(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestStringToFrameworkLegacy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/string_test.go
+++ b/internal/framework/flex/string_test.go
@@ -332,6 +332,17 @@ func TestStringToFrameworkARN(t *testing.T) {
 	}
 }
 
+func BenchmarkStringToFrameworkARN(b *testing.B) {
+	ctx := context.Background()
+	input := aws.String("arn:aws:iam::123456789012:user/David")
+	for n := 0; n < b.N; n++ {
+		r := flex.StringToFrameworkARN(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestEmptyStringAsNull(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/string_test.go
+++ b/internal/framework/flex/string_test.go
@@ -64,6 +64,56 @@ func BenchmarkStringFromFramework(b *testing.B) {
 	}
 }
 
+func TestStringValueFromFramework(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    types.String
+		expected string
+	}
+	tests := map[string]testCase{
+		"valid string": {
+			input:    types.StringValue("TEST"),
+			expected: "TEST",
+		},
+		"empty string": {
+			input:    types.StringValue(""),
+			expected: "",
+		},
+		"null string": {
+			input:    types.StringNull(),
+			expected: "",
+		},
+		"unknown string": {
+			input:    types.StringUnknown(),
+			expected: "",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.StringValueFromFramework(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkStringValueFromFramework(b *testing.B) {
+	ctx := context.Background()
+	input := types.StringValue("TEST")
+	for n := 0; n < b.N; n++ {
+		r := flex.StringValueFromFramework(ctx, input)
+		if r == "" {
+			b.Fatal("should never see this")
+		}
+	}
+}
+
 func TestStringToFramework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/framework/flex/string_test.go
+++ b/internal/framework/flex/string_test.go
@@ -149,38 +149,14 @@ func TestStringToFramework(t *testing.T) {
 	}
 }
 
-func TestStringToFrameworkLegacy(t *testing.T) {
-	t.Parallel()
-
-	type testCase struct {
-		input    *string
-		expected types.String
-	}
-	tests := map[string]testCase{
-		"valid string": {
-			input:    aws.String("TEST"),
-			expected: types.StringValue("TEST"),
-		},
-		"empty string": {
-			input:    aws.String(""),
-			expected: types.StringValue(""),
-		},
-		"nil string": {
-			input:    nil,
-			expected: types.StringValue(""),
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			got := flex.StringToFrameworkLegacy(context.Background(), test.input)
-
-			if diff := cmp.Diff(got, test.expected); diff != "" {
-				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
-			}
-		})
+func BenchmarkStringToFramework(b *testing.B) {
+	ctx := context.Background()
+	input := aws.String("TEST")
+	for n := 0; n < b.N; n++ {
+		r := flex.StringToFramework(ctx, input)
+		if r.IsNull() {
+			b.Fatal("should never see this")
+		}
 	}
 }
 
@@ -213,6 +189,41 @@ func TestStringValueToFramework(t *testing.T) {
 			t.Parallel()
 
 			got := flex.StringValueToFramework(context.Background(), test.input)
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestStringToFrameworkLegacy(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    *string
+		expected types.String
+	}
+	tests := map[string]testCase{
+		"valid string": {
+			input:    aws.String("TEST"),
+			expected: types.StringValue("TEST"),
+		},
+		"empty string": {
+			input:    aws.String(""),
+			expected: types.StringValue(""),
+		},
+		"nil string": {
+			input:    nil,
+			expected: types.StringValue(""),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flex.StringToFrameworkLegacy(context.Background(), test.input)
 
 			if diff := cmp.Diff(got, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/service/emr/supported_instance_types_data_source.go
+++ b/internal/service/emr/supported_instance_types_data_source.go
@@ -155,7 +155,7 @@ func flattenSupportedInstanceTypes(ctx context.Context, apiObjects []awstypes.Su
 			"ebs_storage_only":         flex.BoolToFramework(ctx, apiObject.EbsStorageOnly),
 			"instance_family_id":       flex.StringToFramework(ctx, apiObject.InstanceFamilyId),
 			"is_64_bits_only":          flex.BoolToFramework(ctx, apiObject.Is64BitsOnly),
-			"memory_gb":                flex.Float32ToFramework(ctx, apiObject.MemoryGB),
+			"memory_gb":                flex.Float32ToFrameworkFloat64(ctx, apiObject.MemoryGB),
 			"number_of_disks":          flex.Int32ToFrameworkInt64(ctx, apiObject.NumberOfDisks),
 			"storage_gb":               flex.Int32ToFrameworkInt64(ctx, apiObject.StorageGB),
 			names.AttrType:             flex.StringToFramework(ctx, apiObject.Type),


### PR DESCRIPTION
### Description

Currnently, type-specific Flattener and Expander functions call through into `flex.Flatten` or `flex.Expand`, which need to determine source and target types and perform debug logging. These are not needed when the source and target types are known. Logging and type reflection performs on approximately 100 allocations for a total of 6500 to 9000 bytes.

By directly calling Framework `types` functions, allocations are reduced to 0 to 2 allocations of minor size. Execution time is also reduced by approximately 99%.

See commit messages for specific improvements.