### PR TITLE
bug fix: Appflow max_parallelism property fix. Issue 41431

### DIFF
--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -987,7 +987,7 @@ func resourceFlow() *schema.Resource {
 													MaxItems: 1,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
-															"max_page_size": {
+															"max_parallelism": {
 																Type:         schema.TypeInt,
 																Required:     true,
 																ValidateFunc: validation.IntBetween(1, 10),
@@ -3601,7 +3601,7 @@ func flattenSAPODataSourceProperties(sapoDataSourceProperties *types.SAPODataSou
 	}
 
 	if v := sapoDataSourceProperties.ParallelismConfig; v != nil {
-		m["pagination_config"] = flattenSAPODataParallelismConfigProperties(v)
+		m["parallelism_config"] = flattenSAPODataParallelismConfigProperties(v)
 	}
 
 	return m


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixed issue related to a probable copy/paste problem.

Previous behavior: if max_parallelism is used in Aws Appflow Flow, terraform plan returns the errors:
- The argument "max_page_size" is required, but no definition was found.
- An argument named "max_parallelism" is not expected here.

Fix:
- set "max_parallelism" parameter (internal\service\appflow\flow.go - Line 990)
- set m["parallelism_config"] (internal\service\appflow\flow.go - Line 3604)

Fixed behavior:
terraform plan/apply works as described in the documentation:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appflow_flow#max_parallelism-1

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41431

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appflow_flow#max_parallelism-1

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Any testing requires a fully functioning SAP system.
