### PR TITLE
Add validation for master_username in aws_redshift_cluster resource

### DIFF
--- a/.changelog/41582.txt
+++ b/.changelog/41582.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshift_cluster: Fix `master_username` validation
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -328,9 +328,8 @@ func resourceCluster() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 128),
-					validation.StringMatch(regexache.MustCompile(`^\w+$`), "must contain only alphanumeric characters"),
-					validation.StringMatch(regexache.MustCompile(`(?i)^[a-z_]`), "first character must be a letter"),
-				),
+					validation.StringMatch(regexache.MustCompile(`^[A-Za-z][0-9A-Za-z_.@+-]*$`),
+						"must start with a letter and only contain alphanumeric characters, underscores, plus signs, dots, @ symbols, or hyphens")),
 			},
 			"multi_az": {
 				Type:     schema.TypeBool,

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-version"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -515,7 +516,7 @@ func TestAccRedshiftCluster_tags(t *testing.T) {
 	})
 }
 
-func TestAccRedshiftCluster_forceNewUsername(t *testing.T) {
+func TestAccRedshiftCluster_masterUsername(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2 awstypes.Cluster
 	resourceName := "aws_redshift_cluster.test"
@@ -528,7 +529,7 @@ func TestAccRedshiftCluster_forceNewUsername(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_basic(rName),
+				Config: testAccClusterConfig_masterUsername(rName, "foo_test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v1),
 					testAccCheckClusterMasterUsername(&v1, "foo_test"),
@@ -536,13 +537,42 @@ func TestAccRedshiftCluster_forceNewUsername(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClusterConfig_updatedUsername(rName),
+				Config: testAccClusterConfig_masterUsername(rName, "new-username"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v2),
-					testAccCheckClusterRecreated(&v1, &v2),
-					testAccCheckClusterMasterUsername(&v2, "new_username"),
-					resource.TestCheckResourceAttr(resourceName, "master_username", "new_username"),
+					testAccCheckClusterMasterUsername(&v2, "new-username"),
+					resource.TestCheckResourceAttr(resourceName, "master_username", "new-username"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccRedshiftCluster_masterUsername_invalid(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccClusterConfig_masterUsername(rName, "invalid username"), // no spaces
+				ExpectError: regexache.MustCompile(`Error: invalid value for master_username`),
+			},
+			{
+				Config:      testAccClusterConfig_masterUsername(rName, "1invalidusername"), // must start with letter
+				ExpectError: regexache.MustCompile(`Error: invalid value for master_username`),
+			},
+			{
+				Config:      testAccClusterConfig_masterUsername(rName, "-invalidusername"), // must start with letter
+				ExpectError: regexache.MustCompile(`Error: invalid value for master_username`),
 			},
 		},
 	})
@@ -1053,21 +1083,6 @@ func testAccCheckClusterNotRecreated(i, j *awstypes.Cluster) resource.TestCheckF
 		// Clusters with the same identifier can/will have an overlapping Endpoint.Address.
 		if aws.ToString(i.ClusterPublicKey) != aws.ToString(j.ClusterPublicKey) {
 			return errors.New("Redshift Cluster was recreated")
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckClusterRecreated(i, j *awstypes.Cluster) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// In lieu of some other uniquely identifying attribute from the API that always changes
-		// when a cluster is destroyed and recreated with the same identifier, we use the SSH key
-		// as it will get regenerated when a cluster is destroyed.
-		// Certain update operations (e.g KMS encrypting a cluster) will change ClusterCreateTime.
-		// Clusters with the same identifier can/will have an overlapping Endpoint.Address.
-		if aws.ToString(i.ClusterPublicKey) == aws.ToString(j.ClusterPublicKey) {
-			return errors.New("Redshift Cluster was not recreated")
 		}
 
 		return nil
@@ -1913,4 +1928,22 @@ resource "aws_redshift_cluster" "test" {
   skip_final_snapshot                 = true
 }
 `, rName, password, passwordVersion))
+}
+
+func testAccClusterConfig_masterUsername(rName, username string) string {
+	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+resource "aws_redshift_cluster" "test" {
+  cluster_identifier                  = %[1]q
+  availability_zone                   = data.aws_availability_zones.available.names[0]
+  database_name                       = "mydb"
+  encrypted                           = true
+  master_username                     = %[2]q
+  master_password                     = "Mustbe8characters"
+  multi_az                            = false
+  node_type                           = "dc2.large"
+  automated_snapshot_retention_period = 0
+  allow_version_upgrade               = false
+  skip_final_snapshot                 = true
+}
+`, rName, username))
 }


### PR DESCRIPTION
Description
PR https://github.com/hashicorp/terraform-provider-aws/issues/41437: fixes a bug that prevented the master_username value in Redshift clusters from accepting special characters. The validation logic has been updated to allow alphanumeric characters, underscores (_), plus signs (+), dots (.), and @ symbols, ensuring the master_username adheres to the correct format and constraints.

Relations
Closes https://github.com/hashicorp/terraform-provider-aws/issues/41437

### Output from Acceptance Testing
```console
 make testacc PKG=redshift TESTS=TestAccRedshiftCluster_masterUsername
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/redshift/... -v -count 1 -parallel 20 -run='TestAccRedshiftCluster_masterUsername'  -timeout 360m -vet=off
2025/02/27 12:41:11 Initializing Terraform AWS Provider...
=== RUN   TestAccRedshiftCluster_masterUsername
=== PAUSE TestAccRedshiftCluster_masterUsername
=== RUN   TestAccRedshiftCluster_masterUsername_invalid
=== PAUSE TestAccRedshiftCluster_masterUsername_invalid
=== CONT  TestAccRedshiftCluster_masterUsername
=== CONT  TestAccRedshiftCluster_masterUsername_invalid
--- PASS: TestAccRedshiftCluster_masterUsername_invalid (3.23s)
--- PASS: TestAccRedshiftCluster_masterUsername (339.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshift   344.675s
```
