### PR TITLE
docs/aws_sqs_queue: Timeout with incompatible arguments

### DIFF
--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -12,6 +12,8 @@ Amazon SQS (Simple Queue Service) is a fully managed message queuing service tha
 
 !> AWS will hang indefinitely, leading to a `timeout while waiting` error, when creating or updating an `aws_sqs_queue` with an associated [`aws_sqs_queue_policy`](/docs/providers/aws/r/sqs_queue_policy.html) if `Version = "2012-10-17"` is not explicitly set in the policy.
 
+!> AWS will hang indefinitely and trigger a `timeout while waiting` error when creating or updating an `aws_sqs_queue` if `kms_data_key_reuse_period_seconds` is set to a non-default value, `sqs_managed_sse_enabled` is `false` (explicitly or by default), and `kms_master_key_id` is not set.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

SQS has an unusual behavior where certain misconfigurations cause it to hang indefinitely rather than return an error. Specifically, creating or updating an `aws_sqs_queue` results in a `timeout while waiting` error if:  

- `kms_data_key_reuse_period_seconds` is set to a non-default value,  
- `sqs_managed_sse_enabled` is `false` (explicitly or by default), and  
- `kms_master_key_id` is not set.  

While `resourceQueueCustomizeDiff` already handles `kms_data_key_reuse_period_seconds` in some cases, we don't modify configurations to prevent this hanging behavior. Instead of enforcing a change, this PR updates the documentation to make users aware of the issue. We could also connect `kms_data_key_reuse_period_seconds`, `sqs_managed_sse_enabled`, and `kms_master_key_id` to provide invalid configuration errors.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41234

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

N/A
