### PR TITLE
docs: add missing ip_address_type option for aws_lightsail_instance

### DIFF
--- a/website/docs/r/lightsail_instance.html.markdown
+++ b/website/docs/r/lightsail_instance.html.markdown
@@ -82,17 +82,17 @@ This resource supports the following arguments:
 * `key_pair_name` - (Optional) The name of your key pair. Created in the
 Lightsail console (cannot use `aws_key_pair` at this time)
 * `user_data` - (Optional) Single lined launch script as a string to configure server with additional user data
-* `ip_address_type` - (Optional) The IP address type of the Lightsail Instance. Valid Values: `dualstack` | `ipv4`.
-* `add_on` - (Optional) The add on configuration for the instance. [Detailed below](#add_on).
+* `ip_address_type` - (Optional) The IP address type of the Lightsail Instance. Valid Values: `dualstack`,  `ipv4`, and `ipv6`.
+* `add_on` - (Optional) The add-on configuration for the instance. [Detailed below](#add_on).
 * `tags` - (Optional) A map of tags to assign to the resource. To create a key-only tag, use an empty string as the value. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### `add_on`
 
-Defines the add on configuration for the instance. The `add_on` configuration block supports the following arguments:
+Defines the add-on configuration for the instance. The `add_on` configuration block supports the following arguments:
 
 * `type` - (Required) The add-on type. There is currently only one valid type `AutoSnapshot`.
 * `snapshot_time` - (Required) The daily time when an automatic snapshot will be created. Must be in HH:00 format, and in an hourly increment and specified in Coordinated Universal Time (UTC). The snapshot will be automatically created between the time specified and up to 45 minutes after.
-* `status` - (Required) The status of the add on. Valid Values: `Enabled`, `Disabled`.
+* `status` - (Required) The status of the add-on. Valid Values: `Enabled`, `Disabled`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description

- Add the missing value `ipv6` to the list of possible values for `ip_address_type` of the resource `aws_lightsail_instance`.
- In the resource documentation there is also inconsistent spelling of _add-on_:  add-on vs. add on. This was changed to add-on in all places as this term in used in the official AWS docs (e.g. [here](https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_AddOn.html) or [here](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lightsail/enable-add-on.html)). 

When using `ipv6` as value, one needs to specify a bundle that supports this type. Here an example

```hcl
resource "aws_lightsail_instance" "gitlab_test" {
  name              = "custom_gitlab"
  availability_zone = "us-east-1b"
  blueprint_id      = "amazon_linux_2"
  bundle_id         = "nano_ipv6_3_0"
  ip_address_type = "ipv6"
  tags = {
    foo = "bar"
  }
}
```

and the output of `terraform apply`


```shell
❯ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_lightsail_instance.gitlab_test will be created
  + resource "aws_lightsail_instance" "gitlab_test" {
      + arn                = (known after apply)
      + availability_zone  = "us-east-1b"
      + blueprint_id       = "amazon_linux_2"
      + bundle_id          = "nano_ipv6_3_0"
      + cpu_count          = (known after apply)
      + created_at         = (known after apply)
      + id                 = (known after apply)
      + ip_address_type    = "ipv6"
      + ipv6_addresses     = (known after apply)
      + is_static_ip       = (known after apply)
      + name               = "custom_gitlab"
      + private_ip_address = (known after apply)
      + public_ip_address  = (known after apply)
      + ram_size           = (known after apply)
      + tags               = {
          + "foo" = "bar"
        }
      + tags_all           = {
          + "foo" = "bar"
        }
      + username           = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_lightsail_instance.gitlab_test: Creating...
aws_lightsail_instance.gitlab_test: Still creating... [10s elapsed]
aws_lightsail_instance.gitlab_test: Still creating... [20s elapsed]
aws_lightsail_instance.gitlab_test: Creation complete after 29s [id=custom_gitlab]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```


### Relations

Closes #41498 

### References

[Lightsail API Docs - SetIpAddressType](https://docs.aws.amazon.com/lightsail/2016-11-28/api-reference/API_SetIpAddressType.html#API_SetIpAddressType_RequestSyntax)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.