### PR TITLE
.ci/semgrep: add `avoid-SingleNestedBlock` rule

### DIFF
--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -670,3 +670,13 @@ rules:
       - pattern-either:
           - pattern: errs.Must(...)
     severity: WARNING
+
+  - id: avoid-SingleNestedBlock
+    languages: [go]
+    message: Avoid use of `SingleNestedBlock` in schema definitions. Use `ListNestedBlock` with a size validator instead.
+    paths:
+      include:
+        - internal/service
+    patterns:
+      - pattern: schema.SingleNestedBlock{ ... }
+    severity: ERROR

--- a/internal/service/bedrock/model_invocation_logging_configuration.go
+++ b/internal/service/bedrock/model_invocation_logging_configuration.go
@@ -40,7 +40,7 @@ func (r *resourceModelInvocationLoggingConfiguration) Schema(ctx context.Context
 			names.AttrID: framework.IDAttribute(),
 		},
 		Blocks: map[string]schema.Block{
-			"logging_config": schema.SingleNestedBlock{
+			"logging_config": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 				CustomType: fwtypes.NewObjectTypeOf[loggingConfigModel](ctx),
 				Validators: []validator.Object{
 					objectvalidator.IsRequired(),
@@ -68,7 +68,7 @@ func (r *resourceModelInvocationLoggingConfiguration) Schema(ctx context.Context
 					},
 				},
 				Blocks: map[string]schema.Block{
-					"cloudwatch_config": schema.SingleNestedBlock{
+					"cloudwatch_config": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 						CustomType: fwtypes.NewObjectTypeOf[cloudWatchConfigModel](ctx),
 						Attributes: map[string]schema.Attribute{
 							names.AttrLogGroupName: schema.StringAttribute{
@@ -83,7 +83,7 @@ func (r *resourceModelInvocationLoggingConfiguration) Schema(ctx context.Context
 							},
 						},
 						Blocks: map[string]schema.Block{
-							"large_data_delivery_s3_config": schema.SingleNestedBlock{
+							"large_data_delivery_s3_config": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 								CustomType: fwtypes.NewObjectTypeOf[s3ConfigModel](ctx),
 								Attributes: map[string]schema.Attribute{
 									names.AttrBucketName: schema.StringAttribute{
@@ -97,7 +97,7 @@ func (r *resourceModelInvocationLoggingConfiguration) Schema(ctx context.Context
 							},
 						},
 					},
-					"s3_config": schema.SingleNestedBlock{
+					"s3_config": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 						CustomType: fwtypes.NewObjectTypeOf[s3ConfigModel](ctx),
 						Attributes: map[string]schema.Attribute{
 							names.AttrBucketName: schema.StringAttribute{

--- a/internal/service/elbv2/listener_rule_data_source.go
+++ b/internal/service/elbv2/listener_rule_data_source.go
@@ -69,7 +69,7 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 						},
 					},
 					Blocks: map[string]schema.Block{
-						"authenticate_cognito": schema.SingleNestedBlock{
+						"authenticate_cognito": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							CustomType: fwtypes.NewObjectTypeOf[authenticateCognitoActionConfigModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"authentication_request_extra_params": schema.MapAttribute{
@@ -99,7 +99,7 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 								},
 							},
 						},
-						"authenticate_oidc": schema.SingleNestedBlock{
+						"authenticate_oidc": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							Attributes: map[string]schema.Attribute{
 								"authentication_request_extra_params": schema.MapAttribute{
 									ElementType: types.StringType,
@@ -134,7 +134,7 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 								},
 							},
 						},
-						"fixed_response": schema.SingleNestedBlock{
+						"fixed_response": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							Attributes: map[string]schema.Attribute{
 								names.AttrContentType: schema.StringAttribute{
 									Computed: true,
@@ -147,9 +147,9 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 								},
 							},
 						},
-						"forward": schema.SingleNestedBlock{
+						"forward": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							Blocks: map[string]schema.Block{
-								"stickiness": schema.SingleNestedBlock{
+								"stickiness": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 									Attributes: map[string]schema.Attribute{
 										names.AttrDuration: schema.Int32Attribute{
 											Computed: true,
@@ -173,7 +173,7 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 								},
 							},
 						},
-						"redirect": schema.SingleNestedBlock{
+						"redirect": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
 									Computed: true,
@@ -202,7 +202,7 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 				CustomType: fwtypes.NewSetNestedObjectTypeOf[ruleConditionModel](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
-						"host_header": schema.SingleNestedBlock{
+						"host_header": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							CustomType: fwtypes.NewObjectTypeOf[hostHeaderConfigModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								names.AttrValues: schema.SetAttribute{
@@ -211,7 +211,7 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 								},
 							},
 						},
-						"http_header": schema.SingleNestedBlock{
+						"http_header": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							CustomType: fwtypes.NewObjectTypeOf[httpHeaderConfigModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								"http_header_name": schema.StringAttribute{
@@ -223,7 +223,7 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 								},
 							},
 						},
-						"http_request_method": schema.SingleNestedBlock{
+						"http_request_method": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							CustomType: fwtypes.NewObjectTypeOf[httpRquestMethodConfigModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								names.AttrValues: schema.SetAttribute{
@@ -232,7 +232,7 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 								},
 							},
 						},
-						"path_pattern": schema.SingleNestedBlock{
+						"path_pattern": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							CustomType: fwtypes.NewObjectTypeOf[pathPatternConfigModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								names.AttrValues: schema.SetAttribute{
@@ -241,7 +241,7 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 								},
 							},
 						},
-						"query_string": schema.SingleNestedBlock{
+						"query_string": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							CustomType: fwtypes.NewObjectTypeOf[queryStringConfigModel](ctx),
 							Blocks: map[string]schema.Block{
 								names.AttrValues: schema.SetNestedBlock{
@@ -259,7 +259,7 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 								},
 							},
 						},
-						"source_ip": schema.SingleNestedBlock{
+						"source_ip": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							CustomType: fwtypes.NewObjectTypeOf[pathPatternConfigModel](ctx),
 							Attributes: map[string]schema.Attribute{
 								names.AttrValues: schema.SetAttribute{

--- a/internal/service/opensearchserverless/security_config.go
+++ b/internal/service/opensearchserverless/security_config.go
@@ -78,7 +78,7 @@ func (r *resourceSecurityConfig) Schema(ctx context.Context, req resource.Schema
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"saml_options": schema.SingleNestedBlock{
+			"saml_options": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 				Attributes: map[string]schema.Attribute{
 					"group_attribute": schema.StringAttribute{
 						Optional: true,

--- a/internal/service/opensearchserverless/security_config_data_source.go
+++ b/internal/service/opensearchserverless/security_config_data_source.go
@@ -53,7 +53,7 @@ func (d *dataSourceSecurityConfig) Schema(ctx context.Context, req datasource.Sc
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"saml_options": schema.SingleNestedBlock{
+			"saml_options": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 				Attributes: map[string]schema.Attribute{
 					"group_attribute": schema.StringAttribute{
 						Computed: true,

--- a/internal/service/paymentcryptography/key.go
+++ b/internal/service/paymentcryptography/key.go
@@ -116,7 +116,7 @@ func (r *resourceKey) Schema(ctx context.Context, request resource.SchemaRequest
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
-			"key_attributes": schema.SingleNestedBlock{
+			"key_attributes": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 				CustomType: fwtypes.NewObjectTypeOf[keyAttributesModel](ctx),
 				Attributes: map[string]schema.Attribute{
 					"key_algorithm": schema.StringAttribute{
@@ -142,7 +142,7 @@ func (r *resourceKey) Schema(ctx context.Context, request resource.SchemaRequest
 					},
 				},
 				Blocks: map[string]schema.Block{
-					"key_modes_of_use": schema.SingleNestedBlock{
+					"key_modes_of_use": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 						CustomType: fwtypes.NewObjectTypeOf[keyModesOfUseModel](ctx),
 						Attributes: map[string]schema.Attribute{
 							"decrypt": schema.BoolAttribute{

--- a/internal/service/rekognition/stream_processor.go
+++ b/internal/service/rekognition/stream_processor.go
@@ -213,7 +213,7 @@ func (r *resourceStreamProcessor) Schema(ctx context.Context, req resource.Schem
 						objectvalidator.AtLeastOneOf(path.MatchRelative().AtName("bounding_box"), path.MatchRelative().AtName("polygon")),
 					},
 					Blocks: map[string]schema.Block{
-						"bounding_box": schema.SingleNestedBlock{
+						"bounding_box": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 							CustomType:  fwtypes.NewObjectTypeOf[boundingBoxModel](ctx),
 							Description: "The box representing a region of interest on screen.",
 							Validators: []validator.Object{

--- a/internal/service/resiliencehub/resiliency_policy.go
+++ b/internal/service/resiliencehub/resiliency_policy.go
@@ -129,14 +129,14 @@ func (r *resourceResiliencyPolicy) Schema(ctx context.Context, req resource.Sche
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
-			names.AttrPolicy: schema.SingleNestedBlock{
+			names.AttrPolicy: schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 				Description: "The resiliency failure policy.",
 				CustomType:  fwtypes.NewObjectTypeOf[resourceResiliencyPolicyModel](ctx),
 				Validators: []validator.Object{
 					objectvalidator.IsRequired(),
 				},
 				Blocks: map[string]schema.Block{
-					"az": schema.SingleNestedBlock{
+					"az": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 						CustomType:  fwtypes.NewObjectTypeOf[resourceResiliencyObjectiveModel](ctx),
 						Description: "The RTO and RPO target to measure resiliency for potential availability zone disruptions.",
 						Validators: []validator.Object{
@@ -144,7 +144,7 @@ func (r *resourceResiliencyPolicy) Schema(ctx context.Context, req resource.Sche
 						},
 						Attributes: requiredObjAttrs,
 					},
-					"hardware": schema.SingleNestedBlock{
+					"hardware": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 						CustomType:  fwtypes.NewObjectTypeOf[resourceResiliencyObjectiveModel](ctx),
 						Description: "The RTO and RPO target to measure resiliency for potential infrastructure disruptions.",
 						Validators: []validator.Object{
@@ -152,7 +152,7 @@ func (r *resourceResiliencyPolicy) Schema(ctx context.Context, req resource.Sche
 						},
 						Attributes: requiredObjAttrs,
 					},
-					"software": schema.SingleNestedBlock{
+					"software": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 						CustomType:  fwtypes.NewObjectTypeOf[resourceResiliencyObjectiveModel](ctx),
 						Description: "The RTO and RPO target to measure resiliency for potential application disruptions.",
 						Validators: []validator.Object{
@@ -160,7 +160,7 @@ func (r *resourceResiliencyPolicy) Schema(ctx context.Context, req resource.Sche
 						},
 						Attributes: requiredObjAttrs,
 					},
-					names.AttrRegion: schema.SingleNestedBlock{
+					names.AttrRegion: schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 						CustomType:  fwtypes.NewObjectTypeOf[resourceResiliencyObjectiveModel](ctx),
 						Description: "The RTO and RPO target to measure resiliency for potential region disruptions.",
 						Validators: []validator.Object{

--- a/internal/service/verifiedpermissions/schema.go
+++ b/internal/service/verifiedpermissions/schema.go
@@ -58,7 +58,7 @@ func (r *resourceSchema) Schema(ctx context.Context, request resource.SchemaRequ
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"definition": schema.SingleNestedBlock{
+			"definition": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
 				Validators: []validator.Object{
 					objectvalidator.IsRequired(),
 				},


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This rule will check for any usage of `schema.SingleNestedBlock` within the `internal/service` subfolder. Pre-existing instances of `SingleNestedBlock`s have been annotated with `nosemgrep` trailing comments. These will be migrated in the future.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #35813


