### PR TITLE
bug: support instance class when restoring a db cluster from a snapshot

### DIFF
--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -748,6 +748,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			input.DatabaseName = aws.String(v.(string))
 		}
 
+		if v, ok := d.GetOk("db_cluster_instance_class"); ok {
+			input.DBClusterInstanceClass = aws.String(v.(string))
+		}
+
 		if v, ok := d.GetOk("db_cluster_parameter_group_name"); ok {
 			input.DBClusterParameterGroupName = aws.String(v.(string))
 		}


### PR DESCRIPTION
### Description
The `db_cluster_instance_class` property was not respected when restoring a cluster from a snapshot despite the API supporting it.

### Relations
Closes #26773

### References
[RestoreDBClusterFromSnapshot](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBClusterFromSnapshot.html] documentation containing `DBClusterInstanceClass`.
