### PR TITLE
resource/aws_dataexchange_event_action: Adds `IsRequired` validation to nested blocks

### DIFF
--- a/internal/service/dataexchange/event_action.go
+++ b/internal/service/dataexchange/event_action.go
@@ -66,6 +66,7 @@ func (r *resourceEventAction) Schema(ctx context.Context, req resource.SchemaReq
 			names.AttrAction: schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[actionModel](ctx),
 				Validators: []validator.List{
+					listvalidator.IsRequired(),
 					listvalidator.SizeAtMost(1),
 				},
 				NestedObject: schema.NestedBlockObject{
@@ -73,6 +74,7 @@ func (r *resourceEventAction) Schema(ctx context.Context, req resource.SchemaReq
 						"export_revision_to_s3": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[autoExportRevisionToS3RequestDetailsModel](ctx),
 							Validators: []validator.List{
+								listvalidator.IsRequired(),
 								listvalidator.SizeAtMost(1),
 							},
 							NestedObject: schema.NestedBlockObject{
@@ -101,6 +103,7 @@ func (r *resourceEventAction) Schema(ctx context.Context, req resource.SchemaReq
 									"revision_destination": schema.ListNestedBlock{
 										CustomType: fwtypes.NewListNestedObjectTypeOf[autoExportRevisionDestinationEntryModel](ctx),
 										Validators: []validator.List{
+											listvalidator.IsRequired(),
 											listvalidator.SizeAtMost(1),
 										},
 										NestedObject: schema.NestedBlockObject{
@@ -125,6 +128,7 @@ func (r *resourceEventAction) Schema(ctx context.Context, req resource.SchemaReq
 			"event": schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[eventModel](ctx),
 				Validators: []validator.List{
+					listvalidator.IsRequired(),
 					listvalidator.SizeAtMost(1),
 				},
 				NestedObject: schema.NestedBlockObject{
@@ -132,6 +136,7 @@ func (r *resourceEventAction) Schema(ctx context.Context, req resource.SchemaReq
 						"revision_published": schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[revisionPublishedModel](ctx),
 							Validators: []validator.List{
+								listvalidator.IsRequired(),
 								listvalidator.SizeAtMost(1),
 							},
 							NestedObject: schema.NestedBlockObject{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Adds `IsRequired` validation to nested blocks

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #40552

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=dataexchange TESTS=TestAccDataExchangeEventAction_ ACCTEST_PARALLELISM=5

--- PASS: TestAccDataExchangeEventAction_basic (21.00s)
--- PASS: TestAccDataExchangeEventAction_keyPattern (34.55s)
--- PASS: TestAccDataExchangeEventAction_encryption_kmsKey (34.92s)
--- PASS: TestAccDataExchangeEventAction_encryption_AES256 (34.03s)
--- PASS: TestAccDataExchangeEventAction_disappears (17.64s)
--- PASS: TestAccDataExchangeEventAction_update (35.31s)
```
