### PR TITLE
Add aws_guardduty_malware_scan_settings resource

### DIFF
--- a/internal/service/guardduty/exports_test.go
+++ b/internal/service/guardduty/exports_test.go
@@ -7,6 +7,7 @@ package guardduty
 var (
 	ResourceInviteAccepter        = resourceInviteAccepter
 	ResourceMalwareProtectionPlan = newResourceMalwareProtectionPlan
+	ResourceMalwareScanSettings   = newResourceMalwareScanSettings
 
 	FindMemberDetectorFeatureByThreePartKey = findMemberDetectorFeatureByThreePartKey
 )

--- a/internal/service/guardduty/malware_scan_settings.go
+++ b/internal/service/guardduty/malware_scan_settings.go
@@ -1,0 +1,534 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package guardduty
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	guardduty_v2 "github.com/aws/aws-sdk-go-v2/service/guardduty"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_guardduty_malware_scan_settings", name="Malware Scan Settings")
+func newResourceMalwareScanSettings(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceMalwareScanSettings{}
+
+	return r, nil
+}
+
+const (
+	ResNameMalwareScanSettings = "Malware Scan Settings"
+	errScanSettingsNotFound    = "The request is rejected because the input detectorId is not owned by the current account."
+)
+
+type resourceMalwareScanSettings struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceMalwareScanSettings) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"detector_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+			"ebs_snapshot_preservation": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(enum.Values[awstypes.EbsSnapshotPreservation]()...),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"scan_resource_criteria": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[scanResourceCriteriaModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"include": scanConditionTypeBlock(ctx, scanConditionTypeBlockOpts{
+							conflictsWith: path.MatchRelative().AtParent().AtName("exclude"),
+						}),
+						"exclude": scanConditionTypeBlock(ctx, scanConditionTypeBlockOpts{
+							conflictsWith: path.MatchRelative().AtParent().AtName("include"),
+						}),
+					},
+				},
+			},
+		},
+	}
+}
+
+type scanConditionTypeBlockOpts struct {
+	conflictsWith path.Expression
+}
+
+func scanConditionTypeBlock(ctx context.Context, opts scanConditionTypeBlockOpts) schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[scanConditionTypeModel](ctx),
+		Validators: []validator.List{
+			listvalidator.SizeAtLeast(1),
+			listvalidator.SizeAtMost(1),
+			listvalidator.ConflictsWith(opts.conflictsWith),
+		},
+
+		NestedObject: schema.NestedBlockObject{
+			Blocks: map[string]schema.Block{
+				"ec2_instance_tag": schema.ListNestedBlock{
+					CustomType: fwtypes.NewListNestedObjectTypeOf[ec2InstanceTagScanConditionsModel](ctx),
+					Validators: []validator.List{
+						listvalidator.SizeAtLeast(1),
+						listvalidator.SizeAtMost(1),
+					},
+					NestedObject: schema.NestedBlockObject{
+						Blocks: map[string]schema.Block{
+							"map_equals": schema.ListNestedBlock{
+								CustomType: fwtypes.NewListNestedObjectTypeOf[scanConditionPairModel](ctx),
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+									listvalidator.UniqueValues(),
+								},
+								NestedObject: schema.NestedBlockObject{
+									Attributes: map[string]schema.Attribute{
+										"key": schema.StringAttribute{
+											Required: true,
+											Validators: []validator.String{
+												stringvalidator.LengthBetween(1, 128),
+											},
+										},
+										"value": schema.StringAttribute{
+											Optional: true,
+											Validators: []validator.String{
+												stringvalidator.LengthAtMost(256),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceMalwareScanSettings) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().GuardDutyClient(ctx)
+	var plan malwareScanSettingsResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input, diags := expandMalwareScanSettings(ctx, plan)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := conn.UpdateMalwareScanSettings(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.GuardDuty, create.ErrActionUpdating, ResNameMalwareScanSettings, plan.DetectorID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	out, err := GetMalwareScanSettingsForDetector(ctx, conn, plan.DetectorID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.GuardDuty, create.ErrActionSetting, ResNameMalwareScanSettings, plan.DetectorID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	model, diags := flattenMalwareScanSettings(ctx, plan.DetectorID.ValueString(), out)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+func (r *resourceMalwareScanSettings) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().GuardDutyClient(ctx)
+	var state malwareScanSettingsResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := GetMalwareScanSettingsForDetector(ctx, conn, state.DetectorID.ValueString())
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.GuardDuty, create.ErrActionSetting, ResNameMalwareScanSettings, state.DetectorID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	model, diags := flattenMalwareScanSettings(ctx, state.DetectorID.ValueString(), out)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+func (r *resourceMalwareScanSettings) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().GuardDutyClient(ctx)
+	var plan malwareScanSettingsResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input, diags := expandMalwareScanSettings(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := conn.UpdateMalwareScanSettings(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.GuardDuty, create.ErrActionUpdating, ResNameMalwareScanSettings, plan.DetectorID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	out, err := GetMalwareScanSettingsForDetector(ctx, conn, plan.DetectorID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.GuardDuty, create.ErrActionSetting, ResNameMalwareScanSettings, plan.DetectorID.ValueString(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	model, diags := flattenMalwareScanSettings(ctx, plan.DetectorID.ValueString(), out)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+}
+
+func (r *resourceMalwareScanSettings) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	conn := r.Meta().GuardDutyClient(ctx)
+	var state malwareScanSettingsResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// reset to default settings on destroy
+	input := &guardduty.UpdateMalwareScanSettingsInput{
+		DetectorId:              flex.StringFromFramework(ctx, state.DetectorID),
+		EbsSnapshotPreservation: awstypes.EbsSnapshotPreservationNoRetention,
+		ScanResourceCriteria:    &awstypes.ScanResourceCriteria{},
+	}
+
+	_, err := conn.UpdateMalwareScanSettings(ctx, input)
+	if err != nil {
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) {
+			return
+		}
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.GuardDuty, create.ErrActionDeleting, ResNameMalwareScanSettings, state.DetectorID.ValueString(), err),
+			err.Error(),
+		)
+	}
+}
+
+func (r *resourceMalwareScanSettings) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("detector_id"), req, resp)
+}
+
+func GetMalwareScanSettingsForDetector(ctx context.Context, conn *guardduty_v2.Client, detectorID string) (*guardduty_v2.GetMalwareScanSettingsOutput, error) {
+	input := &guardduty_v2.GetMalwareScanSettingsInput{
+		DetectorId: aws.String(detectorID),
+	}
+
+	result, err := conn.GetMalwareScanSettings(ctx, input)
+	if err != nil {
+		var nfe *awstypes.ResourceNotFoundException
+		if errors.As(err, &nfe) || strings.Contains(err.Error(), errScanSettingsNotFound) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: input,
+			}
+		}
+
+		return nil, err
+	}
+
+	if result == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return result, nil
+}
+
+func expandMalwareScanSettings(ctx context.Context, model malwareScanSettingsResourceModel) (*guardduty.UpdateMalwareScanSettingsInput, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	input := &guardduty.UpdateMalwareScanSettingsInput{}
+
+	input.DetectorId = flex.StringFromFramework(ctx, model.DetectorID)
+	input.EbsSnapshotPreservation = awstypes.EbsSnapshotPreservation(model.EBSSnapshotPreservation.ValueString())
+
+	if model.ScanResourceCriteria.IsNull() || model.ScanResourceCriteria.IsUnknown() || len(model.ScanResourceCriteria.Elements()) == 0 {
+		return input, diags
+	}
+
+	input.ScanResourceCriteria = &awstypes.ScanResourceCriteria{}
+
+	var scanResourceCriteria []scanResourceCriteriaModel
+	diags.Append(model.ScanResourceCriteria.ElementsAs(ctx, &scanResourceCriteria, false)...)
+	if diags.HasError() || len(scanResourceCriteria) == 0 {
+		return input, diags
+	}
+
+	includeScanConditions, d := expandScanConditions(ctx, scanResourceCriteria[0].Include)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	input.ScanResourceCriteria.Include = includeScanConditions
+
+	excludeScanConditions, d := expandScanConditions(ctx, scanResourceCriteria[0].Exclude)
+	diags.Append(d...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	input.ScanResourceCriteria.Exclude = excludeScanConditions
+
+	return input, diags
+}
+
+func expandScanConditions(ctx context.Context, model fwtypes.ListNestedObjectValueOf[scanConditionTypeModel]) (map[string]awstypes.ScanCondition, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if model.IsNull() || model.IsUnknown() || len(model.Elements()) == 0 {
+		return nil, diags
+	}
+
+	var scanConditionTypes []scanConditionTypeModel
+	diags.Append(model.ElementsAs(ctx, &scanConditionTypes, false)...)
+	if diags.HasError() || len(scanConditionTypes) == 0 {
+		return nil, diags
+	}
+
+	scanConditionsByType := map[string]awstypes.ScanCondition{}
+
+	ec2ScanConditionsModel := scanConditionTypes[0].EC2InstanceTagConditons
+	if ec2ScanConditionsModel.IsNull() || ec2ScanConditionsModel.IsUnknown() || len(ec2ScanConditionsModel.Elements()) == 0 {
+		return scanConditionsByType, diags
+	}
+
+	scanConditionsByType[string(awstypes.ScanCriterionKeyEc2InstanceTag)] = awstypes.ScanCondition{}
+
+	var ec2InstanceTagScanConditions []ec2InstanceTagScanConditionsModel
+	diags.Append(ec2ScanConditionsModel.ElementsAs(ctx, &ec2InstanceTagScanConditions, false)...)
+	if diags.HasError() || len(ec2InstanceTagScanConditions) == 0 {
+		return scanConditionsByType, diags
+	}
+
+	ec2TagEqualsScanConditionsModel := ec2InstanceTagScanConditions[0].MapEquals
+	if ec2TagEqualsScanConditionsModel.IsNull() || ec2TagEqualsScanConditionsModel.IsUnknown() || len(ec2TagEqualsScanConditionsModel.Elements()) == 0 {
+		return scanConditionsByType, diags
+	}
+
+	var ec2InstanceTagEqualPairs []scanConditionPairModel
+	diags.Append(ec2TagEqualsScanConditionsModel.ElementsAs(ctx, &ec2InstanceTagEqualPairs, false)...)
+	if diags.HasError() {
+		return scanConditionsByType, diags
+	}
+
+	sc := awstypes.ScanCondition{}
+	for _, condition := range ec2InstanceTagEqualPairs {
+		pair := awstypes.ScanConditionPair{
+			Key:   flex.StringFromFramework(ctx, condition.Key),
+			Value: flex.StringFromFramework(ctx, condition.Value),
+		}
+		sc.MapEquals = append(sc.MapEquals, pair)
+	}
+
+	scanConditionsByType[string(awstypes.ScanCriterionKeyEc2InstanceTag)] = sc
+
+	return scanConditionsByType, diags
+}
+
+func flattenMalwareScanSettings(ctx context.Context, detectorID string, output *guardduty.GetMalwareScanSettingsOutput) (malwareScanSettingsResourceModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	model := malwareScanSettingsResourceModel{
+		ID:         types.StringValue(detectorID),
+		DetectorID: types.StringValue(detectorID),
+	}
+
+	model.EBSSnapshotPreservation = types.StringValue(string(output.EbsSnapshotPreservation))
+
+	if isEmptyScanCriteria(output.ScanResourceCriteria) {
+		model.ScanResourceCriteria = fwtypes.NewListNestedObjectValueOfNull[scanResourceCriteriaModel](ctx)
+		return model, diags
+	}
+
+	includeScanConditions, d := flattenScanConditionType(ctx, output.ScanResourceCriteria.Include)
+	diags.Append(d...)
+	if diags.HasError() {
+		return model, diags
+	}
+
+	excludeScanConditions, d := flattenScanConditionType(ctx, output.ScanResourceCriteria.Exclude)
+	diags.Append(d...)
+	if diags.HasError() {
+		return model, diags
+	}
+
+	scanResourceCriteria := scanResourceCriteriaModel{
+		Include: includeScanConditions,
+		Exclude: excludeScanConditions,
+	}
+
+	scanResourceCriteriaList, d := fwtypes.NewListNestedObjectValueOfSlice(ctx, []*scanResourceCriteriaModel{&scanResourceCriteria}, nil)
+	diags.Append(d...)
+	if diags.HasError() {
+		return model, diags
+	}
+
+	model.ScanResourceCriteria = scanResourceCriteriaList
+	return model, diags
+}
+
+func flattenScanConditionType(ctx context.Context, scanConditionsByType map[string]awstypes.ScanCondition) (fwtypes.ListNestedObjectValueOf[scanConditionTypeModel], diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if scanConditionsByType == nil || len(scanConditionsByType) == 0 {
+		return fwtypes.NewListNestedObjectValueOfNull[scanConditionTypeModel](ctx), diags
+	}
+
+	ec2InstanceTagScanConditions, ok := scanConditionsByType[string(awstypes.ScanCriterionKeyEc2InstanceTag)]
+	if !ok {
+		return newListNestedObjectValueOfSlice(ctx, &diags, []*scanConditionTypeModel{
+			{
+				EC2InstanceTagConditons: fwtypes.NewListNestedObjectValueOfNull[ec2InstanceTagScanConditionsModel](ctx),
+			},
+		}), diags
+	}
+
+	if len(ec2InstanceTagScanConditions.MapEquals) == 0 {
+		return newListNestedObjectValueOfSlice(ctx, &diags, []*scanConditionTypeModel{
+			{
+				EC2InstanceTagConditons: newListNestedObjectValueOfSlice(ctx, &diags, []*ec2InstanceTagScanConditionsModel{
+					{
+						MapEquals: fwtypes.NewListNestedObjectValueOfNull[scanConditionPairModel](ctx),
+					},
+				}),
+			},
+		}), diags
+	}
+
+	var ec2InstanceTagEqualsConditions []*scanConditionPairModel
+	for _, condition := range ec2InstanceTagScanConditions.MapEquals {
+		pair := &scanConditionPairModel{
+			Key: types.StringValue(*condition.Key),
+		}
+		if condition.Value == nil {
+			pair.Value = types.StringNull()
+		} else {
+			pair.Value = types.StringValue(*condition.Value)
+		}
+
+		ec2InstanceTagEqualsConditions = append(ec2InstanceTagEqualsConditions, pair)
+	}
+
+	return newListNestedObjectValueOfSlice(ctx, &diags, []*scanConditionTypeModel{
+		{
+			EC2InstanceTagConditons: newListNestedObjectValueOfSlice(ctx, &diags, []*ec2InstanceTagScanConditionsModel{
+				{
+					MapEquals: newListNestedObjectValueOfSlice(ctx, &diags, ec2InstanceTagEqualsConditions),
+				},
+			}),
+		},
+	}), diags
+}
+
+func isEmptyScanCriteria(c *awstypes.ScanResourceCriteria) bool {
+	return c == nil || (len(c.Include) == 0 && len(c.Exclude) == 0)
+}
+
+func newListNestedObjectValueOfSlice[T any](ctx context.Context, diags *diag.Diagnostics, slice []*T) fwtypes.ListNestedObjectValueOf[T] {
+	ret, d := fwtypes.NewListNestedObjectValueOfSlice(ctx, slice, nil)
+	diags.Append(d...)
+	return ret
+}
+
+type malwareScanSettingsResourceModel struct {
+	ID                      types.String                                               `tfsdk:"id"`
+	DetectorID              types.String                                               `tfsdk:"detector_id"`
+	EBSSnapshotPreservation types.String                                               `tfsdk:"ebs_snapshot_preservation"`
+	ScanResourceCriteria    fwtypes.ListNestedObjectValueOf[scanResourceCriteriaModel] `tfsdk:"scan_resource_criteria"`
+}
+
+type scanResourceCriteriaModel struct {
+	Include fwtypes.ListNestedObjectValueOf[scanConditionTypeModel] `tfsdk:"include"`
+	Exclude fwtypes.ListNestedObjectValueOf[scanConditionTypeModel] `tfsdk:"exclude"`
+}
+
+type scanConditionTypeModel struct {
+	EC2InstanceTagConditons fwtypes.ListNestedObjectValueOf[ec2InstanceTagScanConditionsModel] `tfsdk:"ec2_instance_tag"`
+}
+
+type ec2InstanceTagScanConditionsModel struct {
+	MapEquals fwtypes.ListNestedObjectValueOf[scanConditionPairModel] `tfsdk:"map_equals"`
+}
+
+type scanConditionPairModel struct {
+	Key   types.String `tfsdk:"key"`
+	Value types.String `tfsdk:"value"`
+}

--- a/internal/service/guardduty/malware_scan_settings_test.go
+++ b/internal/service/guardduty/malware_scan_settings_test.go
@@ -1,0 +1,355 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package guardduty_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/guardduty"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	tfguardduty "github.com/hashicorp/terraform-provider-aws/internal/service/guardduty"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccGuardDutyMalwareScanSettings_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	detectorName := "aws_guardduty_detector.test"
+	resourceName := "aws_guardduty_malware_scan_settings.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMalwareScanSettingsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMalwareScanSettingsConfig_basic(awstypes.EbsSnapshotPreservationNoRetention),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMalwareScanSettingsExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", detectorName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_snapshot_preservation", "NO_RETENTION"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.#", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+			{
+				// update retention setting
+				Config: testAccMalwareScanSettingsConfig_basic(awstypes.EbsSnapshotPreservationRetentionWithFinding),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMalwareScanSettingsExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "detector_id", detectorName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "ebs_snapshot_preservation", "RETENTION_WITH_FINDING"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGuardDutyMalwareScanSettings_scanResourceCriteria(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_guardduty_malware_scan_settings.test"
+
+	cond1 := awstypes.ScanConditionPair{
+		Key:   aws.String("abc"),
+		Value: aws.String("def"),
+	}
+	cond2 := awstypes.ScanConditionPair{
+		Key:   aws.String("qwe"),
+		Value: aws.String("rty"),
+	}
+	cond3 := awstypes.ScanConditionPair{
+		Key: aws.String("keyonly"),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMalwareScanSettingsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				// only use include ec2_instance_tag conditions
+				Config: testAccMalwareScanSettingsConfig_scanResourceCriteria([]awstypes.ScanConditionPair{cond1}, nil),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.0.ec2_instance_tag.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.0.ec2_instance_tag.0.map_equals.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.0.ec2_instance_tag.0.map_equals.0.key", "abc"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.0.ec2_instance_tag.0.map_equals.0.value", "def"),
+
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.#", "0"),
+				),
+			},
+			{
+				// update of include ec2_instance_tag conditions
+				Config: testAccMalwareScanSettingsConfig_scanResourceCriteria([]awstypes.ScanConditionPair{cond1, cond2}, nil),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.0.ec2_instance_tag.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.0.ec2_instance_tag.0.map_equals.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.0.ec2_instance_tag.0.map_equals.0.key", "abc"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.0.ec2_instance_tag.0.map_equals.0.value", "def"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.0.ec2_instance_tag.0.map_equals.1.key", "qwe"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.0.ec2_instance_tag.0.map_equals.1.value", "rty"),
+
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.#", "0"),
+				),
+			},
+			{
+				// only use exclude ec2_instance_tag conditions
+				Config: testAccMalwareScanSettingsConfig_scanResourceCriteria(nil, []awstypes.ScanConditionPair{cond1}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.0.key", "abc"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.0.value", "def"),
+				),
+			},
+			{
+				// update of exclude ec2_instance_tag conditions
+				Config: testAccMalwareScanSettingsConfig_scanResourceCriteria(nil, []awstypes.ScanConditionPair{cond1, cond2}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.0.key", "abc"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.0.value", "def"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.1.key", "qwe"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.1.value", "rty"),
+				),
+			},
+			{
+				// key-only condition
+				Config: testAccMalwareScanSettingsConfig_scanResourceCriteria(nil, []awstypes.ScanConditionPair{cond3}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.include.#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.0.key", "keyonly"),
+					resource.TestCheckNoResourceAttr(resourceName, "scan_resource_criteria.0.exclude.0.ec2_instance_tag.0.map_equals.0.value"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGuardDutyMalwareScanSettings_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resourceName := "aws_guardduty_malware_scan_settings.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckMalwareScanSettingsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMalwareScanSettingsConfig_forDisappears(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMalwareScanSettingsExists(ctx, resourceName),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfguardduty.ResourceMalwareScanSettings, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("ebs_snapshot_preservation"), knownvalue.StringExact(string(awstypes.EbsSnapshotPreservationRetentionWithFinding))),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("scan_resource_criteria"), knownvalue.ListSizeExact(1)),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckMalwareScanSettingsDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).GuardDutyClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_guardduty_malware_scan_settings" {
+				continue
+			}
+
+			_, err := tfguardduty.GetMalwareScanSettingsForDetector(ctx, conn, rs.Primary.ID)
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return create.Error(names.GuardDuty, create.ErrActionCheckingDestroyed, tfguardduty.ResNameMalwareScanSettings, rs.Primary.ID, err)
+			}
+
+			return fmt.Errorf("expected GuardDuty Scan Settings (%s) to be removed", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMalwareScanSettingsExists(ctx context.Context, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.GuardDuty, create.ErrActionCheckingExistence, tfguardduty.ResNameMalwareScanSettings, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.GuardDuty, create.ErrActionCheckingExistence, tfguardduty.ResNameMalwareScanSettings, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).GuardDutyClient(ctx)
+		_, err := conn.GetMalwareScanSettings(ctx, &guardduty.GetMalwareScanSettingsInput{
+			DetectorId: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return create.Error(names.GuardDuty, create.ErrActionCheckingExistence, tfguardduty.ResNameMalwareScanSettings, rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccMalwareScanSettingsConfigBase() string {
+	return `
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_guardduty_detector" "test" {
+  enable = true
+}
+`
+}
+
+func testAccMalwareScanSettingsConfig_basic(snapshotPreservation awstypes.EbsSnapshotPreservation) string {
+	return acctest.ConfigCompose(
+		testAccMalwareScanSettingsConfigBase(), fmt.Sprintf(`
+resource "aws_guardduty_malware_scan_settings" "test" {
+  detector_id               = aws_guardduty_detector.test.id
+  ebs_snapshot_preservation = %[1]q
+}
+`, snapshotPreservation),
+	)
+}
+
+func testAccMalwareScanSettingsConfig_forDisappears() string {
+	return acctest.ConfigCompose(
+		testAccMalwareScanSettingsConfigBase(), `
+resource "aws_guardduty_malware_scan_settings" "test" {
+  detector_id               = aws_guardduty_detector.test.id
+  ebs_snapshot_preservation = "RETENTION_WITH_FINDING"
+
+  scan_resource_criteria {
+    include {
+      ec2_instance_tag {
+        map_equals {
+          key   = "abc"
+          value = "def"
+        }
+      }
+    }
+  }
+}
+`)
+}
+
+func testAccMalwareScanSettingsConfig_scanResourceCriteria(includeEC2InstanceTags, excludeEC2InstanceTags []awstypes.ScanConditionPair) string {
+	includeStatement := makeScanConditionsStatement("include", includeEC2InstanceTags)
+	excludeStatement := makeScanConditionsStatement("exclude", excludeEC2InstanceTags)
+
+	return acctest.ConfigCompose(
+		testAccMalwareScanSettingsConfigBase(), fmt.Sprintf(`
+resource "aws_guardduty_malware_scan_settings" "test" {
+  detector_id               = aws_guardduty_detector.test.id
+  ebs_snapshot_preservation = "NO_RETENTION"
+
+  scan_resource_criteria {
+%[1]s
+%[2]s
+  }
+}
+`, includeStatement, excludeStatement))
+}
+
+func makeScanConditionsStatement(blockName string, c []awstypes.ScanConditionPair) string {
+	if len(c) == 0 {
+		return ""
+	}
+
+	conditions := []string{}
+	for _, cond := range c {
+		conditions = append(conditions, makeScanConditionStatement(cond))
+	}
+
+	return fmt.Sprintf(`
+    %s {
+      ec2_instance_tag {
+      %s
+      }
+    }
+`, blockName, strings.Join(conditions, "\n"))
+}
+
+func makeScanConditionStatement(cond awstypes.ScanConditionPair) string {
+	stmt := fmt.Sprintf(`
+        map_equals {
+          key   = %[1]q
+        }`, *cond.Key)
+	if cond.Value == nil {
+		return stmt
+	}
+	return fmt.Sprintf(`
+        map_equals {
+          key   = %[1]q
+          value = %[2]q
+        }`, *cond.Key, *cond.Value,
+	)
+}

--- a/internal/service/guardduty/service_package_gen.go
+++ b/internal/service/guardduty/service_package_gen.go
@@ -35,6 +35,11 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 			},
 		},
 		{
+			Factory:  newResourceMalwareScanSettings,
+			TypeName: "aws_guardduty_malware_scan_settings",
+			Name:     "Malware Scan Settings",
+		},
+		{
 			Factory:  newMemberDetectorFeatureResource,
 			TypeName: "aws_guardduty_member_detector_feature",
 			Name:     "Member Detector Feature",

--- a/website/docs/r/guardduty_malware_scan_settings.html.markdown
+++ b/website/docs/r/guardduty_malware_scan_settings.html.markdown
@@ -1,0 +1,80 @@
+---
+subcategory: "GuardDuty"
+layout: "aws"
+page_title: "AWS: aws_guardduty_malware_scan_settings"
+description: |-
+  Provides a resource to manage the Malware Scan Settings of a GuardDuty detector
+---
+
+# Resource: aws_guardduty_malware_scan_settings
+
+Provides a resource to manage the Malware Scan Settings of a GuardDuty detector.
+
+## Example Usage
+
+```terraform
+resource "aws_guardduty_malware_scan_settings" "example" {
+  detector_id = aws_guardduty_detector.example.id
+
+  ebs_snapshot_preservation = "RETENTION_WITH_FINDING"
+
+  scan_resource_criteria {
+    include {
+      ec2_instance_tag {
+        tag_equals {
+          key   = "key1"
+          value = "value1"
+        }
+
+        tag_equals {
+          key   = "key2"
+          value = "value2"
+        }
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+This resource supports the following arguments:
+
+* `detector_id` - (Required, Forces new resource) The identifier of the GuardDuty detector.
+* `ebs_snapshot_preservation` - (Required) The [snapshot retention](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-customizations.html#mp-snapshots-retention) setting for scanned EBS volumes. Valid values are `NO_RETENTION` and `RETENTION_WITH_FINDING`.
+* `scan_resource_criteria` - (Optional) The [criteria](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-customizations.html#mp-scan-options) to be used in the filter when selecting resources to scan. See [`scan_resource_criteria`](#scan_resource_criteria-argument-reference) below.
+
+### `scan_resource_criteria` argument reference
+
+* `exclude` - (Optional) The conditions that when matched will prevent a malware scan for a certain resource. Conflicts with `include`. See [`exclude`](#exclude-and-include-argument-reference) below.
+* `include` - (Optional) The conditions that when matched will allow a malware scan for a certain resource. Conflicts with `exclude`. See [`include`](#exclude-and-include-argument-reference) below.
+
+### `exclude` and `include` argument reference
+
+* `ec2_instance_tag` - (Required) The EC2 instance tag conditions for a malware scan. See [`ec2_instance_tag`](#ec2_instance_tag-argument-reference) below.
+
+### `ec2_instance_tag` argument reference
+
+* `map_equals` - (Required) Represents one or more [map equals conditions](https://docs.aws.amazon.com/guardduty/latest/APIReference/API_ScanCondition.html) to be applied to EC2 instance tags for triggering a malware scan. Multiple conditions are logically OR-ed together. See [`map_equals`](#map_equals-argument-reference) below.
+
+#### `map_equals` argument reference
+
+* `key` - (Required) Represents the key in the map condition.
+* `value` - (Optional) Represents value in the map condition. If not specified, only the key will be matched.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import malware scan settings using their GuardDuty detector IDs. For example:
+
+```terraform
+import {
+  to = aws_guardduty_malware_scan_settings.example
+  id = "1234567890abcdef0123"
+}
+```
+
+Using `terraform import`, import malware scan settings using their GuardDuty dectector IDs. For example:
+
+```console
+% terraform import aws_guardduty_malware_scan_settings.example 1234567890abcdef0123
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds aws_guardduty_malware_scan_settings resource. This allows configuring scan criteria (tag filtering) and volume retention policies for EC2 malware scanning.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33979

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection-customizations.html
- https://docs.aws.amazon.com/guardduty/latest/APIReference/API_UpdateMalwareScanSettings.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
╰─ make testacc TESTS=TestAccGuardDutyMalwareScanSettings PKG=guardduty
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/guardduty/... -v -count 1 -parallel 20 -run='TestAccGuardDutyMalwareScanSettings'  -timeout 360m -vet=off
2025/03/01 22:08:18 Initializing Terraform AWS Provider...
=== RUN   TestAccGuardDutyMalwareScanSettings_basic
--- PASS: TestAccGuardDutyMalwareScanSettings_basic (26.74s)
=== RUN   TestAccGuardDutyMalwareScanSettings_scanResourceCriteria
--- PASS: TestAccGuardDutyMalwareScanSettings_scanResourceCriteria (48.52s)
=== RUN   TestAccGuardDutyMalwareScanSettings_disappears
--- PASS: TestAccGuardDutyMalwareScanSettings_disappears (13.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/guardduty  95.355s
...
```
