### PR TITLE
Updating glue_job documentation to provide example for Glue Job v5.0

### DIFF
--- a/website/docs/r/glue_job.html.markdown
+++ b/website/docs/r/glue_job.html.markdown
@@ -18,11 +18,13 @@ Provides a Glue Job resource.
 
 ```terraform
 resource "aws_glue_job" "example" {
-  name     = "example"
+  name         = "example"
+  glue_version = "5.0"
   role_arn = aws_iam_role.example.arn
 
   command {
     script_location = "s3://${aws_s3_bucket.example.bucket}/example.py"
+    python_version  = "3"
   }
 }
 ```
@@ -133,7 +135,7 @@ This resource supports the following arguments:
 
 * `name` - (Optional) The name of the job command. Defaults to `glueetl`. Use `pythonshell` for Python Shell Job Type, `glueray` for Ray Job Type, or `gluestreaming` for Streaming Job Type. `max_capacity` needs to be set if `pythonshell` is chosen.
 * `script_location` - (Required) Specifies the S3 path to a script that executes a job.
-* `python_version` - (Optional) The Python version being used to execute a Python shell job. Allowed values are 2, 3 or 3.9. Version 3 refers to Python 3.6.
+* `python_version` - (Optional) The Python version being used to execute a Python shell job. Allowed values are 2, 3 or 3.9. Version 3 refers to Python 3.11 when `glue_version` is set to 5.0.
 * `runtime` - (Optional) In Ray jobs, runtime is used to specify the versions of Ray, Python and additional libraries available in your environment. This field is not used in other job types. For supported runtime environment values, see [Working with Ray jobs](https://docs.aws.amazon.com/glue/latest/dg/ray-jobs-section.html#author-job-ray-runtimes) in the Glue Developer Guide.
 
 ### execution_property Argument Reference


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
* This pull request updates the documentation for the `aws_glue_job` resource to notify the consumer that setting `python_version` to `3` when setting `glue_version` to `"5.0"` uses Python v3.11 instead of v3.6 as the the documentation previously stated.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41213 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
* N/A