### PR TITLE
[TechDebt]: Standardize deprecation messages

### DIFF
--- a/.ci/.semgrep.yml
+++ b/.ci/.semgrep.yml
@@ -680,3 +680,21 @@ rules:
     patterns:
       - pattern: schema.SingleNestedBlock{ ... }
     severity: ERROR
+
+  - id: include-argument-name-in-deprecation-message
+    languages: [go]
+    message: Deprecation messages should begin with `argument_name is deprecated`.
+    paths:
+      include:
+        - internal/service
+    patterns:
+      - pattern-inside: "Schema: map[string]*schema.Schema{ ... }"
+      - pattern: |
+          {
+            ..., Deprecated: $MESSAGE, ...
+          }
+      - metavariable-pattern:
+          metavariable: $MESSAGE
+          patterns:
+            - pattern-not-regex: ([a-zA-Z0-9_]+ is deprecated\.)
+    severity: WARNING

--- a/internal/service/apigateway/deployment.go
+++ b/internal/service/apigateway/deployment.go
@@ -70,7 +70,7 @@ func resourceDeployment() *schema.Resource {
 						},
 					},
 				},
-				Deprecated: `The attribute "canary_settings" will be removed in a future major version. Use an explicit "aws_api_gateway_stage" instead.`,
+				Deprecated: "canary_settings is deprecated. Use the aws_api_gateway_stage resource instead.",
 			},
 			"execution_arn": {
 				Type:     schema.TypeString,
@@ -89,13 +89,13 @@ func resourceDeployment() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				ForceNew:   true,
-				Deprecated: `The attribute "stage_description" will be removed in a future major version. Use an explicit "aws_api_gateway_stage" instead.`,
+				Deprecated: "stage_description is deprecated. Use the aws_api_gateway_stage resource instead.",
 			},
 			"stage_name": {
 				Type:       schema.TypeString,
 				Optional:   true,
 				ForceNew:   true,
-				Deprecated: `The attribute "stage_name" will be removed in a future major version. Use an explicit "aws_api_gateway_stage" instead.`,
+				Deprecated: "stage_name is deprecated. Use the aws_api_gateway_stage resource instead.",
 			},
 			names.AttrTriggers: {
 				Type:     schema.TypeMap,

--- a/internal/service/directconnect/gateway_association.go
+++ b/internal/service/directconnect/gateway_association.go
@@ -100,7 +100,7 @@ func resourceGatewayAssociation() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
-				Deprecated:    "use 'associated_gateway_id' argument instead",
+				Deprecated:    "vpn_gateway_id is deprecated. Use associated_gateway_id instead.",
 			},
 		},
 

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -144,7 +144,7 @@ func resourceEIP() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
-				Deprecated:    "use domain attribute instead",
+				Deprecated:    "vpc is deprecated. Use domain instead.",
 				ConflictsWith: []string{names.AttrDomain},
 			},
 		},

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -174,7 +174,7 @@ func resourceInstance() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				Deprecated:    "use 'cpu_options' argument instead",
+				Deprecated:    "cpu_core_count is deprecated. Use cpu_options instead.",
 				ConflictsWith: []string{"cpu_options.0.core_count"},
 			},
 			"cpu_threads_per_core": {
@@ -182,7 +182,7 @@ func resourceInstance() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				Deprecated:    "use 'cpu_options' argument instead",
+				Deprecated:    "cpu_threads_per_core is deprecated. Use cpu_options instead.",
 				ConflictsWith: []string{"cpu_options.0.threads_per_core"},
 			},
 			"credit_specification": {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -5939,7 +5939,7 @@ func TestInstanceCPUCoreCountSchema(t *testing.T) {
 		Optional:      true,
 		Computed:      true,
 		ForceNew:      true,
-		Deprecated:    "use 'cpu_options' argument instead",
+		Deprecated:    "cpu_core_count is deprecated. Use cpu_options instead.",
 		ConflictsWith: []string{"cpu_options.0.core_count"},
 	}
 	if !reflect.DeepEqual(actualSchema, expectedSchema) {
@@ -5959,7 +5959,7 @@ func TestInstanceCPUThreadsPerCoreSchema(t *testing.T) {
 		Optional:      true,
 		Computed:      true,
 		ForceNew:      true,
-		Deprecated:    "use 'cpu_options' argument instead",
+		Deprecated:    "cpu_threads_per_core is deprecated. Use cpu_options instead.",
 		ConflictsWith: []string{"cpu_options.0.threads_per_core"},
 	}
 	if !reflect.DeepEqual(actualSchema, expectedSchema) {

--- a/internal/service/ec2/vpc_flow_log.go
+++ b/internal/service/ec2/vpc_flow_log.go
@@ -121,7 +121,7 @@ func resourceFlowLog() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"log_destination"},
-				Deprecated:    "use 'log_destination' argument instead",
+				Deprecated:    "log_group_name is deprecated. Use log_destination instead.",
 			},
 			"max_aggregation_interval": {
 				Type:         schema.TypeInt,

--- a/internal/service/eks/addon.go
+++ b/internal/service/eks/addon.go
@@ -113,7 +113,7 @@ func resourceAddon() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: enum.Validate[types.ResolveConflicts](),
-				Deprecated:       `The "resolve_conflicts" attribute can't be set to "PRESERVE" on initial resource creation. Use "resolve_conflicts_on_create" and/or "resolve_conflicts_on_update" instead`,
+				Deprecated:       `resolve_conflicts is deprecated. The resolve_conflicts attribute can't be set to "PRESERVE" on initial resource creation. Use resolve_conflicts_on_create and/or resolve_conflicts_on_update instead.`,
 			},
 			"resolve_conflicts_on_create": {
 				Type:     schema.TypeString,

--- a/internal/service/events/rule.go
+++ b/internal/service/events/rule.go
@@ -88,7 +88,7 @@ func resourceRule() *schema.Resource {
 			"is_enabled": {
 				Type:       schema.TypeBool,
 				Optional:   true,
-				Deprecated: `Use "state" instead`,
+				Deprecated: "is_enabled is deprecated. Use state instead.",
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 					rawPlan := d.GetRawPlan()
 					rawIsEnabled := rawPlan.GetAttr("is_enabled")

--- a/internal/service/fsx/ontap_storage_virtual_machine_migrate.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_migrate.go
@@ -71,7 +71,7 @@ func resourceONTAPStorageVirtualMachineV0() *schema.Resource {
 										Optional:      true,
 										ForceNew:      true,
 										ValidateFunc:  validation.StringLenBetween(1, 2000),
-										Deprecated:    "use 'organizational_unit_distinguished_name' instead",
+										Deprecated:    "organizational_unit_distinguidshed_name is deprecated. Use organizational_unit_distinguished_name instead.",
 										ConflictsWith: []string{"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name"},
 									},
 									"organizational_unit_distinguished_name": {

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -40,7 +40,7 @@ func ResourceOrganizationConfiguration() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ExactlyOneOf: []string{"auto_enable", "auto_enable_organization_members"},
-				Deprecated:   "Use auto_enable_organization_members instead",
+				Deprecated:   "auto_enable is deprecated. Use auto_enable_organization_members instead.",
 			},
 			"auto_enable_organization_members": {
 				Type:             schema.TypeString,

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -73,7 +73,8 @@ func dataSourcePolicyDocument() *schema.Resource {
 					Type:         schema.TypeString,
 					Optional:     true,
 					ValidateFunc: validation.StringIsEmpty,
-					Deprecated:   "Not used",
+					Deprecated: "override_json is deprecated. This argument is retained only for " +
+						"backward compatibility with previous versions of this data source.",
 				},
 				"override_policy_documents": {
 					Type:     schema.TypeList,
@@ -92,7 +93,8 @@ func dataSourcePolicyDocument() *schema.Resource {
 					Type:         schema.TypeString,
 					Optional:     true,
 					ValidateFunc: validation.StringIsEmpty,
-					Deprecated:   "Not used",
+					Deprecated: "source_json is deprecated. This argument is retained only for " +
+						"backward compatibility with previous versions of this data source.",
 				},
 				"source_policy_documents": {
 					Type:     schema.TypeList,

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -91,7 +91,7 @@ func resourceRole() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				Deprecated: "The inline_policy argument is deprecated. " +
+				Deprecated: "inline_policy is deprecated. " +
 					"Use the aws_iam_role_policy resource instead. If Terraform should " +
 					"exclusively manage all inline policy associations (the current " +
 					"behavior of this argument), use the aws_iam_role_policies_exclusive " +
@@ -131,7 +131,7 @@ func resourceRole() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				Deprecated: "The managed_policy_arns argument is deprecated. " +
+				Deprecated: "managed_policy_arns is deprecated. " +
 					"Use the aws_iam_role_policy_attachment resource instead. If Terraform should " +
 					"exclusively manage all managed policy attachments (the current " +
 					"behavior of this argument), use the aws_iam_role_policy_attachments_exclusive " +

--- a/internal/service/identitystore/group_data_source.go
+++ b/internal/service/identitystore/group_data_source.go
@@ -96,7 +96,7 @@ func dataSourceGroup() *schema.Resource {
 				},
 			},
 			names.AttrFilter: {
-				Deprecated:    "Use the alternate_identifier attribute instead.",
+				Deprecated:    "filter is deprecated. Use alternate_identifier instead.",
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,

--- a/internal/service/identitystore/user_data_source.go
+++ b/internal/service/identitystore/user_data_source.go
@@ -152,7 +152,7 @@ func dataSourceUser() *schema.Resource {
 				},
 			},
 			names.AttrFilter: {
-				Deprecated:    "Use the alternate_identifier attribute instead.",
+				Deprecated:    "filter is deprecated. Use alternate_identifier instead.",
 				Type:          schema.TypeList,
 				Optional:      true,
 				MaxItems:      1,

--- a/internal/service/lambda/function_data_source.go
+++ b/internal/service/lambda/function_data_source.go
@@ -194,7 +194,7 @@ func dataSourceFunction() *schema.Resource {
 			"source_code_hash": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: "This attribute is deprecated and will be removed in a future major version. Use `code_sha256` instead.",
+				Deprecated: "source_code_hash is deprecated. Use code_sha256 instead.",
 			},
 			"source_code_size": {
 				Type:     schema.TypeInt,

--- a/internal/service/lambda/layer_version_data_source.go
+++ b/internal/service/lambda/layer_version_data_source.go
@@ -89,7 +89,7 @@ func dataSourceLayerVersion() *schema.Resource {
 			"source_code_hash": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: "This attribute is deprecated and will be removed in a future major version. Use `code_sha256` instead.",
+				Deprecated: "source_code_hash is deprecated. Use code_sha256 instead.",
 			},
 			"source_code_size": {
 				Type:     schema.TypeInt,

--- a/internal/service/networkmanager/core_network.go
+++ b/internal/service/networkmanager/core_network.go
@@ -80,7 +80,7 @@ func resourceCoreNetwork() *schema.Resource {
 				ConflictsWith: []string{"base_policy_region", "base_policy_regions"},
 			},
 			"base_policy_region": {
-				Deprecated: "Use the base_policy_regions argument instead. " +
+				Deprecated: "base_policy_region is deprecated. Use base_policy_regions instead. " +
 					"This argument will be removed in the next major version of the provider.",
 				Type:          schema.TypeString,
 				Optional:      true,

--- a/internal/service/networkmanager/core_network_policy_document_data_source.go
+++ b/internal/service/networkmanager/core_network_policy_document_data_source.go
@@ -271,7 +271,7 @@ func dataSourceCoreNetworkPolicyDocument() *schema.Resource {
 												"use_edge": {
 													Type:       schema.TypeString,
 													Optional:   true,
-													Deprecated: "Use use_edge_location",
+													Deprecated: "use_edge is deprecated. Use use_edge_location instead.",
 												},
 											},
 										},

--- a/internal/service/opensearch/domain.go
+++ b/internal/service/opensearch/domain.go
@@ -488,7 +488,7 @@ func resourceDomain() *schema.Resource {
 			"kibana_endpoint": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: "use 'dashboard_endpoint' attribute instead",
+				Deprecated: "kibana_endpoint is deprecated. Use dashboard_endpoint instead.",
 			},
 			"log_publishing_options": {
 				Type:     schema.TypeSet,

--- a/internal/service/opensearch/domain_data_source.go
+++ b/internal/service/opensearch/domain_data_source.go
@@ -296,7 +296,7 @@ func dataSourceDomain() *schema.Resource {
 			"kibana_endpoint": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: "use 'dashboard_endpoint' attribute instead",
+				Deprecated: "kibana_endpoint is deprecated. Use dashboard_endpoint instead.",
 			},
 			"log_publishing_options": {
 				Type:     schema.TypeSet,

--- a/internal/service/quicksight/data_set_data_source.go
+++ b/internal/service/quicksight/data_set_data_source.go
@@ -62,7 +62,7 @@ func dataSourceDataSet() *schema.Resource {
 					Optional:   true,
 					Computed:   true,
 					Elem:       &schema.Schema{Type: schema.TypeString},
-					Deprecated: `this attribute has been deprecated`,
+					Deprecated: "tags_all is deprecated. This argument will be removed in a future major version.",
 				},
 			}
 		},

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -68,7 +68,7 @@ func resourceCluster() *schema.Resource {
 				Optional:         true,
 				Computed:         true,
 				ValidateDiagFunc: enum.Validate[awstypes.AquaConfigurationStatus](),
-				Deprecated:       "This parameter is no longer supported by the AWS API. It will be removed in the next major version of the provider.",
+				Deprecated:       "aqua_configuration_status is deprecated. This parameter is no longer supported by the AWS API. It will be removed in the next major version of the provider.",
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 					return true
 				},
@@ -225,7 +225,7 @@ func resourceCluster() *schema.Resource {
 			},
 			"logging": {
 				Type: schema.TypeList,
-				Deprecated: "Use the aws_redshift_logging resource instead. " +
+				Deprecated: "logging is deprecated. Use the aws_redshift_logging resource instead. " +
 					"This argument will be removed in a future major version.",
 				MaxItems:         1,
 				Optional:         true,
@@ -389,7 +389,7 @@ func resourceCluster() *schema.Resource {
 			},
 			"snapshot_copy": {
 				Type: schema.TypeList,
-				Deprecated: "Use the aws_redshift_snapshot_copy resource instead. " +
+				Deprecated: "snapshot_copy is deprecated. Use the aws_redshift_snapshot_copy resource instead. " +
 					"This argument will be removed in a future major version.",
 				MaxItems: 1,
 				Optional: true,

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -74,7 +74,7 @@ func resourceBucket() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
-				Deprecated:       "Use the aws_s3_bucket_accelerate_configuration resource instead",
+				Deprecated:       "acceleration_status is deprecated. Use the aws_s3_bucket_accelerate_configuration resource instead.",
 				ValidateDiagFunc: enum.Validate[types.BucketAccelerateStatus](),
 			},
 			"acl": {
@@ -83,7 +83,7 @@ func resourceBucket() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{"grant"},
 				ValidateFunc:  validation.StringInSlice(bucketCannedACL_Values(), false),
-				Deprecated:    "Use the aws_s3_bucket_acl resource instead",
+				Deprecated:    "acl is deprecated. Use the aws_s3_bucket_acl resource instead.",
 			},
 			names.AttrARN: {
 				Type:     schema.TypeString,
@@ -122,7 +122,7 @@ func resourceBucket() *schema.Resource {
 				Type:       schema.TypeList,
 				Optional:   true,
 				Computed:   true,
-				Deprecated: "Use the aws_s3_bucket_cors_configuration resource instead",
+				Deprecated: "cors_rule is deprecated. Use the aws_s3_bucket_cors_configuration resource instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_headers": {
@@ -162,7 +162,7 @@ func resourceBucket() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"acl"},
-				Deprecated:    "Use the aws_s3_bucket_acl resource instead",
+				Deprecated:    "grant is deprecated. Use the aws_s3_bucket_acl resource instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrID: {
@@ -202,7 +202,7 @@ func resourceBucket() *schema.Resource {
 				Type:       schema.TypeList,
 				Optional:   true,
 				Computed:   true,
-				Deprecated: "Use the aws_s3_bucket_lifecycle_configuration resource instead",
+				Deprecated: "lifecycle_rule is deprecated. Use the aws_s3_bucket_lifecycle_configuration resource instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"abort_incomplete_multipart_upload_days": {
@@ -310,7 +310,7 @@ func resourceBucket() *schema.Resource {
 				Optional:   true,
 				Computed:   true,
 				MaxItems:   1,
-				Deprecated: "Use the aws_s3_bucket_logging resource instead",
+				Deprecated: "logging is deprecated. Use the aws_s3_bucket_logging resource instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"target_bucket": {
@@ -329,7 +329,7 @@ func resourceBucket() *schema.Resource {
 				Optional:   true,
 				Computed:   true,
 				MaxItems:   1,
-				Deprecated: "Use the top-level parameter object_lock_enabled and the aws_s3_bucket_object_lock_configuration resource instead",
+				Deprecated: "object_lock_configuration is deprecated. Use the top-level parameter object_lock_enabled and the aws_s3_bucket_object_lock_configuration resource instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"object_lock_enabled": {
@@ -338,12 +338,12 @@ func resourceBucket() *schema.Resource {
 							ForceNew:         true,
 							ConflictsWith:    []string{"object_lock_enabled"},
 							ValidateDiagFunc: enum.Validate[types.ObjectLockEnabled](),
-							Deprecated:       "Use the top-level parameter object_lock_enabled instead",
+							Deprecated:       "object_lock_enabled is deprecated. Use the top-level parameter object_lock_enabled instead.",
 						},
 						names.AttrRule: {
 							Type:       schema.TypeList,
 							Optional:   true,
-							Deprecated: "Use the aws_s3_bucket_object_lock_configuration resource instead",
+							Deprecated: "rule is deprecated. Use the aws_s3_bucket_object_lock_configuration resource instead.",
 							MaxItems:   1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -389,7 +389,7 @@ func resourceBucket() *schema.Resource {
 				Type:                  schema.TypeString,
 				Optional:              true,
 				Computed:              true,
-				Deprecated:            "Use the aws_s3_bucket_policy resource instead",
+				Deprecated:            "policy is deprecated. Use the aws_s3_bucket_policy resource instead.",
 				ValidateFunc:          validation.StringIsJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
@@ -407,7 +407,7 @@ func resourceBucket() *schema.Resource {
 				Optional:   true,
 				Computed:   true,
 				MaxItems:   1,
-				Deprecated: "Use the aws_s3_bucket_replication_configuration resource instead",
+				Deprecated: "replication_configuration is deprecated. Use the aws_s3_bucket_replication_configuration resource instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrRole: {
@@ -579,7 +579,7 @@ func resourceBucket() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
-				Deprecated:       "Use the aws_s3_bucket_request_payment_configuration resource instead",
+				Deprecated:       "request_payer is deprecated. Use the aws_s3_bucket_request_payment_configuration resource instead.",
 				ValidateDiagFunc: enum.Validate[types.Payer](),
 			},
 			"server_side_encryption_configuration": {
@@ -587,7 +587,7 @@ func resourceBucket() *schema.Resource {
 				MaxItems:   1,
 				Optional:   true,
 				Computed:   true,
-				Deprecated: "Use the aws_s3_bucket_server_side_encryption_configuration resource instead",
+				Deprecated: "server_side_encryption_configuration is deprecated. Use the aws_s3_bucket_server_side_encryption_configuration resource instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrRule: {
@@ -631,7 +631,7 @@ func resourceBucket() *schema.Resource {
 				Optional:   true,
 				Computed:   true,
 				MaxItems:   1,
-				Deprecated: "Use the aws_s3_bucket_versioning resource instead",
+				Deprecated: "versioning is deprecated. Use the aws_s3_bucket_versioning resource instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						names.AttrEnabled: {
@@ -652,7 +652,7 @@ func resourceBucket() *schema.Resource {
 				Optional:   true,
 				Computed:   true,
 				MaxItems:   1,
-				Deprecated: "Use the aws_s3_bucket_website_configuration resource instead",
+				Deprecated: "website is deprecated. Use the aws_s3_bucket_website_configuration resource instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"error_document": {
@@ -694,12 +694,12 @@ func resourceBucket() *schema.Resource {
 			"website_domain": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: "Use the aws_s3_bucket_website_configuration resource",
+				Deprecated: "website_domain is deprecated. Use the aws_s3_bucket_website_configuration resource instead.",
 			},
 			"website_endpoint": {
 				Type:       schema.TypeString,
 				Computed:   true,
-				Deprecated: "Use the aws_s3_bucket_website_configuration resource",
+				Deprecated: "website_endpoint is deprecated. Use the aws_s3_bucket_website_configuration resource instead.",
 			},
 		},
 	}

--- a/internal/service/s3/bucket_object.go
+++ b/internal/service/s3/bucket_object.go
@@ -66,7 +66,7 @@ func resourceBucketObject() *schema.Resource {
 				Computed: true,
 			},
 			names.AttrBucket: {
-				Deprecated:   "Use the aws_s3_object resource instead",
+				Deprecated:   "bucket is deprecated. Use the aws_s3_object resource instead.",
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
@@ -123,7 +123,7 @@ func resourceBucketObject() *schema.Resource {
 				Default:  false,
 			},
 			names.AttrKey: {
-				Deprecated:   "Use the aws_s3_object resource instead",
+				Deprecated:   "key is deprecated. Use the aws_s3_object resource instead.",
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,

--- a/internal/service/s3/bucket_object_data_source.go
+++ b/internal/service/s3/bucket_object_data_source.go
@@ -40,7 +40,7 @@ func dataSourceBucketObject() *schema.Resource {
 				Computed: true,
 			},
 			names.AttrBucket: {
-				Deprecated: "Use the aws_s3_object data source instead",
+				Deprecated: "bucket is deprecated. Use the aws_s3_object data source instead.",
 				Type:       schema.TypeString,
 				Required:   true,
 			},

--- a/internal/service/s3/bucket_objects_data_source.go
+++ b/internal/service/s3/bucket_objects_data_source.go
@@ -27,7 +27,7 @@ func dataSourceBucketObjects() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			names.AttrBucket: {
-				Deprecated: "Use the aws_s3_objects data source instead",
+				Deprecated: "bucket is deprecated. Use the aws_s3_objects data source instead.",
 				Type:       schema.TypeString,
 				Required:   true,
 			},

--- a/internal/service/s3/bucket_replication_configuration.go
+++ b/internal/service/s3/bucket_replication_configuration.go
@@ -252,7 +252,7 @@ func resourceBucketReplicationConfiguration() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringLenBetween(0, 1024),
-							Deprecated:   "Use filter instead",
+							Deprecated:   "prefix is deprecated. Use filter instead.",
 						},
 						names.AttrPriority: {
 							Type:     schema.TypeInt,

--- a/internal/service/servicediscovery/service_data_source.go
+++ b/internal/service/servicediscovery/service_data_source.go
@@ -107,7 +107,7 @@ func dataSourceService() *schema.Resource {
 				Optional:   true,
 				Computed:   true,
 				Elem:       &schema.Schema{Type: schema.TypeString},
-				Deprecated: `this attribute has been deprecated`,
+				Deprecated: "tags_all is deprecated. This argument will be removed in a future major version.",
 			},
 		},
 	}

--- a/internal/service/ssm/association.go
+++ b/internal/service/ssm/association.go
@@ -88,7 +88,7 @@ func resourceAssociation() *schema.Resource {
 				Type:       schema.TypeString,
 				ForceNew:   true,
 				Optional:   true,
-				Deprecated: "use 'targets' argument instead. https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_CreateAssociation.html#systemsmanager-CreateAssociation-request-InstanceId",
+				Deprecated: "instance_id is deprecated. Use targets instead.",
 			},
 			"max_concurrency": {
 				Type:         schema.TypeString,

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -97,7 +97,7 @@ func resourceParameter() *schema.Resource {
 			"overwrite": {
 				Type:       schema.TypeBool,
 				Optional:   true,
-				Deprecated: "this attribute has been deprecated",
+				Deprecated: "overwrite is deprecated. This argument will be removed in a future major version.",
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Standardizes the format of all deprecation messages such that they include the affected argument name. This will prevent confusion for practitioners as the default message does not always include the attribute path (Terraform diagnostic messages [do not support set paths](https://github.com/hashicorp/terraform-plugin-sdk/issues/1094#issuecomment-1307536150)).

Also adds a `semgrep` rule to enforce inclusion of the argument name in new deprecation messages.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40050


