### PR TITLE
docs: fix attributes on secretsmanager_secret_versions data source

### DIFF
--- a/website/docs/d/secretsmanager_secret_versions.html.markdown
+++ b/website/docs/d/secretsmanager_secret_versions.html.markdown
@@ -57,7 +57,7 @@ This data source exports the following attributes in addition to the arguments a
 
 ### versions
 
-* `created_date` - Date and time this version of the secret was created.
+* `created_time` - Date and time this version of the secret was created.
 * `last_accessed_date` - Date that this version of the secret was last accessed.
 * `version_id` - Unique version identifier of this version of the secret.
-* `version_stage` - Staging label attached to the version.
+* `version_stages` - List of staging labels attached to the version.


### PR DESCRIPTION
### Description

Update secretsmanager_secret_versions attributes to match what they actually are.


https://github.com/hashicorp/terraform-provider-aws/blob/1ee987528f7d96390c56bc4c9439fc0de0d40828/internal/service/secretsmanager/secret_versions_data_source.go#L114-L117
