### PR TITLE
r/aws_rds_shard_group: Add sweeper

### DIFF
--- a/.ci/semgrep/migrate/context.yml
+++ b/.ci/semgrep/migrate/context.yml
@@ -24,6 +24,8 @@ rules:
       include:
         - internal/service/*
         - internal/acctest/*
+      exclude:
+        - internal/service/*/sweep.go
     patterns:
       - pattern-either:
           - pattern: $D.Create($DATA, $META)

--- a/internal/service/configservice/sweep.go
+++ b/internal/service/configservice/sweep.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/configservice"
@@ -198,12 +197,12 @@ type configurationRecorderSweeper struct {
 	name   string
 }
 
-func (s *configurationRecorderSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
+func (s *configurationRecorderSweeper) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
 	r := resourceConfigurationRecorderStatus()
 	d := r.Data(nil)
 	d.SetId(s.name)
 
-	if err := sdk.NewSweepResource(r, d, s.client).Delete(ctx, timeout, optFns...); err != nil {
+	if err := sdk.NewSweepResource(r, d, s.client).Delete(ctx, optFns...); err != nil {
 		return err
 	}
 
@@ -211,7 +210,7 @@ func (s *configurationRecorderSweeper) Delete(ctx context.Context, timeout time.
 	d = r.Data(nil)
 	d.SetId(s.name)
 
-	return sdk.NewSweepResource(r, d, s.client).Delete(ctx, timeout, optFns...)
+	return sdk.NewSweepResource(r, d, s.client).Delete(ctx, optFns...)
 }
 
 func sweepConfigurationRecorder(region string) error {

--- a/internal/service/datasync/sweep.go
+++ b/internal/service/datasync/sweep.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/datasync"
@@ -131,7 +130,7 @@ type sweepableLocation struct {
 	conn *datasync.Client
 }
 
-func (sweepable *sweepableLocation) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
+func (sweepable *sweepableLocation) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
 	log.Printf("[DEBUG] Deleting DataSync Location: %s", sweepable.arn)
 	input := datasync.DeleteLocationInput{
 		LocationArn: aws.String(sweepable.arn),

--- a/internal/service/dynamodb/sweep.go
+++ b/internal/service/dynamodb/sweep.go
@@ -149,11 +149,14 @@ type backupSweeper struct {
 	arn  string
 }
 
-func (bs backupSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
+func (bs backupSweeper) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
 	input := &dynamodb.DeleteBackupInput{
 		BackupArn: aws.String(bs.arn),
 	}
 
+	const (
+		timeout = 10 * time.Minute
+	)
 	err := tfresource.Retry(ctx, timeout, func() *retry.RetryError {
 		log.Printf("[DEBUG] Deleting DynamoDB Backup: %s", bs.arn)
 		_, err := bs.conn.DeleteBackup(ctx, input)

--- a/internal/service/fms/sweep.go
+++ b/internal/service/fms/sweep.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/fms"
@@ -94,8 +93,8 @@ func newAdminAccountSweeper(resource *schema.Resource, d *schema.ResourceData, c
 	}
 }
 
-func (aas adminAccountSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
-	err := aas.sweepable.Delete(ctx, timeout, optFns...)
+func (aas adminAccountSweeper) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
+	err := aas.sweepable.Delete(ctx, optFns...)
 	if err != nil && strings.Contains(err.Error(), "AccessDeniedException") {
 		tflog.Warn(ctx, "Skipping resource", map[string]any{
 			"attr.account_id": aas.d.Get(names.AttrAccountID),

--- a/internal/service/iam/sweep.go
+++ b/internal/service/iam/sweep.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -408,8 +407,8 @@ func newPolicySweeper(resource *schema.Resource, d *schema.ResourceData, client 
 	}
 }
 
-func (ps policySweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
-	if err := ps.sweepable.Delete(ctx, timeout, optFns...); err != nil {
+func (ps policySweeper) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
+	if err := ps.sweepable.Delete(ctx, optFns...); err != nil {
 		accessDenied := regexache.MustCompile(`AccessDenied: .+ with an explicit deny`)
 		if accessDenied.MatchString(err.Error()) {
 			log.Printf("[DEBUG] Skipping IAM Policy (%s): %s", ps.d.Id(), err)

--- a/internal/service/organizations/sweep.go
+++ b/internal/service/organizations/sweep.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
@@ -95,8 +94,8 @@ func newAccountSweeper(resource *schema.Resource, d *schema.ResourceData, client
 	}
 }
 
-func (as accountSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
-	if err := as.sweepable.Delete(ctx, timeout, optFns...); err != nil {
+func (as accountSweeper) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
+	if err := as.sweepable.Delete(ctx, optFns...); err != nil {
 		if strings.Contains(err.Error(), "exceeded close account quota") {
 			tflog.Info(ctx, "Ignoring error", map[string]any{
 				"error": err.Error(),
@@ -196,8 +195,8 @@ func newOrganizationalUnitSweeper(resource *schema.Resource, d *schema.ResourceD
 	}
 }
 
-func (ous organizationalUnitSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
-	if err := ous.sweepable.Delete(ctx, timeout, optFns...); err != nil {
+func (ous organizationalUnitSweeper) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
+	if err := ous.sweepable.Delete(ctx, optFns...); err != nil {
 		if strings.Contains(err.Error(), "OrganizationalUnitNotEmptyException:") {
 			tflog.Info(ctx, "Ignoring error", map[string]any{
 				"error": err.Error(),

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -446,11 +446,7 @@ func (s instanceAutomatedBackupSweeper) Delete(ctx context.Context, optFns ...tf
 		DBInstanceAutomatedBackupsArn: aws.String(s.backupARN),
 	})
 
-	if errs.IsA[*types.DBInstanceAutomatedBackupNotFoundFault](err) {
-		err = nil
-	}
-
-	if errs.IsA[*types.InvalidDBInstanceAutomatedBackupStateFault](err) {
+	if errs.IsA[*types.DBInstanceAutomatedBackupNotFoundFault](err) || errs.IsA[*types.InvalidDBInstanceAutomatedBackupStateFault](err) {
 		err = nil
 	}
 

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -450,6 +450,10 @@ func (s instanceAutomatedBackupSweeper) Delete(ctx context.Context, optFns ...tf
 		err = nil
 	}
 
+	if errs.IsA[*types.InvalidDBInstanceAutomatedBackupStateFault](err) {
+		err = nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("deleting RDS Instance Automated Backup (%s): %w", s.backupARN, err)
 	}

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
@@ -431,8 +430,8 @@ func newInstanceAutomatedBackupSweeper(ctx context.Context, resource *schema.Res
 	}
 }
 
-func (s instanceAutomatedBackupSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
-	if err := s.sweepable.Delete(ctx, timeout, optFns...); err != nil {
+func (s instanceAutomatedBackupSweeper) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
+	if err := s.sweepable.Delete(ctx, optFns...); err != nil {
 		return err
 	}
 

--- a/internal/service/rds/sweep.go
+++ b/internal/service/rds/sweep.go
@@ -438,7 +438,7 @@ func (s instanceAutomatedBackupSweeper) Delete(ctx context.Context, timeout time
 
 	// Since there is no resource for automated backups themselves, they are swept here.
 	tflog.Info(ctx, "Deleting RDS Instance Automated Backup", map[string]any{
-		"skip_reason": s.backupARN,
+		"backup ARN": s.backupARN,
 	})
 
 	_, err := s.conn.DeleteDBInstanceAutomatedBackup(ctx, &rds.DeleteDBInstanceAutomatedBackupInput{

--- a/internal/service/s3/sweep.go
+++ b/internal/service/s3/sweep.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -130,7 +129,7 @@ type objectSweeper struct {
 	locked bool
 }
 
-func (os objectSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
+func (os objectSweeper) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
 	// Delete everything including locked objects.
 	tflog.Info(ctx, "Emptying S3 General Purpose Bucket")
 	n, err := emptyBucket(ctx, os.conn, os.bucket, os.locked)
@@ -148,7 +147,7 @@ type directoryBucketObjectSweeper struct {
 	bucket string
 }
 
-func (os directoryBucketObjectSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
+func (os directoryBucketObjectSweeper) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
 	tflog.Info(ctx, "Emptying S3 Directory Bucket")
 	n, err := emptyDirectoryBucket(ctx, os.conn, os.bucket)
 	if err != nil {

--- a/internal/service/sagemaker/sweep.go
+++ b/internal/service/sagemaker/sweep.go
@@ -1034,7 +1034,7 @@ func sweepProjects(region string) error {
 			d := r.Data(nil)
 			d.SetId(name)
 
-			if err := sdk.NewSweepResource(r, d, client).Delete(ctx); err != nil { // nosemgrep:ci.semgrep.migrate.direct-CRUD-calls
+			if err := sdk.NewSweepResource(r, d, client).Delete(ctx); err != nil {
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 			}
 		}

--- a/internal/service/sagemaker/sweep.go
+++ b/internal/service/sagemaker/sweep.go
@@ -1034,7 +1034,7 @@ func sweepProjects(region string) error {
 			d := r.Data(nil)
 			d.SetId(name)
 
-			if err := sdk.NewSweepResource(r, d, client).Delete(ctx, sweep.ThrottlingRetryTimeout); err != nil { // nosemgrep:ci.semgrep.migrate.direct-CRUD-calls
+			if err := sdk.NewSweepResource(r, d, client).Delete(ctx); err != nil { // nosemgrep:ci.semgrep.migrate.direct-CRUD-calls
 				sweeperErrs = multierror.Append(sweeperErrs, err)
 			}
 		}

--- a/internal/service/ssm/sweep.go
+++ b/internal/service/ssm/sweep.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -104,7 +103,7 @@ type defaultPatchBaselineSweeper struct {
 	os   awstypes.OperatingSystem
 }
 
-func (s defaultPatchBaselineSweeper) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
+func (s defaultPatchBaselineSweeper) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
 	diags := defaultPatchBaselineRestoreOSDefault(ctx, s.conn, s.os)
 
 	for _, d := range sdkdiag.Warnings(diags) {

--- a/internal/sweep/framework/resource.go
+++ b/internal/sweep/framework/resource.go
@@ -5,20 +5,14 @@ package framework
 
 import (
 	"context"
-	"math/rand"
-	"strings"
-	"time"
 
-	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
-	"github.com/hashicorp/terraform-provider-aws/internal/maps"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -48,23 +42,28 @@ func NewSweepResource(factory func(context.Context) (fwresource.ResourceWithConf
 	}
 }
 
-func (sr *sweepResource) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
+func (sr *sweepResource) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
 	resource, err := sr.factory(ctx)
-
 	if err != nil {
 		return err
 	}
 
-	resource.Configure(ctx, fwresource.ConfigureRequest{ProviderData: sr.meta}, &fwresource.ConfigureResponse{})
+	var configureResp fwresource.ConfigureResponse
+	resource.Configure(ctx, fwresource.ConfigureRequest{ProviderData: sr.meta}, &configureResp)
+	if configureResp.Diagnostics.HasError() {
+		return fwdiag.DiagnosticsError(configureResp.Diagnostics)
+	}
 
-	schemaResp := fwresource.SchemaResponse{}
+	var schemaResp fwresource.SchemaResponse
 	resource.Schema(ctx, fwresource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		return fwdiag.DiagnosticsError(schemaResp.Diagnostics)
+	}
 
 	state := tfsdk.State{
 		Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
 		Schema: schemaResp.Schema,
 	}
-
 	for _, attr := range sr.attributes {
 		d := state.SetAttribute(ctx, path.Root(attr.path), attr.value)
 		if d.HasError() {
@@ -75,44 +74,7 @@ func (sr *sweepResource) Delete(ctx context.Context, timeout time.Duration, optF
 
 	tflog.Info(ctx, "Sweeping resource")
 
-	jitter := time.Duration(rand.Int63n(int64(1*time.Second))) - 1*time.Second/2
-	defaultOpts := []tfresource.OptionsFunc{
-		tfresource.WithMinPollInterval(2*time.Second + jitter),
-	}
-	// Put defaults first so subsequent optFns will override them
-	optFns = append(defaultOpts, optFns...)
-
-	err = tfresource.Retry(ctx, timeout, func() *retry.RetryError {
-		err := deleteResource(ctx, state, resource)
-
-		if err != nil {
-			var throttled bool
-			for _, code := range maps.Keys(awsretry.DefaultThrottleErrorCodes) {
-				// The resource delete operation returns a diag.Diagnostics, so we have to do a
-				// string comparison instead of checking the error code of an actual error
-				if strings.Contains(err.Error(), code) {
-					throttled = true
-					break
-				}
-			}
-			if throttled {
-				tflog.Info(ctx, "Retrying throttling error", map[string]any{
-					"err": err.Error(),
-				})
-				return retry.RetryableError(err)
-			}
-
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
-	}, optFns...)
-
-	if tfresource.TimedOut(err) {
-		err = deleteResource(ctx, state, resource)
-	}
-
-	return err
+	return deleteResource(ctx, state, resource)
 }
 
 func deleteResource(ctx context.Context, state tfsdk.State, resource fwresource.Resource) error {

--- a/internal/sweep/sdk/resource.go
+++ b/internal/sweep/sdk/resource.go
@@ -5,18 +5,12 @@ package sdk
 
 import (
 	"context"
-	"math/rand"
-	"strings"
-	"time"
 
-	retry_sdkv2 "github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	"github.com/hashicorp/terraform-provider-aws/internal/maps"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -39,54 +33,10 @@ func newSweepResource(resource *schema.Resource, d *schema.ResourceData, meta *c
 	}
 }
 
-func (sr *sweepResource) Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error {
+func (sr *sweepResource) Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error {
 	ctx = tflog.SetField(ctx, "id", sr.d.Id())
 
-	// TODO
-	// TODO Once all services have moved to AWS SDK for Go v2 I _think_ we can remove this
-	// TODO custom retry logic as the API clients have been configured to use Adaptive retry.
-	// TODO
-
-	jitter := time.Duration(rand.Int63n(int64(1*time.Second))) - 1*time.Second/2
-	defaultOpts := []tfresource.OptionsFunc{
-		tfresource.WithMinPollInterval(2*time.Second + jitter),
-	}
-	// Put defaults first so subsequent optFns will override them
-	optFns = append(defaultOpts, optFns...)
-
-	err := tfresource.Retry(ctx, timeout, func() *retry.RetryError {
-		err := deleteResource(ctx, sr.resource, sr.d, sr.meta)
-
-		if err != nil {
-			var throttled bool
-			// The throttling error codes defined by the AWS SDK for Go v2 are a superset of the
-			// codes defined by v1, so use the v2 codes here.
-			for _, code := range maps.Keys(retry_sdkv2.DefaultThrottleErrorCodes) {
-				// The resource delete operation returns a diag.Diagnostics, so we have to do a
-				// string comparison instead of checking the error code of an actual error
-				if strings.Contains(err.Error(), code) {
-					throttled = true
-					break
-				}
-			}
-			if throttled {
-				tflog.Info(ctx, "Retrying throttling error", map[string]any{
-					"err": err.Error(),
-				})
-				return retry.RetryableError(err)
-			}
-
-			return retry.NonRetryableError(err)
-		}
-
-		return nil
-	}, optFns...)
-
-	if tfresource.TimedOut(err) {
-		err = deleteResource(ctx, sr.resource, sr.d, sr.meta)
-	}
-
-	return err
+	return deleteResource(ctx, sr.resource, sr.d, sr.meta)
 }
 
 type readerSweepResource struct {

--- a/internal/sweep/sweep.go
+++ b/internal/sweep/sweep.go
@@ -19,8 +19,6 @@ import (
 )
 
 const (
-	ThrottlingRetryTimeout = 10 * time.Minute
-
 	ResourcePrefix = "tf-acc-test"
 )
 
@@ -103,7 +101,7 @@ func SharedRegionalSweepClient(ctx context.Context, region string) (*conns.AWSCl
 }
 
 type Sweepable interface {
-	Delete(ctx context.Context, timeout time.Duration, optFns ...tfresource.OptionsFunc) error
+	Delete(ctx context.Context, optFns ...tfresource.OptionsFunc) error
 }
 
 func SweepOrchestrator(ctx context.Context, sweepables []Sweepable, optFns ...tfresource.OptionsFunc) error {
@@ -115,7 +113,7 @@ func SweepOrchestrator(ctx context.Context, sweepables []Sweepable, optFns ...tf
 
 	for _, sweepable := range sweepables {
 		g.Go(func() error {
-			return sweepable.Delete(ctx, ThrottlingRetryTimeout, optFns...)
+			return sweepable.Delete(ctx, optFns...)
 		})
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds sweeper for `aws_rds_shard_group`.
Migrates RDS sweepers to `awsv2.Register` pattern.
Adds sweeper for RDS Blue/Green Deployments.
Removes 10 minute hard timeout for resource deletion in sweepers.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41254.