### PR TITLE
testing: Reduce uses of resource.TestCheckResourceAttrSet with ARN attributes: remaining services

### DIFF
--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -4,7 +4,6 @@ rules:
     message: Use one of the `acctest` ARN value checks or TestCheckResourceAttrPair
     paths:
       exclude:
-        - "internal/service/organizations"
         - "internal/service/redshift"
     patterns:
       - pattern: |

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -4,7 +4,6 @@ rules:
     message: Use one of the `acctest` ARN value checks or TestCheckResourceAttrPair
     paths:
       exclude:
-        - "internal/service/controltower"
         - "internal/service/organizations"
         - "internal/service/redshift"
     patterns:

--- a/.ci/semgrep/acctest/checks/arn.yml
+++ b/.ci/semgrep/acctest/checks/arn.yml
@@ -2,9 +2,6 @@ rules:
   - id: arn-resourceattrset
     languages: [go]
     message: Use one of the `acctest` ARN value checks or TestCheckResourceAttrPair
-    paths:
-      exclude:
-        - "internal/service/redshift"
     patterns:
       - pattern: |
           resource.TestCheckResourceAttrSet($NAME, $ATTR)
@@ -13,5 +10,5 @@ rules:
           patterns:
             - pattern-either:
                 - pattern: names.AttrARN
-                # - pattern-regex: arn
+                # - pattern-regex: _arn
     severity: ERROR

--- a/internal/service/controltower/landing_zone_test.go
+++ b/internal/service/controltower/landing_zone_test.go
@@ -37,7 +37,7 @@ func testAccLandingZone_basic(t *testing.T) {
 				Config: testAccLandingZoneConfig_basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckLandingZoneExists(ctx, resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "controltower", "landingzone/${id}"),
 					resource.TestCheckResourceAttr(resourceName, "drift_status.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "latest_available_version"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "1.0"),

--- a/internal/service/organizations/account_test.go
+++ b/internal/service/organizations/account_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -57,7 +58,7 @@ func testAccAccount_basic(t *testing.T) {
 				Config: testAccAccountConfig_basic(name, email),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAccountExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "organizations", regexache.MustCompile("account/o-.+")),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEmail, email),
 					resource.TestCheckResourceAttrSet(resourceName, "joined_method"),
 					acctest.CheckResourceAttrRFC3339(resourceName, "joined_timestamp"),
@@ -96,7 +97,7 @@ func testAccAccount_CloseOnDeletion(t *testing.T) {
 				Config: testAccAccountConfig_closeOnDeletion(name, email),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAccountExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "organizations", regexache.MustCompile("account/o-.+")),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEmail, email),
 					resource.TestCheckResourceAttr(resourceName, "govcloud_id", ""),
 					resource.TestCheckResourceAttrSet(resourceName, "joined_method"),

--- a/internal/service/organizations/organization_data_source_test.go
+++ b/internal/service/organizations/organization_data_source_test.go
@@ -65,7 +65,7 @@ func testAccOrganizationDataSource_memberAccount(t *testing.T) {
 				Config: testAccOrganizationDataSourceConfig_basic,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckNoResourceAttr(dataSourceName, "accounts.#"),
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, dataSourceName, names.AttrARN, "organizations", "organization/o-{id}"),
 					resource.TestCheckNoResourceAttr(dataSourceName, "aws_service_access_principals.#"),
 					resource.TestCheckNoResourceAttr(dataSourceName, "enabled_policy_types.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "feature_set"),
@@ -100,7 +100,7 @@ func testAccOrganizationDataSource_delegatedAdministrator(t *testing.T) {
 				Config: testAccOrganizationDataSourceConfig_delegatedAdministrator,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceAttrGreaterThanValue(dataSourceName, "accounts.#", 2),
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrARN),
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, dataSourceName, names.AttrARN, "organizations", "organization/o-{id}"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "aws_service_access_principals.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "enabled_policy_types.#"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "feature_set"),

--- a/internal/service/organizations/organizational_unit_test.go
+++ b/internal/service/organizations/organizational_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -39,7 +40,7 @@ func testAccOrganizationalUnit_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOrganizationalUnitExists(ctx, resourceName, &unit),
 					resource.TestCheckResourceAttr(resourceName, "accounts.#", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.MatchResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "organizations", regexache.MustCompile("ou/o-.+")),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),

--- a/internal/service/redshift/cluster_data_source_test.go
+++ b/internal/service/redshift/cluster_data_source_test.go
@@ -27,6 +27,7 @@ func TestAccRedshiftClusterDataSource_basic(t *testing.T) {
 			{
 				Config: testAccClusterDataSourceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, dataSourceName, names.AttrARN, "redshift", "cluster:{id}"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_nodes.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_nodes.0.public_ip_address"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "allow_version_upgrade"),
@@ -50,7 +51,6 @@ func TestAccRedshiftClusterDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrPreferredMaintenanceWindow),
 					resource.TestCheckResourceAttrSet(dataSourceName, "manual_snapshot_retention_period"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "maintenance_track_name"),
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrARN),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrPubliclyAccessible),
 					resource.TestCheckResourceAttrPair(dataSourceName, "availability_zone_relocation_enabled", resourceName, "availability_zone_relocation_enabled"),
 					resource.TestCheckResourceAttrPair(dataSourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),

--- a/internal/service/redshift/snapshot_schedule_test.go
+++ b/internal/service/redshift/snapshot_schedule_test.go
@@ -38,7 +38,7 @@ func TestAccRedshiftSnapshotSchedule_basic(t *testing.T) {
 				Config: testAccSnapshotScheduleConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckSnapshotScheduleExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttrSet(resourceName, names.AttrARN),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "redshift", "snapshotschedule:{id}"),
 					resource.TestCheckResourceAttr(resourceName, "definitions.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "definitions.*", "rate(12 hours)"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Reduce uses of `resource.TestCheckResourceAttrSet` on ARN attributes in favour of explicit checks.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/41271.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/41107.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/40993.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/40930.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/40928.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/40909.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/40854.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/40822.