### PR TITLE
docs: add required permissions for using aws_sqs_queue data source

### DIFF
--- a/website/docs/d/sqs_queue.html.markdown
+++ b/website/docs/d/sqs_queue.html.markdown
@@ -12,6 +12,8 @@ Use this data source to get the ARN and URL of queue in AWS Simple Queue Service
 By using this data source, you can reference SQS queues without having to hardcode
 the ARNs as input.
 
+~> **NOTE:** To use this data source, you must have the `sqs:GetQueueAttributes` and `sqs:GetQueueURL` permissions.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
### Description

Add details on the required permissions for using the data source `aws_sqs_queue`:

- `sqs:GetQueueAttributes` 
- `sqs:GetQueueUrl`

### Relations

Closes #41458 

### References

- [Source code reference for requiring `sqs:GetQueueAttributes` ](https://github.com/hashicorp/terraform-provider-aws/blob/db3928d11ab7d908c70023e598b2e97c5a62b15b/internal/service/sqs/queue.go#L476) (via calling `findQueueAttributeByTwoPartKey` in the data source)
- [Source code reference for requiring `sqs:GetQueueUrl`](https://github.com/hashicorp/terraform-provider-aws/blob/db3928d11ab7d908c70023e598b2e97c5a62b15b/internal/service/sqs/queue_data_source.go#L77)


### Output from Acceptance Testing

Not applicable. Only documentation is updated.