### PR TITLE
Add RDS Aurora Global Cluster Data Source

### DIFF
--- a/.changelog/41668.txt
+++ b/.changelog/41668.txt
@@ -1,0 +1,3 @@
+```release-note:new-data-source
+aws_rds_global_cluster
+```

--- a/internal/service/rds/global_cluster_data_source.go
+++ b/internal/service/rds/global_cluster_data_source.go
@@ -1,0 +1,134 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @SDKDataSource("aws_rds_global_cluster", name="Global Cluster")
+func DataSourceGlobalCluster() *schema.Resource {
+	return &schema.Resource{
+		ReadWithoutTimeout: dataSourceGlobalClusterRead,
+
+		Schema: map[string]*schema.Schema{
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrDatabaseName: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrDeletionProtection: {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			names.AttrEndpoint: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrEngine: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_lifecycle_support": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrEngineVersion: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_version_actual": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"global_cluster_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"global_cluster_members": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"db_cluster_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_writer": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"global_cluster_resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			names.AttrStorageEncrypted: {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			names.AttrTags: tftags.TagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+	conn := meta.(*conns.AWSClient).RDSClient(ctx)
+
+	globalClusterID := d.Get("global_cluster_identifier").(string)
+	globalCluster, err := findGlobalClusterByID(ctx, conn, globalClusterID)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading RDS Global Cluster (%s): %s", globalClusterID, err)
+	}
+
+	d.SetId(aws.ToString(globalCluster.GlobalClusterIdentifier))
+	d.Set(names.AttrARN, globalCluster.GlobalClusterArn)
+	d.Set(names.AttrDatabaseName, globalCluster.DatabaseName)
+	d.Set(names.AttrDeletionProtection, globalCluster.DeletionProtection)
+	d.Set(names.AttrEndpoint, globalCluster.Endpoint)
+	d.Set(names.AttrEngine, globalCluster.Engine)
+	d.Set("engine_lifecycle_support", globalCluster.EngineLifecycleSupport)
+	d.Set("global_cluster_identifier", globalCluster.GlobalClusterIdentifier)
+	if err := d.Set("global_cluster_members", flattenGlobalClusterMembers(globalCluster.GlobalClusterMembers)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting global_cluster_members: %s", err)
+	}
+	d.Set("global_cluster_resource_id", globalCluster.GlobalClusterResourceId)
+	d.Set(names.AttrStorageEncrypted, globalCluster.StorageEncrypted)
+
+	oldEngineVersion, newEngineVersion := d.Get(names.AttrEngineVersion).(string), aws.ToString(globalCluster.EngineVersion)
+
+	// For example a configured engine_version of "5.6.10a" and a returned engine_version of "5.6.global_10a".
+	if oldParts, newParts := strings.Split(oldEngineVersion, "."), strings.Split(newEngineVersion, "."); len(oldParts) == 3 &&
+		len(newParts) == 3 &&
+		oldParts[0] == newParts[0] &&
+		oldParts[1] == newParts[1] &&
+		strings.HasSuffix(newParts[2], oldParts[2]) {
+		d.Set(names.AttrEngineVersion, oldEngineVersion)
+		d.Set("engine_version_actual", newEngineVersion)
+	} else {
+		d.Set(names.AttrEngineVersion, newEngineVersion)
+		d.Set("engine_version_actual", newEngineVersion)
+	}
+
+	// Use the same approach as the resource for setting tags
+	setTagsOut(ctx, globalCluster.TagList)
+
+	return diags
+}

--- a/internal/service/rds/global_cluster_data_source_test.go
+++ b/internal/service/rds/global_cluster_data_source_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rds_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccRDSGlobalClusterDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_rds_global_cluster.test"
+	resourceName := "aws_rds_global_cluster.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClusterDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDatabaseName, resourceName, names.AttrDatabaseName),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDeletionProtection, resourceName, names.AttrDeletionProtection),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrEndpoint, resourceName, names.AttrEndpoint),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrEngine, resourceName, names.AttrEngine),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine_lifecycle_support", resourceName, "engine_lifecycle_support"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrEngineVersion, resourceName, names.AttrEngineVersion),
+					resource.TestCheckResourceAttrPair(dataSourceName, "engine_version_actual", resourceName, "engine_version_actual"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_identifier", resourceName, "global_cluster_identifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_members.#", resourceName, "global_cluster_members.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_resource_id", resourceName, "global_cluster_resource_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrStorageEncrypted, resourceName, names.AttrStorageEncrypted),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRDSGlobalClusterDataSource_withTags(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSourceName := "data.aws_rds_global_cluster.test"
+	resourceName := "aws_rds_global_cluster.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalCluster(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalClusterDataSourceConfig_tags(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, "global_cluster_identifier", resourceName, "global_cluster_identifier"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrTags, resourceName, names.AttrTags),
+				),
+			},
+		},
+	})
+}
+
+func testAccGlobalClusterDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_global_cluster" "test" {
+  global_cluster_identifier = %[1]q
+  engine                    = "aurora-postgresql"
+}
+
+data "aws_rds_global_cluster" "test" {
+  global_cluster_identifier = aws_rds_global_cluster.test.global_cluster_identifier
+}
+`, rName)
+}
+
+func testAccGlobalClusterDataSourceConfig_tags(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_rds_global_cluster" "test" {
+  global_cluster_identifier = %[1]q
+  engine                    = "aurora-postgresql"
+
+  tags = {
+    Name  = %[1]q
+    Key1  = "Value1"
+    Key2  = "Value2"
+  }
+}
+
+data "aws_rds_global_cluster" "test" {
+  global_cluster_identifier = aws_rds_global_cluster.test.global_cluster_identifier
+}
+`, rName)
+}

--- a/internal/service/rds/service_package_gen.go
+++ b/internal/service/rds/service_package_gen.go
@@ -130,6 +130,11 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Name:     "Engine Version",
 		},
 		{
+			Factory:  DataSourceGlobalCluster,
+			TypeName: "aws_rds_global_cluster",
+			Name:     "Global Cluster",
+		},
+		{
 			Factory:  dataSourceOrderableInstance,
 			TypeName: "aws_rds_orderable_db_instance",
 			Name:     "Orderable DB Instance",

--- a/website/docs/d/rds_global_cluster.html.markdown
+++ b/website/docs/d/rds_global_cluster.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "RDS (Relational Database)"
+layout: "aws"
+page_title: "AWS: aws_rds_global_cluster"
+description: |-
+  Terraform data source for retrieving information about an AWS RDS Global Cluster.
+---
+
+# Data Source: aws_rds_global_cluster
+
+Terraform data source for retrieving information about an AWS RDS Global Cluster.
+
+## Example Usage
+
+```terraform
+data "aws_rds_global_cluster" "example" {
+  global_cluster_identifier = "example-global-cluster"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `global_cluster_identifier` - (Required) Identifier of the RDS Global Cluster.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the RDS Global Cluster.
+* `database_name` - Name of the database.
+* `deletion_protection` - Whether the Global Cluster has deletion protection enabled.
+* `endpoint` - Writer endpoint for the RDS Global Cluster.
+* `engine` - Database engine used by the Global Cluster (e.g., `aurora`, `aurora-mysql`, `aurora-postgresql`).
+* `engine_lifecycle_support` - Lifecycle support state for the cluster's engine.
+* `engine_version` - Engine version of the Aurora global database.
+* `engine_version_actual` - Full engine version information, containing version number and additional details.
+* `global_cluster_members` - Set of global cluster members (RDS Clusters) that are part of this global cluster. Detailed below.
+* `global_cluster_resource_id` - Immutable identifier assigned by AWS for the global cluster.
+* `id` - Identifier of the RDS Global Cluster.
+* `storage_encrypted` - Whether the Global Cluster is encrypted.
+* `tags` - Map of tags assigned to the Global Cluster.
+
+### global_cluster_members
+
+The `global_cluster_members` attribute has these exported attributes:
+
+* `db_cluster_arn` - ARN of the RDS Cluster.
+* `is_writer` - Whether the RDS Cluster is the primary/writer cluster.


### PR DESCRIPTION
### Description

Add a data source matching the resource reader for `aws_rds_global_cluster

Unfortunately, I created this before seeing that #37286 existed. However it is currently out of sync, so perhaps this is still warranted.

I did start with the latest framework type coming from skaff, but had some issues with tagging, and thought it would be better to keep consistent with the matching resource anyway, so the sdk type is used here.

### Relations

- Part of #13289
- Closes #20171

### Output from Acceptance Testing


```console
ᐅ make testacc TESTS=TestAccRDSGlobalClusterDataSource PKG=rds ACCTEST_PARALLELISM=4
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/rds/... -v -count 1 -parallel 4 -run='TestAccRDSGlobalClusterDataSource'  -timeout 360m -vet=off
2025/03/05 14:11:27 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSGlobalClusterDataSource_basic
=== PAUSE TestAccRDSGlobalClusterDataSource_basic
=== RUN   TestAccRDSGlobalClusterDataSource_withTags
=== PAUSE TestAccRDSGlobalClusterDataSource_withTags
=== CONT  TestAccRDSGlobalClusterDataSource_basic
=== CONT  TestAccRDSGlobalClusterDataSource_withTags
--- PASS: TestAccRDSGlobalClusterDataSource_basic (16.86s)
--- PASS: TestAccRDSGlobalClusterDataSource_withTags (17.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	22.904s
```
