### PR TITLE
Deprecate aws_opsworks*

### DIFF
--- a/.changelog/41674.txt
+++ b/.changelog/41674.txt
@@ -1,0 +1,67 @@
+```release-note:note
+resource/aws_opsworks_application: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_custom_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_ecs_cluster_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_ganglia_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_haproxy_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_instance: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_java_app_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_memcached_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_mysql_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_nodejs_app_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_permission: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_php_app_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_rails_app_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_rds_db_instance: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_stack: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_static_web_layer: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```
+
+```release-note:note
+resource/aws_opsworks_user_profile: OpsWorks is no longer supported by AWS. This resource is deprecated and will be removed in the next major version.
+```

--- a/internal/service/opsworks/application.go
+++ b/internal/service/opsworks/application.go
@@ -29,6 +29,7 @@ import (
 // @SDKResource("aws_opsworks_application", name="Application")
 func resourceApplication() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: "This resource is deprecated and will be removed in the next major version of the AWS Provider. Consider the AWS Systems Manager service for managing applications.",
 
 		CreateWithoutTimeout: resourceApplicationCreate,
 		ReadWithoutTimeout:   resourceApplicationRead,

--- a/internal/service/opsworks/instance.go
+++ b/internal/service/opsworks/instance.go
@@ -30,6 +30,7 @@ import (
 // @SDKResource("aws_opsworks_instance", name="Instance")
 func resourceInstance() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage:   "This resource is deprecated and will be removed in the next major version of the AWS Provider. Consider the AWS Systems Manager service instead.",
 		CreateWithoutTimeout: resourceInstanceCreate,
 		ReadWithoutTimeout:   resourceInstanceRead,
 		UpdateWithoutTimeout: resourceInstanceUpdate,

--- a/internal/service/opsworks/layers.go
+++ b/internal/service/opsworks/layers.go
@@ -447,6 +447,7 @@ func (lt *opsworksLayerType) resourceSchema() *schema.Resource {
 	}
 
 	return &schema.Resource{
+		DeprecationMessage: "This resource is deprecated and will be removed in the next major version of the AWS Provider. Consider the AWS Systems Manager service instead.",
 		CreateWithoutTimeout: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 			return lt.Create(ctx, d, meta)
 		},

--- a/internal/service/opsworks/permission.go
+++ b/internal/service/opsworks/permission.go
@@ -23,6 +23,7 @@ import (
 // @SDKResource("aws_opsworks_permission", name="Permission")
 func resourcePermission() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage:   "This resource is deprecated and will be removed in the next major version of the AWS Provider. Consider the AWS Systems Manager service instead.",
 		CreateWithoutTimeout: resourceSetPermission,
 		ReadWithoutTimeout:   resourcePermissionRead,
 		UpdateWithoutTimeout: resourceSetPermission,

--- a/internal/service/opsworks/rds_db_instance.go
+++ b/internal/service/opsworks/rds_db_instance.go
@@ -22,6 +22,7 @@ import (
 // @SDKResource("aws_opsworks_rds_db_instance", name="RDS DB Instance")
 func resourceRDSDBInstance() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage:   "This resource is deprecated and will be removed in the next major version of the AWS Provider. Consider the AWS Systems Manager service instead.",
 		CreateWithoutTimeout: resourceRDSDBInstanceCreate,
 		UpdateWithoutTimeout: resourceRDSDBInstanceUpdate,
 		DeleteWithoutTimeout: resourceRDSDBInstanceDelete,

--- a/internal/service/opsworks/stack.go
+++ b/internal/service/opsworks/stack.go
@@ -36,6 +36,7 @@ const (
 // @Tags
 func resourceStack() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage:   "This resource is deprecated and will be removed in the next major version of the AWS Provider. Consider the AWS Systems Manager service instead.",
 		CreateWithoutTimeout: resourceStackCreate,
 		ReadWithoutTimeout:   resourceStackRead,
 		UpdateWithoutTimeout: resourceStackUpdate,

--- a/internal/service/opsworks/user_profile.go
+++ b/internal/service/opsworks/user_profile.go
@@ -22,6 +22,7 @@ import (
 // @SDKResource("aws_opsworks_user_profile", name="Profile")
 func resourceUserProfile() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage:   "This resource is deprecated and will be removed in the next major version of the AWS Provider. Consider the AWS Systems Manager service instead.",
 		CreateWithoutTimeout: resourceUserProfileCreate,
 		ReadWithoutTimeout:   resourceUserProfileRead,
 		UpdateWithoutTimeout: resourceUserProfileUpdate,

--- a/website/docs/r/opsworks_application.html.markdown
+++ b/website/docs/r/opsworks_application.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks application resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_custom_layer.html.markdown
+++ b/website/docs/r/opsworks_custom_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks custom layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_ecs_cluster_layer.html.markdown
+++ b/website/docs/r/opsworks_ecs_cluster_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks ECS Cluster layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_ganglia_layer.html.markdown
+++ b/website/docs/r/opsworks_ganglia_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks Ganglia layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_haproxy_layer.html.markdown
+++ b/website/docs/r/opsworks_haproxy_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks haproxy layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_instance.html.markdown
+++ b/website/docs/r/opsworks_instance.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks instance resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_java_app_layer.html.markdown
+++ b/website/docs/r/opsworks_java_app_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks Java application layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_memcached_layer.html.markdown
+++ b/website/docs/r/opsworks_memcached_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks memcached layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_mysql_layer.html.markdown
+++ b/website/docs/r/opsworks_mysql_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks MySQL layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ~> **Note:** All arguments including the root password will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 

--- a/website/docs/r/opsworks_nodejs_app_layer.html.markdown
+++ b/website/docs/r/opsworks_nodejs_app_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks NodeJS application layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_permission.html.markdown
+++ b/website/docs/r/opsworks_permission.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks permission resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_php_app_layer.html.markdown
+++ b/website/docs/r/opsworks_php_app_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks PHP application layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_rails_app_layer.html.markdown
+++ b/website/docs/r/opsworks_rails_app_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks Ruby on Rails application layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_rds_db_instance.html.markdown
+++ b/website/docs/r/opsworks_rds_db_instance.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks RDS DB Instance resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 

--- a/website/docs/r/opsworks_stack.html.markdown
+++ b/website/docs/r/opsworks_stack.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks stack resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_static_web_layer.html.markdown
+++ b/website/docs/r/opsworks_static_web_layer.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks static web server layer resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/opsworks_user_profile.html.markdown
+++ b/website/docs/r/opsworks_user_profile.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an OpsWorks User Profile resource.
 
+!> **ALERT:** AWS no longer supports OpsWorks Stacks. All related resources will be removed from the Terraform AWS Provider in the next major version.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This ensures that we're all on the same page, providing notice that opsworks resources will be removed as part of v6.0.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #35701

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
