### PR TITLE
Deprecate `aws_ecs_task_execution` `overrides.inference_accelerator_overrides`

### DIFF
--- a/.changelog/41676.txt
+++ b/.changelog/41676.txt
@@ -1,3 +1,3 @@
 ```release-note:note
-resource/aws_ecs_task_execution: `overrides` `inference_accelerator_overrides` is deprecated. AWS no longer provides the Elastic Inference service.
+resource/aws_ecs_task_execution: `overrides.inference_accelerator_overrides` is deprecated. AWS no longer provides the Elastic Inference service.
 ```

--- a/.changelog/41676.txt
+++ b/.changelog/41676.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_ecs_task_execution: `overrides` `inference_accelerator_overrides` is deprecated. AWS no longer provides the Elastic Inference service.
+```

--- a/internal/service/ecs/task_execution_data_source.go
+++ b/internal/service/ecs/task_execution_data_source.go
@@ -181,8 +181,9 @@ func dataSourceTaskExecution() *schema.Resource {
 							Optional: true,
 						},
 						"inference_accelerator_overrides": {
-							Type:     schema.TypeSet,
-							Optional: true,
+							Deprecated: "inference_accelerator_overrides is deprecated. AWS no longer supports the Elastic Inference service.",
+							Type:       schema.TypeSet,
+							Optional:   true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									names.AttrDeviceName: {

--- a/website/docs/d/ecs_task_execution.html.markdown
+++ b/website/docs/d/ecs_task_execution.html.markdown
@@ -76,7 +76,7 @@ For more information, see the [Task Networking](https://docs.aws.amazon.com/Amaz
 * `container_overrides` - (Optional) One or more container overrides that are sent to a task. See below.
 * `cpu` - (Optional) The CPU override for the task.
 * `execution_role_arn` - (Optional) Amazon Resource Name (ARN) of the task execution role override for the task.
-* `inference_accelerator_overrides` - (Optional) Elastic Inference accelerator override for the task. See below.
+* `inference_accelerator_overrides` - (Optional) **DEPRECATED** Elastic Inference accelerator override for the task. See below.
 * `memory` - (Optional) The memory override for the task.
 * `task_role_arn` - (Optional) Amazon Resource Name (ARN) of the role that containers in this task can assume.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The Elastic Inference service has been removed from AWS. EC2 and ECS references to it are not supported.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #40992

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
