### PR TITLE
B account region enable

### DIFF
--- a/.changelog/41678.txt
+++ b/.changelog/41678.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource/aws_account_region: Prevent errors when the region is an ENABLING or DISABLING state during creation.
+resource/aws_account_region: Prevent errors when the region is an ENABLING or DISABLING state during creation
 ```
 
 ```release-note:enhancement
-resource/aws_account_region: Allow adoption of regions in an ENABLED or DISABLED state without an explicit import operation.
+resource/aws_account_region: Allow adoption of regions in an ENABLED or DISABLED state without an explicit import operation
 ```

--- a/.changelog/41678.txt
+++ b/.changelog/41678.txt
@@ -1,3 +1,7 @@
-```release-note:note
-resource/aws_account_region: Change the way to handle region enable/disable when already enabled/disabled in state
+```release-note:enhancement
+resource/aws_account_region: Prevent errors when the region is an ENABLING or DISABLING state during creation.
+```
+
+```release-note:enhancement
+resource/aws_account_region: Allow adoption of regions in an ENABLED or DISABLED state without an explicit import operation.
 ```

--- a/.changelog/41678.txt
+++ b/.changelog/41678.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_account_region: Change the way to handle region enable/disable when already enabled/disabled in state
+```

--- a/internal/service/account/region.go
+++ b/internal/service/account/region.go
@@ -247,7 +247,7 @@ func waitRegionDisabled(ctx context.Context, conn *account.Client, accountID, re
 
 func requiresStatusChange(status types.RegionOptStatus, enable bool) bool {
 	if enable {
-		return status != types.RegionOptStatusEnabled
+		return status != types.RegionOptStatusEnabled && status != types.RegionOptStatusEnabling
 	}
 	return status != types.RegionOptStatusDisabled && status != types.RegionOptStatusDisabling
 }

--- a/internal/service/account/region.go
+++ b/internal/service/account/region.go
@@ -251,5 +251,5 @@ func skipRegionUpdate(status types.RegionOptStatus, enable bool) bool {
 	if enable {
 		return status == types.RegionOptStatusEnabled || status == types.RegionOptStatusEnabledByDefault
 	}
-	return status == types.RegionOptStatusDisabled
+	return status == types.RegionOptStatusDisabled || status == types.RegionOptStatusDisabling
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Currently, when attempting to enable a region that is already in the enabling  or  enabled status, an error occurs. This change will prevent this error by allowing the process to skip the EnableRegion API call. Instead, it would go directly to the waitRegionEnabled status if the region is already enabling or enabled. Essentially, this change modifies the behavior by letting the process continue without error/failing.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41430

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTARGS="-run=TestAccAccount_serial/Region" PKG=account
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/account/... -v -count 1 -parallel 20  -run=TestAccAccount_serial/Region -timeout 360m -vet=off
2025/03/06 10:23:09 Initializing Terraform AWS Provider...
=== RUN   TestAccAccount_serial
=== PAUSE TestAccAccount_serial
=== CONT  TestAccAccount_serial
=== RUN   TestAccAccount_serial/Region
=== RUN   TestAccAccount_serial/Region/basic
=== RUN   TestAccAccount_serial/Region/AccountID
    region_test.go:70: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- PASS: TestAccAccount_serial (413.81s)
    --- PASS: TestAccAccount_serial/Region (413.81s)
        --- PASS: TestAccAccount_serial/Region/basic (413.81s)
        --- SKIP: TestAccAccount_serial/Region/AccountID (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/account    420.625s

...
```
