### PR TITLE
Fix interpolation of token output in triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -95,7 +95,7 @@ jobs:
         if: github.event_name == 'issues'
         uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
         with:
-          repo-token: steps.token.outputs.token
+          repo-token: ${{ steps.token.outputs.token }}
           configuration-path: .github/labeler-issue-trigger.yml
           enable-versioned-regex: 0
           include-title: 1


### PR DESCRIPTION
### Description

Fixes interpolation because `string` != `${{ string }}`, and I am once again wishing for a better way to test workflows locally 😅 

