### PR TITLE
Allow updates to aws_msk_connector connector_configuration

### DIFF
--- a/internal/service/kafkaconnect/connector.go
+++ b/internal/service/kafkaconnect/connector.go
@@ -537,7 +537,6 @@ func resourceConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 			// If we're also changing connector config we need the new version
 			if d.HasChange("connector_configuration") {
-
 				res, err := conn.DescribeConnector(ctx, &kafkaconnect.DescribeConnectorInput{ConnectorArn: aws.String(d.Id())})
 
 				if err != nil {

--- a/internal/service/kafkaconnect/connector.go
+++ b/internal/service/kafkaconnect/connector.go
@@ -143,7 +143,6 @@ func resourceConnector() *schema.Resource {
 				Type:     schema.TypeMap,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Required: true,
-				ForceNew: true,
 			},
 			names.AttrDescription: {
 				Type:         schema.TypeString,
@@ -517,20 +516,54 @@ func resourceConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	conn := meta.(*conns.AWSClient).KafkaConnectClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
-		input := &kafkaconnect.UpdateConnectorInput{
-			Capacity:       expandCapacityUpdate(d.Get("capacity").([]interface{})[0].(map[string]interface{})),
-			ConnectorArn:   aws.String(d.Id()),
-			CurrentVersion: aws.String(d.Get(names.AttrVersion).(string)),
+		currentVersion := aws.String(d.Get(names.AttrVersion).(string))
+
+		if d.HasChange("capacity") {
+			input := &kafkaconnect.UpdateConnectorInput{
+				Capacity:       expandCapacityUpdate(d.Get("capacity").([]interface{})[0].(map[string]interface{})),
+				ConnectorArn:   aws.String(d.Id()),
+				CurrentVersion: currentVersion,
+			}
+
+			_, err := conn.UpdateConnector(ctx, input)
+
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating MSK Connect Connector Capacity (%s): %s", d.Id(), err)
+			}
+
+			if _, err := waitConnectorUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for MSK Connect Connector (%s) update: %s", d.Id(), err)
+			}
+
+			// If we're also changing connector config we need the new version
+			if d.HasChange("connector_configuration") {
+
+				res, err := conn.DescribeConnector(ctx, &kafkaconnect.DescribeConnectorInput{ConnectorArn: aws.String(d.Id())})
+
+				if err != nil {
+					return sdkdiag.AppendErrorf(diags, "getting new MSK Connect Connector version (%s): %s", d.Id(), err)
+				}
+
+				currentVersion = res.CurrentVersion
+			}
 		}
 
-		_, err := conn.UpdateConnector(ctx, input)
+		if d.HasChange("connector_configuration") {
+			input := &kafkaconnect.UpdateConnectorInput{
+				ConnectorConfiguration: flex.ExpandStringValueMap(d.Get("connector_configuration").(map[string]interface{})),
+				ConnectorArn:           aws.String(d.Id()),
+				CurrentVersion:         currentVersion,
+			}
 
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating MSK Connect Connector (%s): %s", d.Id(), err)
-		}
+			_, err := conn.UpdateConnector(ctx, input)
 
-		if _, err := waitConnectorUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "waiting for MSK Connect Connector (%s) update: %s", d.Id(), err)
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "updating MSK Connect Connector Configuration (%s): %s", d.Id(), err)
+			}
+
+			if _, err := waitConnectorUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for MSK Connect Connector (%s) update: %s", d.Id(), err)
+			}
 		}
 	}
 

--- a/internal/service/kafkaconnect/connector_test.go
+++ b/internal/service/kafkaconnect/connector_test.go
@@ -186,7 +186,7 @@ func TestAccKafkaConnectConnector_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConnectorConfig_allAttributesCapacityUpdated(rName),
+				Config: testAccConnectorConfig_allAttributesCapacityAndConnectorConfigUpdated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckConnectorExists(ctx, resourceName),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "kafkaconnect", regexache.MustCompile(`connector/`+rName+`/`+kafkaConnectUUIDRegexPattern+`$`)),
@@ -198,7 +198,7 @@ func TestAccKafkaConnectConnector_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "connector_configuration.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "connector_configuration.connector.class", "com.github.jcustenborder.kafka.connect.simulator.SimulatorSinkConnector"),
 					resource.TestCheckResourceAttr(resourceName, "connector_configuration.tasks.max", "1"),
-					resource.TestCheckResourceAttr(resourceName, "connector_configuration.topics", "t1"),
+					resource.TestCheckResourceAttr(resourceName, "connector_configuration.topics", "t1, t2"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, "kafka_cluster.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "kafka_cluster.0.apache_kafka_cluster.#", "1"),
@@ -579,7 +579,7 @@ resource "aws_mskconnect_connector" "test" {
 `, rName))
 }
 
-func testAccConnectorConfig_allAttributesCapacityUpdated(rName string) string {
+func testAccConnectorConfig_allAttributesCapacityAndConnectorConfigUpdated(rName string) string {
 	return acctest.ConfigCompose(
 		testAccCustomPluginConfig_basic(rName),
 		testAccWorkerConfigurationConfig_basic(rName),
@@ -603,7 +603,7 @@ resource "aws_mskconnect_connector" "test" {
   connector_configuration = {
     "connector.class" = "com.github.jcustenborder.kafka.connect.simulator.SimulatorSinkConnector"
     "tasks.max"       = "1"
-    "topics"          = "t1"
+    "topics"          = "t1, t2"
   }
 
   kafka_cluster {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
In January 2025 MSK was updated to allow changes to a connector's configuration without recreating the connector.

The `aws_mskconnect_connector` needs updating to handle this. `UpdateConnector` only accepts **one of** `capacity` or `connectorConfiguration` per call. As such, we need to check which of these has changes and call the API separately for each change. We also need to get the new connector version in between the requests.

### Relations
Closes #40914

### References
* [Announcement about config updates](https://aws.amazon.com/about-aws/whats-new/2025/01/amazon-msk-connect-updating-connector-configuration/)
* [UpdateConnector documentation](https://docs.aws.amazon.com/MSKC/latest/mskc/API_UpdateConnector.html) 

### Output from Acceptance Testing
The test should pass (verified the expected values in the console), but ran into some errors on the cleanup due to restricted delete permissions for kafka clusters and S3 buckets on my end.

```console
❯ make testacc TESTS=TestAccKafkaConnectConnector_update PKG=kafkaconnect
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/kafkaconnect/... -v -count 1 -parallel 20 -run='TestAccKafkaConnectConnector_update'  -timeout 360m -vet=off
2025/03/06 15:40:15 Initializing Terraform AWS Provider...
=== RUN   TestAccKafkaConnectConnector_update
=== PAUSE TestAccKafkaConnectConnector_update
=== CONT  TestAccKafkaConnectConnector_update
    connector_test.go:122: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: deleting S3 Bucket (tf-acc-test-4099055771575791490): operation error S3: DeleteBucket, https response error StatusCode: 403, RequestID: R9NKR1WS1JSP2W2E, HostID: G6fnpG9rOz/WZifQi3BT8+iVeWL6Dv67kkzKl7l/tw3Qz6Jc28mAChlOmzQbqrKgzFF98Y43tinrNRYpDEc2CQ==, api error AccessDenied: <redacted> is not authorized to perform: s3:DeleteBucket on resource: "arn:aws:s3:::tf-acc-test-4099055771575791490" with an explicit deny in an identity-based policy


        Error: deleting MSK Cluster (<redacted>): operation error Kafka: DeleteCluster, https response error StatusCode: 403, RequestID: 8fb02e2e-b131-4e70-a012-c91fa84daba3, api error AccessDeniedException: <redacted> is not authorized to perform: kafka:DeleteCluster on <redacted> with an explicit deny

--- FAIL: TestAccKafkaConnectConnector_update (2786.44s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect	2791.752s
FAIL
make: *** [testacc] Error 1
```