### PR TITLE
r/cognito_resource_server allow name change without ForceNew

### DIFF
--- a/.changelog/41702.txt
+++ b/.changelog/41702.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cognito_resource_server: Allow changes to `name` attribute without deleting and recreating.
+```

--- a/internal/service/cognitoidp/resource_server.go
+++ b/internal/service/cognitoidp/resource_server.go
@@ -45,7 +45,6 @@ func resourceResourceServer() *schema.Resource {
 			names.AttrName: {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			names.AttrScope: {
 				Type:     schema.TypeSet,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Allow updates to the name (which is really just a description) of the cognito resource server without deleting and recreating it.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41347 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccCognitoIDPResourceServer PKG=cognitoidp
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPResourceServer'  -timeout 360m -vet=off
2025/03/06 09:32:09 Initializing Terraform AWS Provider...
=== RUN   TestAccCognitoIDPResourceServer_basic
=== PAUSE TestAccCognitoIDPResourceServer_basic
=== RUN   TestAccCognitoIDPResourceServer_disappears
=== PAUSE TestAccCognitoIDPResourceServer_disappears
=== RUN   TestAccCognitoIDPResourceServer_scope
=== PAUSE TestAccCognitoIDPResourceServer_scope
=== RUN   TestAccCognitoIDPResourceServer_nameChange
=== PAUSE TestAccCognitoIDPResourceServer_nameChange
=== CONT  TestAccCognitoIDPResourceServer_basic
=== CONT  TestAccCognitoIDPResourceServer_scope
=== CONT  TestAccCognitoIDPResourceServer_nameChange
=== CONT  TestAccCognitoIDPResourceServer_disappears
--- PASS: TestAccCognitoIDPResourceServer_disappears (15.33s)
--- PASS: TestAccCognitoIDPResourceServer_basic (17.68s)
--- PASS: TestAccCognitoIDPResourceServer_nameChange (22.90s)
--- PASS: TestAccCognitoIDPResourceServer_scope (33.54s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp	33.666s

```
