### PR TITLE
Add aws-compatible-server label

### DIFF
--- a/infrastructure/repository/labels-workflow.tf
+++ b/infrastructure/repository/labels-workflow.tf
@@ -13,6 +13,10 @@ variable "workflow_labels" {
       color       = "844fba", # color:terraform (main)
       description = "Pertains to AutoFlex."
     },
+    "aws-compatible-service" = {
+      color       = "ff9900", # color:aws
+      description = "Issues related to compatibility with AWS-compatible services."
+    },
     "aws-sdk-go-migration" = {
       color       = "844fba", # color:terraform (main)
       description = "Issues that are related to the providers migration to AWS SDK for Go v2."


### PR DESCRIPTION
### Description

Adds a label for tracking issues that pertain to AWS-compatible services for better tracking
