### PR TITLE
Allow Usage of `sessionCredentialFromConsole` in Data Store Selectors

### DIFF
--- a/internal/service/cloudtrail/consts.go
+++ b/internal/service/cloudtrail/consts.go
@@ -22,13 +22,14 @@ func resourceType_Values() []string {
 }
 
 const (
-	fieldEventCategory   = "eventCategory"
-	fieldEventName       = "eventName"
-	fieldEventSource     = "eventSource"
-	fieldReadOnly        = "readOnly"
-	fieldResourcesARN    = "resources.ARN"
-	fieldResourcesType   = "resources.type"
-	fieldUserIdentityARN = "userIdentity.arn"
+	fieldEventCategory                = "eventCategory"
+	fieldEventName                    = "eventName"
+	fieldEventSource                  = "eventSource"
+	fieldReadOnly                     = "readOnly"
+	fieldResourcesARN                 = "resources.ARN"
+	fieldResourcesType                = "resources.type"
+	fieldUserIdentityARN              = "userIdentity.arn"
+	fieldsessionCredentialFromConsole = "sessionCredentialFromConsole"
 )
 
 func field_Values() []string {
@@ -40,6 +41,7 @@ func field_Values() []string {
 		fieldResourcesARN,
 		fieldResourcesType,
 		fieldUserIdentityARN,
+		fieldsessionCredentialFromConsole,
 	}
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Add a field allowed by AWS Cloudtrail API and described in this documentation https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_AdvancedEventSelector.html

Similar to https://github.com/hashicorp/terraform-provider-aws/pull/40629

Currently, the following Terraform resource should be valid:

```hcl
resource "aws_cloudtrail_event_data_store" "dynamodb_events_data_store" {
  name = "dynamodb-events-data-store"

  advanced_event_selector {
    name = "Log all DynamoDB data events emitted by AWS Console users"

    field_selector {
      field  = "eventCategory"
      equals = ["Data"]
    }

    field_selector {
      field  = "resources.type"
      equals = ["AWS::DynamoDB::Table"]
    }

    field_selector {
      field  = "sessionCredentialFromConsole"
      equals = ["true"]
    }
  }
}
```

However, the plan fails due to:

```sh
╷
│ Error: expected advanced_event_selector.1.field_selector.2.field to be one of ["eventCategory" "eventName" "eventSource" "readOnly" "resources.ARN" "resources.type" "userIdentity.arn"], got sessionCredentialFromConsole
│ 
│   with aws_cloudtrail_event_data_store.dynamodb_events_data_store,
│   on cloudtrail.tf line 44, in resource "aws_cloudtrail_event_data_store" "dynamodb_events_data_store":
│   44:   advanced_event_selector {
```
