### PR TITLE
r/aws_mskconnect_connector: Allow `connector_configuration` to be updated in-place

### DIFF
--- a/.changelog/41685.txt
+++ b/.changelog/41685.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_mskconnect_connector: Allow `connector_configuration` to be updated in-place
+```

--- a/internal/service/kafkaconnect/connector.go
+++ b/internal/service/kafkaconnect/connector.go
@@ -655,7 +655,7 @@ func waitConnectorCreated(ctx context.Context, conn *kafkaconnect.Client, arn st
 	return nil, err
 }
 
-func waitConnectorUpdated(ctx context.Context, conn *kafkaconnect.Client, arn string, timeout time.Duration) (*kafkaconnect.DescribeConnectorOutput, error) {
+func waitConnectorUpdated(ctx context.Context, conn *kafkaconnect.Client, arn string, timeout time.Duration) (*kafkaconnect.DescribeConnectorOutput, error) { //nolint:unparam
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ConnectorStateUpdating),
 		Target:  enum.Slice(awstypes.ConnectorStateRunning),

--- a/internal/service/kafkaconnect/connector.go
+++ b/internal/service/kafkaconnect/connector.go
@@ -655,7 +655,7 @@ func waitConnectorCreated(ctx context.Context, conn *kafkaconnect.Client, arn st
 	return nil, err
 }
 
-func waitConnectorUpdated(ctx context.Context, conn *kafkaconnect.Client, arn string, timeout time.Duration) (*kafkaconnect.DescribeConnectorOutput, error) { //nolint:unparam
+func waitConnectorUpdated(ctx context.Context, conn *kafkaconnect.Client, arn string, timeout time.Duration) (*kafkaconnect.DescribeConnectorOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ConnectorStateUpdating),
 		Target:  enum.Slice(awstypes.ConnectorStateRunning),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Removes _ForceNew_ from `aws_mskconnect_connector.connector_configuration`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/pull/41685.
Closes https://github.com/hashicorp/terraform-provider-aws/issues/40914.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccKafkaConnectConnector_update' PKG=kafkaconnect
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/kafkaconnect/... -v -count 1 -parallel 20  -run=TestAccKafkaConnectConnector_update -timeout 360m -vet=off
2025/03/06 15:42:19 Initializing Terraform AWS Provider...
=== RUN   TestAccKafkaConnectConnector_update
=== PAUSE TestAccKafkaConnectConnector_update
=== CONT  TestAccKafkaConnectConnector_update
--- PASS: TestAccKafkaConnectConnector_update (3186.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kafkaconnect	3192.630s
```
