### PR TITLE
Per-resource Region override prep 2

### DIFF
--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -404,6 +404,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 			}
 
 			typeName := v.TypeName
+			var modifyPlanFuncs []modifyPlanFunc
 			interceptors := resourceInterceptors{}
 			if v.Tags != nil {
 				// The resource has opted in to transparent tagging.
@@ -430,6 +431,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 					continue
 				}
 
+				modifyPlanFuncs = append(modifyPlanFuncs, setTagsAll)
 				interceptors = append(interceptors, newTagsResourceInterceptor(v.Tags))
 			}
 
@@ -447,9 +449,9 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 
 					return ctx, diags
 				},
-				interceptors:           interceptors,
-				typeName:               typeName,
-				usesTransparentTagging: v.Tags != nil,
+				interceptors:    interceptors,
+				modifyPlanFuncs: modifyPlanFuncs,
+				typeName:        typeName,
 			}
 			resources = append(resources, func() resource.Resource {
 				return newWrappedResource(inner, opts)

--- a/internal/provider/fwprovider/tags_interceptor.go
+++ b/internal/provider/fwprovider/tags_interceptor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/provider/interceptors"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -72,7 +71,7 @@ func (r tagsDataSourceInterceptor) read(ctx context.Context, opts interceptorOpt
 
 		tags := tagsInContext.TagsOut.UnwrapOrDefault()
 		// Remove any provider configured ignore_tags and system tags from those returned from the service API.
-		stateTags := flex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreSystem(sp.ServicePackageName()).IgnoreConfig(c.IgnoreTagsConfig(ctx)).Map())
+		stateTags := fwflex.FlattenFrameworkStringValueMapLegacy(ctx, tags.IgnoreSystem(sp.ServicePackageName()).IgnoreConfig(c.IgnoreTagsConfig(ctx)).Map())
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTags), tftags.NewMapFromMapValue(stateTags))...)
 		if diags.HasError() {
 			return diags
@@ -127,7 +126,7 @@ func (r tagsResourceInterceptor) create(ctx context.Context, opts interceptorOpt
 		// Set values for unknowns.
 		// Remove any provider configured ignore_tags and system tags from those passed to the service API.
 		// Computed tags_all include any provider configured default_tags.
-		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, tagsInContext.TagsIn.MustUnwrap().IgnoreSystem(sp.ServicePackageName()).IgnoreConfig(c.IgnoreTagsConfig(ctx)).Map())
+		stateTagsAll := fwflex.FlattenFrameworkStringValueMapLegacy(ctx, tagsInContext.TagsIn.MustUnwrap().IgnoreSystem(sp.ServicePackageName()).IgnoreConfig(c.IgnoreTagsConfig(ctx)).Map())
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTagsAll), tftags.NewMapFromMapValue(stateTagsAll))...)
 		if diags.HasError() {
 			return diags
@@ -178,7 +177,7 @@ func (r tagsResourceInterceptor) read(ctx context.Context, opts interceptorOptio
 		// Remove any provider configured ignore_tags and system tags from those returned from the service API.
 		// The resource's configured tags do not include any provider configured default_tags.
 		if v := apiTags.IgnoreSystem(sp.ServicePackageName()).IgnoreConfig(c.IgnoreTagsConfig(ctx)).ResolveDuplicatesFramework(ctx, c.DefaultTagsConfig(ctx), c.IgnoreTagsConfig(ctx), response, &diags).Map(); len(v) > 0 {
-			stateTags = tftags.NewMapFromMapValue(flex.FlattenFrameworkStringValueMapLegacy(ctx, v))
+			stateTags = tftags.NewMapFromMapValue(fwflex.FlattenFrameworkStringValueMapLegacy(ctx, v))
 		}
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTags), &stateTags)...)
 		if diags.HasError() {
@@ -186,7 +185,7 @@ func (r tagsResourceInterceptor) read(ctx context.Context, opts interceptorOptio
 		}
 
 		// Computed tags_all do.
-		stateTagsAll := flex.FlattenFrameworkStringValueMapLegacy(ctx, apiTags.IgnoreSystem(sp.ServicePackageName()).IgnoreConfig(c.IgnoreTagsConfig(ctx)).Map())
+		stateTagsAll := fwflex.FlattenFrameworkStringValueMapLegacy(ctx, apiTags.IgnoreSystem(sp.ServicePackageName()).IgnoreConfig(c.IgnoreTagsConfig(ctx)).Map())
 		diags.Append(response.State.SetAttribute(ctx, path.Root(names.AttrTagsAll), tftags.NewMapFromMapValue(stateTagsAll))...)
 		if diags.HasError() {
 			return diags

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -361,6 +361,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 				continue
 			}
 
+			var customizeDiffFuncs []schema.CustomizeDiffFunc
 			interceptors := interceptorItems{}
 			if v.Tags != nil {
 				schema := r.SchemaMap()
@@ -386,6 +387,7 @@ func New(ctx context.Context) (*schema.Provider, error) {
 					continue
 				}
 
+				customizeDiffFuncs = append(customizeDiffFuncs, setTagsAll)
 				interceptors = append(interceptors, interceptorItem{
 					when:        Before | After | Finally,
 					why:         Create | Read | Update,
@@ -406,9 +408,9 @@ func New(ctx context.Context) (*schema.Provider, error) {
 
 					return ctx, diags
 				},
-				interceptors:           interceptors,
-				typeName:               typeName,
-				usesTransparentTagging: v.Tags != nil,
+				customizeDiffFuncs: customizeDiffFuncs,
+				interceptors:       interceptors,
+				typeName:           typeName,
 			}
 			wrapResource(r, opts)
 			provider.ResourcesMap[typeName] = r


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Instead of hard-coding knowledge of resource transparent tagging into `wrap.go`, pass a list of plan modifiers (`CustomizeDiffFunc`s for Plugin SDK resources).
This can then be extended for per-resource Region override.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/41576.
Relates https://github.com/hashicorp/terraform-provider-aws/issues/27758.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/41207.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sane
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2025/03/06 15:24:53 Initializing Terraform AWS Provider...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMPolicy_basic
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (12.22s)
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (12.42s)
--- PASS: TestAccIAMRole_disappears (16.05s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (16.97s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (17.07s)
--- PASS: TestAccIAMPolicy_basic (17.64s)
--- PASS: TestAccIAMRole_basic (18.01s)
--- PASS: TestAccIAMRole_namePrefix (18.88s)
--- PASS: TestAccIAMRolePolicy_basic (19.05s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (19.31s)
--- PASS: TestAccIAMInstanceProfile_basic (22.80s)
--- PASS: TestAccIAMPolicy_policy (25.40s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (26.59s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (34.24s)
--- PASS: TestAccIAMPolicy_tags (51.60s)
--- PASS: TestAccIAMInstanceProfile_tags (72.30s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	77.946s
2025/03/06 15:26:31 Initializing Terraform AWS Provider...
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_multiple
--- PASS: TestAccLogsGroup_multiple (12.43s)
--- PASS: TestAccLogsGroup_basic (15.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	21.693s
2025/03/06 15:26:45 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPC_tenancy
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
=== CONT  TestAccVPCSecurityGroup_egressMode
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
--- PASS: TestAccVPCSubnet_basic (21.31s)
--- PASS: TestAccVPCRouteTable_basic (21.48s)
--- PASS: TestAccVPCSecurityGroup_basic (22.25s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (23.48s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (24.03s)
--- PASS: TestAccVPCDataSource_basic (29.34s)
--- PASS: TestAccVPCSecurityGroup_egressMode (43.23s)
--- PASS: TestAccVPC_tenancy (45.05s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (51.14s)
--- PASS: TestAccVPCSecurityGroupRule_race (161.85s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	172.317s
2025/03/06 15:26:50 Initializing Terraform AWS Provider...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (22.32s)
--- PASS: TestAccECSService_basic (78.69s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	93.277s
2025/03/06 15:26:41 Initializing Terraform AWS Provider...
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (20.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	26.299s
2025/03/06 15:26:54 Initializing Terraform AWS Provider...
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (23.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	41.987s
2025/03/06 15:30:15 Initializing Terraform AWS Provider...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (29.20s)
--- PASS: TestAccLambdaFunction_basic (40.27s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	54.611s
2025/03/06 15:30:06 Initializing Terraform AWS Provider...
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaPartitionDataSource_basic (10.41s)
--- PASS: TestAccMetaRegionDataSource_basic (10.42s)
--- PASS: TestAccMetaRegionDataSource_endpoint (10.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	16.247s
2025/03/06 15:30:11 Initializing Terraform AWS Provider...
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_Latency_basic
--- PASS: TestAccRoute53ZoneDataSource_name (77.71s)
--- PASS: TestAccRoute53Record_basic (152.51s)
--- PASS: TestAccRoute53Record_Latency_basic (158.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	168.500s
2025/03/06 15:30:19 Initializing Terraform AWS Provider...
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3BucketPolicy_basic
--- PASS: TestAccS3BucketPublicAccessBlock_basic (20.06s)
--- PASS: TestAccS3Object_basic (20.07s)
--- PASS: TestAccS3BucketPolicy_basic (20.41s)
--- PASS: TestAccS3Bucket_Basic_basic (21.12s)
--- PASS: TestAccS3BucketACL_updateACL (32.04s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (33.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	52.147s
2025/03/06 15:30:32 Initializing Terraform AWS Provider...
=== RUN   TestAccSSMParameterEphemeral_basic
=== PAUSE TestAccSSMParameterEphemeral_basic
=== CONT  TestAccSSMParameterEphemeral_basic
--- PASS: TestAccSSMParameterEphemeral_basic (11.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	43.101s
2025/03/06 15:30:28 Initializing Terraform AWS Provider...
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_basic (15.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	42.223s
2025/03/06 15:30:23 Initializing Terraform AWS Provider...
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (10.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	33.122s
```
```console
% make testacc TESTARGS='-run=TestAccXRayGroup_' PKG=xray ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/xray/... -v -count 1 -parallel 3  -run=TestAccXRayGroup_ -timeout 360m -vet=off
2025/03/06 15:34:00 Initializing Terraform AWS Provider...
=== RUN   TestAccXRayGroup_tags
=== PAUSE TestAccXRayGroup_tags
=== RUN   TestAccXRayGroup_tags_null
=== PAUSE TestAccXRayGroup_tags_null
=== RUN   TestAccXRayGroup_tags_EmptyMap
=== PAUSE TestAccXRayGroup_tags_EmptyMap
=== RUN   TestAccXRayGroup_tags_AddOnUpdate
=== PAUSE TestAccXRayGroup_tags_AddOnUpdate
=== RUN   TestAccXRayGroup_tags_EmptyTag_OnCreate
=== PAUSE TestAccXRayGroup_tags_EmptyTag_OnCreate
=== RUN   TestAccXRayGroup_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccXRayGroup_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccXRayGroup_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccXRayGroup_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccXRayGroup_tags_DefaultTags_providerOnly
=== PAUSE TestAccXRayGroup_tags_DefaultTags_providerOnly
=== RUN   TestAccXRayGroup_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccXRayGroup_tags_DefaultTags_nonOverlapping
=== RUN   TestAccXRayGroup_tags_DefaultTags_overlapping
=== PAUSE TestAccXRayGroup_tags_DefaultTags_overlapping
=== RUN   TestAccXRayGroup_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccXRayGroup_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccXRayGroup_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccXRayGroup_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccXRayGroup_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccXRayGroup_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccXRayGroup_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccXRayGroup_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccXRayGroup_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccXRayGroup_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccXRayGroup_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccXRayGroup_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccXRayGroup_tags_ComputedTag_OnCreate
=== PAUSE TestAccXRayGroup_tags_ComputedTag_OnCreate
=== RUN   TestAccXRayGroup_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccXRayGroup_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccXRayGroup_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccXRayGroup_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccXRayGroup_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccXRayGroup_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccXRayGroup_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccXRayGroup_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccXRayGroup_basic
=== PAUSE TestAccXRayGroup_basic
=== RUN   TestAccXRayGroup_insights
=== PAUSE TestAccXRayGroup_insights
=== RUN   TestAccXRayGroup_disappears
=== PAUSE TestAccXRayGroup_disappears
=== CONT  TestAccXRayGroup_tags
=== CONT  TestAccXRayGroup_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccXRayGroup_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccXRayGroup_tags_DefaultTags_emptyResourceTag (14.86s)
=== CONT  TestAccXRayGroup_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccXRayGroup_tags_ComputedTag_OnUpdate_Replace (26.74s)
=== CONT  TestAccXRayGroup_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccXRayGroup_tags_DefaultTags_nullNonOverlappingResourceTag (13.41s)
=== CONT  TestAccXRayGroup_tags_ComputedTag_OnCreate
--- PASS: TestAccXRayGroup_tags_ComputedTag_OnCreate (17.19s)
=== CONT  TestAccXRayGroup_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccXRayGroup_tags (47.40s)
=== CONT  TestAccXRayGroup_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccXRayGroup_tags_ComputedTag_OnUpdate_Add (26.03s)
=== CONT  TestAccXRayGroup_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccXRayGroup_tags_DefaultTags_nullOverlappingResourceTag (13.36s)
=== CONT  TestAccXRayGroup_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccXRayGroup_tags_EmptyTag_OnUpdate_Replace (21.30s)
=== CONT  TestAccXRayGroup_tags_DefaultTags_overlapping
--- PASS: TestAccXRayGroup_tags_DefaultTags_updateToResourceOnly (20.54s)
=== CONT  TestAccXRayGroup_tags_DefaultTags_nonOverlapping
--- PASS: TestAccXRayGroup_tags_DefaultTags_updateToProviderOnly (21.91s)
=== CONT  TestAccXRayGroup_tags_DefaultTags_providerOnly
--- PASS: TestAccXRayGroup_tags_DefaultTags_overlapping (35.66s)
=== CONT  TestAccXRayGroup_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccXRayGroup_tags_DefaultTags_nonOverlapping (35.42s)
=== CONT  TestAccXRayGroup_tags_AddOnUpdate
--- PASS: TestAccXRayGroup_tags_DefaultTags_emptyProviderOnlyTag (13.83s)
=== CONT  TestAccXRayGroup_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccXRayGroup_tags_DefaultTags_providerOnly (47.34s)
=== CONT  TestAccXRayGroup_tags_EmptyTag_OnCreate
--- PASS: TestAccXRayGroup_tags_AddOnUpdate (22.51s)
=== CONT  TestAccXRayGroup_tags_EmptyMap
--- PASS: TestAccXRayGroup_tags_EmptyMap (16.80s)
=== CONT  TestAccXRayGroup_basic
--- PASS: TestAccXRayGroup_tags_EmptyTag_OnUpdate_Add (33.01s)
=== CONT  TestAccXRayGroup_disappears
--- PASS: TestAccXRayGroup_tags_EmptyTag_OnCreate (24.47s)
=== CONT  TestAccXRayGroup_insights
--- PASS: TestAccXRayGroup_disappears (10.46s)
=== CONT  TestAccXRayGroup_tags_null
--- PASS: TestAccXRayGroup_basic (19.83s)
=== CONT  TestAccXRayGroup_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccXRayGroup_insights (19.47s)
=== CONT  TestAccXRayGroup_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccXRayGroup_tags_null (16.77s)
--- PASS: TestAccXRayGroup_tags_IgnoreTags_Overlap_DefaultTag (28.01s)
--- PASS: TestAccXRayGroup_tags_IgnoreTags_Overlap_ResourceTag (32.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/xray	210.026s
```
```console
% make testacc TESTARGS='-run=TestAccVPCLatticeResourceGateway_' PKG=vpclattice ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/vpclattice/... -v -count 1 -parallel 3  -run=TestAccVPCLatticeResourceGateway_ -timeout 360m -vet=off
2025/03/06 15:38:45 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCLatticeResourceGateway_tags
=== PAUSE TestAccVPCLatticeResourceGateway_tags
=== RUN   TestAccVPCLatticeResourceGateway_tags_null
=== PAUSE TestAccVPCLatticeResourceGateway_tags_null
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyMap
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyMap
=== RUN   TestAccVPCLatticeResourceGateway_tags_AddOnUpdate
=== PAUSE TestAccVPCLatticeResourceGateway_tags_AddOnUpdate
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate
=== PAUSE TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate
=== RUN   TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_basic
=== PAUSE TestAccVPCLatticeResourceGateway_basic
=== RUN   TestAccVPCLatticeResourceGateway_addressTypeDualstack
=== PAUSE TestAccVPCLatticeResourceGateway_addressTypeDualstack
=== RUN   TestAccVPCLatticeResourceGateway_addressTypeIPv6
=== PAUSE TestAccVPCLatticeResourceGateway_addressTypeIPv6
=== RUN   TestAccVPCLatticeResourceGateway_multipleSubnets
=== PAUSE TestAccVPCLatticeResourceGateway_multipleSubnets
=== RUN   TestAccVPCLatticeResourceGateway_update
=== PAUSE TestAccVPCLatticeResourceGateway_update
=== RUN   TestAccVPCLatticeResourceGateway_disappears
=== PAUSE TestAccVPCLatticeResourceGateway_disappears
=== CONT  TestAccVPCLatticeResourceGateway_tags
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag (34.65s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag (34.16s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_tags (80.32s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly (85.28s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag (34.31s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly (46.36s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly (48.05s)
=== CONT  TestAccVPCLatticeResourceGateway_basic
--- PASS: TestAccVPCLatticeResourceGateway_basic (32.03s)
=== CONT  TestAccVPCLatticeResourceGateway_disappears
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping (69.14s)
=== CONT  TestAccVPCLatticeResourceGateway_update
--- PASS: TestAccVPCLatticeResourceGateway_disappears (30.32s)
=== CONT  TestAccVPCLatticeResourceGateway_multipleSubnets
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping (70.45s)
=== CONT  TestAccVPCLatticeResourceGateway_addressTypeIPv6
--- PASS: TestAccVPCLatticeResourceGateway_multipleSubnets (34.69s)
=== CONT  TestAccVPCLatticeResourceGateway_addressTypeDualstack
--- PASS: TestAccVPCLatticeResourceGateway_addressTypeIPv6 (34.89s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeResourceGateway_update (63.73s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_addressTypeDualstack (33.89s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace (48.94s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag (57.90s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag (34.20s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate
--- PASS: TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag (54.83s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add (50.82s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate (49.55s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyMap
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace (49.11s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_AddOnUpdate
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyMap (34.03s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_null
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add (60.77s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate
--- PASS: TestAccVPCLatticeResourceGateway_tags_AddOnUpdate (46.25s)
--- PASS: TestAccVPCLatticeResourceGateway_tags_null (33.08s)
--- PASS: TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate (38.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice	449.508s
```
