### PR TITLE
RDS Aurora storage type back to default

### DIFF
--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -679,11 +679,24 @@ func resourceCluster() *schema.Resource {
 				if diff.Id() == "" {
 					return nil
 				}
+
+				engineType := diff.Get(names.AttrEngine).(string)
+				if !strings.HasPrefix(engineType, "aurora") {
+					return nil
+				}
+
 				// The control plane will always return an empty string if a cluster is created with a storage_type of aurora
 				old, new := diff.GetChange(names.AttrStorageType)
 
 				if new.(string) == "aurora" && old.(string) == "" {
 					if err := diff.SetNew(names.AttrStorageType, ""); err != nil {
+						return err
+					}
+					return nil
+				}
+
+				if new.(string) == "" && old.(string) != "" {
+					if err := diff.SetNew(names.AttrStorageType, "aurora"); err != nil {
 						return err
 					}
 					return nil


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
As stated in the provider documentation for RDS [storage_type](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#storage_type-1):

> Valid values are: "", aurora-iopt1 (Aurora DB Clusters); io1, io2 (Multi-AZ DB Clusters). Default: "" (Aurora DB Clusters); io1 (Multi-AZ DB Clusters).

However, when creating/modifying an Aurora DB Clusters with `aurora-iopt1` and then go back to the default, ie: remove the value or set it to `""`, the provider does not actually revert back to `aurora` storage type. 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[storage_type](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#storage_type-1): terraform-provider-aws definition for RDS storage_type
[ModifyAPICluster](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBCluster.html): AWS ModifyAPI Cluster API
