### PR TITLE
update VPC Lattice documentation

### DIFF
--- a/website/docs/d/vpclattice_service.html.markdown
+++ b/website/docs/d/vpclattice_service.html.markdown
@@ -36,7 +36,9 @@ This data source exports the following attributes in addition to the arguments a
 * `auth_type` - Type of IAM policy. Either `NONE` or `AWS_IAM`.
 * `certificate_arn` - Amazon Resource Name (ARN) of the certificate.
 * `custom_domain_name` - Custom domain name of the service.
-* `dns_entry` - DNS name of the service.
+* `dns_entry` - List of objects with DNS names.
+    * `domain_name` - DNS name for the service.
+    * `hosted_zone_id` - Hosted zone ID where the DNS name is registered.
 * `id` - Unique identifier for the service.
 * `status` - Status of the service.
 * `tags` - List of tags associated with the service.


### PR DESCRIPTION
### Description
This is a documentation change for the VPC lattice service data source attributes. The current documentation does not indicate the the `dns_entry` attribute is a list of objects. The updated documentation is based on the schema defined in the data source itself.

### Relations
None

### References
Data source schema for `dns_entry`: https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/vpclattice/service_data_source.go#L47-L62


### Output from Acceptance Testing
N/A - only documentation changed
