### PR TITLE
Fix `terraform.lang.security.ec2-imdsv1-optional.ec2-imdsv1-optional` security findings

### DIFF
--- a/examples/count/main.tf
+++ b/examples/count/main.tf
@@ -46,6 +46,11 @@ resource "aws_instance" "web" {
   instance_type = "t2.small"
   ami           = data.aws_ami.ubuntu.id
 
+  # Force IMDSv2.
+  metadata_options {
+    http_tokens = "required"
+  }
+
   # This will create 4 instances
   count = 4
 }

--- a/examples/eip/main.tf
+++ b/examples/eip/main.tf
@@ -67,7 +67,12 @@ resource "aws_instance" "web" {
   # this should be on port 80
   user_data = file("userdata.sh")
 
-  #Instance tags
+  # Force IMDSv2.
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  # Instance tags.
   tags = {
     Name = "eip-example"
   }

--- a/examples/elb/main.tf
+++ b/examples/elb/main.tf
@@ -172,7 +172,12 @@ resource "aws_instance" "web" {
   subnet_id              = aws_subnet.tf_test_subnet.id
   user_data              = file("userdata.sh")
 
-  #Instance tags
+  # Force IMDSv2.
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  # Instance tags
 
   tags = {
     Name = "elb-example"

--- a/examples/two-tier/main.tf
+++ b/examples/two-tier/main.tf
@@ -136,6 +136,11 @@ resource "aws_instance" "web" {
   # backend instances.
   subnet_id = aws_subnet.default.id
 
+  # Force IMDSv2.
+  metadata_options {
+    http_tokens = "required"
+  }
+
   # We run a remote provisioner on the instance after creating it.
   # In this case, we just install nginx and start it. By default,
   # this should be on port 80

--- a/internal/service/ec2/testdata/Instance/data.tags/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/data.tags/main_gen.tf
@@ -10,6 +10,10 @@ resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = "t4g.nano"
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags = var.resource_tags
 }
 

--- a/internal/service/ec2/testdata/Instance/data.tags_defaults/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/data.tags_defaults/main_gen.tf
@@ -16,6 +16,10 @@ resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = "t4g.nano"
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags = var.resource_tags
 }
 

--- a/internal/service/ec2/testdata/Instance/data.tags_ignore/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/data.tags_ignore/main_gen.tf
@@ -19,6 +19,10 @@ resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = "t4g.nano"
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags = var.resource_tags
 }
 

--- a/internal/service/ec2/testdata/Instance/tags/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/tags/main_gen.tf
@@ -5,6 +5,10 @@ resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = "t4g.nano"
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags = var.resource_tags
 }
 

--- a/internal/service/ec2/testdata/Instance/tagsComputed1/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/tagsComputed1/main_gen.tf
@@ -7,6 +7,10 @@ resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = "t4g.nano"
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags = {
     (var.unknownTagKey) = null_resource.test.id
   }

--- a/internal/service/ec2/testdata/Instance/tagsComputed2/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/tagsComputed2/main_gen.tf
@@ -7,6 +7,10 @@ resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = "t4g.nano"
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags = {
     (var.unknownTagKey) = null_resource.test.id
     (var.knownTagKey)   = var.knownTagValue

--- a/internal/service/ec2/testdata/Instance/tags_defaults/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/tags_defaults/main_gen.tf
@@ -11,6 +11,10 @@ resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = "t4g.nano"
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags = var.resource_tags
 }
 

--- a/internal/service/ec2/testdata/Instance/tags_ignore/main_gen.tf
+++ b/internal/service/ec2/testdata/Instance/tags_ignore/main_gen.tf
@@ -14,6 +14,10 @@ resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = "t4g.nano"
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags = var.resource_tags
 }
 

--- a/internal/service/ec2/testdata/tmpl/ec2_instance_tags.gtpl
+++ b/internal/service/ec2/testdata/tmpl/ec2_instance_tags.gtpl
@@ -2,6 +2,10 @@ resource "aws_instance" "test" {
   ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-arm64.id
   instance_type = "t4g.nano"
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
 {{- template "tags" . }}
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Addresses the semgrep `terraform.lang.security.ec2-imdsv1-optional.ec2-imdsv1-optional` code scanning security findings such as https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/450.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=^TestAccEC2Instance_tags$$' PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=^TestAccEC2Instance_tags$ -timeout 360m -vet=off
2025/03/07 12:18:26 Initializing Terraform AWS Provider...
=== RUN   TestAccEC2Instance_tags
=== PAUSE TestAccEC2Instance_tags
=== CONT  TestAccEC2Instance_tags
--- PASS: TestAccEC2Instance_tags (416.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	422.183s
```
