### PR TITLE
Fix `terraform.aws.security.aws-cloudwatch-log-group-no-retention.aws-cloudwatch-log-group-no-retention` security findings

### DIFF
--- a/examples/ecs-alb/main.tf
+++ b/examples/ecs-alb/main.tf
@@ -289,9 +289,11 @@ resource "aws_alb_listener" "front_end" {
 ## CloudWatch Logs
 
 resource "aws_cloudwatch_log_group" "ecs" {
-  name = "tf-ecs-group/ecs-agent"
+  name              = "tf-ecs-group/ecs-agent"
+  retention_in_days = 1
 }
 
 resource "aws_cloudwatch_log_group" "app" {
-  name = "tf-ecs-group/app-ghost"
+  name              = "tf-ecs-group/app-ghost"
+  retention_in_days = 1
 }

--- a/internal/service/logs/testdata/LogGroup/data.tags/main_gen.tf
+++ b/internal/service/logs/testdata/LogGroup/data.tags/main_gen.tf
@@ -9,6 +9,8 @@ data "aws_cloudwatch_log_group" "test" {
 resource "aws_cloudwatch_log_group" "test" {
   name = var.rName
 
+  retention_in_days = 1
+
   tags = var.resource_tags
 }
 

--- a/internal/service/logs/testdata/LogGroup/data.tags_defaults/main_gen.tf
+++ b/internal/service/logs/testdata/LogGroup/data.tags_defaults/main_gen.tf
@@ -15,6 +15,8 @@ data "aws_cloudwatch_log_group" "test" {
 resource "aws_cloudwatch_log_group" "test" {
   name = var.rName
 
+  retention_in_days = 1
+
   tags = var.resource_tags
 }
 

--- a/internal/service/logs/testdata/LogGroup/data.tags_ignore/main_gen.tf
+++ b/internal/service/logs/testdata/LogGroup/data.tags_ignore/main_gen.tf
@@ -18,6 +18,8 @@ data "aws_cloudwatch_log_group" "test" {
 resource "aws_cloudwatch_log_group" "test" {
   name = var.rName
 
+  retention_in_days = 1
+
   tags = var.resource_tags
 }
 

--- a/internal/service/logs/testdata/LogGroup/tags/main_gen.tf
+++ b/internal/service/logs/testdata/LogGroup/tags/main_gen.tf
@@ -4,6 +4,8 @@
 resource "aws_cloudwatch_log_group" "test" {
   name = var.rName
 
+  retention_in_days = 1
+
   tags = var.resource_tags
 }
 

--- a/internal/service/logs/testdata/LogGroup/tagsComputed1/main_gen.tf
+++ b/internal/service/logs/testdata/LogGroup/tagsComputed1/main_gen.tf
@@ -6,6 +6,8 @@ provider "null" {}
 resource "aws_cloudwatch_log_group" "test" {
   name = var.rName
 
+  retention_in_days = 1
+
   tags = {
     (var.unknownTagKey) = null_resource.test.id
   }

--- a/internal/service/logs/testdata/LogGroup/tagsComputed2/main_gen.tf
+++ b/internal/service/logs/testdata/LogGroup/tagsComputed2/main_gen.tf
@@ -6,6 +6,8 @@ provider "null" {}
 resource "aws_cloudwatch_log_group" "test" {
   name = var.rName
 
+  retention_in_days = 1
+
   tags = {
     (var.unknownTagKey) = null_resource.test.id
     (var.knownTagKey)   = var.knownTagValue

--- a/internal/service/logs/testdata/LogGroup/tags_defaults/main_gen.tf
+++ b/internal/service/logs/testdata/LogGroup/tags_defaults/main_gen.tf
@@ -10,6 +10,8 @@ provider "aws" {
 resource "aws_cloudwatch_log_group" "test" {
   name = var.rName
 
+  retention_in_days = 1
+
   tags = var.resource_tags
 }
 

--- a/internal/service/logs/testdata/LogGroup/tags_ignore/main_gen.tf
+++ b/internal/service/logs/testdata/LogGroup/tags_ignore/main_gen.tf
@@ -13,6 +13,8 @@ provider "aws" {
 resource "aws_cloudwatch_log_group" "test" {
   name = var.rName
 
+  retention_in_days = 1
+
   tags = var.resource_tags
 }
 

--- a/internal/service/logs/testdata/tmpl/group_tags.gtpl
+++ b/internal/service/logs/testdata/tmpl/group_tags.gtpl
@@ -1,5 +1,7 @@
 resource "aws_cloudwatch_log_group" "test" {
   name = var.rName
 
+  retention_in_days = 1
+
 {{- template "tags" . }}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Addresses the semgrep `terraform.aws.security.aws-cloudwatch-log-group-no-retention.aws-cloudwatch-log-group-no-retention` code scanning security findings such as https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/462.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=^TestAccLogsLogGroup_tags$$' PKG=logs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/logs/... -v -count 1 -parallel 20  -run=^TestAccLogsLogGroup_tags$ -timeout 360m -vet=off
2025/03/07 12:43:56 Initializing Terraform AWS Provider...
=== RUN   TestAccLogsLogGroup_tags
=== PAUSE TestAccLogsLogGroup_tags
=== CONT  TestAccLogsLogGroup_tags
--- PASS: TestAccLogsLogGroup_tags (51.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	56.618s
```
