### PR TITLE
Fix `terraform.aws.security.aws-kms-no-rotation.aws-kms-no-rotation` security findings

### DIFF
--- a/examples/workspaces/main.tf
+++ b/examples/workspaces/main.tf
@@ -121,5 +121,7 @@ resource "aws_directory_service_directory" "example" {
 }
 
 resource "aws_kms_key" "example" {
-  description = "WorkSpaces example key"
+  description             = "WorkSpaces example key"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }

--- a/internal/service/kms/testdata/Key/tags/main_gen.tf
+++ b/internal/service/kms/testdata/Key/tags/main_gen.tf
@@ -4,6 +4,7 @@
 resource "aws_kms_key" "test" {
   description             = var.rName
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   tags = var.resource_tags
 }

--- a/internal/service/kms/testdata/Key/tagsComputed1/main_gen.tf
+++ b/internal/service/kms/testdata/Key/tagsComputed1/main_gen.tf
@@ -6,6 +6,7 @@ provider "null" {}
 resource "aws_kms_key" "test" {
   description             = var.rName
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   tags = {
     (var.unknownTagKey) = null_resource.test.id

--- a/internal/service/kms/testdata/Key/tagsComputed2/main_gen.tf
+++ b/internal/service/kms/testdata/Key/tagsComputed2/main_gen.tf
@@ -6,6 +6,7 @@ provider "null" {}
 resource "aws_kms_key" "test" {
   description             = var.rName
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   tags = {
     (var.unknownTagKey) = null_resource.test.id

--- a/internal/service/kms/testdata/Key/tags_defaults/main_gen.tf
+++ b/internal/service/kms/testdata/Key/tags_defaults/main_gen.tf
@@ -10,6 +10,7 @@ provider "aws" {
 resource "aws_kms_key" "test" {
   description             = var.rName
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   tags = var.resource_tags
 }

--- a/internal/service/kms/testdata/Key/tags_ignore/main_gen.tf
+++ b/internal/service/kms/testdata/Key/tags_ignore/main_gen.tf
@@ -13,6 +13,7 @@ provider "aws" {
 resource "aws_kms_key" "test" {
   description             = var.rName
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   tags = var.resource_tags
 }

--- a/internal/service/kms/testdata/tmpl/key_tags.gtpl
+++ b/internal/service/kms/testdata/tmpl/key_tags.gtpl
@@ -1,6 +1,7 @@
 resource "aws_kms_key" "test" {
   description             = var.rName
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
 {{- template "tags" . }}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Addresses the semgrep `terraform.aws.security.aws-kms-no-rotation.aws-kms-no-rotation` code scanning security findings such as https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/356.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=^TestAccKMSKey_tags$$' PKG=kms
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/kms/... -v -count 1 -parallel 20  -run=^TestAccKMSKey_tags$ -timeout 360m -vet=off
2025/03/07 12:57:42 Initializing Terraform AWS Provider...
=== RUN   TestAccKMSKey_tags
=== PAUSE TestAccKMSKey_tags
=== CONT  TestAccKMSKey_tags
--- PASS: TestAccKMSKey_tags (79.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	84.892s
```
