### PR TITLE
Set Terraform version for `acctest Provider`

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -313,6 +313,7 @@ func PreCheck(ctx context.Context, t *testing.T) {
 		region := Region()
 		os.Setenv(envvar.DefaultRegion, region)
 
+		Provider.TerraformVersion = "1.0.0"
 		diags := Provider.Configure(ctx, terraformsdk.NewResourceConfigRaw(nil))
 		if err := sdkdiag.DiagnosticsError(diags); err != nil {
 			t.Fatalf("configuring provider: %s", err)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Otherwise

```console
% make sane
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2025/03/07 16:41:00 Initializing Terraform AWS Provider...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRole_namePrefix
=== NAME  TestAccIAMRolePolicy_basic
    acctest.go:318: configuring provider: unsupported Terraform version: 0.11+compatible. This version of Terraform is not supported with pre-release version of the Terraform AWS Provider but will be supported at GA. See https://developer.hashicorp.com/terraform/language/providers/requirements#v0-12-compatible-provider-requirements for details of how to specify an exact provider version to use
--- FAIL: TestAccIAMRolePolicy_basic (0.00s)
--- FAIL: TestAccIAMPolicy_basic (8.88s)
panic: runtime error: invalid memory address or nil pointer dereference
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x111966ee4]

goroutine 13 [running]:
testing.tRunner.func1.2({0x118a17180, 0x125eeadf0})
	/Users/kewbank/sdk/go1.24.1/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
	/Users/kewbank/sdk/go1.24.1/src/testing/testing.go:1737 +0x334
panic({0x118a17180?, 0x125eeadf0?})
	/Users/kewbank/sdk/go1.24.1/src/runtime/panic.go:792 +0x124
github.com/hashicorp/terraform-provider-aws/internal/service/iam.(*servicePackage).NewClient(0x126a84a40, {0x11ad29ad8, 0x1400fa002a0}, 0x1400fa002d0)
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/service/iam/service_package_gen.go:337 +0x64
github.com/hashicorp/terraform-provider-aws/internal/conns.client[...]({0x11ad29ad8, 0x140049ceab0}, 0x14001532b40, {0x114f60e86, 0x3}, 0x1400825e308)
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/conns/awsclient.go:388 +0x488
github.com/hashicorp/terraform-provider-aws/internal/conns.(*AWSClient).IAMClient(0x14001532b40, {0x11ad29ad8, 0x140049ceab0})
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/conns/awsclient_gen.go:722 +0x94
github.com/hashicorp/terraform-provider-aws/internal/service/iam_test.TestAccIAMPolicy_basic.testAccCheckPolicyDestroy.func3(0x1401a76e0e0)
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/service/iam/policy_test.go:430 +0x5c
github.com/hashicorp/terraform-plugin-testing/helper/resource.runPostTestDestroy({0x11ad29ad8, 0x140059e73b0}, {0x11ae119a0, 0x14000d20380}, {0x0, 0x140049f80c0, {0x0, 0x0, 0x0}, 0x0, ...}, ...)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.11.0/helper/resource/testing_new.go:41 +0xfc
github.com/hashicorp/terraform-plugin-testing/helper/resource.runNewTest.func1()
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.11.0/helper/resource/testing_new.go:87 +0x294
panic({0x118a17180?, 0x125eeadf0?})
	/Users/kewbank/sdk/go1.24.1/src/runtime/panic.go:792 +0x124
github.com/hashicorp/terraform-provider-aws/internal/service/iam.(*servicePackage).NewClient(0x126a84a40, {0x11ad29ad8, 0x14010e49440}, 0x14010e49530)
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/service/iam/service_package_gen.go:337 +0x64
github.com/hashicorp/terraform-provider-aws/internal/conns.client[...]({0x11ad29ad8, 0x140049ceab0}, 0x14001532b40, {0x114f60e86, 0x3}, 0x1400825efd8)
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/conns/awsclient.go:388 +0x488
github.com/hashicorp/terraform-provider-aws/internal/conns.(*AWSClient).IAMClient(0x14001532b40, {0x11ad29ad8, 0x140049ceab0})
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/conns/awsclient_gen.go:722 +0x94
github.com/hashicorp/terraform-provider-aws/internal/service/iam_test.TestAccIAMPolicy_basic.testAccCheckPolicyExists.func4(0x0?)
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/service/iam/policy_test.go:414 +0xa0
github.com/hashicorp/terraform-provider-aws/internal/service/iam_test.TestAccIAMPolicy_basic.ComposeTestCheckFunc.func13(0x1400638c2a0)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.11.0/helper/resource/testing.go:967 +0x64
github.com/hashicorp/terraform-plugin-testing/helper/resource.testStepNewConfig({_, _}, {_, _}, {0x0, 0x140049f80c0, {0x0, 0x0, 0x0}, 0x0, ...}, ...)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.11.0/helper/resource/testing_new_config.go:214 +0xd40
github.com/hashicorp/terraform-plugin-testing/helper/resource.runNewTest({0x11ad29ad8, 0x140059e73b0}, {0x11ae119a0, 0x14000d20380}, {0x0, 0x140049f80c0, {0x0, 0x0, 0x0}, 0x0, ...}, ...)
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.11.0/helper/resource/testing_new.go:370 +0x1da8
github.com/hashicorp/terraform-plugin-testing/helper/resource.Test({0x11ae119a0, 0x14000d20380}, {0x0, 0x140049f80c0, {0x0, 0x0, 0x0}, 0x0, 0x140010ea390, 0x0, ...})
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.11.0/helper/resource/testing.go:926 +0x57c
github.com/hashicorp/terraform-plugin-testing/helper/resource.ParallelTest({0x11ae119a0, 0x14000d20380}, {0x0, 0x140049f80c0, {0x0, 0x0, 0x0}, 0x0, 0x140010ea390, 0x0, ...})
	/Users/kewbank/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.11.0/helper/resource/testing.go:818 +0x68
github.com/hashicorp/terraform-provider-aws/internal/service/iam_test.TestAccIAMPolicy_basic(0x14000d20380)
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/service/iam/policy_test.go:30 +0xa10
testing.tRunner(0x14000d20380, 0x11a9d7680)
	/Users/kewbank/sdk/go1.24.1/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 1
	/Users/kewbank/sdk/go1.24.1/src/testing/testing.go:1851 +0x374
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/iam	14.660s
FAIL
make: *** [sane] Error 1
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/41722.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sane
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2025/03/07 16:51:47 Initializing Terraform AWS Provider...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMInstanceProfile_basic
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (11.84s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (11.96s)
--- PASS: TestAccIAMRole_disappears (15.90s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (16.96s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (16.96s)
--- PASS: TestAccIAMPolicy_basic (17.59s)
--- PASS: TestAccIAMRole_basic (18.11s)
--- PASS: TestAccIAMRole_namePrefix (18.17s)
--- PASS: TestAccIAMRolePolicy_basic (18.78s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (19.17s)
--- PASS: TestAccIAMInstanceProfile_basic (22.60s)
--- PASS: TestAccIAMPolicy_policy (25.63s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (26.61s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (34.79s)
--- PASS: TestAccIAMPolicy_tags (53.89s)
--- PASS: TestAccIAMInstanceProfile_tags (77.28s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	83.145s
2025/03/07 16:53:29 Initializing Terraform AWS Provider...
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_multiple
--- PASS: TestAccLogsGroup_multiple (13.93s)
--- PASS: TestAccLogsGroup_basic (15.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	21.108s
2025/03/07 16:53:48 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
=== CONT  TestAccVPCSecurityGroup_egressMode
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPC_tenancy
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
--- PASS: TestAccVPCSubnet_basic (20.04s)
--- PASS: TestAccVPCRouteTable_basic (20.19s)
--- PASS: TestAccVPCSecurityGroup_basic (21.84s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (26.68s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (28.13s)
--- PASS: TestAccVPCDataSource_basic (33.12s)
--- PASS: TestAccVPCSecurityGroup_egressMode (44.28s)
--- PASS: TestAccVPC_tenancy (47.44s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (53.98s)
--- PASS: TestAccVPCSecurityGroupRule_race (159.03s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	177.949s
2025/03/07 16:53:44 Initializing Terraform AWS Provider...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (23.07s)
--- PASS: TestAccECSService_basic (72.49s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	86.852s
2025/03/07 16:53:40 Initializing Terraform AWS Provider...
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (19.79s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	29.920s
2025/03/07 16:53:36 Initializing Terraform AWS Provider...
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (23.46s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	29.330s
2025/03/07 16:57:09 Initializing Terraform AWS Provider...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (29.35s)
--- PASS: TestAccLambdaFunction_basic (41.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	56.107s
2025/03/07 16:57:05 Initializing Terraform AWS Provider...
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaRegionDataSource_endpoint (10.16s)
--- PASS: TestAccMetaPartitionDataSource_basic (10.18s)
--- PASS: TestAccMetaRegionDataSource_basic (10.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	20.580s
2025/03/07 16:57:00 Initializing Terraform AWS Provider...
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_Latency_basic
--- PASS: TestAccRoute53ZoneDataSource_name (72.94s)
--- PASS: TestAccRoute53Record_basic (152.81s)
--- PASS: TestAccRoute53Record_Latency_basic (159.01s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	165.011s
2025/03/07 16:57:17 Initializing Terraform AWS Provider...
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
--- PASS: TestAccS3Bucket_Basic_basic (20.08s)
--- PASS: TestAccS3Object_basic (20.30s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (20.56s)
--- PASS: TestAccS3BucketPolicy_basic (20.70s)
--- PASS: TestAccS3BucketACL_updateACL (32.56s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (33.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	56.919s
2025/03/07 16:57:13 Initializing Terraform AWS Provider...
=== RUN   TestAccSSMParameterEphemeral_basic
=== PAUSE TestAccSSMParameterEphemeral_basic
=== CONT  TestAccSSMParameterEphemeral_basic
--- PASS: TestAccSSMParameterEphemeral_basic (11.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	30.319s
2025/03/07 16:57:26 Initializing Terraform AWS Provider...
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_basic (14.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	45.527s
2025/03/07 16:57:22 Initializing Terraform AWS Provider...
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (8.84s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	35.977s
```
