### PR TITLE
Add data_source AWS Account regions

### DIFF
--- a/internal/service/account/regions_data_source_test.go
+++ b/internal/service/account/regions_data_source_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package account_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAccountRegionsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	dataSourceName := "data.aws_account_regions.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AccountServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountRegionsDataSourceConfig_inAccount(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "regions.*", map[string]string{
+						"region_name":       "us-east-1",
+						"region_opt_status": "ENABLED",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "regions.*", map[string]string{
+						"region_name":       "us-east-2",
+						"region_opt_status": "ENABLED",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "regions.*", map[string]string{
+						"region_name":       "us-west-1",
+						"region_opt_status": "ENABLED",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "regions.*", map[string]string{
+						"region_name":       "us-west-2",
+						"region_opt_status": "ENABLED",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "regions.*", map[string]string{
+						"region_name":       "af-south-1",
+						"region_opt_status": "DISABLED",
+					}),
+					resource.TestCheckResourceAttrPair(dataSourceName, "account_id", "data.aws_caller_identity.current", "account_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAccountRegionsDataSourceConfig_inAccount() string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_account_regions" "test" {}
+`)
+}

--- a/internal/service/account/service_package_gen.go
+++ b/internal/service/account/service_package_gen.go
@@ -15,7 +15,13 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newDataSourceRegions,
+			TypeName: "aws_account_regions",
+			Name:     "Regions",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/website/docs/d/account_regions.html.markdown
+++ b/website/docs/d/account_regions.html.markdown
@@ -1,0 +1,39 @@
+---
+subcategory: "Account Management"
+layout: "aws"
+page_title: "AWS: aws_account_regions"
+description: |-
+  Terraform data source for managing an AWS Account Management Regions.
+---
+
+# Data Source: aws_account_regions
+
+Terraform data source for managing an AWS Account Management Regions.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_account_regions" "example" {}
+```
+
+## Argument Reference
+
+
+The following arguments are optional:
+
+* `account_id` - (Optional) AWS account ID. Must be a member account in the same organization.
+* `region_opt_status_contains` - (Optional) A list of Region statuses (Enabling, Enabled, Disabling, Disabled, Enabled_by_default) to use to filter the list of Regions for a given account.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `regions` - The [regions](#region) for a given account
+
+### region
+
+* `region_name` - The Region code of a given Region
+* `region_opt_status` - One of potential statuses a Region can undergo (Enabled, Enabling, Disabled, Disabling, Enabled_By_Default).
+


### PR DESCRIPTION
**Description**

This PR adds a data_source aws_account_regions

**Relations**

Closes https://github.com/hashicorp/terraform-provider-aws/issues/41527

**References**

https://docs.aws.amazon.com/cli/latest/reference/account/list-regions.html

**Output from Acceptance Testing**
```
% make testacc TESTS=TestAccAccountRegionsDataSource_basic PKG=account
 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/account/... -v -count 1 -parallel 20 -run='TestAccAccountRegionsDataSource_basic'  -timeout 360m -vet=off
2025/03/08 00:24:07 Initializing Terraform AWS Provider...
=== RUN   TestAccAccountRegionsDataSource_basic
=== PAUSE TestAccAccountRegionsDataSource_basic
=== CONT  TestAccAccountRegionsDataSource_basic
--- PASS: TestAccAccountRegionsDataSource_basic (25.31s)
PASS
ok      [github.com/hashicorp/terraform-provider-aws/internal/service/account](http://github.com/hashicorp/terraform-provider-aws/internal/service/account)    **25.456s**
```
