### PR TITLE
`aws_cloudwatch_log_destinations` new data source

### DIFF
--- a/internal/service/logs/destinations_data_source.go
+++ b/internal/service/logs/destinations_data_source.go
@@ -5,8 +5,6 @@ package logs
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -94,7 +92,6 @@ func findLogDestinationsByPrefix(ctx context.Context, conn *cloudwatchlogs.Clien
 		}
 
 		for _, dest := range page.Destinations {
-			fmt.Printf("Destination: %v\n", *dest.DestinationName)
 			out = append(out, dest)
 		}
 	}

--- a/internal/service/logs/destinations_data_source.go
+++ b/internal/service/logs/destinations_data_source.go
@@ -1,0 +1,121 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_cloudwatch_log_destinations", name="Destinations")
+func newDataSourceDestinations(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceDestinations{}, nil
+}
+
+const (
+	DSNameDestinations = "Destinations Data Source"
+)
+
+type dataSourceDestinations struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceDestinations) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) { // nosemgrep:ci.meta-in-func-name
+	resp.TypeName = "aws_logs_destinations"
+}
+
+func (d *dataSourceDestinations) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"destination_name_prefix": schema.StringAttribute{
+				Optional: true,
+			},
+			"destinations": schema.ListAttribute{
+				Computed:   true,
+				CustomType: fwtypes.NewListNestedObjectTypeOf[logDestinationModel](ctx),
+			},
+		},
+	}
+}
+
+func (d *dataSourceDestinations) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().LogsClient(ctx)
+
+	var data dataSourceLogDestinationsModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TIP: -- 3. Get information about a resource from AWS
+	out, err := findLogDestinationsByPrefix(ctx, conn, data.DestinationNamePrefix.ValueStringPointer())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudWatch, create.ErrActionReading, DSNameDestinations, data.DestinationNamePrefix.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func findLogDestinationsByPrefix(ctx context.Context, conn *cloudwatchlogs.Client, destinationNamePrefix *string) (*cloudwatchlogs.DescribeDestinationsOutput, error) {
+	input := &cloudwatchlogs.DescribeDestinationsInput{}
+
+	if destinationNamePrefix != nil {
+		input.DestinationNamePrefix = destinationNamePrefix
+	}
+
+	out := make([]awstypes.Destination, 0)
+
+	destPaginator := cloudwatchlogs.NewDescribeDestinationsPaginator(conn, input)
+	for destPaginator.HasMorePages() {
+		page, err := destPaginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, dest := range page.Destinations {
+			fmt.Printf("Destination: %v\n", *dest.DestinationName)
+			out = append(out, dest)
+		}
+	}
+
+	destinationsLogOut := &cloudwatchlogs.DescribeDestinationsOutput{
+		Destinations: out,
+	}
+
+	return destinationsLogOut, nil
+}
+
+type dataSourceLogDestinationsModel struct {
+	DestinationNamePrefix types.String                                         `tfsdk:"destination_name_prefix"`
+	Destinations          fwtypes.ListNestedObjectValueOf[logDestinationModel] `tfsdk:"destinations"`
+}
+
+type logDestinationModel struct {
+	ARN             types.String `tfsdk:"arn"`
+	DestinationName types.String `tfsdk:"destination_name"`
+	RoleARN         types.String `tfsdk:"role_arn"`
+	AccessPolicy    types.String `tfsdk:"access_policy"`
+	TargetARN       types.String `tfsdk:"target_arn"`
+	CreationTime    types.Int64  `tfsdk:"creation_time"`
+}

--- a/internal/service/logs/destinations_data_source_test.go
+++ b/internal/service/logs/destinations_data_source_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logs_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccLogsDestinationsDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	// TIP: This is a long-running test guard for tests that run longer than
+	// 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_cloudwatch_log_destinations.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDestinationsDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "destinations.#", 1),
+				),
+			},
+		},
+	})
+}
+
+func testAccDestinationsDataSourceConfig_basic(rName string) string {
+	return acctest.ConfigCompose(testAccDestinationConfig_basic(rName), fmt.Sprintf(`
+data "aws_cloudwatch_log_destinations" "test" {
+  depends_on = [aws_cloudwatch_log_destination.test]
+}
+`))
+}

--- a/internal/service/logs/service_package_gen.go
+++ b/internal/service/logs/service_package_gen.go
@@ -15,7 +15,13 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newDataSourceDestinations,
+			TypeName: "aws_cloudwatch_log_destinations",
+			Name:     "Destinations",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/website/docs/d/cloudwatch_log_destinations.html.markdown
+++ b/website/docs/d/cloudwatch_log_destinations.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "CloudWatch Logs"
+layout: "aws"
+page_title: "AWS: aws_logs_destinations"
+description: |-
+  Terraform data source for managing an AWS CloudWatch Logs Destinations.
+---
+<!---
+TIP: A few guiding principles for writing documentation:
+1. Use simple language while avoiding jargon and figures of speech.
+2. Focus on brevity and clarity to keep a reader's attention.
+3. Use active voice and present tense whenever you can.
+4. Document your feature as it exists now; do not mention the future or past if you can help it.
+5. Use accessible and inclusive language.
+--->
+
+# Data Source: aws_logs_destinations
+
+Terraform data source for managing an AWS CloudWatch Logs Destinations.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_logs_destinations" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Destinations. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Added `aws_cloudwatch_log_destinations` datasource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41728 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsDestinationsDataSource_basic'  -timeout 360m -vet=off
2025/03/08 16:20:10 Initializing Terraform AWS Provider...
=== RUN   TestAccLogsDestinationsDataSource_basic
=== PAUSE TestAccLogsDestinationsDataSource_basic
=== CONT  TestAccLogsDestinationsDataSource_basic
--- PASS: TestAccLogsDestinationsDataSource_basic (50.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	56.393s
...
```
