### PR TITLE
r/aws_codebuild_fleet: Add sweeper

### DIFF
--- a/internal/service/codebuild/sweep.go
+++ b/internal/service/codebuild/sweep.go
@@ -17,6 +17,7 @@ func RegisterSweepers() {
 	awsv2.Register("aws_codebuild_report_group", sweepReportGroups)
 	awsv2.Register("aws_codebuild_project", sweepProjects)
 	awsv2.Register("aws_codebuild_source_credential", sweepSourceCredentials)
+	awsv2.Register("aws_codebuild_fleet", sweepFleets)
 }
 
 func sweepReportGroups(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
@@ -88,6 +89,31 @@ func sweepSourceCredentials(ctx context.Context, client *conns.AWSClient) ([]swe
 		d.SetId(id)
 
 		sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+	}
+
+	return sweepResources, nil
+}
+
+func sweepFleets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	conn := client.CodeBuildClient(ctx)
+	var input codebuild.ListFleetsInput
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := codebuild.NewListFleetsPaginator(conn, &input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.Fleets {
+			r := resourceFleet()
+			d := r.Data(nil)
+			d.SetId(v)
+
+			sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+		}
 	}
 
 	return sweepResources, nil

--- a/internal/sweep/awsv2/skip.go
+++ b/internal/sweep/awsv2/skip.go
@@ -69,6 +69,10 @@ func SkipSweepError(err error) bool {
 	if tfawserr.ErrMessageContains(err, "InvalidInputException", "Domain-related APIs are only available in the us-east-1 Region") {
 		return true
 	}
+	// Example (codebuild): InvalidInputException: Unknown operation ListFleets
+	if tfawserr.ErrMessageContains(err, "InvalidInputException", "Unknown operation") {
+		return true
+	}
 	// For example from us-west-2 Route53 key signing key
 	if tfawserr.ErrMessageContains(err, "InvalidKeySigningKeyStatus", "cannot be deleted because") {
 		return true


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds missing `aws_codebuild_fleet` sweeper, burning 💲💲💲.

```console
% SWEEPERS=aws_codebuild_fleet make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.23.7 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run='aws_codebuild_fleet' -timeout 360m -vet=off
2025/03/10 13:58:58 [DEBUG] Running Sweepers for region (us-west-2):
2025/03/10 13:58:58 [DEBUG] Running Sweeper (aws_codebuild_fleet) in region (us-west-2)
2025/03/10 13:58:58 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:58.962-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-2 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:58.962-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:58.962-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-2 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:58.962-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-2 tf_resource_type=aws_codebuild_fleet tf_aws.credentials_source=EnvConfigCredentials
2025-03-10T13:58:58.962-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:58:58 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-west-2 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:58:58 [DEBUG] sweeper: Retrieving AWS account details: tf_resource_type=aws_codebuild_fleet sweeper_region=us-west-2
2025-03-10T13:58:58.962-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:59.438-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: tf_resource_type=aws_codebuild_fleet sweeper_region=us-west-2
2025/03/10 13:58:59 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:58:59 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:58:59 [DEBUG] Completed Sweeper (aws_codebuild_fleet) in region (us-west-2) in 890.270917ms
2025/03/10 13:58:59 Completed Sweepers for region (us-west-2) in 890.44475ms
2025/03/10 13:58:59 Sweeper Tests for region (us-west-2) ran successfully:
2025/03/10 13:58:59 	- aws_codebuild_fleet
2025/03/10 13:58:59 [DEBUG] Running Sweepers for region (us-east-1):
2025/03/10 13:58:59 [DEBUG] Running Sweeper (aws_codebuild_fleet) in region (us-east-1)
2025/03/10 13:58:59 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:59.851-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:59.851-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:59.852-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:59.852-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet tf_aws.credentials_source=EnvConfigCredentials
2025-03-10T13:58:59.852-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:58:59 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:58:59 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:59.852-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:58:59.964-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:58:59 [INFO]  sweeper: listing resources: tf_resource_type=aws_codebuild_fleet sweeper_region=us-east-1
2025/03/10 13:59:00 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:59:00 [DEBUG] Completed Sweeper (aws_codebuild_fleet) in region (us-east-1) in 250.806042ms
2025/03/10 13:59:00 Completed Sweepers for region (us-east-1) in 250.832375ms
2025/03/10 13:59:00 Sweeper Tests for region (us-east-1) ran successfully:
2025/03/10 13:59:00 	- aws_codebuild_fleet
2025/03/10 13:59:00 [DEBUG] Running Sweepers for region (us-east-2):
2025/03/10 13:59:00 [DEBUG] Running Sweeper (aws_codebuild_fleet) in region (us-east-2)
2025/03/10 13:59:00 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-2 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:59:00.102-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-2 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:59:00.102-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:59:00.103-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: tf_resource_type=aws_codebuild_fleet sweeper_region=us-east-2
2025-03-10T13:59:00.103-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-2 tf_resource_type=aws_codebuild_fleet tf_aws.credentials_source=EnvConfigCredentials
2025-03-10T13:59:00.103-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-2 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:59:00 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-east-2 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:59:00 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-2 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:59:00.103-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: tf_resource_type=aws_codebuild_fleet sweeper_region=us-east-2
2025-03-10T13:59:00.282-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: tf_resource_type=aws_codebuild_fleet sweeper_region=us-east-2
2025/03/10 13:59:00 [INFO]  sweeper: listing resources: sweeper_region=us-east-2 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:59:00 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:59:00 [DEBUG] Completed Sweeper (aws_codebuild_fleet) in region (us-east-2) in 446.695333ms
2025/03/10 13:59:00 Completed Sweepers for region (us-east-2) in 446.71925ms
2025/03/10 13:59:00 Sweeper Tests for region (us-east-2) ran successfully:
2025/03/10 13:59:00 	- aws_codebuild_fleet
2025/03/10 13:59:00 [DEBUG] Running Sweepers for region (us-west-1):
2025/03/10 13:59:00 [DEBUG] Running Sweeper (aws_codebuild_fleet) in region (us-west-1)
2025/03/10 13:59:00 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-1 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:59:00.549-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: tf_resource_type=aws_codebuild_fleet sweeper_region=us-west-1
2025-03-10T13:59:00.549-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1 tf_resource_type=aws_codebuild_fleet
2025-03-10T13:59:00.549-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: tf_resource_type=aws_codebuild_fleet sweeper_region=us-west-1
2025-03-10T13:59:00.549-0400 [INFO]  sweeper.aws-base: Retrieved credentials: tf_resource_type=aws_codebuild_fleet sweeper_region=us-west-1 tf_aws.credentials_source=EnvConfigCredentials
2025-03-10T13:59:00.549-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:59:00 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-west-1 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:59:00 [DEBUG] sweeper: Retrieving AWS account details: tf_resource_type=aws_codebuild_fleet sweeper_region=us-west-1
2025-03-10T13:59:00.550-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: tf_resource_type=aws_codebuild_fleet sweeper_region=us-west-1
2025-03-10T13:59:00.967-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-1 tf_resource_type=aws_codebuild_fleet
2025/03/10 13:59:00 [INFO]  sweeper: listing resources: tf_resource_type=aws_codebuild_fleet sweeper_region=us-west-1
2025/03/10 13:59:01 [WARN]  sweeper: Skipping sweeper: sweeper_region=us-west-1 tf_resource_type=aws_codebuild_fleet error="operation error CodeBuild: ListFleets, https response error StatusCode: 400, RequestID: ee163fcd-95fc-4913-95a8-2cd531d1aba8, InvalidInputException: Unknown operation ListFleets"
2025/03/10 13:59:01 [DEBUG] Completed Sweeper (aws_codebuild_fleet) in region (us-west-1) in 1.017399458s
2025/03/10 13:59:01 Completed Sweepers for region (us-west-1) in 1.017423416s
2025/03/10 13:59:01 Sweeper Tests for region (us-west-1) ran successfully:
2025/03/10 13:59:01 	- aws_codebuild_fleet
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	8.349s
```