### PR TITLE
autoflex: Handle all `StringValuable` values consistently

### DIFF
--- a/internal/framework/flex/auto_expand.go
+++ b/internal/framework/flex/auto_expand.go
@@ -1164,7 +1164,7 @@ func mapBlockKey(ctx context.Context, from any) (reflect.Value, diag.Diagnostics
 	tflog.SubsystemError(ctx, subsystemName, "Source has no map block key")
 	diags.Append(diagExpandingNoMapBlockKey(valFrom.Type()))
 
-	return reflect.Zero(reflect.TypeOf("")), diags
+	return reflect.Zero(reflect.TypeFor[string]()), diags
 }
 
 func expandExpander(ctx context.Context, fromExpander Expander, toVal reflect.Value) diag.Diagnostics {

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -1513,21 +1513,23 @@ func setMapBlockKey(ctx context.Context, to any, key reflect.Value) diag.Diagnos
 			continue
 		}
 
-		fieldVal := valTo.Field(i)
-
-		if _, ok := fieldVal.Interface().(basetypes.StringValue); ok {
-			fieldVal.Set(reflect.ValueOf(basetypes.NewStringValue(key.String())))
+		fieldVal := valTo.Field(i)                            // vTo
+		fieldAttrVal, ok := fieldVal.Interface().(attr.Value) // valTo
+		if !ok {
+			tflog.SubsystemError(ctx, subsystemName, "Target does not implement attr.Value")
+			diags.Append(diagFlatteningTargetDoesNotImplementAttrValue(reflect.TypeOf(fieldVal.Interface())))
 			return diags
 		}
+		tTo := fieldAttrVal.Type(ctx)
 
-		fieldType := valTo.Field(i).Type()
-
-		method, found := fieldType.MethodByName("StringEnumValue")
-		if found {
-			result := fieldType.Method(method.Index).Func.Call([]reflect.Value{fieldVal, key})
-			if len(result) > 0 {
-				fieldVal.Set(result[0])
+		switch tTo := tTo.(type) {
+		case basetypes.StringTypable:
+			v, d := tTo.ValueFromString(ctx, types.StringValue(key.String()))
+			diags.Append(d...)
+			if diags.HasError() {
+				return diags
 			}
+			fieldVal.Set(reflect.ValueOf(v))
 		}
 
 		return diags

--- a/internal/framework/flex/auto_flatten.go
+++ b/internal/framework/flex/auto_flatten.go
@@ -1513,8 +1513,10 @@ func setMapBlockKey(ctx context.Context, to any, key reflect.Value) diag.Diagnos
 			continue
 		}
 
-		if _, ok := valTo.Field(i).Interface().(basetypes.StringValue); ok {
-			valTo.Field(i).Set(reflect.ValueOf(basetypes.NewStringValue(key.String())))
+		fieldVal := valTo.Field(i)
+
+		if _, ok := fieldVal.Interface().(basetypes.StringValue); ok {
+			fieldVal.Set(reflect.ValueOf(basetypes.NewStringValue(key.String())))
 			return diags
 		}
 
@@ -1522,9 +1524,9 @@ func setMapBlockKey(ctx context.Context, to any, key reflect.Value) diag.Diagnos
 
 		method, found := fieldType.MethodByName("StringEnumValue")
 		if found {
-			result := fieldType.Method(method.Index).Func.Call([]reflect.Value{valTo.Field(i), key})
+			result := fieldType.Method(method.Index).Func.Call([]reflect.Value{fieldVal, key})
 			if len(result) > 0 {
-				valTo.Field(i).Set(result[0])
+				fieldVal.Set(result[0])
 			}
 		}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

The function `mapBlockKey` currently uses `reflect.Value.MethodByName` to detect values that can be converted to `StringValue`. Instead, check for any type that implements `StringValuable`

Note: Uses of `reflect.Value.MethodByName` weaken the dead code elimination in the Go linker
