### PR TITLE
acctest: Use `t.Context()`

### DIFF
--- a/internal/acctest/context.go
+++ b/internal/acctest/context.go
@@ -18,7 +18,7 @@ func Context(t *testing.T) context.Context {
 
 	helperlogging.SetOutput(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tfsdklog.RegisterTestSink(ctx, t)
 	ctx = logger(ctx, t, "acctest")
 	ctx = awsSDKLogger(ctx)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

After upgrade to Go v1.24, use `t.Context()` instead of `context.Background()` for the acceptance testing `Context`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/41755.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sane
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2025/03/11 09:47:49 Initializing Terraform AWS Provider...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMRolePolicyAttachment_basic
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (14.66s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (14.84s)
--- PASS: TestAccIAMRole_disappears (17.90s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (18.59s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (18.72s)
--- PASS: TestAccIAMRole_basic (19.90s)
--- PASS: TestAccIAMRolePolicy_basic (20.75s)
--- PASS: TestAccIAMRole_namePrefix (20.76s)
--- PASS: TestAccIAMPolicy_basic (20.77s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (21.88s)
--- PASS: TestAccIAMInstanceProfile_basic (24.06s)
--- PASS: TestAccIAMPolicy_policy (27.68s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (28.85s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (35.92s)
--- PASS: TestAccIAMPolicy_tags (54.66s)
--- PASS: TestAccIAMInstanceProfile_tags (73.80s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	79.450s
2025/03/11 09:49:27 Initializing Terraform AWS Provider...
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_multiple
--- PASS: TestAccLogsGroup_multiple (12.69s)
--- PASS: TestAccLogsGroup_basic (14.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	20.573s
2025/03/11 09:49:50 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCSecurityGroup_egressMode
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
=== CONT  TestAccVPC_tenancy
--- PASS: TestAccVPCSubnet_basic (20.23s)
--- PASS: TestAccVPCRouteTable_basic (20.78s)
--- PASS: TestAccVPCSecurityGroup_basic (22.07s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (22.89s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (23.36s)
--- PASS: TestAccVPCDataSource_basic (28.48s)
--- PASS: TestAccVPCSecurityGroup_egressMode (42.67s)
--- PASS: TestAccVPC_tenancy (42.81s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (50.13s)
--- PASS: TestAccVPCSecurityGroupRule_race (164.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	183.135s
2025/03/11 09:49:41 Initializing Terraform AWS Provider...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (22.57s)
--- PASS: TestAccECSService_basic (78.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	88.777s
2025/03/11 09:49:37 Initializing Terraform AWS Provider...
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (20.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	26.503s
2025/03/11 09:49:46 Initializing Terraform AWS Provider...
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (24.03s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	38.341s
2025/03/11 09:52:58 Initializing Terraform AWS Provider...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (31.49s)
--- PASS: TestAccLambdaFunction_basic (41.52s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	47.458s
2025/03/11 09:53:03 Initializing Terraform AWS Provider...
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaRegionDataSource_basic (10.39s)
--- PASS: TestAccMetaRegionDataSource_endpoint (10.39s)
--- PASS: TestAccMetaPartitionDataSource_basic (10.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	19.897s
2025/03/11 09:53:07 Initializing Terraform AWS Provider...
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_Latency_basic
--- PASS: TestAccRoute53ZoneDataSource_name (80.67s)
--- PASS: TestAccRoute53Record_basic (154.92s)
--- PASS: TestAccRoute53Record_Latency_basic (158.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	171.748s
2025/03/11 09:53:15 Initializing Terraform AWS Provider...
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
=== CONT  TestAccS3BucketPolicy_basic
--- PASS: TestAccS3Bucket_Basic_basic (19.19s)
--- PASS: TestAccS3Object_basic (19.20s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (20.58s)
--- PASS: TestAccS3BucketPolicy_basic (20.86s)
--- PASS: TestAccS3BucketACL_updateACL (32.04s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (33.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	52.736s
2025/03/11 09:53:11 Initializing Terraform AWS Provider...
=== RUN   TestAccSSMParameterEphemeral_basic
=== PAUSE TestAccSSMParameterEphemeral_basic
=== CONT  TestAccSSMParameterEphemeral_basic
--- PASS: TestAccSSMParameterEphemeral_basic (13.22s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	28.350s
2025/03/11 09:53:24 Initializing Terraform AWS Provider...
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_basic (14.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	42.088s
2025/03/11 09:53:20 Initializing Terraform AWS Provider...
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (9.55s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	33.187s
```
