### PR TITLE
docs: Fix cloudwatch metric alarm example with anomaly detection

### DIFF
--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -119,9 +119,9 @@ resource "aws_cloudwatch_metric_alarm" "xx_anomaly_detection" {
   insufficient_data_actions = []
 
   metric_query {
-    id          = "e1"
-    expression  = "ANOMALY_DETECTION_BAND(m1)"
-    label       = "CPUUtilization (Expected)"
+    id         = "e1"
+    expression = "ANOMALY_DETECTION_BAND(m1)"
+    label      = "CPUUtilization (Expected)"
   }
 
   metric_query {

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -122,7 +122,6 @@ resource "aws_cloudwatch_metric_alarm" "xx_anomaly_detection" {
     id          = "e1"
     expression  = "ANOMALY_DETECTION_BAND(m1)"
     label       = "CPUUtilization (Expected)"
-    return_data = "true"
   }
 
   metric_query {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

On the documentation of [cloudwatch_metric_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) that is write : 

> return_data: (Optional) Specify exactly one metric_query to be true to use that metric_query result as the alarm.

But the example with anomaly detection contains 2 return_data. To work we only need to keep the value on m1 metric query.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
