### PR TITLE
[New Data Source] aws_ecrpublic_image

### DIFF
--- a/internal/service/ecrpublic/image_data_source.go
+++ b/internal/service/ecrpublic/image_data_source.go
@@ -1,0 +1,215 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ecrpublic
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/ecrpublic/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_ecrpublic_image", name="Image")
+func newDataSourceImage(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceImage{}, nil
+}
+
+const (
+	DSNameImage = "Image Data Source"
+)
+
+type dataSourceImage struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceImage) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"image_digest": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"image_pushed_at": schema.Int64Attribute{
+				Computed: true,
+			},
+			"image_size_in_bytes": schema.Int64Attribute{
+				Computed: true,
+			},
+			"image_tag": schema.StringAttribute{
+				Optional: true,
+			},
+			"image_tags": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"image_uri": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrMostRecent: schema.BoolAttribute{
+				Optional: true,
+			},
+			"registry_id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d{12}$`), "Match exactly 12 digits (0-9)"),
+				},
+			},
+			names.AttrRepositoryName: schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+}
+
+func (d *dataSourceImage) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().ECRPublicClient(ctx)
+
+	var data dataSourceImageModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := ecrpublic.DescribeImagesInput{
+		RepositoryName: data.RepositoryName.ValueStringPointer(),
+	}
+	if !data.RegistryId.IsNull() {
+		input.RegistryId = data.RegistryId.ValueStringPointer()
+	}
+	if !data.ImageDigest.IsNull() {
+		input.ImageIds = []awstypes.ImageIdentifier{
+			{ImageDigest: data.ImageDigest.ValueStringPointer()},
+		}
+	}
+	if !data.ImageTag.IsNull() {
+		if input.ImageIds == nil {
+			input.ImageIds = []awstypes.ImageIdentifier{
+				{ImageTag: data.ImageTag.ValueStringPointer()},
+			}
+		} else {
+			input.ImageIds[0].ImageTag = data.ImageTag.ValueStringPointer()
+		}
+	}
+
+	imageDetails, err := findImageDetails(ctx, conn, &input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ECRPublic, create.ErrActionReading, DSNameImage, "", err),
+			err.Error(),
+		)
+		return
+	}
+	if len(imageDetails) == 0 {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ECRPublic, create.ErrActionReading, DSNameImage, "", err),
+			"Your query returned no results. Please change your search criteria and try again.")
+		return
+	} else if len(imageDetails) > 1 && data.MostRecent.ValueBool() == false {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ECRPublic, create.ErrActionReading, DSNameImage, "", err),
+			"Your query returned more than one result. Please try a more specific search criteria, or set `most_recent` attribute to true.")
+		return
+	} else if len(imageDetails) > 1 && data.MostRecent.ValueBool() == true {
+		sort.Slice(imageDetails, func(i, j int) bool {
+			return imageDetails[i].ImagePushedAt.After(*imageDetails[j].ImagePushedAt)
+		})
+	}
+	imageDetail := imageDetails[0]
+
+	repository, err := findRepositoryDetail(ctx, conn, data.RepositoryName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.ECRPublic, create.ErrActionReading, DSNameImage, "", err),
+			err.Error(),
+		)
+		return
+	}
+
+	data.Id = types.StringPointerValue(imageDetail.ImageDigest)
+	data.ImagePushedAt = types.Int64Value(imageDetail.ImagePushedAt.Unix())
+	data.ImageURI = types.StringValue(fmt.Sprintf("%s@%s", *repository.RepositoryUri, *imageDetail.ImageDigest))
+	resp.Diagnostics.Append(flex.Flatten(ctx, imageDetail, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (d *dataSourceImage) ConfigValidators(ctx context.Context) []datasource.ConfigValidator {
+	return []datasource.ConfigValidator{
+		datasourcevalidator.AtLeastOneOf(
+			path.MatchRoot("image_digest"),
+			path.MatchRoot("image_tag"),
+			path.MatchRoot(names.AttrMostRecent),
+		),
+		datasourcevalidator.Conflicting(
+			path.MatchRoot("image_tag"),
+			path.MatchRoot(names.AttrMostRecent),
+		),
+		datasourcevalidator.Conflicting(
+			path.MatchRoot("image_digest"),
+			path.MatchRoot(names.AttrMostRecent),
+		),
+	}
+}
+
+func findImageDetails(ctx context.Context, conn *ecrpublic.Client, input *ecrpublic.DescribeImagesInput) ([]awstypes.ImageDetail, error) {
+	var output []awstypes.ImageDetail
+
+	pages := ecrpublic.NewDescribeImagesPaginator(conn, input)
+
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, page.ImageDetails...)
+	}
+
+	return output, nil
+}
+
+func findRepositoryDetail(ctx context.Context, conn *ecrpublic.Client, repositoryName string) (awstypes.Repository, error) {
+	var output awstypes.Repository
+
+	repositoryDetails, err := conn.DescribeRepositories(ctx, &ecrpublic.DescribeRepositoriesInput{
+		RepositoryNames: []string{repositoryName},
+	})
+	if err != nil {
+		return output, err
+	}
+	output = repositoryDetails.Repositories[0]
+	return output, nil
+}
+
+type dataSourceImageModel struct {
+	RepositoryName   types.String `tfsdk:"repository_name"`
+	RegistryId       types.String `tfsdk:"registry_id"`
+	Id               types.String `tfsdk:"id"`
+	MostRecent       types.Bool   `tfsdk:"most_recent"`
+	ImageDigest      types.String `tfsdk:"image_digest"`
+	ImageTag         types.String `tfsdk:"image_tag"`
+	ImagePushedAt    types.Int64  `tfsdk:"image_pushed_at"`
+	ImageSizeInBytes types.Int64  `tfsdk:"image_size_in_bytes"`
+	ImageTags        types.List   `tfsdk:"image_tags"`
+	ImageURI         types.String `tfsdk:"image_uri"`
+}

--- a/internal/service/ecrpublic/service_package_gen.go
+++ b/internal/service/ecrpublic/service_package_gen.go
@@ -15,7 +15,13 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newDataSourceImage,
+			TypeName: "aws_ecrpublic_image",
+			Name:     "Image",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/website/docs/d/ecrpublic_image.html.markdown
+++ b/website/docs/d/ecrpublic_image.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "ECR Public"
+layout: "aws"
+page_title: "AWS: aws_ecrpublic_image"
+description: |-
+  The ECR public Image data source allows the details of an image with a particular tag or digest to be retrieved.
+---
+
+# Data Source: aws_ecrpublic_image
+
+Terraform data source for managing an AWS ECR Public Image.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_ecrpublic_image" "example" {
+   repository_name = "my/service"
+   image_tag       = "latest"
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `repository_name` - (Required) Name of the ECR Public Repository.
+
+The following arguments are optional:
+
+* `registry_id` - (Optional) AWS Account ID of the Registry where the repository resides. Default is yours.
+* `image_digest` - (Optional) Sha256 digest of the image manifest. At least one of `image_digest`, `image_tag`, or `most_recent` must be specified.
+* `image_tag` - (Optional) Tag associated with this image. At least one of `image_digest`, `image_tag`, or `most_recent` must be specified.
+* `most_recent` - (Optional) Return the most recently pushed image. At least one of `image_digest`, `image_tag`, or `most_recent` must be specified.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `id` - SHA256 digest of the image manifest.
+* `image_pushed_at` - Date and time, expressed as a unix timestamp, at which the current image was pushed to the repository.
+* `image_size_in_bytes` - Size, in bytes, of the image in the repository.
+* `image_tags` - List of tags associated with this image.
+* `image_uri` - The URI for the specific image version specified by `image_tag` or `image_digest`.

--- a/website/docs/d/ecrpublic_image.html.markdown
+++ b/website/docs/d/ecrpublic_image.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: aws_ecrpublic_image
 
-Terraform data source for managing an AWS ECR Public Image.
+The ECR public Image data source allows the details of an image with a particular tag or digest to be retrieved.
 
 ## Example Usage
 


### PR DESCRIPTION
### Description

Implements the `aws_ecrpublic_image` data source, which retrieves the details of an image from the ECR public registry.

It is similar to `aws_ecr_image`, but that only works for private registries.  
This implementation was created to support public registries.


### Relations

Closes #41718 
Closes #22509 

### References

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_image
- https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ecr/image_data_source.go

I closely followed this implementation, ensuring that the input, output, and logic are highly similar.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
<!--
```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
-->
Didn't yet.

### Question

Would like to get feedbacks of these questions or anything else.

1. When querying a Docker image, I believe that specifying at least one of `most_recent`, `image_digest`, or `image_tag` should be sufficient to retrieve a unique image.  
Would it make sense to use `ConfigValidators` with `ExactlyOneOf` to enforce this constraint?

2. I added a constraint to `registry_id`, ensuring it consists of a 12-digit numeric string.  
Would this be acceptable?

3. I'm not sure how to write the test.  
In `aws_ecr_image`, it retrieves the AWS official image (`amazonlinux:latest`).  
Although it's in a private registry, I believe it is accessible to anyone.  
In this case, which image should I use for testing?


It's my first time to contribute this repository. Thank you for understanding.
