### PR TITLE
wafregional: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -42,4 +42,5 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - run: make TEST=./internal/service/mq modern-check
+      - run: make TEST=./internal/service/wafregional modern-check
       - run: make TEST=./internal/service/wafv2 modern-check

--- a/internal/service/wafregional/byte_match_set.go
+++ b/internal/service/wafregional/byte_match_set.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/wafregional"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_byte_match_set", name="Byte Match Set")

--- a/internal/service/wafregional/byte_match_set.go
+++ b/internal/service/wafregional/byte_match_set.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKResource("aws_wafregional_byte_match_set", name="Byte Match Set")
@@ -80,13 +81,13 @@ func resourceByteMatchSet() *schema.Resource {
 	}
 }
 
-func resourceByteMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceByteMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.CreateByteMatchSetInput{
 			ChangeToken: token,
 			Name:        aws.String(name),
@@ -104,7 +105,7 @@ func resourceByteMatchSetCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceByteMatchSetUpdate(ctx, d, meta)...)
 }
 
-func resourceByteMatchSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceByteMatchSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -128,7 +129,7 @@ func resourceByteMatchSetRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceByteMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceByteMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -144,20 +145,20 @@ func resourceByteMatchSetUpdate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceByteMatchSetRead(ctx, d, meta)...)
 }
 
-func resourceByteMatchSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceByteMatchSetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if oldT := d.Get("byte_match_tuples").(*schema.Set).List(); len(oldT) > 0 {
-		var newT []interface{}
+		var newT []any
 		if err := updateByteMatchSet(ctx, conn, region, d.Id(), oldT, newT); err != nil && !errs.IsA[*awstypes.WAFNonexistentItemException](err) && !errs.IsA[*awstypes.WAFNonexistentContainerException](err) {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	log.Printf("[INFO] Deleting WAF Regional Byte Match Set: %s", d.Id())
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteByteMatchSetInput{
 			ByteMatchSetId: aws.String(d.Id()),
 			ChangeToken:    token,
@@ -202,8 +203,8 @@ func findByteMatchSetByID(ctx context.Context, conn *wafregional.Client, id stri
 	return output.ByteMatchSet, nil
 }
 
-func updateByteMatchSet(ctx context.Context, conn *wafregional.Client, region, byteMatchSetID string, oldT, newT []interface{}) error {
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+func updateByteMatchSet(ctx context.Context, conn *wafregional.Client, region, byteMatchSetID string, oldT, newT []any) error {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.UpdateByteMatchSetInput{
 			ByteMatchSetId: aws.String(byteMatchSetID),
 			ChangeToken:    token,
@@ -220,17 +221,17 @@ func updateByteMatchSet(ctx context.Context, conn *wafregional.Client, region, b
 	return nil
 }
 
-func flattenByteMatchTuples(in []awstypes.ByteMatchTuple) []interface{} {
-	tuples := make([]interface{}, len(in))
+func flattenByteMatchTuples(in []awstypes.ByteMatchTuple) []any {
+	tuples := make([]any, len(in))
 
 	for i, tuple := range in {
-		fieldToMatchMap := map[string]interface{}{
+		fieldToMatchMap := map[string]any{
 			"data":         aws.ToString(tuple.FieldToMatch.Data),
 			names.AttrType: tuple.FieldToMatch.Type,
 		}
 
-		m := map[string]interface{}{
-			"field_to_match":        []map[string]interface{}{fieldToMatchMap},
+		m := map[string]any{
+			"field_to_match":        []map[string]any{fieldToMatchMap},
 			"positional_constraint": tuple.PositionalConstraint,
 			"target_string":         string(tuple.TargetString),
 			"text_transformation":   tuple.TextTransformation,
@@ -241,21 +242,21 @@ func flattenByteMatchTuples(in []awstypes.ByteMatchTuple) []interface{} {
 	return tuples
 }
 
-func diffByteMatchSetTuple(oldT, newT []interface{}) []awstypes.ByteMatchSetUpdate {
+func diffByteMatchSetTuple(oldT, newT []any) []awstypes.ByteMatchSetUpdate {
 	updates := make([]awstypes.ByteMatchSetUpdate, 0)
 
 	for _, ot := range oldT {
-		tuple := ot.(map[string]interface{})
+		tuple := ot.(map[string]any)
 
 		if idx, contains := sliceContainsMap(newT, tuple); contains {
-			newT = append(newT[:idx], newT[idx+1:]...)
+			newT = slices.Delete(newT, idx, idx+1)
 			continue
 		}
 
 		updates = append(updates, awstypes.ByteMatchSetUpdate{
 			Action: awstypes.ChangeActionDelete,
 			ByteMatchTuple: &awstypes.ByteMatchTuple{
-				FieldToMatch:         expandFieldToMatch(tuple["field_to_match"].([]interface{})[0].(map[string]interface{})),
+				FieldToMatch:         expandFieldToMatch(tuple["field_to_match"].([]any)[0].(map[string]any)),
 				PositionalConstraint: awstypes.PositionalConstraint(tuple["positional_constraint"].(string)),
 				TargetString:         []byte(tuple["target_string"].(string)),
 				TextTransformation:   awstypes.TextTransformation(tuple["text_transformation"].(string)),
@@ -264,12 +265,12 @@ func diffByteMatchSetTuple(oldT, newT []interface{}) []awstypes.ByteMatchSetUpda
 	}
 
 	for _, nt := range newT {
-		tuple := nt.(map[string]interface{})
+		tuple := nt.(map[string]any)
 
 		updates = append(updates, awstypes.ByteMatchSetUpdate{
 			Action: awstypes.ChangeActionInsert,
 			ByteMatchTuple: &awstypes.ByteMatchTuple{
-				FieldToMatch:         expandFieldToMatch(tuple["field_to_match"].([]interface{})[0].(map[string]interface{})),
+				FieldToMatch:         expandFieldToMatch(tuple["field_to_match"].([]any)[0].(map[string]any)),
 				PositionalConstraint: awstypes.PositionalConstraint(tuple["positional_constraint"].(string)),
 				TargetString:         []byte(tuple["target_string"].(string)),
 				TextTransformation:   awstypes.TextTransformation(tuple["text_transformation"].(string)),

--- a/internal/service/wafregional/flex.go
+++ b/internal/service/wafregional/flex.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func expandFieldToMatch(d map[string]interface{}) *awstypes.FieldToMatch {
+func expandFieldToMatch(d map[string]any) *awstypes.FieldToMatch {
 	ftm := &awstypes.FieldToMatch{
 		Type: awstypes.MatchFieldType(d[names.AttrType].(string)),
 	}
@@ -19,13 +19,13 @@ func expandFieldToMatch(d map[string]interface{}) *awstypes.FieldToMatch {
 	return ftm
 }
 
-func flattenFieldToMatch(fm *awstypes.FieldToMatch) []interface{} {
-	m := make(map[string]interface{})
+func flattenFieldToMatch(fm *awstypes.FieldToMatch) []any {
+	m := make(map[string]any)
 	if fm.Data != nil {
 		m["data"] = aws.ToString(fm.Data)
 	}
 
 	m[names.AttrType] = string(fm.Type)
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/wafregional/geo_match_set.go
+++ b/internal/service/wafregional/geo_match_set.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/wafregional"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_geo_match_set", name="Geo Match Set")

--- a/internal/service/wafregional/geo_match_set.go
+++ b/internal/service/wafregional/geo_match_set.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKResource("aws_wafregional_geo_match_set", name="Geo Match Set")
@@ -59,13 +60,13 @@ func resourceGeoMatchSet() *schema.Resource {
 	}
 }
 
-func resourceGeoMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGeoMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	outputRaw, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	outputRaw, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.CreateGeoMatchSetInput{
 			ChangeToken: token,
 			Name:        aws.String(name),
@@ -83,7 +84,7 @@ func resourceGeoMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceGeoMatchSetUpdate(ctx, d, meta)...)
 }
 
-func resourceGeoMatchSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGeoMatchSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -107,7 +108,7 @@ func resourceGeoMatchSetRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceGeoMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGeoMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -123,20 +124,20 @@ func resourceGeoMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceGeoMatchSetRead(ctx, d, meta)...)
 }
 
-func resourceGeoMatchSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGeoMatchSetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if oldConstraints := d.Get("geo_match_constraint").(*schema.Set).List(); len(oldConstraints) > 0 {
-		var newConstraints []interface{}
+		var newConstraints []any
 		if err := updateGeoMatchSet(ctx, conn, region, d.Id(), oldConstraints, newConstraints); err != nil && !errs.IsA[*awstypes.WAFNonexistentItemException](err) && !errs.IsA[*awstypes.WAFNonexistentContainerException](err) {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	log.Printf("[INFO] Deleting WAF Regional Geo Match Set: %s", d.Id())
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteGeoMatchSetInput{
 			ChangeToken:   token,
 			GeoMatchSetId: aws.String(d.Id()),
@@ -181,8 +182,8 @@ func findGeoMatchSetByID(ctx context.Context, conn *wafregional.Client, id strin
 	return output.GeoMatchSet, nil
 }
 
-func updateGeoMatchSet(ctx context.Context, conn *wafregional.Client, region string, geoMatchSetID string, oldConstraints, newConstraints []interface{}) error {
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+func updateGeoMatchSet(ctx context.Context, conn *wafregional.Client, region string, geoMatchSetID string, oldConstraints, newConstraints []any) error {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.UpdateGeoMatchSetInput{
 			ChangeToken:   token,
 			GeoMatchSetId: aws.String(geoMatchSetID),
@@ -199,10 +200,10 @@ func updateGeoMatchSet(ctx context.Context, conn *wafregional.Client, region str
 	return nil
 }
 
-func flattenGeoMatchConstraint(ts []awstypes.GeoMatchConstraint) []interface{} {
-	out := make([]interface{}, len(ts))
+func flattenGeoMatchConstraint(ts []awstypes.GeoMatchConstraint) []any {
+	out := make([]any, len(ts))
 	for i, t := range ts {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 		m[names.AttrType] = string(t.Type)
 		m[names.AttrValue] = string(t.Value)
 		out[i] = m
@@ -210,14 +211,14 @@ func flattenGeoMatchConstraint(ts []awstypes.GeoMatchConstraint) []interface{} {
 	return out
 }
 
-func diffGeoMatchSetConstraints(oldT, newT []interface{}) []awstypes.GeoMatchSetUpdate {
+func diffGeoMatchSetConstraints(oldT, newT []any) []awstypes.GeoMatchSetUpdate {
 	updates := make([]awstypes.GeoMatchSetUpdate, 0)
 
 	for _, od := range oldT {
-		constraint := od.(map[string]interface{})
+		constraint := od.(map[string]any)
 
 		if idx, contains := sliceContainsMap(newT, constraint); contains {
-			newT = append(newT[:idx], newT[idx+1:]...)
+			newT = slices.Delete(newT, idx, idx+1)
 			continue
 		}
 
@@ -231,7 +232,7 @@ func diffGeoMatchSetConstraints(oldT, newT []interface{}) []awstypes.GeoMatchSet
 	}
 
 	for _, nd := range newT {
-		constraint := nd.(map[string]interface{})
+		constraint := nd.(map[string]any)
 
 		updates = append(updates, awstypes.GeoMatchSetUpdate{
 			Action: awstypes.ChangeActionInsert,

--- a/internal/service/wafregional/ipset.go
+++ b/internal/service/wafregional/ipset.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKResource("aws_wafregional_ipset", name="IPSet")
@@ -64,13 +65,13 @@ func resourceIPSet() *schema.Resource {
 	}
 }
 
-func resourceIPSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPSetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.CreateIPSetInput{
 			ChangeToken: token,
 			Name:        aws.String(name),
@@ -88,7 +89,7 @@ func resourceIPSetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceIPSetUpdate(ctx, d, meta)...)
 }
 
-func resourceIPSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -120,7 +121,7 @@ func resourceIPSetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceIPSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPSetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -136,20 +137,20 @@ func resourceIPSetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceIPSetRead(ctx, d, meta)...)
 }
 
-func resourceIPSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPSetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if oldD := d.Get("ip_set_descriptor").(*schema.Set).List(); len(oldD) > 0 {
-		var newD []interface{}
+		var newD []any
 		if err := updateIPSet(ctx, conn, region, d.Id(), oldD, newD); err != nil && !errs.IsA[*awstypes.WAFNonexistentItemException](err) && !errs.IsA[*awstypes.WAFNonexistentContainerException](err) {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	log.Printf("[INFO] Deleting WAF Regional IPSet: %s", d.Id())
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteIPSetInput{
 			ChangeToken: token,
 			IPSetId:     aws.String(d.Id()),
@@ -194,9 +195,9 @@ func findIPSetByID(ctx context.Context, conn *wafregional.Client, id string) (*a
 	return output.IPSet, nil
 }
 
-func updateIPSet(ctx context.Context, conn *wafregional.Client, region, ipSetID string, oldD, newD []interface{}) error {
+func updateIPSet(ctx context.Context, conn *wafregional.Client, region, ipSetID string, oldD, newD []any) error {
 	for _, ipSetUpdates := range diffIPSetDescriptors(oldD, newD) {
-		_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+		_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 			input := &wafregional.UpdateIPSetInput{
 				ChangeToken: token,
 				IPSetId:     aws.String(ipSetID),
@@ -214,11 +215,11 @@ func updateIPSet(ctx context.Context, conn *wafregional.Client, region, ipSetID 
 	return nil
 }
 
-func flattenIPSetDescriptors(in []awstypes.IPSetDescriptor) []interface{} {
-	descriptors := make([]interface{}, len(in))
+func flattenIPSetDescriptors(in []awstypes.IPSetDescriptor) []any {
+	descriptors := make([]any, len(in))
 
 	for i, descriptor := range in {
-		d := map[string]interface{}{
+		d := map[string]any{
 			names.AttrType:  descriptor.Type,
 			names.AttrValue: *descriptor.Value,
 		}
@@ -228,7 +229,7 @@ func flattenIPSetDescriptors(in []awstypes.IPSetDescriptor) []interface{} {
 	return descriptors
 }
 
-func diffIPSetDescriptors(oldD, newD []interface{}) [][]awstypes.IPSetUpdate {
+func diffIPSetDescriptors(oldD, newD []any) [][]awstypes.IPSetUpdate {
 	// WAF requires UpdateIPSet operations be split into batches of 1000 Updates
 	const (
 		ipSetUpdatesLimit = 1000
@@ -237,10 +238,10 @@ func diffIPSetDescriptors(oldD, newD []interface{}) [][]awstypes.IPSetUpdate {
 	updatesBatches := make([][]awstypes.IPSetUpdate, 0)
 
 	for _, od := range oldD {
-		descriptor := od.(map[string]interface{})
+		descriptor := od.(map[string]any)
 
 		if idx, contains := sliceContainsMap(newD, descriptor); contains {
-			newD = append(newD[:idx], newD[idx+1:]...)
+			newD = slices.Delete(newD, idx, idx+1)
 			continue
 		}
 
@@ -259,7 +260,7 @@ func diffIPSetDescriptors(oldD, newD []interface{}) [][]awstypes.IPSetUpdate {
 	}
 
 	for _, nd := range newD {
-		descriptor := nd.(map[string]interface{})
+		descriptor := nd.(map[string]any)
 
 		if len(updates) == ipSetUpdatesLimit {
 			updatesBatches = append(updatesBatches, updates)

--- a/internal/service/wafregional/ipset.go
+++ b/internal/service/wafregional/ipset.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_ipset", name="IPSet")

--- a/internal/service/wafregional/ipset_data_source.go
+++ b/internal/service/wafregional/ipset_data_source.go
@@ -32,7 +32,7 @@ func dataSourceIPSet() *schema.Resource {
 	}
 }
 
-func dataSourceIPSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIPSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 

--- a/internal/service/wafregional/rate_based_rule.go
+++ b/internal/service/wafregional/rate_based_rule.go
@@ -91,13 +91,13 @@ func resourceRateBasedRule() *schema.Resource {
 	}
 }
 
-func resourceRateBasedRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRateBasedRuleCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	outputRaw, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	outputRaw, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.CreateRateBasedRuleInput{
 			ChangeToken: token,
 			MetricName:  aws.String(d.Get(names.AttrMetricName).(string)),
@@ -117,7 +117,7 @@ func resourceRateBasedRuleCreate(ctx context.Context, d *schema.ResourceData, me
 	d.SetId(aws.ToString(outputRaw.(*wafregional.CreateRateBasedRuleOutput).Rule.RuleId))
 
 	if newPredicates := d.Get("predicate").(*schema.Set).List(); len(newPredicates) > 0 {
-		var oldPredicates []interface{}
+		var oldPredicates []any
 
 		if err := updateRateBasedRule(ctx, conn, region, d.Id(), d.Get("rate_limit").(int), oldPredicates, newPredicates); err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
@@ -127,7 +127,7 @@ func resourceRateBasedRuleCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceRateBasedRuleRead(ctx, d, meta)...)
 }
 
-func resourceRateBasedRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRateBasedRuleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -143,10 +143,10 @@ func resourceRateBasedRuleRead(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "reading WAF Regional Rate Based Rule (%s): %s", d.Id(), err)
 	}
 
-	var predicates []map[string]interface{}
+	var predicates []map[string]any
 
 	for _, predicateSet := range rule.MatchPredicates {
-		predicates = append(predicates, map[string]interface{}{
+		predicates = append(predicates, map[string]any{
 			"data_id":      aws.ToString(predicateSet.DataId),
 			"negated":      aws.ToBool(predicateSet.Negated),
 			names.AttrType: predicateSet.Type,
@@ -172,7 +172,7 @@ func resourceRateBasedRuleRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceRateBasedRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRateBasedRuleUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -188,20 +188,20 @@ func resourceRateBasedRuleUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceRateBasedRuleRead(ctx, d, meta)...)
 }
 
-func resourceRateBasedRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRateBasedRuleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if oldPredicates := d.Get("predicate").(*schema.Set).List(); len(oldPredicates) > 0 {
-		var newPredicates []interface{}
+		var newPredicates []any
 		if err := updateRateBasedRule(ctx, conn, region, d.Id(), d.Get("rate_limit").(int), oldPredicates, newPredicates); err != nil && !errs.IsA[*awstypes.WAFNonexistentItemException](err) && !errs.IsA[*awstypes.WAFNonexistentContainerException](err) {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	log.Printf("[INFO] Deleting WAF Regional Rate Based Rule: %s", d.Id())
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteRateBasedRuleInput{
 			ChangeToken: token,
 			RuleId:      aws.String(d.Id()),
@@ -246,8 +246,8 @@ func findRateBasedRuleByID(ctx context.Context, conn *wafregional.Client, id str
 	return output.Rule, nil
 }
 
-func updateRateBasedRule(ctx context.Context, conn *wafregional.Client, region, ruleID string, rateLimit int, oldP, newP []interface{}) error {
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+func updateRateBasedRule(ctx context.Context, conn *wafregional.Client, region, ruleID string, rateLimit int, oldP, newP []any) error {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.UpdateRateBasedRuleInput{
 			ChangeToken: token,
 			RateLimit:   aws.Int64(int64(rateLimit)),

--- a/internal/service/wafregional/rate_based_rule_data_source.go
+++ b/internal/service/wafregional/rate_based_rule_data_source.go
@@ -32,7 +32,7 @@ func dataSourceRateBasedRule() *schema.Resource {
 	}
 }
 
-func dataSourceRateBasedRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceRateBasedRuleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 

--- a/internal/service/wafregional/regex_match_set.go
+++ b/internal/service/wafregional/regex_match_set.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_regex_match_set", name="Regex Match Set")

--- a/internal/service/wafregional/regex_match_set.go
+++ b/internal/service/wafregional/regex_match_set.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKResource("aws_wafregional_regex_match_set", name="Regex Match Set")
@@ -57,7 +58,7 @@ func resourceRegexMatchSet() *schema.Resource {
 									"data": {
 										Type:     schema.TypeString,
 										Optional: true,
-										StateFunc: func(v interface{}) string {
+										StateFunc: func(v any) string {
 											return strings.ToLower(v.(string))
 										},
 									},
@@ -83,13 +84,13 @@ func resourceRegexMatchSet() *schema.Resource {
 	}
 }
 
-func resourceRegexMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegexMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	outputRaw, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	outputRaw, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.CreateRegexMatchSetInput{
 			ChangeToken: token,
 			Name:        aws.String(name),
@@ -107,7 +108,7 @@ func resourceRegexMatchSetCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceRegexMatchSetUpdate(ctx, d, meta)...)
 }
 
-func resourceRegexMatchSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegexMatchSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -131,7 +132,7 @@ func resourceRegexMatchSetRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceRegexMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegexMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -147,20 +148,20 @@ func resourceRegexMatchSetUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceRegexMatchSetRead(ctx, d, meta)...)
 }
 
-func resourceRegexMatchSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegexMatchSetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if oldT := d.Get("regex_match_tuple").(*schema.Set).List(); len(oldT) > 0 {
-		var newT []interface{}
+		var newT []any
 		if err := updateRegexMatchSet(ctx, conn, region, d.Id(), oldT, newT); err != nil && !errs.IsA[*awstypes.WAFNonexistentItemException](err) && !errs.IsA[*awstypes.WAFNonexistentContainerException](err) {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	log.Printf("[INFO] Deleting WAF Regional Regex Match Set: %s", d.Id())
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteRegexMatchSetInput{
 			ChangeToken:     token,
 			RegexMatchSetId: aws.String(d.Id()),
@@ -205,8 +206,8 @@ func findRegexMatchSetByID(ctx context.Context, conn *wafregional.Client, id str
 	return output.RegexMatchSet, nil
 }
 
-func updateRegexMatchSet(ctx context.Context, conn *wafregional.Client, region, regexMatchSetID string, oldT, newT []interface{}) error {
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+func updateRegexMatchSet(ctx context.Context, conn *wafregional.Client, region, regexMatchSetID string, oldT, newT []any) error {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.UpdateRegexMatchSetInput{
 			ChangeToken:     token,
 			RegexMatchSetId: aws.String(regexMatchSetID),
@@ -223,10 +224,10 @@ func updateRegexMatchSet(ctx context.Context, conn *wafregional.Client, region, 
 	return nil
 }
 
-func flattenRegexMatchTuples(tuples []awstypes.RegexMatchTuple) []interface{} {
-	out := make([]interface{}, len(tuples))
+func flattenRegexMatchTuples(tuples []awstypes.RegexMatchTuple) []any {
+	out := make([]any, len(tuples))
 	for i, t := range tuples {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 
 		if t.FieldToMatch != nil {
 			m["field_to_match"] = flattenFieldToMatch(t.FieldToMatch)
@@ -239,23 +240,23 @@ func flattenRegexMatchTuples(tuples []awstypes.RegexMatchTuple) []interface{} {
 	return out
 }
 
-func expandRegexMatchTuple(tuple map[string]interface{}) *awstypes.RegexMatchTuple {
-	ftm := tuple["field_to_match"].([]interface{})
+func expandRegexMatchTuple(tuple map[string]any) *awstypes.RegexMatchTuple {
+	ftm := tuple["field_to_match"].([]any)
 	return &awstypes.RegexMatchTuple{
-		FieldToMatch:       expandFieldToMatch(ftm[0].(map[string]interface{})),
+		FieldToMatch:       expandFieldToMatch(ftm[0].(map[string]any)),
 		RegexPatternSetId:  aws.String(tuple["regex_pattern_set_id"].(string)),
 		TextTransformation: awstypes.TextTransformation(tuple["text_transformation"].(string)),
 	}
 }
 
-func diffRegexMatchSetTuples(oldT, newT []interface{}) []awstypes.RegexMatchSetUpdate {
+func diffRegexMatchSetTuples(oldT, newT []any) []awstypes.RegexMatchSetUpdate {
 	updates := make([]awstypes.RegexMatchSetUpdate, 0)
 
 	for _, ot := range oldT {
-		tuple := ot.(map[string]interface{})
+		tuple := ot.(map[string]any)
 
 		if idx, contains := sliceContainsMap(newT, tuple); contains {
-			newT = append(newT[:idx], newT[idx+1:]...)
+			newT = slices.Delete(newT, idx, idx+1)
 			continue
 		}
 
@@ -266,7 +267,7 @@ func diffRegexMatchSetTuples(oldT, newT []interface{}) []awstypes.RegexMatchSetU
 	}
 
 	for _, nt := range newT {
-		tuple := nt.(map[string]interface{})
+		tuple := nt.(map[string]any)
 
 		updates = append(updates, awstypes.RegexMatchSetUpdate{
 			Action:          awstypes.ChangeActionInsert,
@@ -276,12 +277,12 @@ func diffRegexMatchSetTuples(oldT, newT []interface{}) []awstypes.RegexMatchSetU
 	return updates
 }
 
-func regexMatchSetTupleHash(v interface{}) int {
+func regexMatchSetTupleHash(v any) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m := v.(map[string]any)
 	if v, ok := m["field_to_match"]; ok {
-		ftms := v.([]interface{})
-		ftm := ftms[0].(map[string]interface{})
+		ftms := v.([]any)
+		ftm := ftms[0].(map[string]any)
 
 		if v, ok := ftm["data"]; ok {
 			buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(v.(string))))

--- a/internal/service/wafregional/regex_match_set_test.go
+++ b/internal/service/wafregional/regex_match_set_test.go
@@ -295,7 +295,7 @@ resource "aws_wafregional_regex_match_set" "test" {
 
 func computeRegexMatchSetTuple(patternSet *awstypes.RegexPatternSet, fieldToMatch *awstypes.FieldToMatch, textTransformation string, idx *int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"field_to_match":       tfwafregional.FlattenFieldToMatch(fieldToMatch),
 			"regex_pattern_set_id": *patternSet.RegexPatternSetId,
 			"text_transformation":  textTransformation,

--- a/internal/service/wafregional/regex_pattern_set.go
+++ b/internal/service/wafregional/regex_pattern_set.go
@@ -20,6 +20,7 @@ import (
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKResource("aws_wafregional_regex_pattern_set", name="Regex Pattern Set")
@@ -49,13 +50,13 @@ func resourceRegexPatternSet() *schema.Resource {
 	}
 }
 
-func resourceRegexPatternSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegexPatternSetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	outputRaw, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	outputRaw, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.CreateRegexPatternSetInput{
 			ChangeToken: token,
 			Name:        aws.String(name),
@@ -73,7 +74,7 @@ func resourceRegexPatternSetCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceRegexPatternSetUpdate(ctx, d, meta)...)
 }
 
-func resourceRegexPatternSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegexPatternSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -95,7 +96,7 @@ func resourceRegexPatternSetRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceRegexPatternSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegexPatternSetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -111,20 +112,20 @@ func resourceRegexPatternSetUpdate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceRegexPatternSetRead(ctx, d, meta)...)
 }
 
-func resourceRegexPatternSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegexPatternSetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if oldPatterns := d.Get("regex_pattern_strings").(*schema.Set).List(); len(oldPatterns) > 0 {
-		var newPatterns []interface{}
+		var newPatterns []any
 		if err := updateRegexPatternSet(ctx, conn, region, d.Id(), oldPatterns, newPatterns); err != nil && !errs.IsA[*awstypes.WAFNonexistentItemException](err) && !errs.IsA[*awstypes.WAFNonexistentContainerException](err) {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	log.Printf("[INFO] Deleting WAF Regional Regex Pattern Set: %s", d.Id())
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteRegexPatternSetInput{
 			ChangeToken:       token,
 			RegexPatternSetId: aws.String(d.Id()),
@@ -169,8 +170,8 @@ func findRegexPatternSetByID(ctx context.Context, conn *wafregional.Client, id s
 	return output.RegexPatternSet, nil
 }
 
-func updateRegexPatternSet(ctx context.Context, conn *wafregional.Client, region, regexPatternSetID string, oldPatterns, newPatterns []interface{}) error {
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+func updateRegexPatternSet(ctx context.Context, conn *wafregional.Client, region, regexPatternSetID string, oldPatterns, newPatterns []any) error {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.UpdateRegexPatternSetInput{
 			ChangeToken:       token,
 			RegexPatternSetId: aws.String(regexPatternSetID),
@@ -187,12 +188,12 @@ func updateRegexPatternSet(ctx context.Context, conn *wafregional.Client, region
 	return nil
 }
 
-func diffRegexPatternSetPatternStrings(oldPatterns, newPatterns []interface{}) []awstypes.RegexPatternSetUpdate {
+func diffRegexPatternSetPatternStrings(oldPatterns, newPatterns []any) []awstypes.RegexPatternSetUpdate {
 	updates := make([]awstypes.RegexPatternSetUpdate, 0)
 
 	for _, op := range oldPatterns {
 		if idx := tfslices.IndexOf(newPatterns, op.(string)); idx > -1 {
-			newPatterns = append(newPatterns[:idx], newPatterns[idx+1:]...)
+			newPatterns = slices.Delete(newPatterns, idx, idx+1)
 			continue
 		}
 

--- a/internal/service/wafregional/regex_pattern_set.go
+++ b/internal/service/wafregional/regex_pattern_set.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/wafregional"
@@ -20,7 +21,6 @@ import (
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_regex_pattern_set", name="Regex Pattern Set")

--- a/internal/service/wafregional/rule.go
+++ b/internal/service/wafregional/rule.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -23,7 +24,6 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_rule", name="Rule")

--- a/internal/service/wafregional/rule.go
+++ b/internal/service/wafregional/rule.go
@@ -23,6 +23,7 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKResource("aws_wafregional_rule", name="Rule")
@@ -81,13 +82,13 @@ func resourceRule() *schema.Resource {
 	}
 }
 
-func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	outputRaw, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	outputRaw, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.CreateRuleInput{
 			ChangeToken: token,
 			MetricName:  aws.String(d.Get(names.AttrMetricName).(string)),
@@ -105,7 +106,7 @@ func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	d.SetId(aws.ToString(outputRaw.(*wafregional.CreateRuleOutput).Rule.RuleId))
 
 	if newPredicates := d.Get("predicate").(*schema.Set).List(); len(newPredicates) > 0 {
-		var oldPredicates []interface{}
+		var oldPredicates []any
 		if err := updateRule(ctx, conn, region, d.Id(), oldPredicates, newPredicates); err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
@@ -114,7 +115,7 @@ func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceRuleRead(ctx, d, meta)...)
 }
 
-func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -147,7 +148,7 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	return diags
 }
 
-func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -163,20 +164,20 @@ func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceRuleRead(ctx, d, meta)...)
 }
 
-func resourceRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRuleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if oldPredicates := d.Get("predicate").(*schema.Set).List(); len(oldPredicates) > 0 {
-		var newPredicates []interface{}
+		var newPredicates []any
 		if err := updateRule(ctx, conn, region, d.Id(), oldPredicates, newPredicates); err != nil && !errs.IsA[*awstypes.WAFNonexistentItemException](err) && !errs.IsA[*awstypes.WAFNonexistentContainerException](err) {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	log.Printf("[INFO] Deleting WAF Regional Rule: %s", d.Id())
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteRuleInput{
 			ChangeToken: token,
 			RuleId:      aws.String(d.Id()),
@@ -221,8 +222,8 @@ func findRuleByID(ctx context.Context, conn *wafregional.Client, id string) (*aw
 	return output.Rule, nil
 }
 
-func updateRule(ctx context.Context, conn *wafregional.Client, region, ruleID string, oldP, newP []interface{}) error {
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+func updateRule(ctx context.Context, conn *wafregional.Client, region, ruleID string, oldP, newP []any) error {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.UpdateRuleInput{
 			ChangeToken: token,
 			RuleId:      aws.String(ruleID),
@@ -239,10 +240,10 @@ func updateRule(ctx context.Context, conn *wafregional.Client, region, ruleID st
 	return nil
 }
 
-func flattenPredicates(ts []awstypes.Predicate) []interface{} {
-	out := make([]interface{}, len(ts))
+func flattenPredicates(ts []awstypes.Predicate) []any {
+	out := make([]any, len(ts))
 	for i, p := range ts {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 		m["negated"] = aws.ToBool(p.Negated)
 		m[names.AttrType] = p.Type
 		m["data_id"] = aws.ToString(p.DataId)
@@ -251,14 +252,14 @@ func flattenPredicates(ts []awstypes.Predicate) []interface{} {
 	return out
 }
 
-func diffRulePredicates(oldP, newP []interface{}) []awstypes.RuleUpdate {
+func diffRulePredicates(oldP, newP []any) []awstypes.RuleUpdate {
 	updates := make([]awstypes.RuleUpdate, 0)
 
 	for _, op := range oldP {
-		predicate := op.(map[string]interface{})
+		predicate := op.(map[string]any)
 
 		if idx, contains := sliceContainsMap(newP, predicate); contains {
-			newP = append(newP[:idx], newP[idx+1:]...)
+			newP = slices.Delete(newP, idx, idx+1)
 			continue
 		}
 
@@ -273,7 +274,7 @@ func diffRulePredicates(oldP, newP []interface{}) []awstypes.RuleUpdate {
 	}
 
 	for _, np := range newP {
-		predicate := np.(map[string]interface{})
+		predicate := np.(map[string]any)
 
 		updates = append(updates, awstypes.RuleUpdate{
 			Action: awstypes.ChangeActionInsert,

--- a/internal/service/wafregional/rule_data_source.go
+++ b/internal/service/wafregional/rule_data_source.go
@@ -32,7 +32,7 @@ func dataSourceRule() *schema.Resource {
 	}
 }
 
-func dataSourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceRuleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 

--- a/internal/service/wafregional/rule_group.go
+++ b/internal/service/wafregional/rule_group.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -21,7 +22,6 @@ import (
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_rule_group", name="Rule Group")

--- a/internal/service/wafregional/rule_group_test.go
+++ b/internal/service/wafregional/rule_group_test.go
@@ -471,9 +471,9 @@ func computeActivatedRuleWithRuleId(rule *awstypes.Rule, actionType string, prio
 	return func(s *terraform.State) error {
 		ruleResource := tfwafregional.ResourceRuleGroup().SchemaMap()["activated_rule"].Elem.(*schema.Resource)
 
-		m := map[string]interface{}{
-			names.AttrAction: []interface{}{
-				map[string]interface{}{
+		m := map[string]any{
+			names.AttrAction: []any{
+				map[string]any{
 					names.AttrType: actionType,
 				},
 			},

--- a/internal/service/wafregional/rule_test.go
+++ b/internal/service/wafregional/rule_test.go
@@ -253,7 +253,7 @@ func TestAccWAFRegionalRule_changePredicates(t *testing.T) {
 func computeRulePredicate(dataId **string, negated bool, pType string, idx *int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		predicateResource := tfwafregional.ResourceRule().SchemaMap()["predicate"].Elem.(*schema.Resource)
-		m := map[string]interface{}{
+		m := map[string]any{
 			"data_id":      **dataId,
 			"negated":      negated,
 			names.AttrType: pType,

--- a/internal/service/wafregional/size_constraint_set.go
+++ b/internal/service/wafregional/size_constraint_set.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/wafregional"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_size_constraint_set", name="Size Constraint Set")

--- a/internal/service/wafregional/size_constraint_set.go
+++ b/internal/service/wafregional/size_constraint_set.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKResource("aws_wafregional_size_constraint_set", name="Size Constraint Set")
@@ -84,13 +85,13 @@ func resourceSizeConstraintSet() *schema.Resource {
 	}
 }
 
-func resourceSizeConstraintSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSizeConstraintSetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.CreateSizeConstraintSetInput{
 			ChangeToken: token,
 			Name:        aws.String(name),
@@ -108,7 +109,7 @@ func resourceSizeConstraintSetCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceSizeConstraintSetUpdate(ctx, d, meta)...)
 }
 
-func resourceSizeConstraintSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSizeConstraintSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -132,7 +133,7 @@ func resourceSizeConstraintSetRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceSizeConstraintSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSizeConstraintSetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -148,20 +149,20 @@ func resourceSizeConstraintSetUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceSizeConstraintSetRead(ctx, d, meta)...)
 }
 
-func resourceSizeConstraintSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSizeConstraintSetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if oldConstraints := d.Get("size_constraints").(*schema.Set).List(); len(oldConstraints) > 0 {
-		noConstraints := []interface{}{}
+		noConstraints := []any{}
 		if err := updateSizeConstraintSet(ctx, conn, region, d.Id(), oldConstraints, noConstraints); err != nil && !errs.IsA[*awstypes.WAFNonexistentItemException](err) && !errs.IsA[*awstypes.WAFNonexistentContainerException](err) {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	log.Printf("[INFO] Deleting WAF Regional Size Constraint Set: %s", d.Id())
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteSizeConstraintSetInput{
 			ChangeToken:         token,
 			SizeConstraintSetId: aws.String(d.Id()),
@@ -206,8 +207,8 @@ func findSizeConstraintSetByID(ctx context.Context, conn *wafregional.Client, id
 	return output.SizeConstraintSet, nil
 }
 
-func updateSizeConstraintSet(ctx context.Context, conn *wafregional.Client, region, id string, oldConstraints, newConstraints []interface{}) error {
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+func updateSizeConstraintSet(ctx context.Context, conn *wafregional.Client, region, id string, oldConstraints, newConstraints []any) error {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.UpdateSizeConstraintSetInput{
 			ChangeToken:         token,
 			SizeConstraintSetId: aws.String(id),
@@ -224,21 +225,21 @@ func updateSizeConstraintSet(ctx context.Context, conn *wafregional.Client, regi
 	return nil
 }
 
-func diffSizeConstraints(oldS, newS []interface{}) []awstypes.SizeConstraintSetUpdate {
+func diffSizeConstraints(oldS, newS []any) []awstypes.SizeConstraintSetUpdate {
 	updates := make([]awstypes.SizeConstraintSetUpdate, 0)
 
 	for _, os := range oldS {
-		constraint := os.(map[string]interface{})
+		constraint := os.(map[string]any)
 
 		if idx, contains := sliceContainsMap(newS, constraint); contains {
-			newS = append(newS[:idx], newS[idx+1:]...)
+			newS = slices.Delete(newS, idx, idx+1)
 			continue
 		}
 
 		updates = append(updates, awstypes.SizeConstraintSetUpdate{
 			Action: awstypes.ChangeActionDelete,
 			SizeConstraint: &awstypes.SizeConstraint{
-				FieldToMatch:       expandFieldToMatch(constraint["field_to_match"].([]interface{})[0].(map[string]interface{})),
+				FieldToMatch:       expandFieldToMatch(constraint["field_to_match"].([]any)[0].(map[string]any)),
 				ComparisonOperator: awstypes.ComparisonOperator(constraint["comparison_operator"].(string)),
 				Size:               int64(constraint[names.AttrSize].(int)),
 				TextTransformation: awstypes.TextTransformation(constraint["text_transformation"].(string)),
@@ -247,12 +248,12 @@ func diffSizeConstraints(oldS, newS []interface{}) []awstypes.SizeConstraintSetU
 	}
 
 	for _, ns := range newS {
-		constraint := ns.(map[string]interface{})
+		constraint := ns.(map[string]any)
 
 		updates = append(updates, awstypes.SizeConstraintSetUpdate{
 			Action: awstypes.ChangeActionInsert,
 			SizeConstraint: &awstypes.SizeConstraint{
-				FieldToMatch:       expandFieldToMatch(constraint["field_to_match"].([]interface{})[0].(map[string]interface{})),
+				FieldToMatch:       expandFieldToMatch(constraint["field_to_match"].([]any)[0].(map[string]any)),
 				ComparisonOperator: awstypes.ComparisonOperator(constraint["comparison_operator"].(string)),
 				Size:               int64(constraint[names.AttrSize].(int)),
 				TextTransformation: awstypes.TextTransformation(constraint["text_transformation"].(string)),
@@ -262,10 +263,10 @@ func diffSizeConstraints(oldS, newS []interface{}) []awstypes.SizeConstraintSetU
 	return updates
 }
 
-func flattenSizeConstraints(sc []awstypes.SizeConstraint) []interface{} {
-	out := make([]interface{}, len(sc))
+func flattenSizeConstraints(sc []awstypes.SizeConstraint) []any {
+	out := make([]any, len(sc))
 	for i, c := range sc {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 		m["comparison_operator"] = c.ComparisonOperator
 		if c.FieldToMatch != nil {
 			m["field_to_match"] = flattenFieldToMatch(c.FieldToMatch)

--- a/internal/service/wafregional/sql_injection_match_set.go
+++ b/internal/service/wafregional/sql_injection_match_set.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKResource("aws_wafregional_sql_injection_match_set", name="SQL Injection Match Set")
@@ -57,7 +58,7 @@ func resourceSQLInjectionMatchSet() *schema.Resource {
 									"data": {
 										Type:     schema.TypeString,
 										Optional: true,
-										StateFunc: func(v interface{}) string {
+										StateFunc: func(v any) string {
 											value := v.(string)
 											return strings.ToLower(value)
 										},
@@ -80,13 +81,13 @@ func resourceSQLInjectionMatchSet() *schema.Resource {
 	}
 }
 
-func resourceSQLInjectionMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSQLInjectionMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		params := &wafregional.CreateSqlInjectionMatchSetInput{
 			ChangeToken: token,
 			Name:        aws.String(name),
@@ -104,7 +105,7 @@ func resourceSQLInjectionMatchSetCreate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceSQLInjectionMatchSetUpdate(ctx, d, meta)...)
 }
 
-func resourceSQLInjectionMatchSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSQLInjectionMatchSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -128,7 +129,7 @@ func resourceSQLInjectionMatchSetRead(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceSQLInjectionMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSQLInjectionMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -144,19 +145,19 @@ func resourceSQLInjectionMatchSetUpdate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceSQLInjectionMatchSetRead(ctx, d, meta)...)
 }
 
-func resourceSQLInjectionMatchSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSQLInjectionMatchSetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if oldTuples := d.Get("sql_injection_match_tuple").(*schema.Set).List(); len(oldTuples) > 0 {
-		noTuples := []interface{}{}
+		noTuples := []any{}
 		if err := updateSQLInjectionMatchSet(ctx, conn, region, d.Id(), oldTuples, noTuples); err != nil && !errs.IsA[*awstypes.WAFNonexistentItemException](err) && !errs.IsA[*awstypes.WAFNonexistentContainerException](err) {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteSqlInjectionMatchSetInput{
 			ChangeToken:            token,
 			SqlInjectionMatchSetId: aws.String(d.Id()),
@@ -201,8 +202,8 @@ func findSQLInjectionMatchSetByID(ctx context.Context, conn *wafregional.Client,
 	return output.SqlInjectionMatchSet, nil
 }
 
-func updateSQLInjectionMatchSet(ctx context.Context, conn *wafregional.Client, region, id string, oldT, newT []interface{}) error {
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+func updateSQLInjectionMatchSet(ctx context.Context, conn *wafregional.Client, region, id string, oldT, newT []any) error {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.UpdateSqlInjectionMatchSetInput{
 			ChangeToken:            token,
 			SqlInjectionMatchSetId: aws.String(id),
@@ -219,36 +220,36 @@ func updateSQLInjectionMatchSet(ctx context.Context, conn *wafregional.Client, r
 	return nil
 }
 
-func diffSQLInjectionMatchTuplesWR(oldT, newT []interface{}) []awstypes.SqlInjectionMatchSetUpdate {
+func diffSQLInjectionMatchTuplesWR(oldT, newT []any) []awstypes.SqlInjectionMatchSetUpdate {
 	updates := make([]awstypes.SqlInjectionMatchSetUpdate, 0)
 
 	for _, od := range oldT {
-		tuple := od.(map[string]interface{})
+		tuple := od.(map[string]any)
 
 		if idx, contains := sliceContainsMap(newT, tuple); contains {
-			newT = append(newT[:idx], newT[idx+1:]...)
+			newT = slices.Delete(newT, idx, idx+1)
 			continue
 		}
 
-		ftm := tuple["field_to_match"].([]interface{})
+		ftm := tuple["field_to_match"].([]any)
 
 		updates = append(updates, awstypes.SqlInjectionMatchSetUpdate{
 			Action: awstypes.ChangeActionDelete,
 			SqlInjectionMatchTuple: &awstypes.SqlInjectionMatchTuple{
-				FieldToMatch:       expandFieldToMatch(ftm[0].(map[string]interface{})),
+				FieldToMatch:       expandFieldToMatch(ftm[0].(map[string]any)),
 				TextTransformation: awstypes.TextTransformation(tuple["text_transformation"].(string)),
 			},
 		})
 	}
 
 	for _, nd := range newT {
-		tuple := nd.(map[string]interface{})
-		ftm := tuple["field_to_match"].([]interface{})
+		tuple := nd.(map[string]any)
+		ftm := tuple["field_to_match"].([]any)
 
 		updates = append(updates, awstypes.SqlInjectionMatchSetUpdate{
 			Action: awstypes.ChangeActionInsert,
 			SqlInjectionMatchTuple: &awstypes.SqlInjectionMatchTuple{
-				FieldToMatch:       expandFieldToMatch(ftm[0].(map[string]interface{})),
+				FieldToMatch:       expandFieldToMatch(ftm[0].(map[string]any)),
 				TextTransformation: awstypes.TextTransformation(tuple["text_transformation"].(string)),
 			},
 		})
@@ -256,12 +257,12 @@ func diffSQLInjectionMatchTuplesWR(oldT, newT []interface{}) []awstypes.SqlInjec
 	return updates
 }
 
-func resourceSQLInjectionMatchSetTupleHash(v interface{}) int {
+func resourceSQLInjectionMatchSetTupleHash(v any) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m := v.(map[string]any)
 	if v, ok := m["field_to_match"]; ok {
-		ftms := v.([]interface{})
-		ftm := ftms[0].(map[string]interface{})
+		ftms := v.([]any)
+		ftm := ftms[0].(map[string]any)
 
 		if v, ok := ftm["data"]; ok {
 			buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(v.(string))))
@@ -273,10 +274,10 @@ func resourceSQLInjectionMatchSetTupleHash(v interface{}) int {
 	return create.StringHashcode(buf.String())
 }
 
-func flattenSQLInjectionMatchTuples(ts []awstypes.SqlInjectionMatchTuple) []interface{} {
-	out := make([]interface{}, len(ts))
+func flattenSQLInjectionMatchTuples(ts []awstypes.SqlInjectionMatchTuple) []any {
+	out := make([]any, len(ts))
 	for i, t := range ts {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 		m["text_transformation"] = t.TextTransformation
 		m["field_to_match"] = flattenFieldToMatch(t.FieldToMatch)
 		out[i] = m

--- a/internal/service/wafregional/sql_injection_match_set.go
+++ b/internal/service/wafregional/sql_injection_match_set.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_sql_injection_match_set", name="SQL Injection Match Set")

--- a/internal/service/wafregional/subscribed_rule_group_data_source.go
+++ b/internal/service/wafregional/subscribed_rule_group_data_source.go
@@ -38,7 +38,7 @@ func dataSourceSubscribedRuleGroup() *schema.Resource {
 	}
 }
 
-func dataSourceSubscribedRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSubscribedRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 

--- a/internal/service/wafregional/token_handlers.go
+++ b/internal/service/wafregional/token_handlers.go
@@ -19,9 +19,9 @@ type retryer struct {
 	region     string
 }
 
-type withTokenFunc func(token *string) (interface{}, error)
+type withTokenFunc func(token *string) (any, error)
 
-func (t *retryer) RetryWithToken(ctx context.Context, f withTokenFunc) (interface{}, error) {
+func (t *retryer) RetryWithToken(ctx context.Context, f withTokenFunc) (any, error) {
 	key := "WafRetryer-" + t.region
 	conns.GlobalMutexKV.Lock(key)
 	defer conns.GlobalMutexKV.Unlock(key)
@@ -29,7 +29,7 @@ func (t *retryer) RetryWithToken(ctx context.Context, f withTokenFunc) (interfac
 	const (
 		timeout = 15 * time.Minute
 	)
-	return tfresource.RetryWhenIsA[*awstypes.WAFStaleDataException](ctx, timeout, func() (interface{}, error) {
+	return tfresource.RetryWhenIsA[*awstypes.WAFStaleDataException](ctx, timeout, func() (any, error) {
 		input := &wafregional.GetChangeTokenInput{}
 		output, err := t.connection.GetChangeToken(ctx, input)
 

--- a/internal/service/wafregional/validate.go
+++ b/internal/service/wafregional/validate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/YakDriver/regexache"
 )
 
-func validMetricName(v interface{}, k string) (ws []string, errors []error) {
+func validMetricName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9A-Za-z]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -20,9 +20,9 @@ func validMetricName(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func sliceContainsMap(l []interface{}, m map[string]interface{}) (int, bool) {
+func sliceContainsMap(l []any, m map[string]any) (int, bool) {
 	for i, t := range l {
-		if reflect.DeepEqual(m, t.(map[string]interface{})) {
+		if reflect.DeepEqual(m, t.(map[string]any)) {
 			return i, true
 		}
 	}

--- a/internal/service/wafregional/web_acl.go
+++ b/internal/service/wafregional/web_acl.go
@@ -6,6 +6,7 @@ package wafregional
 import (
 	"context"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -22,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_web_acl", name="Web ACL")

--- a/internal/service/wafregional/web_acl.go
+++ b/internal/service/wafregional/web_acl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKResource("aws_wafregional_web_acl", name="Web ACL")
@@ -162,16 +163,16 @@ func resourceWebACL() *schema.Resource {
 	}
 }
 
-func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.CreateWebACLInput{
 			ChangeToken:   token,
-			DefaultAction: expandAction(d.Get(names.AttrDefaultAction).([]interface{})),
+			DefaultAction: expandAction(d.Get(names.AttrDefaultAction).([]any)),
 			MetricName:    aws.String(d.Get(names.AttrMetricName).(string)),
 			Name:          aws.String(name),
 			Tags:          getTagsIn(ctx),
@@ -186,7 +187,7 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(aws.ToString(output.(*wafregional.CreateWebACLOutput).WebACL.WebACLId))
 
-	if loggingConfiguration := d.Get(names.AttrLoggingConfiguration).([]interface{}); len(loggingConfiguration) == 1 {
+	if loggingConfiguration := d.Get(names.AttrLoggingConfiguration).([]any); len(loggingConfiguration) == 1 {
 		arn := arn.ARN{
 			Partition: meta.(*conns.AWSClient).Partition(ctx),
 			Service:   "waf-regional",
@@ -207,11 +208,11 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if rules := d.Get(names.AttrRule).(*schema.Set).List(); len(rules) > 0 {
-		_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+		_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 			input := &wafregional.UpdateWebACLInput{
 				ChangeToken:   token,
-				DefaultAction: expandAction(d.Get(names.AttrDefaultAction).([]interface{})),
-				Updates:       diffWebACLRules([]interface{}{}, rules),
+				DefaultAction: expandAction(d.Get(names.AttrDefaultAction).([]any)),
+				Updates:       diffWebACLRules([]any{}, rules),
 				WebACLId:      aws.String(d.Id()),
 			}
 
@@ -226,7 +227,7 @@ func resourceWebACLCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceWebACLRead(ctx, d, meta)...)
 }
 
-func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -265,7 +266,7 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	output, err := conn.GetLoggingConfiguration(ctx, input)
 
-	loggingConfiguration := []interface{}{}
+	loggingConfiguration := []any{}
 	switch {
 	case err == nil:
 		loggingConfiguration = flattenLoggingConfiguration(output.LoggingConfiguration)
@@ -281,7 +282,7 @@ func resourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -290,10 +291,10 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		o, n := d.GetChange(names.AttrRule)
 		oldR, newR := o.(*schema.Set).List(), n.(*schema.Set).List()
 
-		_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+		_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 			input := &wafregional.UpdateWebACLInput{
 				ChangeToken:   token,
-				DefaultAction: expandAction(d.Get(names.AttrDefaultAction).([]interface{})),
+				DefaultAction: expandAction(d.Get(names.AttrDefaultAction).([]any)),
 				Updates:       diffWebACLRules(oldR, newR),
 				WebACLId:      aws.String(d.Id()),
 			}
@@ -307,7 +308,7 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if d.HasChange(names.AttrLoggingConfiguration) {
-		if loggingConfiguration := d.Get(names.AttrLoggingConfiguration).([]interface{}); len(loggingConfiguration) == 1 {
+		if loggingConfiguration := d.Get(names.AttrLoggingConfiguration).([]any); len(loggingConfiguration) == 1 {
 			input := &wafregional.PutLoggingConfigurationInput{
 				LoggingConfiguration: expandLoggingConfiguration(loggingConfiguration, d.Get(names.AttrARN).(string)),
 			}
@@ -333,17 +334,17 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceWebACLRead(ctx, d, meta)...)
 }
 
-func resourceWebACLDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWebACLDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if rules := d.Get(names.AttrRule).(*schema.Set).List(); len(rules) > 0 {
-		_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+		_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 			input := &wafregional.UpdateWebACLInput{
 				ChangeToken:   token,
-				DefaultAction: expandAction(d.Get(names.AttrDefaultAction).([]interface{})),
-				Updates:       diffWebACLRules(rules, []interface{}{}),
+				DefaultAction: expandAction(d.Get(names.AttrDefaultAction).([]any)),
+				Updates:       diffWebACLRules(rules, []any{}),
 				WebACLId:      aws.String(d.Id()),
 			}
 
@@ -356,7 +357,7 @@ func resourceWebACLDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[INFO] Deleting WAF Regional Web ACL: %s", d.Id())
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteWebACLInput{
 			ChangeToken: token,
 			WebACLId:    aws.String(d.Id()),
@@ -401,30 +402,30 @@ func findWebACLByID(ctx context.Context, conn *wafregional.Client, id string) (*
 	return output.WebACL, nil
 }
 
-func expandLoggingConfiguration(l []interface{}, resourceARN string) *awstypes.LoggingConfiguration {
+func expandLoggingConfiguration(l []any, resourceARN string) *awstypes.LoggingConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	loggingConfiguration := &awstypes.LoggingConfiguration{
 		LogDestinationConfigs: []string{
 			m["log_destination"].(string),
 		},
-		RedactedFields: expandRedactedFields(m["redacted_fields"].([]interface{})),
+		RedactedFields: expandRedactedFields(m["redacted_fields"].([]any)),
 		ResourceArn:    aws.String(resourceARN),
 	}
 
 	return loggingConfiguration
 }
 
-func expandRedactedFields(l []interface{}) []awstypes.FieldToMatch {
+func expandRedactedFields(l []any) []awstypes.FieldToMatch {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	if m["field_to_match"] == nil {
 		return nil
@@ -437,18 +438,18 @@ func expandRedactedFields(l []interface{}) []awstypes.FieldToMatch {
 			continue
 		}
 
-		redactedFields = append(redactedFields, *expandFieldToMatch(fieldToMatch.(map[string]interface{})))
+		redactedFields = append(redactedFields, *expandFieldToMatch(fieldToMatch.(map[string]any)))
 	}
 
 	return redactedFields
 }
 
-func flattenLoggingConfiguration(loggingConfiguration *awstypes.LoggingConfiguration) []interface{} {
+func flattenLoggingConfiguration(loggingConfiguration *awstypes.LoggingConfiguration) []any {
 	if loggingConfiguration == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"log_destination": "",
 		"redacted_fields": flattenRedactedFields(loggingConfiguration.RedactedFields),
 	}
@@ -457,12 +458,12 @@ func flattenLoggingConfiguration(loggingConfiguration *awstypes.LoggingConfigura
 		m["log_destination"] = loggingConfiguration.LogDestinationConfigs[0]
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenRedactedFields(fieldToMatches []awstypes.FieldToMatch) []interface{} {
+func flattenRedactedFields(fieldToMatches []awstypes.FieldToMatch) []any {
 	if len(fieldToMatches) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
 	fieldToMatchResource := &schema.Resource{
@@ -477,77 +478,77 @@ func flattenRedactedFields(fieldToMatches []awstypes.FieldToMatch) []interface{}
 			},
 		},
 	}
-	l := make([]interface{}, len(fieldToMatches))
+	l := make([]any, len(fieldToMatches))
 
 	for i, fieldToMatch := range fieldToMatches {
 		l[i] = flattenFieldToMatch(&fieldToMatch)[0]
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"field_to_match": schema.NewSet(schema.HashResource(fieldToMatchResource), l),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func diffWebACLRules(oldR, newR []interface{}) []awstypes.WebACLUpdate {
+func diffWebACLRules(oldR, newR []any) []awstypes.WebACLUpdate {
 	updates := make([]awstypes.WebACLUpdate, 0)
 
 	for _, or := range oldR {
-		aclRule := or.(map[string]interface{})
+		aclRule := or.(map[string]any)
 
 		if idx, contains := sliceContainsMap(newR, aclRule); contains {
-			newR = append(newR[:idx], newR[idx+1:]...)
+			newR = slices.Delete(newR, idx, idx+1)
 			continue
 		}
 		updates = append(updates, expandWebACLUpdate(string(awstypes.ChangeActionDelete), aclRule))
 	}
 
 	for _, nr := range newR {
-		aclRule := nr.(map[string]interface{})
+		aclRule := nr.(map[string]any)
 		updates = append(updates, expandWebACLUpdate(string(awstypes.ChangeActionInsert), aclRule))
 	}
 	return updates
 }
 
-func expandAction(l []interface{}) *awstypes.WafAction {
+func expandAction(l []any) *awstypes.WafAction {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	return &awstypes.WafAction{
 		Type: awstypes.WafActionType(m[names.AttrType].(string)),
 	}
 }
 
-func expandOverrideAction(l []interface{}) *awstypes.WafOverrideAction {
+func expandOverrideAction(l []any) *awstypes.WafOverrideAction {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	return &awstypes.WafOverrideAction{
 		Type: awstypes.WafOverrideActionType(m[names.AttrType].(string)),
 	}
 }
 
-func expandWebACLUpdate(updateAction string, aclRule map[string]interface{}) awstypes.WebACLUpdate {
+func expandWebACLUpdate(updateAction string, aclRule map[string]any) awstypes.WebACLUpdate {
 	var rule *awstypes.ActivatedRule
 
 	switch aclRule[names.AttrType].(string) {
 	case string(awstypes.WafRuleTypeGroup):
 		rule = &awstypes.ActivatedRule{
-			OverrideAction: expandOverrideAction(aclRule["override_action"].([]interface{})),
+			OverrideAction: expandOverrideAction(aclRule["override_action"].([]any)),
 			Priority:       aws.Int32(int32(aclRule[names.AttrPriority].(int))),
 			RuleId:         aws.String(aclRule["rule_id"].(string)),
 			Type:           awstypes.WafRuleType(aclRule[names.AttrType].(string)),
 		}
 	default:
 		rule = &awstypes.ActivatedRule{
-			Action:   expandAction(aclRule[names.AttrAction].([]interface{})),
+			Action:   expandAction(aclRule[names.AttrAction].([]any)),
 			Priority: aws.Int32(int32(aclRule[names.AttrPriority].(int))),
 			RuleId:   aws.String(aclRule["rule_id"].(string)),
 			Type:     awstypes.WafRuleType(aclRule[names.AttrType].(string)),
@@ -562,34 +563,34 @@ func expandWebACLUpdate(updateAction string, aclRule map[string]interface{}) aws
 	return update
 }
 
-func flattenAction(n *awstypes.WafAction) []map[string]interface{} {
+func flattenAction(n *awstypes.WafAction) []map[string]any {
 	if n == nil {
 		return nil
 	}
 
-	result := map[string]interface{}{
+	result := map[string]any{
 		names.AttrType: string(n.Type),
 	}
 
-	return []map[string]interface{}{result}
+	return []map[string]any{result}
 }
 
-func flattenWebACLRules(ts []awstypes.ActivatedRule) []map[string]interface{} {
-	out := make([]map[string]interface{}, len(ts))
+func flattenWebACLRules(ts []awstypes.ActivatedRule) []map[string]any {
+	out := make([]map[string]any, len(ts))
 	for i, r := range ts {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 
 		switch r.Type {
 		case awstypes.WafRuleTypeGroup:
-			actionMap := map[string]interface{}{
+			actionMap := map[string]any{
 				names.AttrType: r.OverrideAction.Type,
 			}
-			m["override_action"] = []map[string]interface{}{actionMap}
+			m["override_action"] = []map[string]any{actionMap}
 		default:
-			actionMap := map[string]interface{}{
+			actionMap := map[string]any{
 				names.AttrType: r.Action.Type,
 			}
-			m[names.AttrAction] = []map[string]interface{}{actionMap}
+			m[names.AttrAction] = []map[string]any{actionMap}
 		}
 
 		m[names.AttrPriority] = r.Priority

--- a/internal/service/wafregional/web_acl_association.go
+++ b/internal/service/wafregional/web_acl_association.go
@@ -55,7 +55,7 @@ func resourceWebACLAssociation() *schema.Resource {
 	}
 }
 
-func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -67,7 +67,7 @@ func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData
 		WebACLId:    aws.String(webACLID),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.WAFUnavailableEntityException](ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
 		return conn.AssociateWebACL(ctx, input)
 	})
 
@@ -80,7 +80,7 @@ func resourceWebACLAssociationCreate(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceWebACLAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWebACLAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -107,7 +107,7 @@ func resourceWebACLAssociationRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceWebACLAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWebACLAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 

--- a/internal/service/wafregional/web_acl_data_source.go
+++ b/internal/service/wafregional/web_acl_data_source.go
@@ -32,7 +32,7 @@ func dataSourceWebACL() *schema.Resource {
 	}
 }
 
-func dataSourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceWebACLRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 

--- a/internal/service/wafregional/web_acl_test.go
+++ b/internal/service/wafregional/web_acl_test.go
@@ -407,15 +407,15 @@ func TestAccWAFRegionalWebACL_logging(t *testing.T) {
 func computeWebACLRuleIndex(ruleId **string, priority int, ruleType string, actionType string, idx *int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ruleResource := tfwafregional.ResourceWebACL().SchemaMap()[names.AttrRule].Elem.(*schema.Resource)
-		actionMap := map[string]interface{}{
+		actionMap := map[string]any{
 			names.AttrType: actionType,
 		}
-		m := map[string]interface{}{
+		m := map[string]any{
 			"rule_id":          **ruleId,
 			names.AttrType:     ruleType,
 			names.AttrPriority: priority,
-			names.AttrAction:   []interface{}{actionMap},
-			"override_action":  []interface{}{},
+			names.AttrAction:   []any{actionMap},
+			"override_action":  []any{},
 		}
 
 		f := schema.HashResource(ruleResource)

--- a/internal/service/wafregional/xss_match_set.go
+++ b/internal/service/wafregional/xss_match_set.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKResource("aws_wafregional_xss_match_set", name="XSS Match Set")
@@ -75,13 +76,13 @@ func resourceXSSMatchSet() *schema.Resource {
 	}
 }
 
-func resourceXSSMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceXSSMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	name := d.Get(names.AttrName).(string)
-	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	output, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.CreateXssMatchSetInput{
 			ChangeToken: token,
 			Name:        aws.String(d.Get(names.AttrName).(string)),
@@ -105,7 +106,7 @@ func resourceXSSMatchSetCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceXSSMatchSetRead(ctx, d, meta)...)
 }
 
-func resourceXSSMatchSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceXSSMatchSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 
@@ -129,7 +130,7 @@ func resourceXSSMatchSetRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceXSSMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceXSSMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
@@ -145,20 +146,20 @@ func resourceXSSMatchSetUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceXSSMatchSetRead(ctx, d, meta)...)
 }
 
-func resourceXSSMatchSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceXSSMatchSetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFRegionalClient(ctx)
 	region := meta.(*conns.AWSClient).Region(ctx)
 
 	if oldT := d.Get("xss_match_tuple").(*schema.Set).List(); len(oldT) > 0 {
-		var newT []interface{}
+		var newT []any
 		if err := updateXSSMatchSet(ctx, conn, region, d.Id(), oldT, newT); err != nil && !errs.IsA[*awstypes.WAFNonexistentItemException](err) && !errs.IsA[*awstypes.WAFNonexistentContainerException](err) {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
 
 	log.Printf("[INFO] Deleting WAF Regional XSS Match Set: %s", d.Id())
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.DeleteXssMatchSetInput{
 			ChangeToken:   token,
 			XssMatchSetId: aws.String(d.Id()),
@@ -203,8 +204,8 @@ func findXSSMatchSetByID(ctx context.Context, conn *wafregional.Client, id strin
 	return output.XssMatchSet, nil
 }
 
-func updateXSSMatchSet(ctx context.Context, conn *wafregional.Client, region, xssMatchSetID string, oldT, newT []interface{}) error {
-	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (interface{}, error) {
+func updateXSSMatchSet(ctx context.Context, conn *wafregional.Client, region, xssMatchSetID string, oldT, newT []any) error {
+	_, err := newRetryer(conn, region).RetryWithToken(ctx, func(token *string) (any, error) {
 		input := &wafregional.UpdateXssMatchSetInput{
 			ChangeToken:   token,
 			Updates:       diffXSSMatchSetTuples(oldT, newT),
@@ -221,10 +222,10 @@ func updateXSSMatchSet(ctx context.Context, conn *wafregional.Client, region, xs
 	return nil
 }
 
-func flattenXSSMatchTuples(ts []awstypes.XssMatchTuple) []interface{} {
-	out := make([]interface{}, len(ts))
+func flattenXSSMatchTuples(ts []awstypes.XssMatchTuple) []any {
+	out := make([]any, len(ts))
 	for i, t := range ts {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 		m["field_to_match"] = flattenFieldToMatch(t.FieldToMatch)
 		m["text_transformation"] = t.TextTransformation
 		out[i] = m
@@ -232,33 +233,33 @@ func flattenXSSMatchTuples(ts []awstypes.XssMatchTuple) []interface{} {
 	return out
 }
 
-func diffXSSMatchSetTuples(oldT, newT []interface{}) []awstypes.XssMatchSetUpdate {
+func diffXSSMatchSetTuples(oldT, newT []any) []awstypes.XssMatchSetUpdate {
 	updates := make([]awstypes.XssMatchSetUpdate, 0)
 
 	for _, od := range oldT {
-		tuple := od.(map[string]interface{})
+		tuple := od.(map[string]any)
 
 		if idx, contains := sliceContainsMap(newT, tuple); contains {
-			newT = append(newT[:idx], newT[idx+1:]...)
+			newT = slices.Delete(newT, idx, idx+1)
 			continue
 		}
 
 		updates = append(updates, awstypes.XssMatchSetUpdate{
 			Action: awstypes.ChangeActionDelete,
 			XssMatchTuple: &awstypes.XssMatchTuple{
-				FieldToMatch:       expandFieldToMatch(tuple["field_to_match"].([]interface{})[0].(map[string]interface{})),
+				FieldToMatch:       expandFieldToMatch(tuple["field_to_match"].([]any)[0].(map[string]any)),
 				TextTransformation: awstypes.TextTransformation(tuple["text_transformation"].(string)),
 			},
 		})
 	}
 
 	for _, nd := range newT {
-		tuple := nd.(map[string]interface{})
+		tuple := nd.(map[string]any)
 
 		updates = append(updates, awstypes.XssMatchSetUpdate{
 			Action: awstypes.ChangeActionInsert,
 			XssMatchTuple: &awstypes.XssMatchTuple{
-				FieldToMatch:       expandFieldToMatch(tuple["field_to_match"].([]interface{})[0].(map[string]interface{})),
+				FieldToMatch:       expandFieldToMatch(tuple["field_to_match"].([]any)[0].(map[string]any)),
 				TextTransformation: awstypes.TextTransformation(tuple["text_transformation"].(string)),
 			},
 		})

--- a/internal/service/wafregional/xss_match_set.go
+++ b/internal/service/wafregional/xss_match_set.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/wafregional"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKResource("aws_wafregional_xss_match_set", name="XSS Match Set")


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T='TestAccWAFRegionalIPSetDataSource_basic|TestAccWAFRegionalIPSet_basic|TestAccWAFRegionalWebACL_basic|TestAccWAFRegionalRegexPatternSet_basic|TestAccWAFRegionalRegexPatternSetDataSource_basic|TestAccWAFRegionalRuleGroup_basic|TestAccWAFRegionalRuleGroupDataSource_basic|TestAccWAFRegionalWebACLDataSource_basic|TestAccWAFRegionalWebACLAssociation_basic|TestAccWAFRegionalWebACLLoggingConfiguration_basic' K=wafregional
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/wafregional/... -v -count 1 -parallel 20 -run='TestAccWAFRegionalIPSetDataSource_basic|TestAccWAFRegionalIPSet_basic|TestAccWAFRegionalWebACL_basic|TestAccWAFRegionalRegexPatternSet_basic|TestAccWAFRegionalRegexPatternSetDataSource_basic|TestAccWAFRegionalRuleGroup_basic|TestAccWAFRegionalRuleGroupDataSource_basic|TestAccWAFRegionalWebACLDataSource_basic|TestAccWAFRegionalWebACLAssociation_basic|TestAccWAFRegionalWebACLLoggingConfiguration_basic'  -timeout 360m -vet=off
2025/03/12 16:43:19 Initializing Terraform AWS Provider...
=== RUN   TestAccWAFRegionalIPSetDataSource_basic
=== PAUSE TestAccWAFRegionalIPSetDataSource_basic
=== RUN   TestAccWAFRegionalIPSet_basic
=== PAUSE TestAccWAFRegionalIPSet_basic
=== RUN   TestAccWAFRegionalRuleGroup_basic
=== PAUSE TestAccWAFRegionalRuleGroup_basic
=== RUN   TestAccWAFRegionalWebACLAssociation_basic
=== PAUSE TestAccWAFRegionalWebACLAssociation_basic
=== RUN   TestAccWAFRegionalWebACLDataSource_basic
=== PAUSE TestAccWAFRegionalWebACLDataSource_basic
=== RUN   TestAccWAFRegionalWebACL_basic
=== PAUSE TestAccWAFRegionalWebACL_basic
=== CONT  TestAccWAFRegionalIPSetDataSource_basic
=== CONT  TestAccWAFRegionalWebACLAssociation_basic
=== CONT  TestAccWAFRegionalWebACL_basic
=== CONT  TestAccWAFRegionalRuleGroup_basic
=== CONT  TestAccWAFRegionalIPSet_basic
=== CONT  TestAccWAFRegionalWebACLDataSource_basic
--- PASS: TestAccWAFRegionalIPSetDataSource_basic (28.12s)
--- PASS: TestAccWAFRegionalWebACLDataSource_basic (29.64s)
--- PASS: TestAccWAFRegionalIPSet_basic (33.02s)
--- PASS: TestAccWAFRegionalRuleGroup_basic (47.96s)
--- PASS: TestAccWAFRegionalWebACL_basic (48.69s)
--- PASS: TestAccWAFRegionalWebACLAssociation_basic (241.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/wafregional	246.268s
```
