### PR TITLE
ec2: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -41,5 +41,6 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      - run: make TEST=./internal/service/ec2 modern-check
       - run: make TEST=./internal/service/mq modern-check
       - run: make TEST=./internal/service/wafv2 modern-check

--- a/internal/service/ec2/ebs_default_kms_key.go
+++ b/internal/service/ec2/ebs_default_kms_key.go
@@ -36,7 +36,7 @@ func resourceEBSDefaultKMSKey() *schema.Resource {
 	}
 }
 
-func resourceEBSDefaultKMSKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSDefaultKMSKeyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -53,7 +53,7 @@ func resourceEBSDefaultKMSKeyCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceEBSDefaultKMSKeyRead(ctx, d, meta)...)
 }
 
-func resourceEBSDefaultKMSKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSDefaultKMSKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -68,7 +68,7 @@ func resourceEBSDefaultKMSKeyRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceEBSDefaultKMSKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSDefaultKMSKeyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ebs_default_kms_key_data_source.go
+++ b/internal/service/ec2/ebs_default_kms_key_data_source.go
@@ -31,7 +31,7 @@ func dataSourceEBSDefaultKMSKey() *schema.Resource {
 		},
 	}
 }
-func dataSourceEBSDefaultKMSKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEBSDefaultKMSKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ebs_encryption_by_default.go
+++ b/internal/service/ec2/ebs_encryption_by_default.go
@@ -37,7 +37,7 @@ func resourceEBSEncryptionByDefault() *schema.Resource {
 	}
 }
 
-func resourceEBSEncryptionByDefaultCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSEncryptionByDefaultCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -52,7 +52,7 @@ func resourceEBSEncryptionByDefaultCreate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceEBSEncryptionByDefaultRead(ctx, d, meta)...)
 }
 
-func resourceEBSEncryptionByDefaultRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSEncryptionByDefaultRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -67,7 +67,7 @@ func resourceEBSEncryptionByDefaultRead(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceEBSEncryptionByDefaultUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSEncryptionByDefaultUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -79,7 +79,7 @@ func resourceEBSEncryptionByDefaultUpdate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceEBSEncryptionByDefaultRead(ctx, d, meta)...)
 }
 
-func resourceEBSEncryptionByDefaultDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSEncryptionByDefaultDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ebs_encryption_by_default_data_source.go
+++ b/internal/service/ec2/ebs_encryption_by_default_data_source.go
@@ -32,7 +32,7 @@ func dataSourceEBSEncryptionByDefault() *schema.Resource {
 		},
 	}
 }
-func dataSourceEBSEncryptionByDefaultRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEBSEncryptionByDefaultRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ebs_snapshot.go
+++ b/internal/service/ec2/ebs_snapshot.go
@@ -110,7 +110,7 @@ func resourceEBSSnapshot() *schema.Resource {
 	}
 }
 
-func resourceEBSSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -129,7 +129,7 @@ func resourceEBSSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 1*time.Minute,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateSnapshot(ctx, &input)
 		},
 		errCodeSnapshotCreationPerVolumeRateExceeded, "The maximum per volume CreateSnapshot request rate has been exceeded")
@@ -141,7 +141,7 @@ func resourceEBSSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta
 	d.SetId(aws.ToString(outputRaw.(*ec2.CreateSnapshotOutput).SnapshotId))
 
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
-		func() (interface{}, error) {
+		func() (any, error) {
 			waiter := ec2.NewSnapshotCompletedWaiter(conn)
 			return waiter.WaitForOutput(ctx, &ec2.DescribeSnapshotsInput{
 				SnapshotIds: []string{d.Id()},
@@ -172,7 +172,7 @@ func resourceEBSSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceEBSSnapshotRead(ctx, d, meta)...)
 }
 
-func resourceEBSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -211,7 +211,7 @@ func resourceEBSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceEBSSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -255,12 +255,12 @@ func resourceEBSSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceEBSSnapshotRead(ctx, d, meta)...)
 }
 
-func resourceEBSSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	log.Printf("[INFO] Deleting EBS Snapshot: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return conn.DeleteSnapshot(ctx, &ec2.DeleteSnapshotInput{
 			SnapshotId: aws.String(d.Id()),
 		})

--- a/internal/service/ec2/ebs_snapshot_block_public_access.go
+++ b/internal/service/ec2/ebs_snapshot_block_public_access.go
@@ -38,7 +38,7 @@ func resourceEBSSnapshotBlockPublicAccess() *schema.Resource {
 	}
 }
 
-func resourceEBSSnapshotBlockPublicAccessPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSSnapshotBlockPublicAccessPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -60,7 +60,7 @@ func resourceEBSSnapshotBlockPublicAccessPut(ctx context.Context, d *schema.Reso
 	return append(diags, resourceEBSSnapshotBlockPublicAccessRead(ctx, d, meta)...)
 }
 
-func resourceEBSSnapshotBlockPublicAccessRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSSnapshotBlockPublicAccessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -76,7 +76,7 @@ func resourceEBSSnapshotBlockPublicAccessRead(ctx context.Context, d *schema.Res
 	return diags
 }
 
-func resourceEBSSnapshotBlockPublicAccessDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSSnapshotBlockPublicAccessDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ebs_snapshot_copy.go
+++ b/internal/service/ec2/ebs_snapshot_copy.go
@@ -116,7 +116,7 @@ func resourceEBSSnapshotCopy() *schema.Resource {
 	}
 }
 
-func resourceEBSSnapshotCopyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSSnapshotCopyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -151,7 +151,7 @@ func resourceEBSSnapshotCopyCreate(ctx context.Context, d *schema.ResourceData, 
 	d.SetId(aws.ToString(output.SnapshotId))
 
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
-		func() (interface{}, error) {
+		func() (any, error) {
 			return ec2.NewSnapshotCompletedWaiter(conn).WaitForOutput(ctx, &ec2.DescribeSnapshotsInput{
 				SnapshotIds: []string{d.Id()},
 			}, d.Timeout(schema.TimeoutCreate))

--- a/internal/service/ec2/ebs_snapshot_create_volume_permission.go
+++ b/internal/service/ec2/ebs_snapshot_create_volume_permission.go
@@ -51,7 +51,7 @@ func resourceSnapshotCreateVolumePermission() *schema.Resource {
 	}
 }
 
-func resourceSnapshotCreateVolumePermissionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotCreateVolumePermissionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -76,7 +76,7 @@ func resourceSnapshotCreateVolumePermissionCreate(ctx context.Context, d *schema
 
 	d.SetId(id)
 
-	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
 		return findCreateSnapshotCreateVolumePermissionByTwoPartKey(ctx, conn, snapshotID, accountID)
 	})
 
@@ -87,7 +87,7 @@ func resourceSnapshotCreateVolumePermissionCreate(ctx context.Context, d *schema
 	return diags
 }
 
-func resourceSnapshotCreateVolumePermissionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotCreateVolumePermissionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -111,7 +111,7 @@ func resourceSnapshotCreateVolumePermissionRead(ctx context.Context, d *schema.R
 	return diags
 }
 
-func resourceSnapshotCreateVolumePermissionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotCreateVolumePermissionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -140,7 +140,7 @@ func resourceSnapshotCreateVolumePermissionDelete(ctx context.Context, d *schema
 		return sdkdiag.AppendErrorf(diags, "deleting EBS Snapshot CreateVolumePermission (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return findCreateSnapshotCreateVolumePermissionByTwoPartKey(ctx, conn, snapshotID, accountID)
 	})
 
@@ -151,7 +151,7 @@ func resourceSnapshotCreateVolumePermissionDelete(ctx context.Context, d *schema
 	return diags
 }
 
-func resourceSnapshotCreateVolumePermissionCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+func resourceSnapshotCreateVolumePermissionCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 	if diff.Id() == "" {
 		if snapshotID := diff.Get(names.AttrSnapshotID).(string); snapshotID != "" {
 			conn := meta.(*conns.AWSClient).EC2Client(ctx)

--- a/internal/service/ec2/ebs_snapshot_data_source.go
+++ b/internal/service/ec2/ebs_snapshot_data_source.go
@@ -116,22 +116,22 @@ func dataSourceEBSSnapshot() *schema.Resource {
 	}
 }
 
-func dataSourceEBSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEBSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := ec2.DescribeSnapshotsInput{}
 
-	if v, ok := d.GetOk("owners"); ok && len(v.([]interface{})) > 0 {
-		input.OwnerIds = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("owners"); ok && len(v.([]any)) > 0 {
+		input.OwnerIds = flex.ExpandStringValueList(v.([]any))
 	}
 
-	if v, ok := d.GetOk("restorable_by_user_ids"); ok && len(v.([]interface{})) > 0 {
-		input.RestorableByUserIds = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("restorable_by_user_ids"); ok && len(v.([]any)) > 0 {
+		input.RestorableByUserIds = flex.ExpandStringValueList(v.([]any))
 	}
 
-	if v, ok := d.GetOk("snapshot_ids"); ok && len(v.([]interface{})) > 0 {
-		input.SnapshotIds = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("snapshot_ids"); ok && len(v.([]any)) > 0 {
+		input.SnapshotIds = flex.ExpandStringValueList(v.([]any))
 	}
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/ebs_snapshot_ids_data_source.go
+++ b/internal/service/ec2/ebs_snapshot_ids_data_source.go
@@ -49,18 +49,18 @@ func dataSourceEBSSnapshotIDs() *schema.Resource {
 	}
 }
 
-func dataSourceEBSSnapshotIDsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEBSSnapshotIDsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := ec2.DescribeSnapshotsInput{}
 
-	if v, ok := d.GetOk("owners"); ok && len(v.([]interface{})) > 0 {
-		input.OwnerIds = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("owners"); ok && len(v.([]any)) > 0 {
+		input.OwnerIds = flex.ExpandStringValueList(v.([]any))
 	}
 
-	if v, ok := d.GetOk("restorable_by_user_ids"); ok && len(v.([]interface{})) > 0 {
-		input.RestorableByUserIds = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("restorable_by_user_ids"); ok && len(v.([]any)) > 0 {
+		input.RestorableByUserIds = flex.ExpandStringValueList(v.([]any))
 	}
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/ebs_snapshot_import.go
+++ b/internal/service/ec2/ebs_snapshot_import.go
@@ -191,7 +191,7 @@ func resourceEBSSnapshotImport() *schema.Resource {
 	}
 }
 
-func resourceEBSSnapshotImportCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSSnapshotImportCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -200,16 +200,16 @@ func resourceEBSSnapshotImportCreate(ctx context.Context, d *schema.ResourceData
 		TagSpecifications: getTagSpecificationsIn(ctx, awstypes.ResourceTypeImportSnapshotTask),
 	}
 
-	if v, ok := d.GetOk("client_data"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ClientData = expandClientData(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("client_data"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ClientData = expandClientData(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
 		input.Description = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("disk_container"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DiskContainer = expandSnapshotDiskContainer(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("disk_container"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DiskContainer = expandSnapshotDiskContainer(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrEncrypted); ok {
@@ -225,7 +225,7 @@ func resourceEBSSnapshotImportCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, iamPropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.ImportSnapshot(ctx, &input)
 		},
 		errCodeInvalidParameter, "provided does not exist or does not have sufficient permissions")
@@ -268,7 +268,7 @@ func resourceEBSSnapshotImportCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceEBSSnapshotImportRead(ctx, d, meta)...)
 }
 
-func resourceEBSSnapshotImportRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEBSSnapshotImportRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -305,7 +305,7 @@ func resourceEBSSnapshotImportRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func expandClientData(tfMap map[string]interface{}) *awstypes.ClientData {
+func expandClientData(tfMap map[string]any) *awstypes.ClientData {
 	if tfMap == nil {
 		return nil
 	}
@@ -335,7 +335,7 @@ func expandClientData(tfMap map[string]interface{}) *awstypes.ClientData {
 	return apiObject
 }
 
-func expandSnapshotDiskContainer(tfMap map[string]interface{}) *awstypes.SnapshotDiskContainer {
+func expandSnapshotDiskContainer(tfMap map[string]any) *awstypes.SnapshotDiskContainer {
 	if tfMap == nil {
 		return nil
 	}
@@ -354,14 +354,14 @@ func expandSnapshotDiskContainer(tfMap map[string]interface{}) *awstypes.Snapsho
 		apiObject.Url = aws.String(v)
 	}
 
-	if v, ok := tfMap["user_bucket"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.UserBucket = expandUserBucket(v[0].(map[string]interface{}))
+	if v, ok := tfMap["user_bucket"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.UserBucket = expandUserBucket(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandUserBucket(tfMap map[string]interface{}) *awstypes.UserBucket {
+func expandUserBucket(tfMap map[string]any) *awstypes.UserBucket {
 	if tfMap == nil {
 		return nil
 	}

--- a/internal/service/ec2/ebs_volume_attachment.go
+++ b/internal/service/ec2/ebs_volume_attachment.go
@@ -37,7 +37,7 @@ func resourceVolumeAttachment() *schema.Resource {
 		DeleteWithoutTimeout: resourceVolumeAttachmentDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				idParts := strings.Split(d.Id(), ":")
 
 				if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
@@ -93,7 +93,7 @@ func resourceVolumeAttachment() *schema.Resource {
 	}
 }
 
-func resourceVolumeAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVolumeAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	deviceName := d.Get(names.AttrDeviceName).(string)
@@ -134,7 +134,7 @@ func resourceVolumeAttachmentCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceVolumeAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceVolumeAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVolumeAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	deviceName := d.Get(names.AttrDeviceName).(string)
@@ -156,7 +156,7 @@ func resourceVolumeAttachmentRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceVolumeAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVolumeAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -343,7 +343,7 @@ func waitVolumeAttachmentDeleted(ctx context.Context, conn *ec2.Client, volumeID
 }
 
 func statusVolumeAttachmentInstanceState(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		// Don't call FindInstanceByID as it maps useful status codes to NotFoundError.
 		output, err := findInstance(ctx, conn, &ec2.DescribeInstancesInput{
 			InstanceIds: []string{id},

--- a/internal/service/ec2/ebs_volume_data_source.go
+++ b/internal/service/ec2/ebs_volume_data_source.go
@@ -92,7 +92,7 @@ func dataSourceEBSVolume() *schema.Resource {
 	}
 }
 
-func dataSourceEBSVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEBSVolumeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ebs_volumes_data_source.go
+++ b/internal/service/ec2/ebs_volumes_data_source.go
@@ -38,14 +38,14 @@ func dataSourceEBSVolumes() *schema.Resource {
 	}
 }
 
-func dataSourceEBSVolumesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEBSVolumesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := ec2.DescribeVolumesInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/ec2_ami.go
+++ b/internal/service/ec2/ec2_ami.go
@@ -154,9 +154,9 @@ func resourceAMI() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
+				Set: func(v any) int {
 					var buf bytes.Buffer
-					m := v.(map[string]interface{})
+					m := v.(map[string]any)
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrSnapshotID].(string)))
 					return create.StringHashcode(buf.String())
@@ -184,9 +184,9 @@ func resourceAMI() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
+				Set: func(v any) int {
 					var buf bytes.Buffer
-					m := v.(map[string]interface{})
+					m := v.(map[string]any)
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrVirtualName].(string)))
 					return create.StringHashcode(buf.String())
@@ -298,7 +298,7 @@ func resourceAMI() *schema.Resource {
 	}
 }
 
-func resourceAMICreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAMICreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -336,7 +336,7 @@ func resourceAMICreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	if v, ok := d.GetOk("ebs_block_device"); ok && v.(*schema.Set).Len() > 0 {
 		for _, tfMapRaw := range v.(*schema.Set).List() {
-			tfMap, ok := tfMapRaw.(map[string]interface{})
+			tfMap, ok := tfMapRaw.(map[string]any)
 
 			if !ok {
 				continue
@@ -395,11 +395,11 @@ func resourceAMICreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return append(diags, resourceAMIRead(ctx, d, meta)...)
 }
 
-func resourceAMIRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAMIRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findImageByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -480,7 +480,7 @@ func resourceAMIRead(ctx context.Context, d *schema.ResourceData, meta interface
 	return diags
 }
 
-func resourceAMIUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAMIUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -506,7 +506,7 @@ func resourceAMIUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return append(diags, resourceAMIRead(ctx, d, meta)...)
 }
 
-func resourceAMIDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAMIDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -530,7 +530,7 @@ func resourceAMIDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		ebsBlockDevsSet := d.Get("ebs_block_device").(*schema.Set)
 		req := ec2.DeleteSnapshotInput{}
 		for _, ebsBlockDevI := range ebsBlockDevsSet.List() {
-			ebsBlockDev := ebsBlockDevI.(map[string]interface{})
+			ebsBlockDev := ebsBlockDevI.(map[string]any)
 			snapshotId := ebsBlockDev[names.AttrSnapshotID].(string)
 			if snapshotId != "" {
 				req.SnapshotId = aws.String(snapshotId)
@@ -621,7 +621,7 @@ func disableImageDeprecation(ctx context.Context, conn *ec2.Client, id string) e
 	return nil
 }
 
-func expandBlockDeviceMappingForAMIEBSBlockDevice(tfMap map[string]interface{}) awstypes.BlockDeviceMapping {
+func expandBlockDeviceMappingForAMIEBSBlockDevice(tfMap map[string]any) awstypes.BlockDeviceMapping {
 	apiObject := awstypes.BlockDeviceMapping{
 		Ebs: &awstypes.EbsBlockDevice{},
 	}
@@ -664,7 +664,7 @@ func expandBlockDeviceMappingForAMIEBSBlockDevice(tfMap map[string]interface{}) 
 	return apiObject
 }
 
-func expandBlockDeviceMappingsForAMIEBSBlockDevice(tfList []interface{}) []awstypes.BlockDeviceMapping {
+func expandBlockDeviceMappingsForAMIEBSBlockDevice(tfList []any) []awstypes.BlockDeviceMapping {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -672,7 +672,7 @@ func expandBlockDeviceMappingsForAMIEBSBlockDevice(tfList []interface{}) []awsty
 	var apiObjects []awstypes.BlockDeviceMapping
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -684,12 +684,12 @@ func expandBlockDeviceMappingsForAMIEBSBlockDevice(tfList []interface{}) []awsty
 	return apiObjects
 }
 
-func flattenBlockDeviceMappingForAMIEBSBlockDevice(apiObject awstypes.BlockDeviceMapping) map[string]interface{} {
+func flattenBlockDeviceMappingForAMIEBSBlockDevice(apiObject awstypes.BlockDeviceMapping) map[string]any {
 	if apiObject.Ebs == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrVolumeType: apiObject.Ebs.VolumeType,
 	}
 
@@ -728,12 +728,12 @@ func flattenBlockDeviceMappingForAMIEBSBlockDevice(apiObject awstypes.BlockDevic
 	return tfMap
 }
 
-func flattenBlockDeviceMappingsForAMIEBSBlockDevice(apiObjects []awstypes.BlockDeviceMapping) []interface{} {
+func flattenBlockDeviceMappingsForAMIEBSBlockDevice(apiObjects []awstypes.BlockDeviceMapping) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if apiObject.Ebs == nil {
@@ -746,7 +746,7 @@ func flattenBlockDeviceMappingsForAMIEBSBlockDevice(apiObjects []awstypes.BlockD
 	return tfList
 }
 
-func expandBlockDeviceMappingForAMIEphemeralBlockDevice(tfMap map[string]interface{}) awstypes.BlockDeviceMapping {
+func expandBlockDeviceMappingForAMIEphemeralBlockDevice(tfMap map[string]any) awstypes.BlockDeviceMapping {
 	apiObject := awstypes.BlockDeviceMapping{}
 
 	if v, ok := tfMap[names.AttrDeviceName].(string); ok && v != "" {
@@ -760,7 +760,7 @@ func expandBlockDeviceMappingForAMIEphemeralBlockDevice(tfMap map[string]interfa
 	return apiObject
 }
 
-func expandBlockDeviceMappingsForAMIEphemeralBlockDevice(tfList []interface{}) []awstypes.BlockDeviceMapping {
+func expandBlockDeviceMappingsForAMIEphemeralBlockDevice(tfList []any) []awstypes.BlockDeviceMapping {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -768,7 +768,7 @@ func expandBlockDeviceMappingsForAMIEphemeralBlockDevice(tfList []interface{}) [
 	var apiObjects []awstypes.BlockDeviceMapping
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -780,8 +780,8 @@ func expandBlockDeviceMappingsForAMIEphemeralBlockDevice(tfList []interface{}) [
 	return apiObjects
 }
 
-func flattenBlockDeviceMappingForAMIEphemeralBlockDevice(apiObject awstypes.BlockDeviceMapping) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenBlockDeviceMappingForAMIEphemeralBlockDevice(apiObject awstypes.BlockDeviceMapping) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.DeviceName; v != nil {
 		tfMap[names.AttrDeviceName] = aws.ToString(v)
@@ -794,12 +794,12 @@ func flattenBlockDeviceMappingForAMIEphemeralBlockDevice(apiObject awstypes.Bloc
 	return tfMap
 }
 
-func flattenBlockDeviceMappingsForAMIEphemeralBlockDevice(apiObjects []awstypes.BlockDeviceMapping) []interface{} {
+func flattenBlockDeviceMappingsForAMIEphemeralBlockDevice(apiObjects []awstypes.BlockDeviceMapping) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if apiObject.Ebs != nil {

--- a/internal/service/ec2/ec2_ami_copy.go
+++ b/internal/service/ec2/ec2_ami_copy.go
@@ -122,9 +122,9 @@ func resourceAMICopy() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
+				Set: func(v any) int {
 					var buf bytes.Buffer
-					m := v.(map[string]interface{})
+					m := v.(map[string]any)
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrSnapshotID].(string)))
 					return create.StringHashcode(buf.String())
@@ -157,9 +157,9 @@ func resourceAMICopy() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
+				Set: func(v any) int {
 					var buf bytes.Buffer
-					m := v.(map[string]interface{})
+					m := v.(map[string]any)
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrVirtualName].(string)))
 					return create.StringHashcode(buf.String())
@@ -273,7 +273,7 @@ func resourceAMICopy() *schema.Resource {
 	}
 }
 
-func resourceAMICopyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAMICopyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -233,7 +233,7 @@ func dataSourceAMI() *schema.Resource {
 	}
 }
 
-func dataSourceAMIRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAMIRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -242,15 +242,15 @@ func dataSourceAMIRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("executable_users"); ok {
-		describeImagesInput.ExecutableUsers = flex.ExpandStringValueList(v.([]interface{}))
+		describeImagesInput.ExecutableUsers = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrFilter); ok {
 		describeImagesInput.Filters = newCustomFilterList(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("owners"); ok && len(v.([]interface{})) > 0 {
-		describeImagesInput.Owners = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("owners"); ok && len(v.([]any)) > 0 {
+		describeImagesInput.Owners = flex.ExpandStringValueList(v.([]any))
 	}
 
 	diags = checkMostRecentAndMissingFilters(diags, &describeImagesInput, d.Get(names.AttrMostRecent).(bool))
@@ -355,21 +355,21 @@ func dataSourceAMIRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func flattenAMIBlockDeviceMappings(apiObjects []awstypes.BlockDeviceMapping) []interface{} {
+func flattenAMIBlockDeviceMappings(apiObjects []awstypes.BlockDeviceMapping) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrDeviceName:  aws.ToString(apiObject.DeviceName),
 			names.AttrVirtualName: aws.ToString(apiObject.VirtualName),
 		}
 
 		if apiObject := apiObject.Ebs; apiObject != nil {
-			ebs := map[string]interface{}{
+			ebs := map[string]any{
 				names.AttrDeleteOnTermination: flex.BoolToStringValue(apiObject.DeleteOnTermination),
 				names.AttrEncrypted:           flex.BoolToStringValue(apiObject.Encrypted),
 				names.AttrIOPS:                flex.Int32ToStringValue(apiObject.Iops),
@@ -388,15 +388,15 @@ func flattenAMIBlockDeviceMappings(apiObjects []awstypes.BlockDeviceMapping) []i
 	return tfList
 }
 
-func flattenAMIProductCodes(apiObjects []awstypes.ProductCode) []interface{} {
+func flattenAMIProductCodes(apiObjects []awstypes.ProductCode) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfList = append(tfList, map[string]interface{}{
+		tfList = append(tfList, map[string]any{
 			"product_code_id":   aws.ToString(apiObject.ProductCodeId),
 			"product_code_type": apiObject.ProductCodeType,
 		})
@@ -421,8 +421,8 @@ func amiRootSnapshotId(image awstypes.Image) string {
 	return ""
 }
 
-func flattenAMIStateReason(m *awstypes.StateReason) map[string]interface{} {
-	s := make(map[string]interface{})
+func flattenAMIStateReason(m *awstypes.StateReason) map[string]any {
+	s := make(map[string]any)
 	if m != nil {
 		s["code"] = aws.ToString(m.Code)
 		s[names.AttrMessage] = aws.ToString(m.Message)

--- a/internal/service/ec2/ec2_ami_from_instance.go
+++ b/internal/service/ec2/ec2_ami_from_instance.go
@@ -116,9 +116,9 @@ func resourceAMIFromInstance() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
+				Set: func(v any) int {
 					var buf bytes.Buffer
-					m := v.(map[string]interface{})
+					m := v.(map[string]any)
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrSnapshotID].(string)))
 					return create.StringHashcode(buf.String())
@@ -145,9 +145,9 @@ func resourceAMIFromInstance() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
+				Set: func(v any) int {
 					var buf bytes.Buffer
-					m := v.(map[string]interface{})
+					m := v.(map[string]any)
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrVirtualName].(string)))
 					return create.StringHashcode(buf.String())
@@ -254,7 +254,7 @@ func resourceAMIFromInstance() *schema.Resource {
 	}
 }
 
-func resourceAMIFromInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAMIFromInstanceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_ami_ids_data_source.go
+++ b/internal/service/ec2/ec2_ami_ids_data_source.go
@@ -73,17 +73,17 @@ func dataSourceAMIIDs() *schema.Resource {
 	}
 }
 
-func dataSourceAMIIDsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAMIIDsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := ec2.DescribeImagesInput{
 		IncludeDeprecated: aws.Bool(d.Get("include_deprecated").(bool)),
-		Owners:            flex.ExpandStringValueList(d.Get("owners").([]interface{})),
+		Owners:            flex.ExpandStringValueList(d.Get("owners").([]any)),
 	}
 
 	if v, ok := d.GetOk("executable_users"); ok {
-		input.ExecutableUsers = flex.ExpandStringValueList(v.([]interface{}))
+		input.ExecutableUsers = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrFilter); ok {

--- a/internal/service/ec2/ec2_ami_launch_permission.go
+++ b/internal/service/ec2/ec2_ami_launch_permission.go
@@ -73,7 +73,7 @@ func resourceAMILaunchPermission() *schema.Resource {
 	}
 }
 
-func resourceAMILaunchPermissionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAMILaunchPermissionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -103,7 +103,7 @@ func resourceAMILaunchPermissionCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceAMILaunchPermissionRead(ctx, d, meta)...)
 }
 
-func resourceAMILaunchPermissionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAMILaunchPermissionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -133,7 +133,7 @@ func resourceAMILaunchPermissionRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceAMILaunchPermissionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAMILaunchPermissionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -164,7 +164,7 @@ func resourceAMILaunchPermissionDelete(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceAMILaunchPermissionImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceAMILaunchPermissionImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	const importIDSeparator = "/"
 	parts := strings.Split(d.Id(), importIDSeparator)
 

--- a/internal/service/ec2/ec2_availability_zone_data_source.go
+++ b/internal/service/ec2/ec2_availability_zone_data_source.go
@@ -84,7 +84,7 @@ func dataSourceAvailabilityZone() *schema.Resource {
 	}
 }
 
-func dataSourceAvailabilityZoneRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAvailabilityZoneRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_availability_zone_group.go
+++ b/internal/service/ec2/ec2_availability_zone_group.go
@@ -49,7 +49,7 @@ func resourceAvailabilityZoneGroup() *schema.Resource {
 	}
 }
 
-func resourceAvailabilityZoneGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAvailabilityZoneGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -71,7 +71,7 @@ func resourceAvailabilityZoneGroupCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceAvailabilityZoneGroupRead(ctx, d, meta)...)
 }
 
-func resourceAvailabilityZoneGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAvailabilityZoneGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -91,7 +91,7 @@ func resourceAvailabilityZoneGroupRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceAvailabilityZoneGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAvailabilityZoneGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_availability_zones_data_source.go
+++ b/internal/service/ec2/ec2_availability_zones_data_source.go
@@ -70,7 +70,7 @@ func dataSourceAvailabilityZones() *schema.Resource {
 	}
 }
 
-func dataSourceAvailabilityZonesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAvailabilityZonesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_capacity_reservation.go
+++ b/internal/service/ec2/ec2_capacity_reservation.go
@@ -127,7 +127,7 @@ func resourceCapacityReservation() *schema.Resource {
 	}
 }
 
-func resourceCapacityReservationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCapacityReservationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -186,7 +186,7 @@ func resourceCapacityReservationCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceCapacityReservationRead(ctx, d, meta)...)
 }
 
-func resourceCapacityReservationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCapacityReservationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -226,7 +226,7 @@ func resourceCapacityReservationRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceCapacityReservationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCapacityReservationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -257,7 +257,7 @@ func resourceCapacityReservationUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceCapacityReservationRead(ctx, d, meta)...)
 }
 
-func resourceCapacityReservationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCapacityReservationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -151,7 +151,7 @@ func resourceEIP() *schema.Resource {
 	}
 }
 
-func resourceEIPCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEIPCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -195,7 +195,7 @@ func resourceEIPCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	d.SetId(aws.ToString(output.AllocationId))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
 		return findEIPByAllocationID(ctx, conn, d.Id())
 	})
 
@@ -205,7 +205,7 @@ func resourceEIPCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	if instanceID, eniID := d.Get("instance").(string), d.Get("network_interface").(string); instanceID != "" || eniID != "" {
 		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
-			func() (interface{}, error) {
+			func() (any, error) {
 				return nil, associateEIP(ctx, conn, d.Id(), instanceID, eniID, d.Get("associate_with_private_ip").(string))
 			}, errCodeInvalidAllocationIDNotFound)
 
@@ -217,7 +217,7 @@ func resourceEIPCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return append(diags, resourceEIPRead(ctx, d, meta)...)
 }
 
-func resourceEIPRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEIPRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -225,7 +225,7 @@ func resourceEIPRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return sdkdiag.AppendErrorf(diags, `with the retirement of EC2-Classic %s domain EC2 EIPs are no longer supported`, types.DomainTypeStandard)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findEIPByAllocationID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -287,7 +287,7 @@ func resourceEIPRead(ctx context.Context, d *schema.ResourceData, meta interface
 	return diags
 }
 
-func resourceEIPUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEIPUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -311,7 +311,7 @@ func resourceEIPUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return append(diags, resourceEIPRead(ctx, d, meta)...)
 }
 
-func resourceEIPDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEIPDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -351,7 +351,7 @@ func resourceEIPDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		const (
 			timeout = 10 * time.Minute // IPAM eventual consistency
 		)
-		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (interface{}, error) {
+		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
 			return findIPAMPoolAllocationsForEIP(ctx, conn, ipamPoolID, d.Get("allocation_id").(string))
 		})
 
@@ -394,7 +394,7 @@ func associateEIP(ctx context.Context, conn *ec2.Client, allocationID, instanceI
 	}
 
 	_, err = tfresource.RetryWhen(ctx, ec2PropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return findEIPByAssociationID(ctx, conn, aws.ToString(output.AssociationId))
 		},
 		func(err error) (bool, error) {

--- a/internal/service/ec2/ec2_eip_association.go
+++ b/internal/service/ec2/ec2_eip_association.go
@@ -79,7 +79,7 @@ func resourceEIPAssociation() *schema.Resource {
 	}
 }
 
-func resourceEIPAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEIPAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -118,7 +118,7 @@ func resourceEIPAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(aws.ToString(output.AssociationId))
 
 	_, err = tfresource.RetryWhen(ctx, ec2PropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return findEIPByAssociationID(ctx, conn, d.Id())
 		},
 		func(err error) (bool, error) {
@@ -142,7 +142,7 @@ func resourceEIPAssociationCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceEIPAssociationRead(ctx, d, meta)...)
 }
 
-func resourceEIPAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEIPAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -171,7 +171,7 @@ func resourceEIPAssociationRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceEIPAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEIPAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_eip_data_source.go
+++ b/internal/service/ec2/ec2_eip_data_source.go
@@ -108,7 +108,7 @@ func dataSourceEIP() *schema.Resource {
 	}
 }
 
-func dataSourceEIPRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEIPRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -123,7 +123,7 @@ func dataSourceEIPRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/ec2_eips_data_source.go
+++ b/internal/service/ec2/ec2_eips_data_source.go
@@ -44,7 +44,7 @@ func dataSourceEIPs() *schema.Resource {
 	}
 }
 
-func dataSourceEIPsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEIPsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -52,7 +52,7 @@ func dataSourceEIPsRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	if tags, tagsOk := d.GetOk(names.AttrTags); tagsOk {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+			Tags(tftags.New(ctx, tags.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/ec2_fleet.go
+++ b/internal/service/ec2/ec2_fleet.go
@@ -728,15 +728,15 @@ func resourceFleet() *schema.Resource {
 	}
 }
 
-func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	fleetType := awstypes.FleetType(d.Get(names.AttrType).(string))
 	input := ec2.CreateFleetInput{
 		ClientToken:                 aws.String(id.UniqueId()),
-		LaunchTemplateConfigs:       expandFleetLaunchTemplateConfigRequests(d.Get("launch_template_config").([]interface{})),
-		TargetCapacitySpecification: expandTargetCapacitySpecificationRequest(d.Get("target_capacity_specification").([]interface{})[0].(map[string]interface{})),
+		LaunchTemplateConfigs:       expandFleetLaunchTemplateConfigRequests(d.Get("launch_template_config").([]any)),
+		TargetCapacitySpecification: expandTargetCapacitySpecificationRequest(d.Get("target_capacity_specification").([]any)[0].(map[string]any)),
 		TagSpecifications:           getTagSpecificationsIn(ctx, awstypes.ResourceTypeFleet),
 		Type:                        fleetType,
 	}
@@ -750,16 +750,16 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		input.ExcessCapacityTerminationPolicy = awstypes.FleetExcessCapacityTerminationPolicy(v.(string))
 	}
 
-	if v, ok := d.GetOk("on_demand_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.OnDemandOptions = expandOnDemandOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("on_demand_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.OnDemandOptions = expandOnDemandOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("replace_unhealthy_instances"); ok {
 		input.ReplaceUnhealthyInstances = aws.Bool(v.(bool))
 	}
 
-	if v, ok := d.GetOk("spot_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.SpotOptions = expandSpotOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("spot_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.SpotOptions = expandSpotOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("terminate_instances_with_expiration"); ok {
@@ -806,7 +806,7 @@ func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceFleetRead(ctx, d, meta)...)
 }
 
-func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -844,7 +844,7 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		return sdkdiag.AppendErrorf(diags, "setting launch_template_config: %s", err)
 	}
 	if fleet.OnDemandOptions != nil {
-		if err := d.Set("on_demand_options", []interface{}{flattenOnDemandOptions(fleet.OnDemandOptions)}); err != nil {
+		if err := d.Set("on_demand_options", []any{flattenOnDemandOptions(fleet.OnDemandOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting on_demand_options: %s", err)
 		}
 	} else {
@@ -852,14 +852,14 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 	d.Set("replace_unhealthy_instances", fleet.ReplaceUnhealthyInstances)
 	if fleet.SpotOptions != nil {
-		if err := d.Set("spot_options", []interface{}{flattenSpotOptions(fleet.SpotOptions)}); err != nil {
+		if err := d.Set("spot_options", []any{flattenSpotOptions(fleet.SpotOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting spot_options: %s", err)
 		}
 	} else {
 		d.Set("spot_options", nil)
 	}
 	if fleet.TargetCapacitySpecification != nil {
-		if err := d.Set("target_capacity_specification", []interface{}{flattenTargetCapacitySpecification(fleet.TargetCapacitySpecification)}); err != nil {
+		if err := d.Set("target_capacity_specification", []any{flattenTargetCapacitySpecification(fleet.TargetCapacitySpecification)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting target_capacity_specification: %s", err)
 		}
 	} else {
@@ -879,7 +879,7 @@ func resourceFleetRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -897,7 +897,7 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			input.ExcessCapacityTerminationPolicy = awstypes.FleetExcessCapacityTerminationPolicy(v.(string))
 		}
 
-		input.LaunchTemplateConfigs = expandFleetLaunchTemplateConfigRequests(d.Get("launch_template_config").([]interface{}))
+		input.LaunchTemplateConfigs = expandFleetLaunchTemplateConfigRequests(d.Get("launch_template_config").([]any))
 
 		// InvalidTargetCapacitySpecification: Currently we only support total target capacity modification.
 		// TargetCapacitySpecification: expandEc2TargetCapacitySpecificationRequest(d.Get("target_capacity_specification").([]interface{})),
@@ -919,7 +919,7 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceFleetRead(ctx, d, meta)...)
 }
 
-func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -963,12 +963,12 @@ func resourceFleetDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceFleetCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func resourceFleetCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if diff.Id() == "" { // New resource.
 		if diff.Get(names.AttrType).(string) != string(awstypes.FleetTypeMaintain) {
-			if v, ok := diff.GetOk("spot_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				tfMap := v.([]interface{})[0].(map[string]interface{})
-				if v, ok := tfMap["maintenance_strategies"].([]interface{}); ok && len(v) > 0 {
+			if v, ok := diff.GetOk("spot_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				tfMap := v.([]any)[0].(map[string]any)
+				if v, ok := tfMap["maintenance_strategies"].([]any); ok && len(v) > 0 {
 					return errors.New(`EC2 Fleet has an invalid configuration and can not be created. Capacity Rebalance maintenance strategies can only be specified for fleets of type maintain.`)
 				}
 			}
@@ -978,7 +978,7 @@ func resourceFleetCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v 
 	return nil
 }
 
-func expandCapacityReservationOptionsRequest(tfMap map[string]interface{}) *awstypes.CapacityReservationOptionsRequest {
+func expandCapacityReservationOptionsRequest(tfMap map[string]any) *awstypes.CapacityReservationOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -992,7 +992,7 @@ func expandCapacityReservationOptionsRequest(tfMap map[string]interface{}) *awst
 	return apiObject
 }
 
-func expandFleetLaunchTemplateConfigRequests(tfList []interface{}) []awstypes.FleetLaunchTemplateConfigRequest {
+func expandFleetLaunchTemplateConfigRequests(tfList []any) []awstypes.FleetLaunchTemplateConfigRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1000,7 +1000,7 @@ func expandFleetLaunchTemplateConfigRequests(tfList []interface{}) []awstypes.Fl
 	var apiObjects []awstypes.FleetLaunchTemplateConfigRequest
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1012,21 +1012,21 @@ func expandFleetLaunchTemplateConfigRequests(tfList []interface{}) []awstypes.Fl
 	return apiObjects
 }
 
-func expandFleetLaunchTemplateConfigRequest(tfMap map[string]interface{}) awstypes.FleetLaunchTemplateConfigRequest {
+func expandFleetLaunchTemplateConfigRequest(tfMap map[string]any) awstypes.FleetLaunchTemplateConfigRequest {
 	apiObject := awstypes.FleetLaunchTemplateConfigRequest{}
 
-	if v, ok := tfMap["launch_template_specification"].([]interface{}); ok && len(v) > 0 {
-		apiObject.LaunchTemplateSpecification = expandFleetLaunchTemplateSpecificationRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["launch_template_specification"].([]any); ok && len(v) > 0 {
+		apiObject.LaunchTemplateSpecification = expandFleetLaunchTemplateSpecificationRequest(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["override"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["override"].([]any); ok && len(v) > 0 {
 		apiObject.Overrides = expandFleetLaunchTemplateOverridesRequests(v)
 	}
 
 	return apiObject
 }
 
-func expandFleetLaunchTemplateSpecificationRequest(tfMap map[string]interface{}) *awstypes.FleetLaunchTemplateSpecificationRequest {
+func expandFleetLaunchTemplateSpecificationRequest(tfMap map[string]any) *awstypes.FleetLaunchTemplateSpecificationRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1048,7 +1048,7 @@ func expandFleetLaunchTemplateSpecificationRequest(tfMap map[string]interface{})
 	return apiObject
 }
 
-func expandFleetLaunchTemplateOverridesRequests(tfList []interface{}) []awstypes.FleetLaunchTemplateOverridesRequest {
+func expandFleetLaunchTemplateOverridesRequests(tfList []any) []awstypes.FleetLaunchTemplateOverridesRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1056,7 +1056,7 @@ func expandFleetLaunchTemplateOverridesRequests(tfList []interface{}) []awstypes
 	var apiObjects []awstypes.FleetLaunchTemplateOverridesRequest
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1068,15 +1068,15 @@ func expandFleetLaunchTemplateOverridesRequests(tfList []interface{}) []awstypes
 	return apiObjects
 }
 
-func expandFleetLaunchTemplateOverridesRequest(tfMap map[string]interface{}) awstypes.FleetLaunchTemplateOverridesRequest {
+func expandFleetLaunchTemplateOverridesRequest(tfMap map[string]any) awstypes.FleetLaunchTemplateOverridesRequest {
 	apiObject := awstypes.FleetLaunchTemplateOverridesRequest{}
 
 	if v, ok := tfMap[names.AttrAvailabilityZone].(string); ok && v != "" {
 		apiObject.AvailabilityZone = aws.String(v)
 	}
 
-	if v, ok := tfMap["instance_requirements"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.InstanceRequirements = expandInstanceRequirementsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := tfMap["instance_requirements"]; ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.InstanceRequirements = expandInstanceRequirementsRequest(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := tfMap[names.AttrInstanceType].(string); ok && v != "" {
@@ -1091,8 +1091,8 @@ func expandFleetLaunchTemplateOverridesRequest(tfMap map[string]interface{}) aws
 		apiObject.MaxPrice = aws.String(v)
 	}
 
-	if v, ok := tfMap["placement"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.Placement = expandPlacement(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := tfMap["placement"]; ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.Placement = expandPlacement(v.([]any)[0].(map[string]any))
 	}
 	if v, ok := tfMap[names.AttrPriority].(float64); ok && v != 0 {
 		apiObject.Priority = aws.Float64(v)
@@ -1109,7 +1109,7 @@ func expandFleetLaunchTemplateOverridesRequest(tfMap map[string]interface{}) aws
 	return apiObject
 }
 
-func expandOnDemandOptionsRequest(tfMap map[string]interface{}) *awstypes.OnDemandOptionsRequest {
+func expandOnDemandOptionsRequest(tfMap map[string]any) *awstypes.OnDemandOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1120,8 +1120,8 @@ func expandOnDemandOptionsRequest(tfMap map[string]interface{}) *awstypes.OnDema
 		apiObject.AllocationStrategy = awstypes.FleetOnDemandAllocationStrategy(v)
 	}
 
-	if v, ok := tfMap["capacity_reservation_options"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.CapacityReservationOptions = expandCapacityReservationOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := tfMap["capacity_reservation_options"]; ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.CapacityReservationOptions = expandCapacityReservationOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["max_total_price"].(string); ok && v != "" {
@@ -1143,7 +1143,7 @@ func expandOnDemandOptionsRequest(tfMap map[string]interface{}) *awstypes.OnDema
 	return apiObject
 }
 
-func expandSpotOptionsRequest(tfMap map[string]interface{}) *awstypes.SpotOptionsRequest {
+func expandSpotOptionsRequest(tfMap map[string]any) *awstypes.SpotOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1165,8 +1165,8 @@ func expandSpotOptionsRequest(tfMap map[string]interface{}) *awstypes.SpotOption
 		apiObject.InstanceInterruptionBehavior = awstypes.SpotInstanceInterruptionBehavior(v)
 	}
 
-	if v, ok := tfMap["maintenance_strategies"].([]interface{}); ok && len(v) > 0 {
-		apiObject.MaintenanceStrategies = expandFleetSpotMaintenanceStrategiesRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["maintenance_strategies"].([]any); ok && len(v) > 0 {
+		apiObject.MaintenanceStrategies = expandFleetSpotMaintenanceStrategiesRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["max_total_price"].(string); ok && v != "" {
@@ -1188,7 +1188,7 @@ func expandSpotOptionsRequest(tfMap map[string]interface{}) *awstypes.SpotOption
 	return apiObject
 }
 
-func expandPlacement(tfMap map[string]interface{}) *awstypes.Placement {
+func expandPlacement(tfMap map[string]any) *awstypes.Placement {
 	if tfMap == nil {
 		return nil
 	}
@@ -1234,21 +1234,21 @@ func expandPlacement(tfMap map[string]interface{}) *awstypes.Placement {
 	return apiObject
 }
 
-func expandFleetSpotMaintenanceStrategiesRequest(tfMap map[string]interface{}) *awstypes.FleetSpotMaintenanceStrategiesRequest {
+func expandFleetSpotMaintenanceStrategiesRequest(tfMap map[string]any) *awstypes.FleetSpotMaintenanceStrategiesRequest {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.FleetSpotMaintenanceStrategiesRequest{}
 
-	if v, ok := tfMap["capacity_rebalance"].([]interface{}); ok && len(v) > 0 {
-		apiObject.CapacityRebalance = expandFleetSpotCapacityRebalanceRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["capacity_rebalance"].([]any); ok && len(v) > 0 {
+		apiObject.CapacityRebalance = expandFleetSpotCapacityRebalanceRequest(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandFleetSpotCapacityRebalanceRequest(tfMap map[string]interface{}) *awstypes.FleetSpotCapacityRebalanceRequest {
+func expandFleetSpotCapacityRebalanceRequest(tfMap map[string]any) *awstypes.FleetSpotCapacityRebalanceRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1266,7 +1266,7 @@ func expandFleetSpotCapacityRebalanceRequest(tfMap map[string]interface{}) *awst
 	return apiObject
 }
 
-func expandTargetCapacitySpecificationRequest(tfMap map[string]interface{}) *awstypes.TargetCapacitySpecificationRequest {
+func expandTargetCapacitySpecificationRequest(tfMap map[string]any) *awstypes.TargetCapacitySpecificationRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1296,12 +1296,12 @@ func expandTargetCapacitySpecificationRequest(tfMap map[string]interface{}) *aws
 	return apiObject
 }
 
-func flattenCapacityReservationsOptions(apiObject *awstypes.CapacityReservationOptions) map[string]interface{} {
+func flattenCapacityReservationsOptions(apiObject *awstypes.CapacityReservationOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.UsageStrategy; v != "" {
 		tfMap["usage_strategy"] = v
@@ -1310,8 +1310,8 @@ func flattenCapacityReservationsOptions(apiObject *awstypes.CapacityReservationO
 	return tfMap
 }
 
-func flattenFleetInstances(apiObject awstypes.DescribeFleetsInstances) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenFleetInstances(apiObject awstypes.DescribeFleetsInstances) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.InstanceIds; v != nil {
 		tfMap["instance_ids"] = v
@@ -1332,12 +1332,12 @@ func flattenFleetInstances(apiObject awstypes.DescribeFleetsInstances) map[strin
 	return tfMap
 }
 
-func flattenFleetInstanceSet(apiObjects []awstypes.DescribeFleetsInstances) []interface{} {
+func flattenFleetInstanceSet(apiObjects []awstypes.DescribeFleetsInstances) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenFleetInstances(apiObject))
@@ -1346,12 +1346,12 @@ func flattenFleetInstanceSet(apiObjects []awstypes.DescribeFleetsInstances) []in
 	return tfList
 }
 
-func flattenFleetLaunchTemplateConfigs(apiObjects []awstypes.FleetLaunchTemplateConfig) []interface{} {
+func flattenFleetLaunchTemplateConfigs(apiObjects []awstypes.FleetLaunchTemplateConfig) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenFleetLaunchTemplateConfig(apiObject))
@@ -1360,11 +1360,11 @@ func flattenFleetLaunchTemplateConfigs(apiObjects []awstypes.FleetLaunchTemplate
 	return tfList
 }
 
-func flattenFleetLaunchTemplateConfig(apiObject awstypes.FleetLaunchTemplateConfig) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenFleetLaunchTemplateConfig(apiObject awstypes.FleetLaunchTemplateConfig) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.LaunchTemplateSpecification; v != nil {
-		tfMap["launch_template_specification"] = []interface{}{flattenFleetLaunchTemplateSpecificationForFleet(v)}
+		tfMap["launch_template_specification"] = []any{flattenFleetLaunchTemplateSpecificationForFleet(v)}
 	}
 
 	if v := apiObject.Overrides; v != nil {
@@ -1374,12 +1374,12 @@ func flattenFleetLaunchTemplateConfig(apiObject awstypes.FleetLaunchTemplateConf
 	return tfMap
 }
 
-func flattenFleetLaunchTemplateSpecificationForFleet(apiObject *awstypes.FleetLaunchTemplateSpecification) map[string]interface{} {
+func flattenFleetLaunchTemplateSpecificationForFleet(apiObject *awstypes.FleetLaunchTemplateSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.LaunchTemplateId; v != nil {
 		tfMap["launch_template_id"] = aws.ToString(v)
@@ -1415,12 +1415,12 @@ func flattenFleetLaunchTemplateSpecificationForFleet(apiObject *awstypes.FleetLa
 // 	return tfMap
 // }
 
-func flattenFleetLaunchTemplateOverrideses(apiObjects []awstypes.FleetLaunchTemplateOverrides) []interface{} {
+func flattenFleetLaunchTemplateOverrideses(apiObjects []awstypes.FleetLaunchTemplateOverrides) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenFleetLaunchTemplateOverrides(&apiObject))
@@ -1429,15 +1429,15 @@ func flattenFleetLaunchTemplateOverrideses(apiObjects []awstypes.FleetLaunchTemp
 	return tfList
 }
 
-func flattenFleetLaunchTemplateOverrides(apiObject *awstypes.FleetLaunchTemplateOverrides) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenFleetLaunchTemplateOverrides(apiObject *awstypes.FleetLaunchTemplateOverrides) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.AvailabilityZone; v != nil {
 		tfMap[names.AttrAvailabilityZone] = aws.ToString(v)
 	}
 
 	if v := apiObject.InstanceRequirements; v != nil {
-		tfMap["instance_requirements"] = []interface{}{flattenInstanceRequirements(v)}
+		tfMap["instance_requirements"] = []any{flattenInstanceRequirements(v)}
 	}
 
 	if v := apiObject.ImageId; v != nil {
@@ -1453,7 +1453,7 @@ func flattenFleetLaunchTemplateOverrides(apiObject *awstypes.FleetLaunchTemplate
 	}
 
 	if v := apiObject.Placement; v != nil {
-		tfMap["placement"] = []interface{}{flattenPlacement(v)}
+		tfMap["placement"] = []any{flattenPlacement(v)}
 	}
 
 	if v := apiObject.Priority; v != nil {
@@ -1471,19 +1471,19 @@ func flattenFleetLaunchTemplateOverrides(apiObject *awstypes.FleetLaunchTemplate
 	return tfMap
 }
 
-func flattenOnDemandOptions(apiObject *awstypes.OnDemandOptions) map[string]interface{} {
+func flattenOnDemandOptions(apiObject *awstypes.OnDemandOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AllocationStrategy; v != "" {
 		tfMap["allocation_strategy"] = v
 	}
 
 	if v := apiObject.CapacityReservationOptions; v != nil {
-		tfMap["capacity_reservation_options"] = []interface{}{flattenCapacityReservationsOptions(v)}
+		tfMap["capacity_reservation_options"] = []any{flattenCapacityReservationsOptions(v)}
 	}
 
 	if v := apiObject.MaxTotalPrice; v != nil {
@@ -1505,12 +1505,12 @@ func flattenOnDemandOptions(apiObject *awstypes.OnDemandOptions) map[string]inte
 	return tfMap
 }
 
-func flattenPlacement(apiObject *awstypes.PlacementResponse) map[string]interface{} {
+func flattenPlacement(apiObject *awstypes.PlacementResponse) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.GroupName; v != nil {
 		tfMap[names.AttrGroupName] = aws.ToString(v)
@@ -1519,12 +1519,12 @@ func flattenPlacement(apiObject *awstypes.PlacementResponse) map[string]interfac
 	return tfMap
 }
 
-func flattenSpotOptions(apiObject *awstypes.SpotOptions) map[string]interface{} {
+func flattenSpotOptions(apiObject *awstypes.SpotOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AllocationStrategy; v != "" {
 		tfMap["allocation_strategy"] = v
@@ -1543,7 +1543,7 @@ func flattenSpotOptions(apiObject *awstypes.SpotOptions) map[string]interface{} 
 	}
 
 	if v := apiObject.MaintenanceStrategies; v != nil {
-		tfMap["maintenance_strategies"] = []interface{}{flattenFleetSpotMaintenanceStrategies(v)}
+		tfMap["maintenance_strategies"] = []any{flattenFleetSpotMaintenanceStrategies(v)}
 	}
 
 	if v := apiObject.MaxTotalPrice; v != nil {
@@ -1565,26 +1565,26 @@ func flattenSpotOptions(apiObject *awstypes.SpotOptions) map[string]interface{} 
 	return tfMap
 }
 
-func flattenFleetSpotMaintenanceStrategies(apiObject *awstypes.FleetSpotMaintenanceStrategies) map[string]interface{} {
+func flattenFleetSpotMaintenanceStrategies(apiObject *awstypes.FleetSpotMaintenanceStrategies) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CapacityRebalance; v != nil {
-		tfMap["capacity_rebalance"] = []interface{}{flattenFleetSpotCapacityRebalance(v)}
+		tfMap["capacity_rebalance"] = []any{flattenFleetSpotCapacityRebalance(v)}
 	}
 
 	return tfMap
 }
 
-func flattenFleetSpotCapacityRebalance(apiObject *awstypes.FleetSpotCapacityRebalance) map[string]interface{} {
+func flattenFleetSpotCapacityRebalance(apiObject *awstypes.FleetSpotCapacityRebalance) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ReplacementStrategy; v != "" {
 		tfMap["replacement_strategy"] = v
@@ -1597,12 +1597,12 @@ func flattenFleetSpotCapacityRebalance(apiObject *awstypes.FleetSpotCapacityReba
 	return tfMap
 }
 
-func flattenTargetCapacitySpecification(apiObject *awstypes.TargetCapacitySpecification) map[string]interface{} {
+func flattenTargetCapacitySpecification(apiObject *awstypes.TargetCapacitySpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.DefaultTargetCapacityType; v != "" {
 		tfMap["default_target_capacity_type"] = v

--- a/internal/service/ec2/ec2_host.go
+++ b/internal/service/ec2/ec2_host.go
@@ -99,7 +99,7 @@ func resourceHost() *schema.Resource {
 	}
 }
 
-func resourceHostCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHostCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -143,7 +143,7 @@ func resourceHostCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceHostRead(ctx, d, meta)...)
 }
 
-func resourceHostRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHostRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -181,7 +181,7 @@ func resourceHostRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	return diags
 }
 
-func resourceHostUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHostUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -224,7 +224,7 @@ func resourceHostUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceHostRead(ctx, d, meta)...)
 }
 
-func resourceHostDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHostDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_host_data_source.go
+++ b/internal/service/ec2/ec2_host_data_source.go
@@ -91,7 +91,7 @@ func dataSourceHost() *schema.Resource {
 	}
 }
 
-func dataSourceHostRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceHostRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_image_block_public_access.go
+++ b/internal/service/ec2/ec2_image_block_public_access.go
@@ -43,7 +43,7 @@ func resourceImageBlockPublicAccess() *schema.Resource {
 	}
 }
 
-func resourceImageBlockPublicAccessPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceImageBlockPublicAccessPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -80,7 +80,7 @@ func resourceImageBlockPublicAccessPut(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceImageBlockPublicAccessRead(ctx, d, meta)...)
 }
 
-func resourceImageBlockPublicAccessRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceImageBlockPublicAccessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -40,6 +40,8 @@ import (
 	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"maps"
+	"slices"
 )
 
 // @SDKResource("aws_instance", name="Instance")
@@ -300,9 +302,9 @@ func resourceInstance() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
+				Set: func(v any) int {
 					var buf bytes.Buffer
-					m := v.(map[string]interface{})
+					m := v.(map[string]any)
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrSnapshotID].(string)))
 					return create.StringHashcode(buf.String())
@@ -356,9 +358,9 @@ func resourceInstance() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
+				Set: func(v any) int {
 					var buf bytes.Buffer
-					m := v.(map[string]interface{})
+					m := v.(map[string]any)
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrVirtualName].(string)))
 					if v, ok := m["no_device"].(bool); ok && v {
@@ -817,7 +819,7 @@ func resourceInstance() *schema.Resource {
 					}
 					return false
 				},
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					switch v := v.(type) {
 					case string:
 						return userDataHashSum(v)
@@ -850,7 +852,7 @@ func resourceInstance() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.All(
-			func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 				_, ok := diff.GetOk(names.AttrLaunchTemplate)
 
 				if diff.Id() != "" && diff.HasChange("launch_template.0.version") && ok {
@@ -899,13 +901,13 @@ func resourceInstance() *schema.Resource {
 
 				return nil
 			},
-			customdiff.ComputedIf("launch_template.0.name", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("launch_template.0.name", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				return diff.HasChange("launch_template.0.id")
 			}),
-			customdiff.ComputedIf("launch_template.0.id", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("launch_template.0.id", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				return diff.HasChange("launch_template.0.name")
 			}),
-			func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 				// Set public_dns and public_ip to newly computed if the instance will be stopped and started
 				// as part of Update and there is already a public_ip value in state.
 				if diff.Id() != "" && diff.HasChanges(names.AttrInstanceType, "user_data", "user_data_base64") {
@@ -924,17 +926,17 @@ func resourceInstance() *schema.Resource {
 
 				return nil
 			},
-			customdiff.ForceNewIf("user_data", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ForceNewIf("user_data", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				return diff.Get("user_data_replace_on_change").(bool)
 			}),
-			customdiff.ForceNewIf("user_data_base64", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ForceNewIf("user_data_base64", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				return diff.Get("user_data_replace_on_change").(bool)
 			}),
-			customdiff.ForceNewIf("enable_primary_ipv6", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ForceNewIf("enable_primary_ipv6", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				o, n := diff.GetChange("enable_primary_ipv6")
 				return o.(bool) && !n.(bool) // can be enabled but not disabled without recreate
 			}),
-			customdiff.ForceNewIf(names.AttrInstanceType, func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ForceNewIf(names.AttrInstanceType, func(ctx context.Context, diff *schema.ResourceDiff, meta any) bool {
 				conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 				_, ok := diff.GetOk(names.AttrInstanceType)
@@ -988,7 +990,7 @@ func throughputDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool
 	return strings.ToLower(v) != string(awstypes.VolumeTypeGp3) && new == "0"
 }
 
-func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1004,7 +1006,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig(ctx)
 	tagSpecifications = append(tagSpecifications,
 		tagSpecificationsFromKeyValue(
-			defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("volume_tags").(map[string]interface{}))),
+			defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get("volume_tags").(map[string]any))),
 			string(awstypes.ResourceTypeVolume))...)
 
 	input := ec2.RunInstancesInput{
@@ -1049,7 +1051,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	log.Printf("[DEBUG] Creating EC2 Instance: %s", d.Id())
 	outputRaw, err := tfresource.RetryWhen(ctx, iamPropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.RunInstances(ctx, &input)
 		},
 		func(err error) (bool, error) {
@@ -1096,13 +1098,13 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	// tags in root_block_device and ebs_block_device
-	blockDeviceTagsToCreate := map[string]map[string]interface{}{}
+	blockDeviceTagsToCreate := map[string]map[string]any{}
 	if v, ok := d.GetOk("root_block_device"); ok {
-		vL := v.([]interface{})
+		vL := v.([]any)
 		for _, v := range vL {
-			bd := v.(map[string]interface{})
+			bd := v.(map[string]any)
 
-			blockDeviceTags, ok := bd[names.AttrTags].(map[string]interface{})
+			blockDeviceTags, ok := bd[names.AttrTags].(map[string]any)
 			if !ok || len(blockDeviceTags) == 0 {
 				continue
 			}
@@ -1119,9 +1121,9 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	if v, ok := d.GetOk("ebs_block_device"); ok {
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
-			bd := v.(map[string]interface{})
+			bd := v.(map[string]any)
 
-			blockDeviceTags, ok := bd[names.AttrTags].(map[string]interface{})
+			blockDeviceTags, ok := bd[names.AttrTags].(map[string]any)
 			if !ok || len(blockDeviceTags) == 0 {
 				continue
 			}
@@ -1145,7 +1147,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceInstanceUpdate(ctx, d, meta)...)
 }
 
-func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1205,7 +1207,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if instance.MaintenanceOptions != nil {
-		if err := d.Set("maintenance_options", []interface{}{flattenInstanceMaintenanceOptions(instance.MaintenanceOptions)}); err != nil {
+		if err := d.Set("maintenance_options", []any{flattenInstanceMaintenanceOptions(instance.MaintenanceOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting maintenance_options: %s", err)
 		}
 	} else {
@@ -1217,7 +1219,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if instance.PrivateDnsNameOptions != nil {
-		if err := d.Set("private_dns_name_options", []interface{}{flattenPrivateDNSNameOptionsResponse(instance.PrivateDnsNameOptions)}); err != nil {
+		if err := d.Set("private_dns_name_options", []any{flattenPrivateDNSNameOptionsResponse(instance.PrivateDnsNameOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting private_dns_name_options: %s", err)
 		}
 	} else {
@@ -1265,7 +1267,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if v, ok := d.GetOk("network_interface"); ok {
 		vL := v.(*schema.Set).List()
 		for _, vi := range vL {
-			mVi := vi.(map[string]interface{})
+			mVi := vi.(map[string]any)
 			configuredDeviceIndexes = append(configuredDeviceIndexes, mVi["device_index"].(int))
 		}
 	}
@@ -1274,9 +1276,9 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	var ipv6Addresses []string
 	if len(instance.NetworkInterfaces) > 0 {
 		var primaryNetworkInterface awstypes.InstanceNetworkInterface
-		var networkInterfaces []map[string]interface{}
+		var networkInterfaces []map[string]any
 		for _, iNi := range instance.NetworkInterfaces {
-			ni := make(map[string]interface{})
+			ni := make(map[string]any)
 			if aws.ToInt32(iNi.Attachment.DeviceIndex) == 0 {
 				primaryNetworkInterface = iNi
 			}
@@ -1389,7 +1391,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if _, ok := d.GetOk("ephemeral_block_device"); !ok {
-		d.Set("ephemeral_block_device", []interface{}{})
+		d.Set("ephemeral_block_device", []any{})
 	}
 
 	// ARN
@@ -1473,7 +1475,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 
 		if instanceCreditSpecification != nil {
-			if err := d.Set("credit_specification", []interface{}{flattenInstanceCreditSpecification(instanceCreditSpecification)}); err != nil {
+			if err := d.Set("credit_specification", []any{flattenInstanceCreditSpecification(instanceCreditSpecification)}); err != nil {
 				return sdkdiag.AppendErrorf(diags, "setting credit_specification: %s", err)
 			}
 		} else {
@@ -1493,7 +1495,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if instance.CapacityReservationSpecification != nil {
-		if err := d.Set("capacity_reservation_specification", []interface{}{flattenCapacityReservationSpecificationResponse(instance.CapacityReservationSpecification)}); err != nil {
+		if err := d.Set("capacity_reservation_specification", []any{flattenCapacityReservationSpecificationResponse(instance.CapacityReservationSpecification)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting capacity_reservation_specification: %s", err)
 		}
 	} else {
@@ -1514,7 +1516,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 			return sdkdiag.AppendErrorf(diags, "reading EC2 Spot Instance Request (%s): %s", spotInstanceRequestID, err)
 		}
 
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"instance_interruption_behavior": apiObject.InstanceInterruptionBehavior,
 			"spot_instance_type":             apiObject.Type,
 		}
@@ -1527,9 +1529,9 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 			tfMap["valid_until"] = aws.ToTime(v).Format(time.RFC3339)
 		}
 
-		if err := d.Set("instance_market_options", []interface{}{map[string]interface{}{
+		if err := d.Set("instance_market_options", []any{map[string]any{
 			"market_type":  awstypes.MarketTypeSpot,
-			"spot_options": []interface{}{tfMap},
+			"spot_options": []any{tfMap},
 		}}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting instance_market_options: %s", err)
 		}
@@ -1542,7 +1544,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1977,8 +1979,8 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if d.HasChange("credit_specification") && !d.IsNewResource() {
-		if v, ok := d.GetOk("credit_specification"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			instanceCreditSpecification := expandInstanceCreditSpecificationRequest(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("credit_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			instanceCreditSpecification := expandInstanceCreditSpecificationRequest(v.([]any)[0].(map[string]any))
 			instanceCreditSpecification.InstanceId = aws.String(d.Id())
 			input := ec2.ModifyInstanceCreditSpecificationInput{
 				ClientToken:                  aws.String(id.UniqueId()),
@@ -1996,7 +1998,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	if d.HasChange("metadata_options") && !d.IsNewResource() {
 		if v, ok := d.GetOk("metadata_options"); ok {
-			if tfMap, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+			if tfMap, ok := v.([]any)[0].(map[string]any); ok {
 				httpEndpoint := awstypes.InstanceMetadataEndpointState(tfMap["http_endpoint"].(string))
 				input := ec2.ModifyInstanceMetadataOptionsInput{
 					HttpEndpoint: httpEndpoint,
@@ -2135,8 +2137,8 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	// To modify capacity reservation attributes of an instance, instance state needs to be in ec2.InstanceStateNameStopped,
 	// otherwise the modification will return an IncorrectInstanceState error
 	if d.HasChange("capacity_reservation_specification") && !d.IsNewResource() {
-		if v, ok := d.GetOk("capacity_reservation_specification"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			if v := expandCapacityReservationSpecification(v.([]interface{})[0].(map[string]interface{})); v != nil && (v.CapacityReservationPreference != "" || v.CapacityReservationTarget != nil) {
+		if v, ok := d.GetOk("capacity_reservation_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			if v := expandCapacityReservationSpecification(v.([]any)[0].(map[string]any)); v != nil && (v.CapacityReservationPreference != "" || v.CapacityReservationTarget != nil) {
 				if err := stopInstance(ctx, conn, d.Id(), false, instanceStopTimeout); err != nil {
 					return sdkdiag.AppendFromErr(diags, err)
 				}
@@ -2180,8 +2182,8 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if d.HasChange("private_dns_name_options") && !d.IsNewResource() {
-		if v, ok := d.GetOk("private_dns_name_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			tfMap := v.([]interface{})[0].(map[string]interface{})
+		if v, ok := d.GetOk("private_dns_name_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			tfMap := v.([]any)[0].(map[string]any)
 
 			input := ec2.ModifyPrivateDnsNameOptionsInput{
 				InstanceId: aws.String(d.Id()),
@@ -2213,7 +2215,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceInstanceRead(ctx, d, meta)...)
 }
 
-func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -2312,7 +2314,7 @@ func modifyInstanceAttributeWithStopStart(ctx context.Context, conn *ec2.Client,
 	return nil
 }
 
-func readBlockDevices(ctx context.Context, d *schema.ResourceData, meta interface{}, instance *awstypes.Instance, ds bool) error {
+func readBlockDevices(ctx context.Context, d *schema.ResourceData, meta any, instance *awstypes.Instance, ds bool) error {
 	ibds, err := readBlockDevicesFromInstance(ctx, d, meta, instance, ds)
 	if err != nil {
 		return fmt.Errorf("reading block devices: %w", err)
@@ -2324,20 +2326,18 @@ func readBlockDevices(ctx context.Context, d *schema.ResourceData, meta interfac
 	// the root block device must be copied over to ibds["ebs"]
 	if ibds != nil {
 		if _, ok := d.GetOk("ebs_block_device"); ok {
-			if v, ok := ibds["ebs"].([]map[string]interface{}); ok && len(v) == 0 {
-				if root, ok := ibds["root"].(map[string]interface{}); ok {
+			if v, ok := ibds["ebs"].([]map[string]any); ok && len(v) == 0 {
+				if root, ok := ibds["root"].(map[string]any); ok {
 					// Make deep copy of data
-					m := make(map[string]interface{})
+					m := make(map[string]any)
 
-					for k, v := range root {
-						m[k] = v
-					}
+					maps.Copy(m, root)
 
 					if snapshotID, ok := ibds[names.AttrSnapshotID].(string); ok {
 						m[names.AttrSnapshotID] = snapshotID
 					}
 
-					ibds["ebs"] = []interface{}{m}
+					ibds["ebs"] = []any{m}
 				}
 			}
 		}
@@ -2349,13 +2349,13 @@ func readBlockDevices(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	// This handles the import case which needs to be defaulted to empty
 	if _, ok := d.GetOk("root_block_device"); !ok {
-		if err := d.Set("root_block_device", []interface{}{}); err != nil {
+		if err := d.Set("root_block_device", []any{}); err != nil {
 			return err // nosemgrep:ci.bare-error-returns
 		}
 	}
 
 	if ibds["root"] != nil {
-		roots := []interface{}{ibds["root"]}
+		roots := []any{ibds["root"]}
 		if err := d.Set("root_block_device", roots); err != nil {
 			return err // nosemgrep:ci.bare-error-returns
 		}
@@ -2364,9 +2364,9 @@ func readBlockDevices(ctx context.Context, d *schema.ResourceData, meta interfac
 	return nil
 }
 
-func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, meta interface{}, instance *awstypes.Instance, ds bool) (map[string]interface{}, error) {
-	blockDevices := make(map[string]interface{})
-	blockDevices["ebs"] = make([]map[string]interface{}, 0)
+func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, meta any, instance *awstypes.Instance, ds bool) (map[string]any, error) {
+	blockDevices := make(map[string]any)
+	blockDevices["ebs"] = make([]map[string]any, 0)
 	blockDevices["root"] = nil
 	// Ephemeral devices don't show up in BlockDeviceMappings or DescribeVolumes so we can't actually set them
 
@@ -2402,7 +2402,7 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 
 	for _, vol := range volResp.Volumes {
 		instanceBd := instanceBlockDevices[aws.ToString(vol.VolumeId)]
-		bd := make(map[string]interface{})
+		bd := make(map[string]any)
 
 		bd["volume_id"] = aws.ToString(vol.VolumeId)
 
@@ -2430,11 +2430,11 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 		if instanceBd.DeviceName != nil {
 			bd[names.AttrDeviceName] = aws.ToString(instanceBd.DeviceName)
 		}
-		if v, ok := d.GetOk("volume_tags"); (!ok || v == nil || len(v.(map[string]interface{})) == 0) && ds {
+		if v, ok := d.GetOk("volume_tags"); (!ok || v == nil || len(v.(map[string]any)) == 0) && ds {
 			bd[names.AttrTags] = keyValueTags(ctx, vol.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()
 		}
 
-		if v, ok := d.GetOk("volume_tags"); (!ok || v == nil || len(v.(map[string]interface{})) == 0) && !ds {
+		if v, ok := d.GetOk("volume_tags"); (!ok || v == nil || len(v.(map[string]any)) == 0) && !ds {
 			tags := keyValueTags(ctx, vol.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 			// default setup, in case we don't find config for the block device (don't resolve duplicates)
@@ -2444,7 +2444,7 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 			if v, ok := d.GetOk("ebs_block_device"); ok && v.(*schema.Set).Len() > 0 {
 				ebdList := v.(*schema.Set).List()
 				for _, ebd := range ebdList {
-					ebd, ok := ebd.(map[string]interface{})
+					ebd, ok := ebd.(map[string]any)
 					if !ok {
 						continue
 					}
@@ -2458,7 +2458,7 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 				}
 			}
 
-			if v, ok := d.GetOk("root_block_device"); ok && len(v.([]interface{})) > 0 && blockDeviceIsRoot(instanceBd, instance) {
+			if v, ok := d.GetOk("root_block_device"); ok && len(v.([]any)) > 0 && blockDeviceIsRoot(instanceBd, instance) {
 				bd[names.AttrTags] = tags.ResolveDuplicates(ctx, defaultTagsConfig, ignoreTagsConfig, d, "root_block_device[0].tags", nil).Map()
 			}
 		}
@@ -2470,14 +2470,14 @@ func readBlockDevicesFromInstance(ctx context.Context, d *schema.ResourceData, m
 				bd[names.AttrSnapshotID] = aws.ToString(vol.SnapshotId)
 			}
 
-			blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]interface{}), bd)
+			blockDevices["ebs"] = append(blockDevices["ebs"].([]map[string]any), bd)
 		}
 	}
 	// If we determine the root device is the only block device mapping
 	// in the instance (including ephemerals) after returning from this function,
 	// we'll need to set the ebs_block_device as a clone of the root device
 	// with the snapshot_id populated; thus, we store the ID for safe-keeping
-	if blockDevices["root"] != nil && len(blockDevices["ebs"].([]map[string]interface{})) == 0 {
+	if blockDevices["root"] != nil && len(blockDevices["ebs"].([]map[string]any)) == 0 {
 		blockDevices[names.AttrSnapshotID] = volResp.Volumes[0].SnapshotId
 	}
 
@@ -2574,7 +2574,7 @@ func findRootDeviceName(ctx context.Context, conn *ec2.Client, amiID string) (*s
 	return rootDeviceName, nil
 }
 
-func buildNetworkInterfaceOpts(d *schema.ResourceData, groups []string, nInterfaces interface{}) []awstypes.InstanceNetworkInterfaceSpecification {
+func buildNetworkInterfaceOpts(d *schema.ResourceData, groups []string, nInterfaces any) []awstypes.InstanceNetworkInterfaceSpecification {
 	networkInterfaces := []awstypes.InstanceNetworkInterfaceSpecification{}
 	// Get necessary items
 	subnet, hasSubnet := d.GetOk(names.AttrSubnetID)
@@ -2610,8 +2610,8 @@ func buildNetworkInterfaceOpts(d *schema.ResourceData, groups []string, nInterfa
 		}
 
 		if v, ok := d.GetOk("ipv6_addresses"); ok {
-			ipv6Addresses := make([]awstypes.InstanceIpv6Address, len(v.([]interface{})))
-			for i, address := range v.([]interface{}) {
+			ipv6Addresses := make([]awstypes.InstanceIpv6Address, len(v.([]any)))
+			for i, address := range v.([]any) {
 				ipv6Addresses[i] = awstypes.InstanceIpv6Address{
 					Ipv6Address: aws.String(address.(string)),
 				}
@@ -2631,7 +2631,7 @@ func buildNetworkInterfaceOpts(d *schema.ResourceData, groups []string, nInterfa
 		// If we have manually specified network interfaces, build and attach those here.
 		vL := nInterfaces.(*schema.Set).List()
 		for _, v := range vL {
-			ini := v.(map[string]interface{})
+			ini := v.(map[string]any)
 			ni := awstypes.InstanceNetworkInterfaceSpecification{
 				DeviceIndex:         aws.Int32(int32(ini["device_index"].(int))),
 				NetworkCardIndex:    aws.Int32(int32(ini["network_card_index"].(int))),
@@ -2651,7 +2651,7 @@ func readBlockDeviceMappingsFromConfig(ctx context.Context, d *schema.ResourceDa
 	if v, ok := d.GetOk("ebs_block_device"); ok {
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
-			bd := v.(map[string]interface{})
+			bd := v.(map[string]any)
 			ebs := &awstypes.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd[names.AttrDeleteOnTermination].(bool)),
 			}
@@ -2707,7 +2707,7 @@ func readBlockDeviceMappingsFromConfig(ctx context.Context, d *schema.ResourceDa
 	if v, ok := d.GetOk("ephemeral_block_device"); ok {
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
-			bd := v.(map[string]interface{})
+			bd := v.(map[string]any)
 			bdm := awstypes.BlockDeviceMapping{
 				DeviceName:  aws.String(bd[names.AttrDeviceName].(string)),
 				VirtualName: aws.String(bd[names.AttrVirtualName].(string)),
@@ -2727,9 +2727,9 @@ func readBlockDeviceMappingsFromConfig(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if v, ok := d.GetOk("root_block_device"); ok {
-		vL := v.([]interface{})
+		vL := v.([]any)
 		for _, v := range vL {
-			bd := v.(map[string]interface{})
+			bd := v.(map[string]any)
 			ebs := &awstypes.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd[names.AttrDeleteOnTermination].(bool)),
 			}
@@ -2775,8 +2775,8 @@ func readBlockDeviceMappingsFromConfig(ctx context.Context, d *schema.ResourceDa
 
 			var amiID string
 
-			if v, ok := d.GetOk(names.AttrLaunchTemplate); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				launchTemplateData, err := findLaunchTemplateData(ctx, conn, expandLaunchTemplateSpecification(v.([]interface{})[0].(map[string]interface{})))
+			if v, ok := d.GetOk(names.AttrLaunchTemplate); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				launchTemplateData, err := findLaunchTemplateData(ctx, conn, expandLaunchTemplateSpecification(v.([]any)[0].(map[string]any)))
 
 				if err != nil {
 					return nil, err
@@ -2981,14 +2981,14 @@ type instanceOpts struct {
 	UserData64                        *string
 }
 
-func buildInstanceOpts(ctx context.Context, d *schema.ResourceData, meta interface{}) (*instanceOpts, error) {
+func buildInstanceOpts(ctx context.Context, d *schema.ResourceData, meta any) (*instanceOpts, error) {
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	opts := &instanceOpts{
 		DisableAPITermination: aws.Bool(d.Get("disable_api_termination").(bool)),
 		EBSOptimized:          aws.Bool(d.Get("ebs_optimized").(bool)),
-		EnclaveOptions:        expandEnclaveOptions(d.Get("enclave_options").([]interface{})),
-		MetadataOptions:       expandInstanceMetadataOptions(d.Get("metadata_options").([]interface{})),
+		EnclaveOptions:        expandEnclaveOptions(d.Get("enclave_options").([]any)),
+		MetadataOptions:       expandInstanceMetadataOptions(d.Get("metadata_options").([]any)),
 	}
 
 	if v, ok := d.GetOk("disable_api_stop"); ok {
@@ -3005,8 +3005,8 @@ func buildInstanceOpts(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	var instanceInterruptionBehavior string
 
-	if v, ok := d.GetOk(names.AttrLaunchTemplate); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		launchTemplateSpecification := expandLaunchTemplateSpecification(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk(names.AttrLaunchTemplate); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		launchTemplateSpecification := expandLaunchTemplateSpecification(v.([]any)[0].(map[string]any))
 		launchTemplateData, err := findLaunchTemplateData(ctx, conn, launchTemplateSpecification)
 
 		if err != nil {
@@ -3029,7 +3029,7 @@ func buildInstanceOpts(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 	}
 
-	if v, ok := d.GetOk("credit_specification"); ok && len(v.([]interface{})) > 0 {
+	if v, ok := d.GetOk("credit_specification"); ok && len(v.([]any)) > 0 {
 		if instanceType != "" {
 			instanceTypeInfo, err := findInstanceTypeByName(ctx, conn, instanceType)
 
@@ -3038,7 +3038,7 @@ func buildInstanceOpts(ctx context.Context, d *schema.ResourceData, meta interfa
 			}
 
 			if aws.ToBool(instanceTypeInfo.BurstablePerformanceSupported) {
-				if v, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+				if v, ok := v.([]any)[0].(map[string]any); ok {
 					opts.CreditSpecification = expandCreditSpecificationRequest(v)
 				} else {
 					log.Print("[WARN] credit_specification is defined but the value of cpu_credits is missing, default value will be used.")
@@ -3107,7 +3107,7 @@ func buildInstanceOpts(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("cpu_options"); ok {
-		opts.CpuOptions = expandCPUOptions(v.([]interface{}))
+		opts.CpuOptions = expandCPUOptions(v.([]any))
 	} else if v := d.Get("cpu_core_count").(int); v > 0 {
 		// preserved to maintain backward compatibility
 		tc := d.Get("cpu_threads_per_core").(int)
@@ -3175,8 +3175,8 @@ func buildInstanceOpts(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 
 		if v, ok := d.GetOk("ipv6_addresses"); ok {
-			ipv6Addresses := make([]awstypes.InstanceIpv6Address, len(v.([]interface{})))
-			for i, address := range v.([]interface{}) {
+			ipv6Addresses := make([]awstypes.InstanceIpv6Address, len(v.([]any)))
+			for i, address := range v.([]any) {
 				ipv6Addresses[i] = awstypes.InstanceIpv6Address{
 					Ipv6Address: aws.String(address.(string)),
 				}
@@ -3204,20 +3204,20 @@ func buildInstanceOpts(ctx context.Context, d *schema.ResourceData, meta interfa
 		opts.BlockDeviceMappings = blockDevices
 	}
 
-	if v, ok := d.GetOk("capacity_reservation_specification"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		opts.CapacityReservationSpecification = expandCapacityReservationSpecification(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("capacity_reservation_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		opts.CapacityReservationSpecification = expandCapacityReservationSpecification(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("maintenance_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		opts.MaintenanceOptions = expandInstanceMaintenanceOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("maintenance_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		opts.MaintenanceOptions = expandInstanceMaintenanceOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("private_dns_name_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		opts.PrivateDNSNameOptions = expandPrivateDNSNameOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("private_dns_name_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		opts.PrivateDNSNameOptions = expandPrivateDNSNameOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("instance_market_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		opts.InstanceMarketOptions = expandInstanceMarketOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("instance_market_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		opts.InstanceMarketOptions = expandInstanceMarketOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
 	return opts, nil
@@ -3233,7 +3233,7 @@ func startInstance(ctx context.Context, conn *ec2.Client, id string, retry bool,
 	if retry {
 		// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16433.
 		_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, ec2PropagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.StartInstances(ctx, &ec2.StartInstancesInput{
 					InstanceIds: []string{id},
 				})
@@ -3493,10 +3493,10 @@ func getVolIDByDeviceName(instance *awstypes.Instance, deviceName string) string
 
 func blockDeviceTagsDefined(d *schema.ResourceData) bool {
 	if v, ok := d.GetOk("root_block_device"); ok {
-		vL := v.([]interface{})
+		vL := v.([]any)
 		for _, v := range vL {
-			bd := v.(map[string]interface{})
-			if blockDeviceTags, ok := bd[names.AttrTags].(map[string]interface{}); ok && len(blockDeviceTags) > 0 {
+			bd := v.(map[string]any)
+			if blockDeviceTags, ok := bd[names.AttrTags].(map[string]any); ok && len(blockDeviceTags) > 0 {
 				return true
 			}
 		}
@@ -3505,8 +3505,8 @@ func blockDeviceTagsDefined(d *schema.ResourceData) bool {
 	if v, ok := d.GetOk("ebs_block_device"); ok {
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
-			bd := v.(map[string]interface{})
-			if blockDeviceTags, ok := bd[names.AttrTags].(map[string]interface{}); ok && len(blockDeviceTags) > 0 {
+			bd := v.(map[string]any)
+			if blockDeviceTags, ok := bd[names.AttrTags].(map[string]any); ok && len(blockDeviceTags) > 0 {
 				return true
 			}
 		}
@@ -3515,12 +3515,12 @@ func blockDeviceTagsDefined(d *schema.ResourceData) bool {
 	return false
 }
 
-func expandInstanceMetadataOptions(l []interface{}) *awstypes.InstanceMetadataOptionsRequest {
+func expandInstanceMetadataOptions(l []any) *awstypes.InstanceMetadataOptionsRequest {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	opts := &awstypes.InstanceMetadataOptionsRequest{
 		HttpEndpoint: awstypes.InstanceMetadataEndpointState(m["http_endpoint"].(string)),
@@ -3548,12 +3548,12 @@ func expandInstanceMetadataOptions(l []interface{}) *awstypes.InstanceMetadataOp
 	return opts
 }
 
-func expandCPUOptions(l []interface{}) *awstypes.CpuOptionsRequest {
+func expandCPUOptions(l []any) *awstypes.CpuOptionsRequest {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	opts := &awstypes.CpuOptionsRequest{}
 
@@ -3573,12 +3573,12 @@ func expandCPUOptions(l []interface{}) *awstypes.CpuOptionsRequest {
 	return opts
 }
 
-func expandEnclaveOptions(l []interface{}) *awstypes.EnclaveOptionsRequest {
+func expandEnclaveOptions(l []any) *awstypes.EnclaveOptionsRequest {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	opts := &awstypes.EnclaveOptionsRequest{
 		Enabled: aws.Bool(m[names.AttrEnabled].(bool)),
@@ -3588,7 +3588,7 @@ func expandEnclaveOptions(l []interface{}) *awstypes.EnclaveOptionsRequest {
 }
 
 // Expands an array of secondary Private IPs into a ec2 Private IP Address Spec
-func expandSecondaryPrivateIPAddresses(ips []interface{}) []awstypes.PrivateIpAddressSpecification {
+func expandSecondaryPrivateIPAddresses(ips []any) []awstypes.PrivateIpAddressSpecification {
 	specs := make([]awstypes.PrivateIpAddressSpecification, 0, len(ips))
 	for _, v := range ips {
 		spec := awstypes.PrivateIpAddressSpecification{
@@ -3600,12 +3600,12 @@ func expandSecondaryPrivateIPAddresses(ips []interface{}) []awstypes.PrivateIpAd
 	return specs
 }
 
-func flattenInstanceMetadataOptions(opts *awstypes.InstanceMetadataOptionsResponse) []interface{} {
+func flattenInstanceMetadataOptions(opts *awstypes.InstanceMetadataOptionsResponse) []any {
 	if opts == nil {
 		return nil
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"http_endpoint":               opts.HttpEndpoint,
 		"http_protocol_ipv6":          opts.HttpProtocolIpv6,
 		"http_put_response_hop_limit": opts.HttpPutResponseHopLimit,
@@ -3613,15 +3613,15 @@ func flattenInstanceMetadataOptions(opts *awstypes.InstanceMetadataOptionsRespon
 		"instance_metadata_tags":      opts.InstanceMetadataTags,
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenCPUOptions(opts *awstypes.CpuOptions) []interface{} {
+func flattenCPUOptions(opts *awstypes.CpuOptions) []any {
 	if opts == nil {
 		return nil
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"amd_sev_snp": opts.AmdSevSnp,
 	}
 
@@ -3633,22 +3633,22 @@ func flattenCPUOptions(opts *awstypes.CpuOptions) []interface{} {
 		m["threads_per_core"] = aws.ToInt32(v)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenEnclaveOptions(opts *awstypes.EnclaveOptions) []interface{} {
+func flattenEnclaveOptions(opts *awstypes.EnclaveOptions) []any {
 	if opts == nil {
 		return nil
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrEnabled: aws.ToBool(opts.Enabled),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func expandCapacityReservationSpecification(tfMap map[string]interface{}) *awstypes.CapacityReservationSpecification {
+func expandCapacityReservationSpecification(tfMap map[string]any) *awstypes.CapacityReservationSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -3659,14 +3659,14 @@ func expandCapacityReservationSpecification(tfMap map[string]interface{}) *awsty
 		apiObject.CapacityReservationPreference = awstypes.CapacityReservationPreference(v)
 	}
 
-	if v, ok := tfMap["capacity_reservation_target"].([]interface{}); ok && len(v) > 0 {
-		apiObject.CapacityReservationTarget = expandCapacityReservationTarget(v[0].(map[string]interface{}))
+	if v, ok := tfMap["capacity_reservation_target"].([]any); ok && len(v) > 0 {
+		apiObject.CapacityReservationTarget = expandCapacityReservationTarget(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandCapacityReservationTarget(tfMap map[string]interface{}) *awstypes.CapacityReservationTarget {
+func expandCapacityReservationTarget(tfMap map[string]any) *awstypes.CapacityReservationTarget {
 	if tfMap == nil {
 		return nil
 	}
@@ -3684,28 +3684,28 @@ func expandCapacityReservationTarget(tfMap map[string]interface{}) *awstypes.Cap
 	return apiObject
 }
 
-func flattenCapacityReservationSpecificationResponse(apiObject *awstypes.CapacityReservationSpecificationResponse) map[string]interface{} {
+func flattenCapacityReservationSpecificationResponse(apiObject *awstypes.CapacityReservationSpecificationResponse) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"capacity_reservation_preference": apiObject.CapacityReservationPreference,
 	}
 
 	if v := apiObject.CapacityReservationTarget; v != nil {
-		tfMap["capacity_reservation_target"] = []interface{}{flattenCapacityReservationTargetResponse(v)}
+		tfMap["capacity_reservation_target"] = []any{flattenCapacityReservationTargetResponse(v)}
 	}
 
 	return tfMap
 }
 
-func flattenCapacityReservationTargetResponse(apiObject *awstypes.CapacityReservationTargetResponse) map[string]interface{} {
+func flattenCapacityReservationTargetResponse(apiObject *awstypes.CapacityReservationTargetResponse) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CapacityReservationId; v != nil {
 		tfMap["capacity_reservation_id"] = aws.ToString(v)
@@ -3758,7 +3758,7 @@ func capacityReservationTargetResponsesEqual(v1 *awstypes.CapacityReservationTar
 	return true
 }
 
-func expandCreditSpecificationRequest(tfMap map[string]interface{}) *awstypes.CreditSpecificationRequest {
+func expandCreditSpecificationRequest(tfMap map[string]any) *awstypes.CreditSpecificationRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3772,7 +3772,7 @@ func expandCreditSpecificationRequest(tfMap map[string]interface{}) *awstypes.Cr
 	return apiObject
 }
 
-func expandInstanceCreditSpecificationRequest(tfMap map[string]interface{}) awstypes.InstanceCreditSpecificationRequest {
+func expandInstanceCreditSpecificationRequest(tfMap map[string]any) awstypes.InstanceCreditSpecificationRequest {
 	apiObject := awstypes.InstanceCreditSpecificationRequest{}
 
 	if v, ok := tfMap["cpu_credits"].(string); ok && v != "" {
@@ -3782,12 +3782,12 @@ func expandInstanceCreditSpecificationRequest(tfMap map[string]interface{}) awst
 	return apiObject
 }
 
-func flattenInstanceCreditSpecification(apiObject *awstypes.InstanceCreditSpecification) map[string]interface{} {
+func flattenInstanceCreditSpecification(apiObject *awstypes.InstanceCreditSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CpuCredits; v != nil {
 		tfMap["cpu_credits"] = aws.ToString(v)
@@ -3796,7 +3796,7 @@ func flattenInstanceCreditSpecification(apiObject *awstypes.InstanceCreditSpecif
 	return tfMap
 }
 
-func expandInstanceMaintenanceOptionsRequest(tfMap map[string]interface{}) *awstypes.InstanceMaintenanceOptionsRequest {
+func expandInstanceMaintenanceOptionsRequest(tfMap map[string]any) *awstypes.InstanceMaintenanceOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3810,19 +3810,19 @@ func expandInstanceMaintenanceOptionsRequest(tfMap map[string]interface{}) *awst
 	return apiObject
 }
 
-func flattenInstanceMaintenanceOptions(apiObject *awstypes.InstanceMaintenanceOptions) map[string]interface{} {
+func flattenInstanceMaintenanceOptions(apiObject *awstypes.InstanceMaintenanceOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"auto_recovery": apiObject.AutoRecovery,
 	}
 
 	return tfMap
 }
 
-func expandPrivateDNSNameOptionsRequest(tfMap map[string]interface{}) *awstypes.PrivateDnsNameOptionsRequest {
+func expandPrivateDNSNameOptionsRequest(tfMap map[string]any) *awstypes.PrivateDnsNameOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3844,12 +3844,12 @@ func expandPrivateDNSNameOptionsRequest(tfMap map[string]interface{}) *awstypes.
 	return apiObject
 }
 
-func flattenPrivateDNSNameOptionsResponse(apiObject *awstypes.PrivateDnsNameOptionsResponse) map[string]interface{} {
+func flattenPrivateDNSNameOptionsResponse(apiObject *awstypes.PrivateDnsNameOptionsResponse) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"hostname_type": apiObject.HostnameType,
 	}
 
@@ -3864,21 +3864,21 @@ func flattenPrivateDNSNameOptionsResponse(apiObject *awstypes.PrivateDnsNameOpti
 	return tfMap
 }
 
-func expandInstanceMarketOptionsRequest(tfMap map[string]interface{}) *awstypes.InstanceMarketOptionsRequest {
+func expandInstanceMarketOptionsRequest(tfMap map[string]any) *awstypes.InstanceMarketOptionsRequest {
 	apiObject := &awstypes.InstanceMarketOptionsRequest{}
 
 	if v, ok := tfMap["market_type"]; ok && v.(string) != "" {
 		apiObject.MarketType = awstypes.MarketType(tfMap["market_type"].(string))
 	}
 
-	if v, ok := tfMap["spot_options"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.SpotOptions = expandSpotMarketOptions(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := tfMap["spot_options"]; ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.SpotOptions = expandSpotMarketOptions(v.([]any)[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandSpotMarketOptions(tfMap map[string]interface{}) *awstypes.SpotMarketOptions {
+func expandSpotMarketOptions(tfMap map[string]any) *awstypes.SpotMarketOptions {
 	apiObject := &awstypes.SpotMarketOptions{}
 
 	if v, ok := tfMap["instance_interruption_behavior"].(string); ok && v != "" {
@@ -3902,7 +3902,7 @@ func expandSpotMarketOptions(tfMap map[string]interface{}) *awstypes.SpotMarketO
 	return apiObject
 }
 
-func expandLaunchTemplateSpecification(tfMap map[string]interface{}) *awstypes.LaunchTemplateSpecification {
+func expandLaunchTemplateSpecification(tfMap map[string]any) *awstypes.LaunchTemplateSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -3924,7 +3924,7 @@ func expandLaunchTemplateSpecification(tfMap map[string]interface{}) *awstypes.L
 	return apiObject
 }
 
-func flattenInstanceLaunchTemplate(ctx context.Context, conn *ec2.Client, instanceID, previousLaunchTemplateVersion string) ([]interface{}, error) {
+func flattenInstanceLaunchTemplate(ctx context.Context, conn *ec2.Client, instanceID, previousLaunchTemplateVersion string) ([]any, error) {
 	launchTemplateID, err := findInstanceLaunchTemplateID(ctx, conn, instanceID)
 
 	if err != nil {
@@ -3945,7 +3945,7 @@ func flattenInstanceLaunchTemplate(ctx context.Context, conn *ec2.Client, instan
 		return nil, fmt.Errorf("reading EC2 Launch Template (%s): %w", launchTemplateID, err)
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrID:   launchTemplateID,
 		names.AttrName: name,
 	}
@@ -3959,7 +3959,7 @@ func flattenInstanceLaunchTemplate(ctx context.Context, conn *ec2.Client, instan
 	_, err = findLaunchTemplateVersionByTwoPartKey(ctx, conn, launchTemplateID, currentLaunchTemplateVersion)
 
 	if tfresource.NotFound(err) {
-		return []interface{}{tfMap}, nil
+		return []any{tfMap}, nil
 	}
 
 	if err != nil {
@@ -3983,7 +3983,7 @@ func flattenInstanceLaunchTemplate(ctx context.Context, conn *ec2.Client, instan
 		tfMap[names.AttrVersion] = currentLaunchTemplateVersion
 	}
 
-	return []interface{}{tfMap}, nil
+	return []any{tfMap}, nil
 }
 
 func findInstanceLaunchTemplateID(ctx context.Context, conn *ec2.Client, id string) (string, error) {
@@ -4121,10 +4121,8 @@ func parseInstanceType(s string) (*instanceType, error) {
 
 func hasCommonElement(slice1 []awstypes.ArchitectureType, slice2 []awstypes.ArchitectureType) bool {
 	for _, type1 := range slice1 {
-		for _, type2 := range slice2 {
-			if type1 == type2 {
-				return true
-			}
+		if slices.Contains(slice2, type1) {
+			return true
 		}
 	}
 	return false

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -40,8 +42,6 @@ import (
 	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"maps"
-	"slices"
 )
 
 // @SDKResource("aws_instance", name="Instance")

--- a/internal/service/ec2/ec2_instance_data_source.go
+++ b/internal/service/ec2/ec2_instance_data_source.go
@@ -123,9 +123,9 @@ func dataSourceInstance() *schema.Resource {
 					},
 				},
 				// This should not be necessary, but currently is (see #7198)
-				Set: func(v interface{}) int {
+				Set: func(v any) int {
 					var buf bytes.Buffer
-					m := v.(map[string]interface{})
+					m := v.(map[string]any)
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
 					buf.WriteString(fmt.Sprintf("%s-", m[names.AttrSnapshotID].(string)))
 					return create.StringHashcode(buf.String())
@@ -406,7 +406,7 @@ func dataSourceInstance() *schema.Resource {
 }
 
 // dataSourceInstanceRead performs the instanceID lookup
-func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -415,7 +415,7 @@ func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	if tags, tagsOk := d.GetOk("instance_tags"); tagsOk {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+			Tags(tftags.New(ctx, tags.(map[string]any))),
 		)...)
 	}
 
@@ -464,7 +464,7 @@ func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 // Populate instance attribute fields with the returned instance
-func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, meta interface{}, instance *awstypes.Instance) error {
+func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, meta any, instance *awstypes.Instance) error {
 	d.SetId(aws.ToString(instance.InstanceId))
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -560,7 +560,7 @@ func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, 
 		return fmt.Errorf("reading EC2 Instance (%s): %w", aws.ToString(instance.InstanceId), err)
 	}
 	if _, ok := d.GetOk("ephemeral_block_device"); !ok {
-		d.Set("ephemeral_block_device", []interface{}{})
+		d.Set("ephemeral_block_device", []any{})
 	}
 
 	// Lookup and Set Instance Attributes
@@ -619,7 +619,7 @@ func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		if instanceCreditSpecification != nil {
-			if err := d.Set("credit_specification", []interface{}{flattenInstanceCreditSpecification(instanceCreditSpecification)}); err != nil {
+			if err := d.Set("credit_specification", []any{flattenInstanceCreditSpecification(instanceCreditSpecification)}); err != nil {
 				return fmt.Errorf("setting credit_specification: %w", err)
 			}
 		} else {
@@ -634,7 +634,7 @@ func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if instance.MaintenanceOptions != nil {
-		if err := d.Set("maintenance_options", []interface{}{flattenInstanceMaintenanceOptions(instance.MaintenanceOptions)}); err != nil {
+		if err := d.Set("maintenance_options", []any{flattenInstanceMaintenanceOptions(instance.MaintenanceOptions)}); err != nil {
 			return fmt.Errorf("setting maintenance_options: %w", err)
 		}
 	} else {
@@ -646,7 +646,7 @@ func instanceDescriptionAttributes(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if instance.PrivateDnsNameOptions != nil {
-		if err := d.Set("private_dns_name_options", []interface{}{flattenPrivateDNSNameOptionsResponse(instance.PrivateDnsNameOptions)}); err != nil {
+		if err := d.Set("private_dns_name_options", []any{flattenPrivateDNSNameOptionsResponse(instance.PrivateDnsNameOptions)}); err != nil {
 			return fmt.Errorf("setting private_dns_name_options: %w", err)
 		}
 	} else {

--- a/internal/service/ec2/ec2_instance_migrate.go
+++ b/internal/service/ec2/ec2_instance_migrate.go
@@ -15,7 +15,7 @@ import (
 )
 
 func instanceMigrateState(
-	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found AWS Instance State v0; migrating to v1")

--- a/internal/service/ec2/ec2_instance_migrate_test.go
+++ b/internal/service/ec2/ec2_instance_migrate_test.go
@@ -18,7 +18,7 @@ func TestInstanceMigrateState(t *testing.T) {
 		StateVersion int
 		Attributes   map[string]string
 		Expected     map[string]string
-		Meta         interface{}
+		Meta         any
 	}{
 		"v0.3.6 and earlier": {
 			StateVersion: 0,
@@ -146,7 +146,7 @@ func TestInstanceMigrateState_empty(t *testing.T) {
 	t.Parallel()
 
 	var is *terraform.InstanceState
-	var meta interface{}
+	var meta any
 
 	// should handle nil
 	is, err := tfec2.InstanceMigrateState(0, is, meta)

--- a/internal/service/ec2/ec2_instance_state.go
+++ b/internal/service/ec2/ec2_instance_state.go
@@ -58,7 +58,7 @@ func resourceInstanceState() *schema.Resource {
 	}
 }
 
-func resourceInstanceStateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceStateCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -78,7 +78,7 @@ func resourceInstanceStateCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceInstanceStateRead(ctx, d, meta)...)
 }
 
-func resourceInstanceStateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceStateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -101,7 +101,7 @@ func resourceInstanceStateRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceInstanceStateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceStateUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_instance_type_data_source.go
+++ b/internal/service/ec2/ec2_instance_type_data_source.go
@@ -437,7 +437,7 @@ func dataSourceInstanceType() *schema.Resource {
 	}
 }
 
-func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -483,9 +483,9 @@ func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("ena_support", v.NetworkInfo.EnaSupport)
 	d.Set("encryption_in_transit_supported", v.NetworkInfo.EncryptionInTransitSupported)
 	if v := v.FpgaInfo; v != nil {
-		tfList := make([]interface{}, len(v.Fpgas))
+		tfList := make([]any, len(v.Fpgas))
 		for i, v := range v.Fpgas {
-			tfMap := map[string]interface{}{
+			tfMap := map[string]any{
 				"count":        aws.ToInt32(v.Count),
 				"manufacturer": aws.ToString(v.Manufacturer),
 				"memory_size":  aws.ToInt32(v.MemoryInfo.SizeInMiB),
@@ -498,9 +498,9 @@ func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, met
 	}
 	d.Set("free_tier_eligible", v.FreeTierEligible)
 	if v := v.GpuInfo; v != nil {
-		tfList := make([]interface{}, len(v.Gpus))
+		tfList := make([]any, len(v.Gpus))
 		for i, v := range v.Gpus {
-			tfMap := map[string]interface{}{
+			tfMap := map[string]any{
 				"count":        aws.ToInt32(v.Count),
 				"manufacturer": aws.ToString(v.Manufacturer),
 				"memory_size":  aws.ToInt32(v.MemoryInfo.SizeInMiB),
@@ -514,9 +514,9 @@ func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("hibernation_supported", v.HibernationSupported)
 	d.Set("hypervisor", v.Hypervisor)
 	if v := v.InferenceAcceleratorInfo; v != nil {
-		tfList := make([]interface{}, len(v.Accelerators))
+		tfList := make([]any, len(v.Accelerators))
 		for i, v := range v.Accelerators {
-			tfMap := map[string]interface{}{
+			tfMap := map[string]any{
 				"count":        aws.ToInt32(v.Count),
 				"manufacturer": aws.ToString(v.Manufacturer),
 				"memory_size":  aws.ToInt32(v.MemoryInfo.SizeInMiB),
@@ -529,9 +529,9 @@ func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, met
 	}
 	if v := v.InstanceStorageInfo; v != nil {
 		if v := v.Disks; v != nil {
-			tfList := make([]interface{}, len(v))
+			tfList := make([]any, len(v))
 			for i, v := range v {
-				tfMap := map[string]interface{}{
+				tfMap := map[string]any{
 					"count":        aws.ToInt32(v.Count),
 					names.AttrSize: aws.ToInt64(v.SizeInGB),
 					names.AttrType: v.Type,
@@ -550,9 +550,9 @@ func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("maximum_network_cards", v.NetworkInfo.MaximumNetworkCards)
 	d.Set("maximum_network_interfaces", v.NetworkInfo.MaximumNetworkInterfaces)
 	if v := v.MediaAcceleratorInfo; v != nil {
-		tfList := make([]interface{}, len(v.Accelerators))
+		tfList := make([]any, len(v.Accelerators))
 		for i, v := range v.Accelerators {
-			tfMap := map[string]interface{}{
+			tfMap := map[string]any{
 				"count":        aws.ToInt32(v.Count),
 				"manufacturer": aws.ToString(v.Manufacturer),
 				"memory_size":  aws.ToInt32(v.MemoryInfo.SizeInMiB),
@@ -565,9 +565,9 @@ func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, met
 	}
 	d.Set("memory_size", v.MemoryInfo.SizeInMiB)
 	if v := v.NeuronInfo; v != nil {
-		tfList := make([]interface{}, len(v.NeuronDevices))
+		tfList := make([]any, len(v.NeuronDevices))
 		for i, v := range v.NeuronDevices {
-			tfMap := map[string]interface{}{
+			tfMap := map[string]any{
 				"count":        aws.ToInt32(v.Count),
 				"core_count":   aws.ToInt32(v.CoreInfo.Count),
 				"core_version": aws.ToInt32(v.CoreInfo.Version),
@@ -588,9 +588,9 @@ func dataSourceInstanceTypeRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("nitro_tpm_supported_versions", nitroTPMSupportedVersions)
 	d.Set("network_performance", v.NetworkInfo.NetworkPerformance)
 	if v := v.NetworkInfo; v != nil {
-		tfList := make([]interface{}, len(v.NetworkCards))
+		tfList := make([]any, len(v.NetworkCards))
 		for i, v := range v.NetworkCards {
-			tfMap := map[string]interface{}{
+			tfMap := map[string]any{
 				"baseline_bandwidth": aws.ToFloat64(v.BaselineBandwidthInGbps),
 				"index":              aws.ToInt32(v.NetworkCardIndex),
 				"maximum_interfaces": aws.ToInt32(v.MaximumNetworkInterfaces),

--- a/internal/service/ec2/ec2_instance_type_offering_data_source.go
+++ b/internal/service/ec2/ec2_instance_type_offering_data_source.go
@@ -5,6 +5,7 @@ package ec2
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/names"
-	"slices"
 )
 
 // @SDKDataSource("aws_ec2_instance_type_offering", name="Instance Type Offering")

--- a/internal/service/ec2/ec2_instance_type_offering_data_source.go
+++ b/internal/service/ec2/ec2_instance_type_offering_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/names"
+	"slices"
 )
 
 // @SDKDataSource("aws_ec2_instance_type_offering", name="Instance Type Offering")
@@ -46,7 +47,7 @@ func dataSourceInstanceTypeOffering() *schema.Resource {
 	}
 }
 
-func dataSourceInstanceTypeOfferingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstanceTypeOfferingRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -81,13 +82,10 @@ func dataSourceInstanceTypeOfferingRead(ctx context.Context, d *schema.ResourceD
 	// Search preferred instance types in their given order and set result
 	// instance type for first match found
 	if v, ok := d.GetOk("preferred_instance_types"); ok {
-		for _, v := range v.([]interface{}) {
+		for _, v := range v.([]any) {
 			if v, ok := v.(string); ok {
-				for _, foundInstanceType := range foundInstanceTypes {
-					if foundInstanceType == v {
-						resultInstanceType = v
-						break
-					}
+				if slices.Contains(foundInstanceTypes, v) {
+					resultInstanceType = v
 				}
 
 				if resultInstanceType != "" {

--- a/internal/service/ec2/ec2_instance_type_offerings_data_source.go
+++ b/internal/service/ec2/ec2_instance_type_offerings_data_source.go
@@ -53,7 +53,7 @@ func dataSourceInstanceTypeOfferings() *schema.Resource {
 	}
 }
 
-func dataSourceInstanceTypeOfferingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstanceTypeOfferingsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_instance_types_data_source.go
+++ b/internal/service/ec2/ec2_instance_types_data_source.go
@@ -35,7 +35,7 @@ func dataSourceInstanceTypes() *schema.Resource {
 	}
 }
 
-func dataSourceInstanceTypesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstanceTypesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_instances_data_source.go
+++ b/internal/service/ec2/ec2_instances_data_source.go
@@ -64,7 +64,7 @@ func dataSourceInstances() *schema.Resource {
 	}
 }
 
-func dataSourceInstancesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstancesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -83,7 +83,7 @@ func dataSourceInstancesRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get("instance_tags").(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get("instance_tags").(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/ec2_key_pair.go
+++ b/internal/service/ec2/ec2_key_pair.go
@@ -81,7 +81,7 @@ func resourceKeyPair() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					switch v := v.(type) {
 					case string:
 						return strings.TrimSpace(v)
@@ -96,7 +96,7 @@ func resourceKeyPair() *schema.Resource {
 	}
 }
 
-func resourceKeyPairCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKeyPairCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -118,7 +118,7 @@ func resourceKeyPairCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceKeyPairRead(ctx, d, meta)...)
 }
 
-func resourceKeyPairRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKeyPairRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -153,7 +153,7 @@ func resourceKeyPairRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceKeyPairUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKeyPairUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -161,7 +161,7 @@ func resourceKeyPairUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceKeyPairRead(ctx, d, meta)...)
 }
 
-func resourceKeyPairDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKeyPairDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_key_pair_data_source.go
+++ b/internal/service/ec2/ec2_key_pair_data_source.go
@@ -70,7 +70,7 @@ func dataSourceKeyPair() *schema.Resource {
 	}
 }
 
-func dataSourceKeyPairRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceKeyPairRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_key_pair_migrate.go
+++ b/internal/service/ec2/ec2_key_pair_migrate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func keyPairMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func keyPairMigrateState(v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found AWS Key Pair State v0; migrating to v1")

--- a/internal/service/ec2/ec2_key_pair_migrate_test.go
+++ b/internal/service/ec2/ec2_key_pair_migrate_test.go
@@ -19,7 +19,7 @@ func TestKeyPairMigrateState(t *testing.T) {
 		ID           string
 		Attributes   map[string]string
 		Expected     string
-		Meta         interface{}
+		Meta         any
 	}{
 		"v0_1": {
 			StateVersion: 0,

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -1017,7 +1017,7 @@ func resourceLaunchTemplate() *schema.Resource {
 		// Enable downstream updates for resources referencing schema attributes
 		// to prevent non-empty plans after "terraform apply"
 		CustomizeDiff: customdiff.Sequence(
-			customdiff.ComputedIf("default_version", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("default_version", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				for _, changedKey := range diff.GetChangedKeysPrefix("") {
 					switch changedKey {
 					case "name", "name_prefix", "description":
@@ -1028,7 +1028,7 @@ func resourceLaunchTemplate() *schema.Resource {
 				}
 				return false
 			}),
-			customdiff.ComputedIf("latest_version", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("latest_version", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				for _, changedKey := range diff.GetChangedKeysPrefix("") {
 					switch changedKey {
 					case "name", "name_prefix", "description", "default_version", "update_default_version":
@@ -1043,7 +1043,7 @@ func resourceLaunchTemplate() *schema.Resource {
 	}
 }
 
-func resourceLaunchTemplateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLaunchTemplateCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1079,7 +1079,7 @@ func resourceLaunchTemplateCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceLaunchTemplateRead(ctx, d, meta)...)
 }
 
-func resourceLaunchTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLaunchTemplateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1125,7 +1125,7 @@ func resourceLaunchTemplateRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceLaunchTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLaunchTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1214,7 +1214,7 @@ func resourceLaunchTemplateUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceLaunchTemplateRead(ctx, d, meta)...)
 }
 
-func resourceLaunchTemplateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLaunchTemplateDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1240,7 +1240,7 @@ const (
 )
 
 func statusLaunchTemplate(ctx context.Context, conn *ec2.Client, id string, idIsName bool) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		var output *awstypes.LaunchTemplate
 		var err error
 		if idIsName {
@@ -1291,19 +1291,19 @@ func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *s
 		apiObject.InstanceType = awstypes.InstanceType(v)
 	}
 
-	if v, ok := d.GetOk("block_device_mappings"); ok && len(v.([]interface{})) > 0 {
-		apiObject.BlockDeviceMappings = expandLaunchTemplateBlockDeviceMappingRequests(v.([]interface{}))
+	if v, ok := d.GetOk("block_device_mappings"); ok && len(v.([]any)) > 0 {
+		apiObject.BlockDeviceMappings = expandLaunchTemplateBlockDeviceMappingRequests(v.([]any))
 	}
 
-	if v, ok := d.GetOk("capacity_reservation_specification"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.CapacityReservationSpecification = expandLaunchTemplateCapacityReservationSpecificationRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("capacity_reservation_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.CapacityReservationSpecification = expandLaunchTemplateCapacityReservationSpecificationRequest(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("cpu_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.CpuOptions = expandLaunchTemplateCPUOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("cpu_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.CpuOptions = expandLaunchTemplateCPUOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("credit_specification"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+	if v, ok := d.GetOk("credit_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		if instanceType != "" {
 			instanceTypeInfo, err := findInstanceTypeByName(ctx, conn, instanceType)
 
@@ -1312,7 +1312,7 @@ func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *s
 			}
 
 			if aws.ToBool(instanceTypeInfo.BurstablePerformanceSupported) {
-				apiObject.CreditSpecification = expandCreditSpecificationRequest(v.([]interface{})[0].(map[string]interface{}))
+				apiObject.CreditSpecification = expandCreditSpecificationRequest(v.([]any)[0].(map[string]any))
 			}
 		}
 	}
@@ -1329,32 +1329,32 @@ func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *s
 		apiObject.EbsOptimized = aws.Bool(v)
 	}
 
-	if v, ok := d.GetOk("elastic_gpu_specifications"); ok && len(v.([]interface{})) > 0 {
-		apiObject.ElasticGpuSpecifications = expandElasticGpuSpecifications(v.([]interface{}))
+	if v, ok := d.GetOk("elastic_gpu_specifications"); ok && len(v.([]any)) > 0 {
+		apiObject.ElasticGpuSpecifications = expandElasticGpuSpecifications(v.([]any))
 	}
 
-	if v, ok := d.GetOk("elastic_inference_accelerator"); ok && len(v.([]interface{})) > 0 {
-		apiObject.ElasticInferenceAccelerators = expandLaunchTemplateElasticInferenceAccelerators(v.([]interface{}))
+	if v, ok := d.GetOk("elastic_inference_accelerator"); ok && len(v.([]any)) > 0 {
+		apiObject.ElasticInferenceAccelerators = expandLaunchTemplateElasticInferenceAccelerators(v.([]any))
 	}
 
-	if v, ok := d.GetOk("enclave_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := d.GetOk("enclave_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		tfMap := v.([]any)[0].(map[string]any)
 
 		apiObject.EnclaveOptions = &awstypes.LaunchTemplateEnclaveOptionsRequest{
 			Enabled: aws.Bool(tfMap[names.AttrEnabled].(bool)),
 		}
 	}
 
-	if v, ok := d.GetOk("hibernation_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := d.GetOk("hibernation_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		tfMap := v.([]any)[0].(map[string]any)
 
 		apiObject.HibernationOptions = &awstypes.LaunchTemplateHibernationOptionsRequest{
 			Configured: aws.Bool(tfMap["configured"].(bool)),
 		}
 	}
 
-	if v, ok := d.GetOk("iam_instance_profile"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.IamInstanceProfile = expandLaunchTemplateIAMInstanceProfileSpecificationRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("iam_instance_profile"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.IamInstanceProfile = expandLaunchTemplateIAMInstanceProfileSpecificationRequest(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("image_id"); ok {
@@ -1365,12 +1365,12 @@ func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *s
 		apiObject.InstanceInitiatedShutdownBehavior = awstypes.ShutdownBehavior(v.(string))
 	}
 
-	if v, ok := d.GetOk("instance_market_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.InstanceMarketOptions = expandLaunchTemplateInstanceMarketOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("instance_market_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.InstanceMarketOptions = expandLaunchTemplateInstanceMarketOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("instance_requirements"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.InstanceRequirements = expandInstanceRequirementsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("instance_requirements"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.InstanceRequirements = expandInstanceRequirementsRequest(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("kernel_id"); ok {
@@ -1385,32 +1385,32 @@ func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *s
 		apiObject.LicenseSpecifications = expandLaunchTemplateLicenseConfigurationRequests(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("maintenance_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.MaintenanceOptions = expandLaunchTemplateInstanceMaintenanceOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("maintenance_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.MaintenanceOptions = expandLaunchTemplateInstanceMaintenanceOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("metadata_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.MetadataOptions = expandLaunchTemplateInstanceMetadataOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("metadata_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.MetadataOptions = expandLaunchTemplateInstanceMetadataOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("monitoring"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := d.GetOk("monitoring"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		tfMap := v.([]any)[0].(map[string]any)
 
 		apiObject.Monitoring = &awstypes.LaunchTemplatesMonitoringRequest{
 			Enabled: aws.Bool(tfMap[names.AttrEnabled].(bool)),
 		}
 	}
 
-	if v, ok := d.GetOk("network_interfaces"); ok && len(v.([]interface{})) > 0 {
-		apiObject.NetworkInterfaces = expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequests(v.([]interface{}))
+	if v, ok := d.GetOk("network_interfaces"); ok && len(v.([]any)) > 0 {
+		apiObject.NetworkInterfaces = expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequests(v.([]any))
 	}
 
-	if v, ok := d.GetOk("placement"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.Placement = expandLaunchTemplatePlacementRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("placement"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.Placement = expandLaunchTemplatePlacementRequest(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("private_dns_name_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.PrivateDnsNameOptions = expandLaunchTemplatePrivateDNSNameOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("private_dns_name_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.PrivateDnsNameOptions = expandLaunchTemplatePrivateDNSNameOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("ram_disk_id"); ok {
@@ -1421,8 +1421,8 @@ func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *s
 		apiObject.SecurityGroups = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("tag_specifications"); ok && len(v.([]interface{})) > 0 {
-		apiObject.TagSpecifications = expandLaunchTemplateTagSpecificationRequests(ctx, v.([]interface{}))
+	if v, ok := d.GetOk("tag_specifications"); ok && len(v.([]any)) > 0 {
+		apiObject.TagSpecifications = expandLaunchTemplateTagSpecificationRequests(ctx, v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrVPCSecurityGroupIDs); ok && v.(*schema.Set).Len() > 0 {
@@ -1432,11 +1432,11 @@ func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *s
 	return apiObject, nil
 }
 
-func expandLaunchTemplateBlockDeviceMappingRequest(tfMap map[string]interface{}) awstypes.LaunchTemplateBlockDeviceMappingRequest {
+func expandLaunchTemplateBlockDeviceMappingRequest(tfMap map[string]any) awstypes.LaunchTemplateBlockDeviceMappingRequest {
 	apiObject := awstypes.LaunchTemplateBlockDeviceMappingRequest{}
 
-	if v, ok := tfMap["ebs"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.Ebs = expandLaunchTemplateEBSBlockDeviceRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["ebs"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.Ebs = expandLaunchTemplateEBSBlockDeviceRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap[names.AttrDeviceName].(string); ok && v != "" {
@@ -1454,7 +1454,7 @@ func expandLaunchTemplateBlockDeviceMappingRequest(tfMap map[string]interface{})
 	return apiObject
 }
 
-func expandLaunchTemplateBlockDeviceMappingRequests(tfList []interface{}) []awstypes.LaunchTemplateBlockDeviceMappingRequest {
+func expandLaunchTemplateBlockDeviceMappingRequests(tfList []any) []awstypes.LaunchTemplateBlockDeviceMappingRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1462,7 +1462,7 @@ func expandLaunchTemplateBlockDeviceMappingRequests(tfList []interface{}) []awst
 	var apiObjects []awstypes.LaunchTemplateBlockDeviceMappingRequest
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1474,7 +1474,7 @@ func expandLaunchTemplateBlockDeviceMappingRequests(tfList []interface{}) []awst
 	return apiObjects
 }
 
-func expandLaunchTemplateEBSBlockDeviceRequest(tfMap map[string]interface{}) *awstypes.LaunchTemplateEbsBlockDeviceRequest {
+func expandLaunchTemplateEBSBlockDeviceRequest(tfMap map[string]any) *awstypes.LaunchTemplateEbsBlockDeviceRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1516,7 +1516,7 @@ func expandLaunchTemplateEBSBlockDeviceRequest(tfMap map[string]interface{}) *aw
 	return apiObject
 }
 
-func expandLaunchTemplateCapacityReservationSpecificationRequest(tfMap map[string]interface{}) *awstypes.LaunchTemplateCapacityReservationSpecificationRequest {
+func expandLaunchTemplateCapacityReservationSpecificationRequest(tfMap map[string]any) *awstypes.LaunchTemplateCapacityReservationSpecificationRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1527,14 +1527,14 @@ func expandLaunchTemplateCapacityReservationSpecificationRequest(tfMap map[strin
 		apiObject.CapacityReservationPreference = awstypes.CapacityReservationPreference(v)
 	}
 
-	if v, ok := tfMap["capacity_reservation_target"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.CapacityReservationTarget = expandCapacityReservationTarget(v[0].(map[string]interface{}))
+	if v, ok := tfMap["capacity_reservation_target"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.CapacityReservationTarget = expandCapacityReservationTarget(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandLaunchTemplateCPUOptionsRequest(tfMap map[string]interface{}) *awstypes.LaunchTemplateCpuOptionsRequest {
+func expandLaunchTemplateCPUOptionsRequest(tfMap map[string]any) *awstypes.LaunchTemplateCpuOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1556,7 +1556,7 @@ func expandLaunchTemplateCPUOptionsRequest(tfMap map[string]interface{}) *awstyp
 	return apiObject
 }
 
-func expandElasticGpuSpecification(tfMap map[string]interface{}) awstypes.ElasticGpuSpecification {
+func expandElasticGpuSpecification(tfMap map[string]any) awstypes.ElasticGpuSpecification {
 	apiObject := awstypes.ElasticGpuSpecification{}
 
 	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
@@ -1566,7 +1566,7 @@ func expandElasticGpuSpecification(tfMap map[string]interface{}) awstypes.Elasti
 	return apiObject
 }
 
-func expandElasticGpuSpecifications(tfList []interface{}) []awstypes.ElasticGpuSpecification {
+func expandElasticGpuSpecifications(tfList []any) []awstypes.ElasticGpuSpecification {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1574,7 +1574,7 @@ func expandElasticGpuSpecifications(tfList []interface{}) []awstypes.ElasticGpuS
 	var apiObjects []awstypes.ElasticGpuSpecification
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1586,7 +1586,7 @@ func expandElasticGpuSpecifications(tfList []interface{}) []awstypes.ElasticGpuS
 	return apiObjects
 }
 
-func expandLaunchTemplateElasticInferenceAccelerator(tfMap map[string]interface{}) awstypes.LaunchTemplateElasticInferenceAccelerator {
+func expandLaunchTemplateElasticInferenceAccelerator(tfMap map[string]any) awstypes.LaunchTemplateElasticInferenceAccelerator {
 	apiObject := awstypes.LaunchTemplateElasticInferenceAccelerator{}
 
 	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
@@ -1596,7 +1596,7 @@ func expandLaunchTemplateElasticInferenceAccelerator(tfMap map[string]interface{
 	return apiObject
 }
 
-func expandLaunchTemplateElasticInferenceAccelerators(tfList []interface{}) []awstypes.LaunchTemplateElasticInferenceAccelerator {
+func expandLaunchTemplateElasticInferenceAccelerators(tfList []any) []awstypes.LaunchTemplateElasticInferenceAccelerator {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1604,7 +1604,7 @@ func expandLaunchTemplateElasticInferenceAccelerators(tfList []interface{}) []aw
 	var apiObjects []awstypes.LaunchTemplateElasticInferenceAccelerator
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1616,7 +1616,7 @@ func expandLaunchTemplateElasticInferenceAccelerators(tfList []interface{}) []aw
 	return apiObjects
 }
 
-func expandLaunchTemplateIAMInstanceProfileSpecificationRequest(tfMap map[string]interface{}) *awstypes.LaunchTemplateIamInstanceProfileSpecificationRequest {
+func expandLaunchTemplateIAMInstanceProfileSpecificationRequest(tfMap map[string]any) *awstypes.LaunchTemplateIamInstanceProfileSpecificationRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1634,7 +1634,7 @@ func expandLaunchTemplateIAMInstanceProfileSpecificationRequest(tfMap map[string
 	return apiObject
 }
 
-func expandLaunchTemplateInstanceMarketOptionsRequest(tfMap map[string]interface{}) *awstypes.LaunchTemplateInstanceMarketOptionsRequest {
+func expandLaunchTemplateInstanceMarketOptionsRequest(tfMap map[string]any) *awstypes.LaunchTemplateInstanceMarketOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1645,22 +1645,22 @@ func expandLaunchTemplateInstanceMarketOptionsRequest(tfMap map[string]interface
 		apiObject.MarketType = awstypes.MarketType(v)
 	}
 
-	if v, ok := tfMap["spot_options"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.SpotOptions = expandLaunchTemplateSpotMarketOptionsRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["spot_options"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.SpotOptions = expandLaunchTemplateSpotMarketOptionsRequest(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandInstanceRequirementsRequest(tfMap map[string]interface{}) *awstypes.InstanceRequirementsRequest {
+func expandInstanceRequirementsRequest(tfMap map[string]any) *awstypes.InstanceRequirementsRequest {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.InstanceRequirementsRequest{}
 
-	if v, ok := tfMap["accelerator_count"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.AcceleratorCount = expandAcceleratorCountRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["accelerator_count"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AcceleratorCount = expandAcceleratorCountRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["accelerator_manufacturers"].(*schema.Set); ok && v.Len() > 0 {
@@ -1671,8 +1671,8 @@ func expandInstanceRequirementsRequest(tfMap map[string]interface{}) *awstypes.I
 		apiObject.AcceleratorNames = flex.ExpandStringyValueSet[awstypes.AcceleratorName](v)
 	}
 
-	if v, ok := tfMap["accelerator_total_memory_mib"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.AcceleratorTotalMemoryMiB = expandAcceleratorTotalMemoryMiBRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["accelerator_total_memory_mib"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AcceleratorTotalMemoryMiB = expandAcceleratorTotalMemoryMiBRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["accelerator_types"].(*schema.Set); ok && v.Len() > 0 {
@@ -1687,8 +1687,8 @@ func expandInstanceRequirementsRequest(tfMap map[string]interface{}) *awstypes.I
 		apiObject.BareMetal = awstypes.BareMetal(v)
 	}
 
-	if v, ok := tfMap["baseline_ebs_bandwidth_mbps"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.BaselineEbsBandwidthMbps = expandBaselineEBSBandwidthMbpsRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["baseline_ebs_bandwidth_mbps"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.BaselineEbsBandwidthMbps = expandBaselineEBSBandwidthMbpsRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["burstable_performance"].(string); ok && v != "" {
@@ -1719,20 +1719,20 @@ func expandInstanceRequirementsRequest(tfMap map[string]interface{}) *awstypes.I
 		apiObject.MaxSpotPriceAsPercentageOfOptimalOnDemandPrice = aws.Int32(int32(v))
 	}
 
-	if v, ok := tfMap["memory_gib_per_vcpu"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.MemoryGiBPerVCpu = expandMemoryGiBPerVCPURequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["memory_gib_per_vcpu"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.MemoryGiBPerVCpu = expandMemoryGiBPerVCPURequest(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["memory_mib"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.MemoryMiB = expandMemoryMiBRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["memory_mib"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.MemoryMiB = expandMemoryMiBRequest(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["network_bandwidth_gbps"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.NetworkBandwidthGbps = expandNetworkBandwidthGbpsRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["network_bandwidth_gbps"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.NetworkBandwidthGbps = expandNetworkBandwidthGbpsRequest(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["network_interface_count"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.NetworkInterfaceCount = expandNetworkInterfaceCountRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["network_interface_count"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.NetworkInterfaceCount = expandNetworkInterfaceCountRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["on_demand_max_price_percentage_over_lowest_price"].(int); ok && v != 0 {
@@ -1747,18 +1747,18 @@ func expandInstanceRequirementsRequest(tfMap map[string]interface{}) *awstypes.I
 		apiObject.SpotMaxPricePercentageOverLowestPrice = aws.Int32(int32(v))
 	}
 
-	if v, ok := tfMap["total_local_storage_gb"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.TotalLocalStorageGB = expandTotalLocalStorageGBRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["total_local_storage_gb"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.TotalLocalStorageGB = expandTotalLocalStorageGBRequest(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["vcpu_count"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.VCpuCount = expandVCPUCountRangeRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["vcpu_count"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.VCpuCount = expandVCPUCountRangeRequest(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandAcceleratorCountRequest(tfMap map[string]interface{}) *awstypes.AcceleratorCountRequest {
+func expandAcceleratorCountRequest(tfMap map[string]any) *awstypes.AcceleratorCountRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1778,7 +1778,7 @@ func expandAcceleratorCountRequest(tfMap map[string]interface{}) *awstypes.Accel
 	return apiObject
 }
 
-func expandAcceleratorTotalMemoryMiBRequest(tfMap map[string]interface{}) *awstypes.AcceleratorTotalMemoryMiBRequest {
+func expandAcceleratorTotalMemoryMiBRequest(tfMap map[string]any) *awstypes.AcceleratorTotalMemoryMiBRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1798,7 +1798,7 @@ func expandAcceleratorTotalMemoryMiBRequest(tfMap map[string]interface{}) *awsty
 	return apiObject
 }
 
-func expandBaselineEBSBandwidthMbpsRequest(tfMap map[string]interface{}) *awstypes.BaselineEbsBandwidthMbpsRequest {
+func expandBaselineEBSBandwidthMbpsRequest(tfMap map[string]any) *awstypes.BaselineEbsBandwidthMbpsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1818,7 +1818,7 @@ func expandBaselineEBSBandwidthMbpsRequest(tfMap map[string]interface{}) *awstyp
 	return apiObject
 }
 
-func expandMemoryGiBPerVCPURequest(tfMap map[string]interface{}) *awstypes.MemoryGiBPerVCpuRequest {
+func expandMemoryGiBPerVCPURequest(tfMap map[string]any) *awstypes.MemoryGiBPerVCpuRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1838,7 +1838,7 @@ func expandMemoryGiBPerVCPURequest(tfMap map[string]interface{}) *awstypes.Memor
 	return apiObject
 }
 
-func expandMemoryMiBRequest(tfMap map[string]interface{}) *awstypes.MemoryMiBRequest {
+func expandMemoryMiBRequest(tfMap map[string]any) *awstypes.MemoryMiBRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1858,7 +1858,7 @@ func expandMemoryMiBRequest(tfMap map[string]interface{}) *awstypes.MemoryMiBReq
 	return apiObject
 }
 
-func expandNetworkBandwidthGbpsRequest(tfMap map[string]interface{}) *awstypes.NetworkBandwidthGbpsRequest {
+func expandNetworkBandwidthGbpsRequest(tfMap map[string]any) *awstypes.NetworkBandwidthGbpsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1878,7 +1878,7 @@ func expandNetworkBandwidthGbpsRequest(tfMap map[string]interface{}) *awstypes.N
 	return apiObject
 }
 
-func expandNetworkInterfaceCountRequest(tfMap map[string]interface{}) *awstypes.NetworkInterfaceCountRequest {
+func expandNetworkInterfaceCountRequest(tfMap map[string]any) *awstypes.NetworkInterfaceCountRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1898,7 +1898,7 @@ func expandNetworkInterfaceCountRequest(tfMap map[string]interface{}) *awstypes.
 	return apiObject
 }
 
-func expandTotalLocalStorageGBRequest(tfMap map[string]interface{}) *awstypes.TotalLocalStorageGBRequest {
+func expandTotalLocalStorageGBRequest(tfMap map[string]any) *awstypes.TotalLocalStorageGBRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1918,7 +1918,7 @@ func expandTotalLocalStorageGBRequest(tfMap map[string]interface{}) *awstypes.To
 	return apiObject
 }
 
-func expandVCPUCountRangeRequest(tfMap map[string]interface{}) *awstypes.VCpuCountRangeRequest {
+func expandVCPUCountRangeRequest(tfMap map[string]any) *awstypes.VCpuCountRangeRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1938,7 +1938,7 @@ func expandVCPUCountRangeRequest(tfMap map[string]interface{}) *awstypes.VCpuCou
 	return apiObject
 }
 
-func expandLaunchTemplateSpotMarketOptionsRequest(tfMap map[string]interface{}) *awstypes.LaunchTemplateSpotMarketOptionsRequest {
+func expandLaunchTemplateSpotMarketOptionsRequest(tfMap map[string]any) *awstypes.LaunchTemplateSpotMarketOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -1970,7 +1970,7 @@ func expandLaunchTemplateSpotMarketOptionsRequest(tfMap map[string]interface{}) 
 	return apiObject
 }
 
-func expandLaunchTemplateLicenseConfigurationRequest(tfMap map[string]interface{}) awstypes.LaunchTemplateLicenseConfigurationRequest {
+func expandLaunchTemplateLicenseConfigurationRequest(tfMap map[string]any) awstypes.LaunchTemplateLicenseConfigurationRequest {
 	apiObject := awstypes.LaunchTemplateLicenseConfigurationRequest{}
 
 	if v, ok := tfMap["license_configuration_arn"].(string); ok && v != "" {
@@ -1980,7 +1980,7 @@ func expandLaunchTemplateLicenseConfigurationRequest(tfMap map[string]interface{
 	return apiObject
 }
 
-func expandLaunchTemplateLicenseConfigurationRequests(tfList []interface{}) []awstypes.LaunchTemplateLicenseConfigurationRequest {
+func expandLaunchTemplateLicenseConfigurationRequests(tfList []any) []awstypes.LaunchTemplateLicenseConfigurationRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1988,7 +1988,7 @@ func expandLaunchTemplateLicenseConfigurationRequests(tfList []interface{}) []aw
 	var apiObjects []awstypes.LaunchTemplateLicenseConfigurationRequest
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -2000,7 +2000,7 @@ func expandLaunchTemplateLicenseConfigurationRequests(tfList []interface{}) []aw
 	return apiObjects
 }
 
-func expandLaunchTemplateInstanceMetadataOptionsRequest(tfMap map[string]interface{}) *awstypes.LaunchTemplateInstanceMetadataOptionsRequest {
+func expandLaunchTemplateInstanceMetadataOptionsRequest(tfMap map[string]any) *awstypes.LaunchTemplateInstanceMetadataOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -2030,7 +2030,7 @@ func expandLaunchTemplateInstanceMetadataOptionsRequest(tfMap map[string]interfa
 	return apiObject
 }
 
-func expandLaunchTemplateInstanceMaintenanceOptionsRequest(tfMap map[string]interface{}) *awstypes.LaunchTemplateInstanceMaintenanceOptionsRequest {
+func expandLaunchTemplateInstanceMaintenanceOptionsRequest(tfMap map[string]any) *awstypes.LaunchTemplateInstanceMaintenanceOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -2044,7 +2044,7 @@ func expandLaunchTemplateInstanceMaintenanceOptionsRequest(tfMap map[string]inte
 	return apiObject
 }
 
-func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequest(tfMap map[string]interface{}) awstypes.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
+func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequest(tfMap map[string]any) awstypes.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
 	apiObject := awstypes.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{}
 
 	if v, null, _ := nullable.Bool(tfMap["associate_carrier_ip_address"].(string)).ValueBool(); !null {
@@ -2055,8 +2055,8 @@ func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequest(tfMap map[
 		apiObject.AssociatePublicIpAddress = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["connection_tracking_specification"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.ConnectionTrackingSpecification = expandConnectionTrackingSpecificationRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["connection_tracking_specification"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ConnectionTrackingSpecification = expandConnectionTrackingSpecificationRequest(v[0].(map[string]any))
 	}
 
 	if v, null, _ := nullable.Bool(tfMap[names.AttrDeleteOnTermination].(string)).ValueBool(); !null {
@@ -2071,8 +2071,8 @@ func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequest(tfMap map[
 		apiObject.DeviceIndex = aws.Int32(int32(v))
 	}
 
-	if v, ok := tfMap["ena_srd_specification"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.EnaSrdSpecification = expandEnaSrdSpecificationRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["ena_srd_specification"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.EnaSrdSpecification = expandEnaSrdSpecificationRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["interface_type"].(string); ok && v != "" {
@@ -2152,7 +2152,7 @@ func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequest(tfMap map[
 	return apiObject
 }
 
-func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequests(tfList []interface{}) []awstypes.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
+func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequests(tfList []any) []awstypes.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -2160,7 +2160,7 @@ func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequests(tfList []
 	var apiObjects []awstypes.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -2172,7 +2172,7 @@ func expandLaunchTemplateInstanceNetworkInterfaceSpecificationRequests(tfList []
 	return apiObjects
 }
 
-func expandLaunchTemplatePlacementRequest(tfMap map[string]interface{}) *awstypes.LaunchTemplatePlacementRequest {
+func expandLaunchTemplatePlacementRequest(tfMap map[string]any) *awstypes.LaunchTemplatePlacementRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -2214,7 +2214,7 @@ func expandLaunchTemplatePlacementRequest(tfMap map[string]interface{}) *awstype
 	return apiObject
 }
 
-func expandLaunchTemplatePrivateDNSNameOptionsRequest(tfMap map[string]interface{}) *awstypes.LaunchTemplatePrivateDnsNameOptionsRequest {
+func expandLaunchTemplatePrivateDNSNameOptionsRequest(tfMap map[string]any) *awstypes.LaunchTemplatePrivateDnsNameOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -2231,14 +2231,14 @@ func expandLaunchTemplatePrivateDNSNameOptionsRequest(tfMap map[string]interface
 	return apiObject
 }
 
-func expandLaunchTemplateTagSpecificationRequest(ctx context.Context, tfMap map[string]interface{}) awstypes.LaunchTemplateTagSpecificationRequest {
+func expandLaunchTemplateTagSpecificationRequest(ctx context.Context, tfMap map[string]any) awstypes.LaunchTemplateTagSpecificationRequest {
 	apiObject := awstypes.LaunchTemplateTagSpecificationRequest{}
 
 	if v, ok := tfMap[names.AttrResourceType].(string); ok && v != "" {
 		apiObject.ResourceType = awstypes.ResourceType(v)
 	}
 
-	if v, ok := tfMap[names.AttrTags].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrTags].(map[string]any); ok && len(v) > 0 {
 		if v := tftags.New(ctx, v).IgnoreAWS(); len(v) > 0 {
 			apiObject.Tags = Tags(v)
 		}
@@ -2247,7 +2247,7 @@ func expandLaunchTemplateTagSpecificationRequest(ctx context.Context, tfMap map[
 	return apiObject
 }
 
-func expandLaunchTemplateTagSpecificationRequests(ctx context.Context, tfList []interface{}) []awstypes.LaunchTemplateTagSpecificationRequest {
+func expandLaunchTemplateTagSpecificationRequests(ctx context.Context, tfList []any) []awstypes.LaunchTemplateTagSpecificationRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -2255,7 +2255,7 @@ func expandLaunchTemplateTagSpecificationRequests(ctx context.Context, tfList []
 	var apiObjects []awstypes.LaunchTemplateTagSpecificationRequest
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -2274,14 +2274,14 @@ func flattenResponseLaunchTemplateData(ctx context.Context, conn *ec2.Client, d 
 		return fmt.Errorf("setting block_device_mappings: %w", err)
 	}
 	if apiObject.CapacityReservationSpecification != nil {
-		if err := d.Set("capacity_reservation_specification", []interface{}{flattenLaunchTemplateCapacityReservationSpecificationResponse(apiObject.CapacityReservationSpecification)}); err != nil {
+		if err := d.Set("capacity_reservation_specification", []any{flattenLaunchTemplateCapacityReservationSpecificationResponse(apiObject.CapacityReservationSpecification)}); err != nil {
 			return fmt.Errorf("setting capacity_reservation_specification: %w", err)
 		}
 	} else {
 		d.Set("capacity_reservation_specification", nil)
 	}
 	if apiObject.CpuOptions != nil {
-		if err := d.Set("cpu_options", []interface{}{flattenLaunchTemplateCPUOptions(apiObject.CpuOptions)}); err != nil {
+		if err := d.Set("cpu_options", []any{flattenLaunchTemplateCPUOptions(apiObject.CpuOptions)}); err != nil {
 			return fmt.Errorf("setting cpu_options: %w", err)
 		}
 	} else {
@@ -2295,7 +2295,7 @@ func flattenResponseLaunchTemplateData(ctx context.Context, conn *ec2.Client, d 
 		}
 
 		if aws.ToBool(instanceTypeInfo.BurstablePerformanceSupported) {
-			if err := d.Set("credit_specification", []interface{}{flattenCreditSpecification(apiObject.CreditSpecification)}); err != nil {
+			if err := d.Set("credit_specification", []any{flattenCreditSpecification(apiObject.CreditSpecification)}); err != nil {
 				return fmt.Errorf("setting credit_specification: %w", err)
 			}
 		}
@@ -2314,29 +2314,29 @@ func flattenResponseLaunchTemplateData(ctx context.Context, conn *ec2.Client, d 
 		return fmt.Errorf("setting elastic_inference_accelerator: %w", err)
 	}
 	if apiObject.EnclaveOptions != nil {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrEnabled: aws.ToBool(apiObject.EnclaveOptions.Enabled),
 		}
 
-		if err := d.Set("enclave_options", []interface{}{tfMap}); err != nil {
+		if err := d.Set("enclave_options", []any{tfMap}); err != nil {
 			return fmt.Errorf("setting enclave_options: %w", err)
 		}
 	} else {
 		d.Set("enclave_options", nil)
 	}
 	if apiObject.HibernationOptions != nil {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"configured": aws.ToBool(apiObject.HibernationOptions.Configured),
 		}
 
-		if err := d.Set("hibernation_options", []interface{}{tfMap}); err != nil {
+		if err := d.Set("hibernation_options", []any{tfMap}); err != nil {
 			return fmt.Errorf("setting hibernation_options: %w", err)
 		}
 	} else {
 		d.Set("hibernation_options", nil)
 	}
 	if apiObject.IamInstanceProfile != nil {
-		if err := d.Set("iam_instance_profile", []interface{}{flattenLaunchTemplateIAMInstanceProfileSpecification(apiObject.IamInstanceProfile)}); err != nil {
+		if err := d.Set("iam_instance_profile", []any{flattenLaunchTemplateIAMInstanceProfileSpecification(apiObject.IamInstanceProfile)}); err != nil {
 			return fmt.Errorf("setting iam_instance_profile: %w", err)
 		}
 	} else {
@@ -2345,14 +2345,14 @@ func flattenResponseLaunchTemplateData(ctx context.Context, conn *ec2.Client, d 
 	d.Set("image_id", apiObject.ImageId)
 	d.Set("instance_initiated_shutdown_behavior", apiObject.InstanceInitiatedShutdownBehavior)
 	if apiObject.InstanceMarketOptions != nil {
-		if err := d.Set("instance_market_options", []interface{}{flattenLaunchTemplateInstanceMarketOptions(apiObject.InstanceMarketOptions)}); err != nil {
+		if err := d.Set("instance_market_options", []any{flattenLaunchTemplateInstanceMarketOptions(apiObject.InstanceMarketOptions)}); err != nil {
 			return fmt.Errorf("setting instance_market_options: %w", err)
 		}
 	} else {
 		d.Set("instance_market_options", nil)
 	}
 	if apiObject.InstanceRequirements != nil {
-		if err := d.Set("instance_requirements", []interface{}{flattenInstanceRequirements(apiObject.InstanceRequirements)}); err != nil {
+		if err := d.Set("instance_requirements", []any{flattenInstanceRequirements(apiObject.InstanceRequirements)}); err != nil {
 			return fmt.Errorf("setting instance_requirements: %w", err)
 		}
 	} else {
@@ -2365,25 +2365,25 @@ func flattenResponseLaunchTemplateData(ctx context.Context, conn *ec2.Client, d 
 		return fmt.Errorf("setting license_specification: %w", err)
 	}
 	if apiObject.MaintenanceOptions != nil {
-		if err := d.Set("maintenance_options", []interface{}{flattenLaunchTemplateInstanceMaintenanceOptions(apiObject.MaintenanceOptions)}); err != nil {
+		if err := d.Set("maintenance_options", []any{flattenLaunchTemplateInstanceMaintenanceOptions(apiObject.MaintenanceOptions)}); err != nil {
 			return fmt.Errorf("setting maintenance_options: %w", err)
 		}
 	} else {
 		d.Set("maintenance_options", nil)
 	}
 	if apiObject.MetadataOptions != nil {
-		if err := d.Set("metadata_options", []interface{}{flattenLaunchTemplateInstanceMetadataOptions(apiObject.MetadataOptions)}); err != nil {
+		if err := d.Set("metadata_options", []any{flattenLaunchTemplateInstanceMetadataOptions(apiObject.MetadataOptions)}); err != nil {
 			return fmt.Errorf("setting metadata_options: %w", err)
 		}
 	} else {
 		d.Set("metadata_options", nil)
 	}
 	if apiObject.Monitoring != nil {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrEnabled: aws.ToBool(apiObject.Monitoring.Enabled),
 		}
 
-		if err := d.Set("monitoring", []interface{}{tfMap}); err != nil {
+		if err := d.Set("monitoring", []any{tfMap}); err != nil {
 			return fmt.Errorf("setting monitoring: %w", err)
 		}
 	} else {
@@ -2393,14 +2393,14 @@ func flattenResponseLaunchTemplateData(ctx context.Context, conn *ec2.Client, d 
 		return fmt.Errorf("setting network_interfaces: %w", err)
 	}
 	if apiObject.Placement != nil {
-		if err := d.Set("placement", []interface{}{flattenLaunchTemplatePlacement(apiObject.Placement)}); err != nil {
+		if err := d.Set("placement", []any{flattenLaunchTemplatePlacement(apiObject.Placement)}); err != nil {
 			return fmt.Errorf("setting placement: %w", err)
 		}
 	} else {
 		d.Set("placement", nil)
 	}
 	if apiObject.PrivateDnsNameOptions != nil {
-		if err := d.Set("private_dns_name_options", []interface{}{flattenLaunchTemplatePrivateDNSNameOptions(apiObject.PrivateDnsNameOptions)}); err != nil {
+		if err := d.Set("private_dns_name_options", []any{flattenLaunchTemplatePrivateDNSNameOptions(apiObject.PrivateDnsNameOptions)}); err != nil {
 			return fmt.Errorf("setting private_dns_name_options: %w", err)
 		}
 	} else {
@@ -2417,15 +2417,15 @@ func flattenResponseLaunchTemplateData(ctx context.Context, conn *ec2.Client, d 
 	return nil
 }
 
-func flattenLaunchTemplateBlockDeviceMapping(apiObject awstypes.LaunchTemplateBlockDeviceMapping) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenLaunchTemplateBlockDeviceMapping(apiObject awstypes.LaunchTemplateBlockDeviceMapping) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.DeviceName; v != nil {
 		tfMap[names.AttrDeviceName] = aws.ToString(v)
 	}
 
 	if v := apiObject.Ebs; v != nil {
-		tfMap["ebs"] = []interface{}{flattenLaunchTemplateEBSBlockDevice(v)}
+		tfMap["ebs"] = []any{flattenLaunchTemplateEBSBlockDevice(v)}
 	}
 
 	if v := apiObject.NoDevice; v != nil {
@@ -2439,12 +2439,12 @@ func flattenLaunchTemplateBlockDeviceMapping(apiObject awstypes.LaunchTemplateBl
 	return tfMap
 }
 
-func flattenLaunchTemplateBlockDeviceMappings(apiObjects []awstypes.LaunchTemplateBlockDeviceMapping) []interface{} {
+func flattenLaunchTemplateBlockDeviceMappings(apiObjects []awstypes.LaunchTemplateBlockDeviceMapping) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenLaunchTemplateBlockDeviceMapping(apiObject))
@@ -2453,12 +2453,12 @@ func flattenLaunchTemplateBlockDeviceMappings(apiObjects []awstypes.LaunchTempla
 	return tfList
 }
 
-func flattenLaunchTemplateEBSBlockDevice(apiObject *awstypes.LaunchTemplateEbsBlockDevice) map[string]interface{} {
+func flattenLaunchTemplateEBSBlockDevice(apiObject *awstypes.LaunchTemplateEbsBlockDevice) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.DeleteOnTermination; v != nil {
 		tfMap[names.AttrDeleteOnTermination] = flex.BoolToStringValue(v)
@@ -2495,30 +2495,30 @@ func flattenLaunchTemplateEBSBlockDevice(apiObject *awstypes.LaunchTemplateEbsBl
 	return tfMap
 }
 
-func flattenLaunchTemplateCapacityReservationSpecificationResponse(apiObject *awstypes.LaunchTemplateCapacityReservationSpecificationResponse) map[string]interface{} {
+func flattenLaunchTemplateCapacityReservationSpecificationResponse(apiObject *awstypes.LaunchTemplateCapacityReservationSpecificationResponse) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CapacityReservationPreference; v != "" {
 		tfMap["capacity_reservation_preference"] = v
 	}
 
 	if v := apiObject.CapacityReservationTarget; v != nil {
-		tfMap["capacity_reservation_target"] = []interface{}{flattenCapacityReservationTargetResponse(v)}
+		tfMap["capacity_reservation_target"] = []any{flattenCapacityReservationTargetResponse(v)}
 	}
 
 	return tfMap
 }
 
-func flattenLaunchTemplateCPUOptions(apiObject *awstypes.LaunchTemplateCpuOptions) map[string]interface{} {
+func flattenLaunchTemplateCPUOptions(apiObject *awstypes.LaunchTemplateCpuOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AmdSevSnp; v != "" {
 		tfMap["amd_sev_snp"] = v
@@ -2535,12 +2535,12 @@ func flattenLaunchTemplateCPUOptions(apiObject *awstypes.LaunchTemplateCpuOption
 	return tfMap
 }
 
-func flattenCreditSpecification(apiObject *awstypes.CreditSpecification) map[string]interface{} {
+func flattenCreditSpecification(apiObject *awstypes.CreditSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CpuCredits; v != nil {
 		tfMap["cpu_credits"] = aws.ToString(v)
@@ -2549,8 +2549,8 @@ func flattenCreditSpecification(apiObject *awstypes.CreditSpecification) map[str
 	return tfMap
 }
 
-func flattenElasticGpuSpecificationResponse(apiObject awstypes.ElasticGpuSpecificationResponse) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenElasticGpuSpecificationResponse(apiObject awstypes.ElasticGpuSpecificationResponse) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.Type; v != nil {
 		tfMap[names.AttrType] = aws.ToString(v)
@@ -2559,12 +2559,12 @@ func flattenElasticGpuSpecificationResponse(apiObject awstypes.ElasticGpuSpecifi
 	return tfMap
 }
 
-func flattenElasticGpuSpecificationResponses(apiObjects []awstypes.ElasticGpuSpecificationResponse) []interface{} {
+func flattenElasticGpuSpecificationResponses(apiObjects []awstypes.ElasticGpuSpecificationResponse) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenElasticGpuSpecificationResponse(apiObject))
@@ -2573,8 +2573,8 @@ func flattenElasticGpuSpecificationResponses(apiObjects []awstypes.ElasticGpuSpe
 	return tfList
 }
 
-func flattenLaunchTemplateElasticInferenceAcceleratorResponse(apiObject awstypes.LaunchTemplateElasticInferenceAcceleratorResponse) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenLaunchTemplateElasticInferenceAcceleratorResponse(apiObject awstypes.LaunchTemplateElasticInferenceAcceleratorResponse) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.Type; v != nil {
 		tfMap[names.AttrType] = aws.ToString(v)
@@ -2583,12 +2583,12 @@ func flattenLaunchTemplateElasticInferenceAcceleratorResponse(apiObject awstypes
 	return tfMap
 }
 
-func flattenLaunchTemplateElasticInferenceAcceleratorResponses(apiObjects []awstypes.LaunchTemplateElasticInferenceAcceleratorResponse) []interface{} {
+func flattenLaunchTemplateElasticInferenceAcceleratorResponses(apiObjects []awstypes.LaunchTemplateElasticInferenceAcceleratorResponse) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenLaunchTemplateElasticInferenceAcceleratorResponse(apiObject))
@@ -2597,12 +2597,12 @@ func flattenLaunchTemplateElasticInferenceAcceleratorResponses(apiObjects []awst
 	return tfList
 }
 
-func flattenLaunchTemplateIAMInstanceProfileSpecification(apiObject *awstypes.LaunchTemplateIamInstanceProfileSpecification) map[string]interface{} {
+func flattenLaunchTemplateIAMInstanceProfileSpecification(apiObject *awstypes.LaunchTemplateIamInstanceProfileSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Arn; v != nil {
 		tfMap[names.AttrARN] = aws.ToString(v)
@@ -2615,33 +2615,33 @@ func flattenLaunchTemplateIAMInstanceProfileSpecification(apiObject *awstypes.La
 	return tfMap
 }
 
-func flattenLaunchTemplateInstanceMarketOptions(apiObject *awstypes.LaunchTemplateInstanceMarketOptions) map[string]interface{} {
+func flattenLaunchTemplateInstanceMarketOptions(apiObject *awstypes.LaunchTemplateInstanceMarketOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.MarketType; v != "" {
 		tfMap["market_type"] = v
 	}
 
 	if v := apiObject.SpotOptions; v != nil {
-		tfMap["spot_options"] = []interface{}{flattenLaunchTemplateSpotMarketOptions(v)}
+		tfMap["spot_options"] = []any{flattenLaunchTemplateSpotMarketOptions(v)}
 	}
 
 	return tfMap
 }
 
-func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[string]interface{} {
+func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AcceleratorCount; v != nil {
-		tfMap["accelerator_count"] = []interface{}{flattenAcceleratorCount(v)}
+		tfMap["accelerator_count"] = []any{flattenAcceleratorCount(v)}
 	}
 
 	if v := apiObject.AcceleratorManufacturers; v != nil {
@@ -2653,7 +2653,7 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.AcceleratorTotalMemoryMiB; v != nil {
-		tfMap["accelerator_total_memory_mib"] = []interface{}{flattenAcceleratorTotalMemoryMiB(v)}
+		tfMap["accelerator_total_memory_mib"] = []any{flattenAcceleratorTotalMemoryMiB(v)}
 	}
 
 	if v := apiObject.AcceleratorTypes; v != nil {
@@ -2669,7 +2669,7 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.BaselineEbsBandwidthMbps; v != nil {
-		tfMap["baseline_ebs_bandwidth_mbps"] = []interface{}{flattenBaselineEBSBandwidthMbps(v)}
+		tfMap["baseline_ebs_bandwidth_mbps"] = []any{flattenBaselineEBSBandwidthMbps(v)}
 	}
 
 	if v := apiObject.BurstablePerformance; v != "" {
@@ -2701,19 +2701,19 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.MemoryGiBPerVCpu; v != nil {
-		tfMap["memory_gib_per_vcpu"] = []interface{}{flattenMemoryGiBPerVCPU(v)}
+		tfMap["memory_gib_per_vcpu"] = []any{flattenMemoryGiBPerVCPU(v)}
 	}
 
 	if v := apiObject.MemoryMiB; v != nil {
-		tfMap["memory_mib"] = []interface{}{flattenMemoryMiB(v)}
+		tfMap["memory_mib"] = []any{flattenMemoryMiB(v)}
 	}
 
 	if v := apiObject.NetworkBandwidthGbps; v != nil {
-		tfMap["network_bandwidth_gbps"] = []interface{}{flattenNetworkBandwidthGbps(v)}
+		tfMap["network_bandwidth_gbps"] = []any{flattenNetworkBandwidthGbps(v)}
 	}
 
 	if v := apiObject.NetworkInterfaceCount; v != nil {
-		tfMap["network_interface_count"] = []interface{}{flattenNetworkInterfaceCount(v)}
+		tfMap["network_interface_count"] = []any{flattenNetworkInterfaceCount(v)}
 	}
 
 	if v := apiObject.OnDemandMaxPricePercentageOverLowestPrice; v != nil {
@@ -2729,22 +2729,22 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.TotalLocalStorageGB; v != nil {
-		tfMap["total_local_storage_gb"] = []interface{}{flattenTotalLocalStorageGB(v)}
+		tfMap["total_local_storage_gb"] = []any{flattenTotalLocalStorageGB(v)}
 	}
 
 	if v := apiObject.VCpuCount; v != nil {
-		tfMap["vcpu_count"] = []interface{}{flattenVCPUCountRange(v)}
+		tfMap["vcpu_count"] = []any{flattenVCPUCountRange(v)}
 	}
 
 	return tfMap
 }
 
-func flattenAcceleratorCount(apiObject *awstypes.AcceleratorCount) map[string]interface{} {
+func flattenAcceleratorCount(apiObject *awstypes.AcceleratorCount) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -2757,12 +2757,12 @@ func flattenAcceleratorCount(apiObject *awstypes.AcceleratorCount) map[string]in
 	return tfMap
 }
 
-func flattenAcceleratorTotalMemoryMiB(apiObject *awstypes.AcceleratorTotalMemoryMiB) map[string]interface{} {
+func flattenAcceleratorTotalMemoryMiB(apiObject *awstypes.AcceleratorTotalMemoryMiB) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -2775,12 +2775,12 @@ func flattenAcceleratorTotalMemoryMiB(apiObject *awstypes.AcceleratorTotalMemory
 	return tfMap
 }
 
-func flattenBaselineEBSBandwidthMbps(apiObject *awstypes.BaselineEbsBandwidthMbps) map[string]interface{} {
+func flattenBaselineEBSBandwidthMbps(apiObject *awstypes.BaselineEbsBandwidthMbps) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -2793,12 +2793,12 @@ func flattenBaselineEBSBandwidthMbps(apiObject *awstypes.BaselineEbsBandwidthMbp
 	return tfMap
 }
 
-func flattenMemoryGiBPerVCPU(apiObject *awstypes.MemoryGiBPerVCpu) map[string]interface{} {
+func flattenMemoryGiBPerVCPU(apiObject *awstypes.MemoryGiBPerVCpu) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToFloat64(v)
@@ -2811,12 +2811,12 @@ func flattenMemoryGiBPerVCPU(apiObject *awstypes.MemoryGiBPerVCpu) map[string]in
 	return tfMap
 }
 
-func flattenMemoryMiB(apiObject *awstypes.MemoryMiB) map[string]interface{} {
+func flattenMemoryMiB(apiObject *awstypes.MemoryMiB) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -2829,12 +2829,12 @@ func flattenMemoryMiB(apiObject *awstypes.MemoryMiB) map[string]interface{} {
 	return tfMap
 }
 
-func flattenNetworkBandwidthGbps(apiObject *awstypes.NetworkBandwidthGbps) map[string]interface{} {
+func flattenNetworkBandwidthGbps(apiObject *awstypes.NetworkBandwidthGbps) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToFloat64(v)
@@ -2847,12 +2847,12 @@ func flattenNetworkBandwidthGbps(apiObject *awstypes.NetworkBandwidthGbps) map[s
 	return tfMap
 }
 
-func flattenNetworkInterfaceCount(apiObject *awstypes.NetworkInterfaceCount) map[string]interface{} {
+func flattenNetworkInterfaceCount(apiObject *awstypes.NetworkInterfaceCount) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -2865,12 +2865,12 @@ func flattenNetworkInterfaceCount(apiObject *awstypes.NetworkInterfaceCount) map
 	return tfMap
 }
 
-func flattenTotalLocalStorageGB(apiObject *awstypes.TotalLocalStorageGB) map[string]interface{} {
+func flattenTotalLocalStorageGB(apiObject *awstypes.TotalLocalStorageGB) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToFloat64(v)
@@ -2883,12 +2883,12 @@ func flattenTotalLocalStorageGB(apiObject *awstypes.TotalLocalStorageGB) map[str
 	return tfMap
 }
 
-func flattenVCPUCountRange(apiObject *awstypes.VCpuCountRange) map[string]interface{} {
+func flattenVCPUCountRange(apiObject *awstypes.VCpuCountRange) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -2901,12 +2901,12 @@ func flattenVCPUCountRange(apiObject *awstypes.VCpuCountRange) map[string]interf
 	return tfMap
 }
 
-func flattenLaunchTemplateSpotMarketOptions(apiObject *awstypes.LaunchTemplateSpotMarketOptions) map[string]interface{} {
+func flattenLaunchTemplateSpotMarketOptions(apiObject *awstypes.LaunchTemplateSpotMarketOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.BlockDurationMinutes; v != nil {
 		tfMap["block_duration_minutes"] = aws.ToInt32(v)
@@ -2931,8 +2931,8 @@ func flattenLaunchTemplateSpotMarketOptions(apiObject *awstypes.LaunchTemplateSp
 	return tfMap
 }
 
-func flattenLaunchTemplateLicenseConfiguration(apiObject awstypes.LaunchTemplateLicenseConfiguration) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenLaunchTemplateLicenseConfiguration(apiObject awstypes.LaunchTemplateLicenseConfiguration) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.LicenseConfigurationArn; v != nil {
 		tfMap["license_configuration_arn"] = aws.ToString(v)
@@ -2941,12 +2941,12 @@ func flattenLaunchTemplateLicenseConfiguration(apiObject awstypes.LaunchTemplate
 	return tfMap
 }
 
-func flattenLaunchTemplateLicenseConfigurations(apiObjects []awstypes.LaunchTemplateLicenseConfiguration) []interface{} {
+func flattenLaunchTemplateLicenseConfigurations(apiObjects []awstypes.LaunchTemplateLicenseConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenLaunchTemplateLicenseConfiguration(apiObject))
@@ -2955,8 +2955,8 @@ func flattenLaunchTemplateLicenseConfigurations(apiObjects []awstypes.LaunchTemp
 	return tfList
 }
 
-func flattenLaunchTemplateInstanceMaintenanceOptions(apiObject *awstypes.LaunchTemplateInstanceMaintenanceOptions) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenLaunchTemplateInstanceMaintenanceOptions(apiObject *awstypes.LaunchTemplateInstanceMaintenanceOptions) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.AutoRecovery; v != "" {
 		tfMap["auto_recovery"] = v
@@ -2965,12 +2965,12 @@ func flattenLaunchTemplateInstanceMaintenanceOptions(apiObject *awstypes.LaunchT
 	return tfMap
 }
 
-func flattenLaunchTemplateInstanceMetadataOptions(apiObject *awstypes.LaunchTemplateInstanceMetadataOptions) map[string]interface{} {
+func flattenLaunchTemplateInstanceMetadataOptions(apiObject *awstypes.LaunchTemplateInstanceMetadataOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.HttpEndpoint; v != "" {
 		tfMap["http_endpoint"] = v
@@ -2995,8 +2995,8 @@ func flattenLaunchTemplateInstanceMetadataOptions(apiObject *awstypes.LaunchTemp
 	return tfMap
 }
 
-func flattenLaunchTemplateInstanceNetworkInterfaceSpecification(apiObject awstypes.LaunchTemplateInstanceNetworkInterfaceSpecification) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenLaunchTemplateInstanceNetworkInterfaceSpecification(apiObject awstypes.LaunchTemplateInstanceNetworkInterfaceSpecification) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.AssociateCarrierIpAddress; v != nil {
 		tfMap["associate_carrier_ip_address"] = flex.BoolToStringValue(v)
@@ -3007,7 +3007,7 @@ func flattenLaunchTemplateInstanceNetworkInterfaceSpecification(apiObject awstyp
 	}
 
 	if v := apiObject.ConnectionTrackingSpecification; v != nil {
-		tfMap["connection_tracking_specification"] = []interface{}{flattenConnectionTrackingSpecification(v)}
+		tfMap["connection_tracking_specification"] = []any{flattenConnectionTrackingSpecification(v)}
 	}
 
 	if v := apiObject.DeleteOnTermination; v != nil {
@@ -3023,7 +3023,7 @@ func flattenLaunchTemplateInstanceNetworkInterfaceSpecification(apiObject awstyp
 	}
 
 	if v := apiObject.EnaSrdSpecification; v != nil {
-		tfMap["ena_srd_specification"] = []interface{}{flattenLaunchTemplateEnaSrdSpecification(v)}
+		tfMap["ena_srd_specification"] = []any{flattenLaunchTemplateEnaSrdSpecification(v)}
 	}
 
 	if v := apiObject.InterfaceType; v != nil {
@@ -3113,12 +3113,12 @@ func flattenLaunchTemplateInstanceNetworkInterfaceSpecification(apiObject awstyp
 	return tfMap
 }
 
-func flattenLaunchTemplateInstanceNetworkInterfaceSpecifications(apiObjects []awstypes.LaunchTemplateInstanceNetworkInterfaceSpecification) []interface{} {
+func flattenLaunchTemplateInstanceNetworkInterfaceSpecifications(apiObjects []awstypes.LaunchTemplateInstanceNetworkInterfaceSpecification) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenLaunchTemplateInstanceNetworkInterfaceSpecification(apiObject))
@@ -3127,12 +3127,12 @@ func flattenLaunchTemplateInstanceNetworkInterfaceSpecifications(apiObjects []aw
 	return tfList
 }
 
-func flattenLaunchTemplatePlacement(apiObject *awstypes.LaunchTemplatePlacement) map[string]interface{} {
+func flattenLaunchTemplatePlacement(apiObject *awstypes.LaunchTemplatePlacement) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Affinity; v != nil {
 		tfMap["affinity"] = aws.ToString(v)
@@ -3169,12 +3169,12 @@ func flattenLaunchTemplatePlacement(apiObject *awstypes.LaunchTemplatePlacement)
 	return tfMap
 }
 
-func flattenLaunchTemplatePrivateDNSNameOptions(apiObject *awstypes.LaunchTemplatePrivateDnsNameOptions) map[string]interface{} {
+func flattenLaunchTemplatePrivateDNSNameOptions(apiObject *awstypes.LaunchTemplatePrivateDnsNameOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"enable_resource_name_dns_aaaa_record": aws.ToBool(apiObject.EnableResourceNameDnsAAAARecord),
 		"enable_resource_name_dns_a_record":    aws.ToBool(apiObject.EnableResourceNameDnsARecord),
 	}
@@ -3186,8 +3186,8 @@ func flattenLaunchTemplatePrivateDNSNameOptions(apiObject *awstypes.LaunchTempla
 	return tfMap
 }
 
-func flattenLaunchTemplateTagSpecification(ctx context.Context, apiObject awstypes.LaunchTemplateTagSpecification) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenLaunchTemplateTagSpecification(ctx context.Context, apiObject awstypes.LaunchTemplateTagSpecification) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.ResourceType; v != "" {
 		tfMap[names.AttrResourceType] = v
@@ -3200,12 +3200,12 @@ func flattenLaunchTemplateTagSpecification(ctx context.Context, apiObject awstyp
 	return tfMap
 }
 
-func flattenLaunchTemplateTagSpecifications(ctx context.Context, apiObjects []awstypes.LaunchTemplateTagSpecification) []interface{} {
+func flattenLaunchTemplateTagSpecifications(ctx context.Context, apiObjects []awstypes.LaunchTemplateTagSpecification) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenLaunchTemplateTagSpecification(ctx, apiObject))
@@ -3226,7 +3226,7 @@ func expandLaunchTemplateIPv4PrefixSpecificationRequest(tfString string) awstype
 	return apiObject
 }
 
-func expandLaunchTemplateIPv4PrefixSpecificationRequests(tfList []interface{}) []awstypes.Ipv4PrefixSpecificationRequest {
+func expandLaunchTemplateIPv4PrefixSpecificationRequests(tfList []any) []awstypes.Ipv4PrefixSpecificationRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -3258,7 +3258,7 @@ func expandLaunchTemplateIPv6PrefixSpecificationRequest(tfString string) awstype
 	return apiObject
 }
 
-func expandLaunchTemplateIPv6PrefixSpecificationRequests(tfList []interface{}) []awstypes.Ipv6PrefixSpecificationRequest {
+func expandLaunchTemplateIPv6PrefixSpecificationRequests(tfList []any) []awstypes.Ipv6PrefixSpecificationRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -3278,7 +3278,7 @@ func expandLaunchTemplateIPv6PrefixSpecificationRequests(tfList []interface{}) [
 	return apiObjects
 }
 
-func expandConnectionTrackingSpecificationRequest(tfMap map[string]interface{}) *awstypes.ConnectionTrackingSpecificationRequest {
+func expandConnectionTrackingSpecificationRequest(tfMap map[string]any) *awstypes.ConnectionTrackingSpecificationRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3300,12 +3300,12 @@ func expandConnectionTrackingSpecificationRequest(tfMap map[string]interface{}) 
 	return apiObject
 }
 
-func flattenConnectionTrackingSpecification(apiObject *awstypes.ConnectionTrackingSpecification) map[string]interface{} {
+func flattenConnectionTrackingSpecification(apiObject *awstypes.ConnectionTrackingSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.TcpEstablishedTimeout; v != nil {
 		tfMap["tcp_established_timeout"] = aws.ToInt32(v)
@@ -3322,7 +3322,7 @@ func flattenConnectionTrackingSpecification(apiObject *awstypes.ConnectionTracki
 	return tfMap
 }
 
-func expandEnaSrdSpecificationRequest(tfMap map[string]interface{}) *awstypes.EnaSrdSpecificationRequest {
+func expandEnaSrdSpecificationRequest(tfMap map[string]any) *awstypes.EnaSrdSpecificationRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3331,30 +3331,30 @@ func expandEnaSrdSpecificationRequest(tfMap map[string]interface{}) *awstypes.En
 		EnaSrdEnabled: aws.Bool(tfMap["ena_srd_enabled"].(bool)),
 	}
 
-	if v, ok := tfMap["ena_srd_udp_specification"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.EnaSrdUdpSpecification = expandEnaSrdUdpSpecificationRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["ena_srd_udp_specification"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.EnaSrdUdpSpecification = expandEnaSrdUdpSpecificationRequest(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func flattenLaunchTemplateEnaSrdSpecification(apiObject *awstypes.LaunchTemplateEnaSrdSpecification) map[string]interface{} {
+func flattenLaunchTemplateEnaSrdSpecification(apiObject *awstypes.LaunchTemplateEnaSrdSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"ena_srd_enabled": aws.ToBool(apiObject.EnaSrdEnabled),
 	}
 
 	if v := apiObject.EnaSrdUdpSpecification; v != nil {
-		tfMap["ena_srd_udp_specification"] = []interface{}{flattenLaunchTemplateEnaSrdUdpSpecification(v)}
+		tfMap["ena_srd_udp_specification"] = []any{flattenLaunchTemplateEnaSrdUdpSpecification(v)}
 	}
 
 	return tfMap
 }
 
-func expandEnaSrdUdpSpecificationRequest(tfMap map[string]interface{}) *awstypes.EnaSrdUdpSpecificationRequest {
+func expandEnaSrdUdpSpecificationRequest(tfMap map[string]any) *awstypes.EnaSrdUdpSpecificationRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3366,12 +3366,12 @@ func expandEnaSrdUdpSpecificationRequest(tfMap map[string]interface{}) *awstypes
 	return apiObject
 }
 
-func flattenLaunchTemplateEnaSrdUdpSpecification(apiObject *awstypes.LaunchTemplateEnaSrdUdpSpecification) map[string]interface{} {
+func flattenLaunchTemplateEnaSrdUdpSpecification(apiObject *awstypes.LaunchTemplateEnaSrdUdpSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"ena_srd_udp_enabled": aws.ToBool(apiObject.EnaSrdUdpEnabled),
 	}
 

--- a/internal/service/ec2/ec2_launch_template_data_source.go
+++ b/internal/service/ec2/ec2_launch_template_data_source.go
@@ -811,7 +811,7 @@ func dataSourceLaunchTemplate() *schema.Resource {
 	}
 }
 
-func dataSourceLaunchTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLaunchTemplateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -830,7 +830,7 @@ func dataSourceLaunchTemplateRead(ctx context.Context, d *schema.ResourceData, m
 	)...)
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	if len(input.Filters) == 0 {

--- a/internal/service/ec2/ec2_placement_group.go
+++ b/internal/service/ec2/ec2_placement_group.go
@@ -81,7 +81,7 @@ func resourcePlacementGroup() *schema.Resource {
 	}
 }
 
-func resourcePlacementGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlacementGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -117,7 +117,7 @@ func resourcePlacementGroupCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourcePlacementGroupRead(ctx, d, meta)...)
 }
 
-func resourcePlacementGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlacementGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -152,7 +152,7 @@ func resourcePlacementGroupRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourcePlacementGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlacementGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -160,7 +160,7 @@ func resourcePlacementGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourcePlacementGroupRead(ctx, d, meta)...)
 }
 
-func resourcePlacementGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlacementGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -187,7 +187,7 @@ func resourcePlacementGroupDelete(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourcePlacementGroupCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func resourcePlacementGroupCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if diff.Id() == "" {
 		if partitionCount, strategy := diff.Get("partition_count").(int), diff.Get("strategy").(string); partitionCount > 0 && strategy != string(awstypes.PlacementGroupStrategyPartition) {
 			return fmt.Errorf("partition_count must not be set when strategy = %q", strategy)

--- a/internal/service/ec2/ec2_public_ipv4_pool_data_source.go
+++ b/internal/service/ec2/ec2_public_ipv4_pool_data_source.go
@@ -71,7 +71,7 @@ func dataSourcePublicIPv4Pool() *schema.Resource {
 	}
 }
 
-func dataSourcePublicIPv4PoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourcePublicIPv4PoolRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
@@ -98,8 +98,8 @@ func dataSourcePublicIPv4PoolRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func flattenPublicIPv4PoolRange(apiObject awstypes.PublicIpv4PoolRange) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenPublicIPv4PoolRange(apiObject awstypes.PublicIpv4PoolRange) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.AddressCount; v != nil {
 		tfMap["address_count"] = aws.ToInt32(v)
@@ -120,12 +120,12 @@ func flattenPublicIPv4PoolRange(apiObject awstypes.PublicIpv4PoolRange) map[stri
 	return tfMap
 }
 
-func flattenPublicIPv4PoolRanges(apiObjects []awstypes.PublicIpv4PoolRange) []interface{} {
+func flattenPublicIPv4PoolRanges(apiObjects []awstypes.PublicIpv4PoolRange) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenPublicIPv4PoolRange(apiObject))

--- a/internal/service/ec2/ec2_public_ipv4_pools_data_source.go
+++ b/internal/service/ec2/ec2_public_ipv4_pools_data_source.go
@@ -33,14 +33,14 @@ func dataSourcePublicIPv4Pools() *schema.Resource {
 	}
 }
 
-func dataSourcePublicIPv4PoolsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourcePublicIPv4PoolsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := ec2.DescribePublicIpv4PoolsInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/ec2_serial_console_access.go
+++ b/internal/service/ec2/ec2_serial_console_access.go
@@ -36,7 +36,7 @@ func resourceSerialConsoleAccess() *schema.Resource {
 	}
 }
 
-func resourceSerialConsoleAccessCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSerialConsoleAccessCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -51,7 +51,7 @@ func resourceSerialConsoleAccessCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceSerialConsoleAccessRead(ctx, d, meta)...)
 }
 
-func resourceSerialConsoleAccessRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSerialConsoleAccessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -68,7 +68,7 @@ func resourceSerialConsoleAccessRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceSerialConsoleAccessUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSerialConsoleAccessUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -81,7 +81,7 @@ func resourceSerialConsoleAccessUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceSerialConsoleAccessRead(ctx, d, meta)...)
 }
 
-func resourceSerialConsoleAccessDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSerialConsoleAccessDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)

--- a/internal/service/ec2/ec2_serial_console_access_data_source.go
+++ b/internal/service/ec2/ec2_serial_console_access_data_source.go
@@ -32,7 +32,7 @@ func dataSourceSerialConsoleAccess() *schema.Resource {
 		},
 	}
 }
-func dataSourceSerialConsoleAccessRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSerialConsoleAccessRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)

--- a/internal/service/ec2/ec2_spot_datafeed_subscription.go
+++ b/internal/service/ec2/ec2_spot_datafeed_subscription.go
@@ -43,7 +43,7 @@ func resourceSpotDataFeedSubscription() *schema.Resource {
 	}
 }
 
-func resourceSpotDataFeedSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotDataFeedSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -66,7 +66,7 @@ func resourceSpotDataFeedSubscriptionCreate(ctx context.Context, d *schema.Resou
 	return append(diags, resourceSpotDataFeedSubscriptionRead(ctx, d, meta)...)
 }
 
-func resourceSpotDataFeedSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotDataFeedSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -88,7 +88,7 @@ func resourceSpotDataFeedSubscriptionRead(ctx context.Context, d *schema.Resourc
 	return diags
 }
 
-func resourceSpotDataFeedSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotDataFeedSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_spot_fleet_request.go
+++ b/internal/service/ec2/ec2_spot_fleet_request.go
@@ -43,7 +43,7 @@ func resourceSpotFleetRequest() *schema.Resource {
 		UpdateWithoutTimeout: resourceSpotFleetRequestUpdate,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set("instance_pools_to_use_count", 1)
 				return []*schema.ResourceData{d}, nil
 			},
@@ -338,7 +338,7 @@ func resourceSpotFleetRequest() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
-							StateFunc: func(v interface{}) string {
+							StateFunc: func(v any) string {
 								switch v := v.(type) {
 								case string:
 									return userDataHashSum(v)
@@ -871,7 +871,7 @@ func resourceSpotFleetRequest() *schema.Resource {
 	}
 }
 
-func resourceSpotFleetRequestCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotFleetRequestCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -920,7 +920,7 @@ func resourceSpotFleetRequestCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if v, ok := d.GetOk("spot_maintenance_strategies"); ok {
-		spotFleetConfig.SpotMaintenanceStrategies = expandSpotMaintenanceStrategies(v.([]interface{}))
+		spotFleetConfig.SpotMaintenanceStrategies = expandSpotMaintenanceStrategies(v.([]any))
 	}
 
 	// InvalidSpotFleetConfig: SpotMaintenanceStrategies option is only available with the spot fleet type maintain.
@@ -998,7 +998,7 @@ func resourceSpotFleetRequestCreate(ctx context.Context, d *schema.ResourceData,
 
 	log.Printf("[DEBUG] Creating EC2 Spot Fleet Request: %s", d.Id())
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, iamPropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.RequestSpotFleet(ctx, &input)
 		},
 		errCodeInvalidSpotFleetRequestConfig, "SpotFleetRequestConfig.IamFleetRole",
@@ -1023,7 +1023,7 @@ func resourceSpotFleetRequestCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceSpotFleetRequestRead(ctx, d, meta)...)
 }
 
-func resourceSpotFleetRequestRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotFleetRequestRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1115,7 +1115,7 @@ func resourceSpotFleetRequestRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceSpotFleetRequestUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotFleetRequestUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -1152,7 +1152,7 @@ func resourceSpotFleetRequestUpdate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceSpotFleetRequestRead(ctx, d, meta)...)
 }
 
-func resourceSpotFleetRequestDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotFleetRequestDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1186,7 +1186,7 @@ func resourceSpotFleetRequestDelete(ctx context.Context, d *schema.ResourceData,
 		return diags
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		input := ec2.DescribeSpotFleetInstancesInput{
 			SpotFleetRequestId: aws.String(d.Id()),
 		}
@@ -1210,7 +1210,7 @@ func resourceSpotFleetRequestDelete(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func buildSpotFleetLaunchSpecification(ctx context.Context, d map[string]interface{}, meta interface{}) (awstypes.SpotFleetLaunchSpecification, error) {
+func buildSpotFleetLaunchSpecification(ctx context.Context, d map[string]any, meta any) (awstypes.SpotFleetLaunchSpecification, error) {
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	opts := awstypes.SpotFleetLaunchSpecification{
@@ -1282,7 +1282,7 @@ func buildSpotFleetLaunchSpecification(ctx context.Context, d map[string]interfa
 		}
 	}
 
-	if m, ok := d[names.AttrTags].(map[string]interface{}); ok && len(m) > 0 {
+	if m, ok := d[names.AttrTags].(map[string]any); ok && len(m) > 0 {
 		tagsSpec := make([]awstypes.SpotFleetTagSpecification, 0)
 
 		tags := Tags(tftags.New(ctx, m).IgnoreAWS())
@@ -1338,13 +1338,13 @@ func buildSpotFleetLaunchSpecification(ctx context.Context, d map[string]interfa
 	return opts, nil
 }
 
-func readSpotFleetBlockDeviceMappingsFromConfig(ctx context.Context, d map[string]interface{}, conn *ec2.Client) ([]awstypes.BlockDeviceMapping, error) {
+func readSpotFleetBlockDeviceMappingsFromConfig(ctx context.Context, d map[string]any, conn *ec2.Client) ([]awstypes.BlockDeviceMapping, error) {
 	blockDevices := make([]awstypes.BlockDeviceMapping, 0)
 
 	if v, ok := d["ebs_block_device"]; ok {
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
-			bd := v.(map[string]interface{})
+			bd := v.(map[string]any)
 			ebs := &awstypes.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd[names.AttrDeleteOnTermination].(bool)),
 			}
@@ -1387,7 +1387,7 @@ func readSpotFleetBlockDeviceMappingsFromConfig(ctx context.Context, d map[strin
 	if v, ok := d["ephemeral_block_device"]; ok {
 		vL := v.(*schema.Set).List()
 		for _, v := range vL {
-			bd := v.(map[string]interface{})
+			bd := v.(map[string]any)
 			blockDevices = append(blockDevices, awstypes.BlockDeviceMapping{
 				DeviceName:  aws.String(bd[names.AttrDeviceName].(string)),
 				VirtualName: aws.String(bd[names.AttrVirtualName].(string)),
@@ -1401,7 +1401,7 @@ func readSpotFleetBlockDeviceMappingsFromConfig(ctx context.Context, d map[strin
 			return nil, fmt.Errorf("Cannot specify more than one root_block_device.")
 		}
 		for _, v := range vL {
-			bd := v.(map[string]interface{})
+			bd := v.(map[string]any)
 			ebs := &awstypes.EbsBlockDevice{
 				DeleteOnTermination: aws.Bool(bd[names.AttrDeleteOnTermination].(bool)),
 			}
@@ -1450,11 +1450,11 @@ func readSpotFleetBlockDeviceMappingsFromConfig(ctx context.Context, d map[strin
 	return blockDevices, nil
 }
 
-func buildSpotFleetLaunchSpecifications(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]awstypes.SpotFleetLaunchSpecification, error) {
+func buildSpotFleetLaunchSpecifications(ctx context.Context, d *schema.ResourceData, meta any) ([]awstypes.SpotFleetLaunchSpecification, error) {
 	userSpecs := d.Get("launch_specification").(*schema.Set).List()
 	specs := make([]awstypes.SpotFleetLaunchSpecification, len(userSpecs))
 	for i, userSpec := range userSpecs {
-		userSpecMap := userSpec.(map[string]interface{})
+		userSpecMap := userSpec.(map[string]any)
 		// panic: interface conversion: interface {} is map[string]interface {}, not *schema.ResourceData
 		opts, err := buildSpotFleetLaunchSpecification(ctx, userSpecMap, meta)
 		if err != nil {
@@ -1466,11 +1466,11 @@ func buildSpotFleetLaunchSpecifications(ctx context.Context, d *schema.ResourceD
 	return specs, nil
 }
 
-func expandLaunchTemplateConfig(tfMap map[string]interface{}) awstypes.LaunchTemplateConfig {
+func expandLaunchTemplateConfig(tfMap map[string]any) awstypes.LaunchTemplateConfig {
 	apiObject := awstypes.LaunchTemplateConfig{}
 
-	if v, ok := tfMap["launch_template_specification"].([]interface{}); ok && len(v) > 0 {
-		apiObject.LaunchTemplateSpecification = expandFleetLaunchTemplateSpecification(v[0].(map[string]interface{}))
+	if v, ok := tfMap["launch_template_specification"].([]any); ok && len(v) > 0 {
+		apiObject.LaunchTemplateSpecification = expandFleetLaunchTemplateSpecification(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["overrides"].(*schema.Set); ok && v.Len() > 0 {
@@ -1480,7 +1480,7 @@ func expandLaunchTemplateConfig(tfMap map[string]interface{}) awstypes.LaunchTem
 	return apiObject
 }
 
-func expandLaunchTemplateConfigs(tfList []interface{}) []awstypes.LaunchTemplateConfig {
+func expandLaunchTemplateConfigs(tfList []any) []awstypes.LaunchTemplateConfig {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1488,7 +1488,7 @@ func expandLaunchTemplateConfigs(tfList []interface{}) []awstypes.LaunchTemplate
 	var apiObjects []awstypes.LaunchTemplateConfig
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1500,7 +1500,7 @@ func expandLaunchTemplateConfigs(tfList []interface{}) []awstypes.LaunchTemplate
 	return apiObjects
 }
 
-func expandFleetLaunchTemplateSpecification(tfMap map[string]interface{}) *awstypes.FleetLaunchTemplateSpecification {
+func expandFleetLaunchTemplateSpecification(tfMap map[string]any) *awstypes.FleetLaunchTemplateSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -1522,15 +1522,15 @@ func expandFleetLaunchTemplateSpecification(tfMap map[string]interface{}) *awsty
 	return apiObject
 }
 
-func expandLaunchTemplateOverrides(tfMap map[string]interface{}) awstypes.LaunchTemplateOverrides {
+func expandLaunchTemplateOverrides(tfMap map[string]any) awstypes.LaunchTemplateOverrides {
 	apiObject := awstypes.LaunchTemplateOverrides{}
 
 	if v, ok := tfMap[names.AttrAvailabilityZone].(string); ok && v != "" {
 		apiObject.AvailabilityZone = aws.String(v)
 	}
 
-	if v, ok := tfMap["instance_requirements"].([]interface{}); ok && len(v) > 0 {
-		apiObject.InstanceRequirements = expandInstanceRequirements(v[0].(map[string]interface{}))
+	if v, ok := tfMap["instance_requirements"].([]any); ok && len(v) > 0 {
+		apiObject.InstanceRequirements = expandInstanceRequirements(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap[names.AttrInstanceType].(string); ok && v != "" {
@@ -1556,7 +1556,7 @@ func expandLaunchTemplateOverrides(tfMap map[string]interface{}) awstypes.Launch
 	return apiObject
 }
 
-func expandLaunchTemplateOverrideses(tfList []interface{}) []awstypes.LaunchTemplateOverrides {
+func expandLaunchTemplateOverrideses(tfList []any) []awstypes.LaunchTemplateOverrides {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1564,7 +1564,7 @@ func expandLaunchTemplateOverrideses(tfList []interface{}) []awstypes.LaunchTemp
 	var apiObjects []awstypes.LaunchTemplateOverrides
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1576,15 +1576,15 @@ func expandLaunchTemplateOverrideses(tfList []interface{}) []awstypes.LaunchTemp
 	return apiObjects
 }
 
-func expandInstanceRequirements(tfMap map[string]interface{}) *awstypes.InstanceRequirements {
+func expandInstanceRequirements(tfMap map[string]any) *awstypes.InstanceRequirements {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.InstanceRequirements{}
 
-	if v, ok := tfMap["accelerator_count"].([]interface{}); ok && len(v) > 0 {
-		apiObject.AcceleratorCount = expandAcceleratorCount(v[0].(map[string]interface{}))
+	if v, ok := tfMap["accelerator_count"].([]any); ok && len(v) > 0 {
+		apiObject.AcceleratorCount = expandAcceleratorCount(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["accelerator_manufacturers"].(*schema.Set); ok && v.Len() > 0 {
@@ -1595,8 +1595,8 @@ func expandInstanceRequirements(tfMap map[string]interface{}) *awstypes.Instance
 		apiObject.AcceleratorNames = flex.ExpandStringyValueSet[awstypes.AcceleratorName](v)
 	}
 
-	if v, ok := tfMap["accelerator_total_memory_mib"].([]interface{}); ok && len(v) > 0 {
-		apiObject.AcceleratorTotalMemoryMiB = expandAcceleratorTotalMemoryMiB(v[0].(map[string]interface{}))
+	if v, ok := tfMap["accelerator_total_memory_mib"].([]any); ok && len(v) > 0 {
+		apiObject.AcceleratorTotalMemoryMiB = expandAcceleratorTotalMemoryMiB(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["accelerator_types"].(*schema.Set); ok && v.Len() > 0 {
@@ -1611,8 +1611,8 @@ func expandInstanceRequirements(tfMap map[string]interface{}) *awstypes.Instance
 		apiObject.BareMetal = awstypes.BareMetal(v)
 	}
 
-	if v, ok := tfMap["baseline_ebs_bandwidth_mbps"].([]interface{}); ok && len(v) > 0 {
-		apiObject.BaselineEbsBandwidthMbps = expandBaselineEBSBandwidthMbps(v[0].(map[string]interface{}))
+	if v, ok := tfMap["baseline_ebs_bandwidth_mbps"].([]any); ok && len(v) > 0 {
+		apiObject.BaselineEbsBandwidthMbps = expandBaselineEBSBandwidthMbps(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["burstable_performance"].(string); ok && v != "" {
@@ -1639,16 +1639,16 @@ func expandInstanceRequirements(tfMap map[string]interface{}) *awstypes.Instance
 		apiObject.LocalStorageTypes = flex.ExpandStringyValueSet[awstypes.LocalStorageType](v)
 	}
 
-	if v, ok := tfMap["memory_gib_per_vcpu"].([]interface{}); ok && len(v) > 0 {
-		apiObject.MemoryGiBPerVCpu = expandMemoryGiBPerVCPU(v[0].(map[string]interface{}))
+	if v, ok := tfMap["memory_gib_per_vcpu"].([]any); ok && len(v) > 0 {
+		apiObject.MemoryGiBPerVCpu = expandMemoryGiBPerVCPU(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["memory_mib"].([]interface{}); ok && len(v) > 0 {
-		apiObject.MemoryMiB = expandMemoryMiB(v[0].(map[string]interface{}))
+	if v, ok := tfMap["memory_mib"].([]any); ok && len(v) > 0 {
+		apiObject.MemoryMiB = expandMemoryMiB(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["network_interface_count"].([]interface{}); ok && len(v) > 0 {
-		apiObject.NetworkInterfaceCount = expandNetworkInterfaceCount(v[0].(map[string]interface{}))
+	if v, ok := tfMap["network_interface_count"].([]any); ok && len(v) > 0 {
+		apiObject.NetworkInterfaceCount = expandNetworkInterfaceCount(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["on_demand_max_price_percentage_over_lowest_price"].(int); ok && v != 0 {
@@ -1663,18 +1663,18 @@ func expandInstanceRequirements(tfMap map[string]interface{}) *awstypes.Instance
 		apiObject.SpotMaxPricePercentageOverLowestPrice = aws.Int32(int32(v))
 	}
 
-	if v, ok := tfMap["total_local_storage_gb"].([]interface{}); ok && len(v) > 0 {
-		apiObject.TotalLocalStorageGB = expandTotalLocalStorageGB(v[0].(map[string]interface{}))
+	if v, ok := tfMap["total_local_storage_gb"].([]any); ok && len(v) > 0 {
+		apiObject.TotalLocalStorageGB = expandTotalLocalStorageGB(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["vcpu_count"].([]interface{}); ok && len(v) > 0 {
-		apiObject.VCpuCount = expandVCPUCountRange(v[0].(map[string]interface{}))
+	if v, ok := tfMap["vcpu_count"].([]any); ok && len(v) > 0 {
+		apiObject.VCpuCount = expandVCPUCountRange(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandAcceleratorCount(tfMap map[string]interface{}) *awstypes.AcceleratorCount {
+func expandAcceleratorCount(tfMap map[string]any) *awstypes.AcceleratorCount {
 	if tfMap == nil {
 		return nil
 	}
@@ -1692,7 +1692,7 @@ func expandAcceleratorCount(tfMap map[string]interface{}) *awstypes.AcceleratorC
 	return apiObject
 }
 
-func expandAcceleratorTotalMemoryMiB(tfMap map[string]interface{}) *awstypes.AcceleratorTotalMemoryMiB {
+func expandAcceleratorTotalMemoryMiB(tfMap map[string]any) *awstypes.AcceleratorTotalMemoryMiB {
 	if tfMap == nil {
 		return nil
 	}
@@ -1710,7 +1710,7 @@ func expandAcceleratorTotalMemoryMiB(tfMap map[string]interface{}) *awstypes.Acc
 	return apiObject
 }
 
-func expandBaselineEBSBandwidthMbps(tfMap map[string]interface{}) *awstypes.BaselineEbsBandwidthMbps {
+func expandBaselineEBSBandwidthMbps(tfMap map[string]any) *awstypes.BaselineEbsBandwidthMbps {
 	if tfMap == nil {
 		return nil
 	}
@@ -1728,7 +1728,7 @@ func expandBaselineEBSBandwidthMbps(tfMap map[string]interface{}) *awstypes.Base
 	return apiObject
 }
 
-func expandMemoryGiBPerVCPU(tfMap map[string]interface{}) *awstypes.MemoryGiBPerVCpu {
+func expandMemoryGiBPerVCPU(tfMap map[string]any) *awstypes.MemoryGiBPerVCpu {
 	if tfMap == nil {
 		return nil
 	}
@@ -1746,7 +1746,7 @@ func expandMemoryGiBPerVCPU(tfMap map[string]interface{}) *awstypes.MemoryGiBPer
 	return apiObject
 }
 
-func expandMemoryMiB(tfMap map[string]interface{}) *awstypes.MemoryMiB {
+func expandMemoryMiB(tfMap map[string]any) *awstypes.MemoryMiB {
 	if tfMap == nil {
 		return nil
 	}
@@ -1764,7 +1764,7 @@ func expandMemoryMiB(tfMap map[string]interface{}) *awstypes.MemoryMiB {
 	return apiObject
 }
 
-func expandNetworkInterfaceCount(tfMap map[string]interface{}) *awstypes.NetworkInterfaceCount {
+func expandNetworkInterfaceCount(tfMap map[string]any) *awstypes.NetworkInterfaceCount {
 	if tfMap == nil {
 		return nil
 	}
@@ -1782,7 +1782,7 @@ func expandNetworkInterfaceCount(tfMap map[string]interface{}) *awstypes.Network
 	return apiObject
 }
 
-func expandTotalLocalStorageGB(tfMap map[string]interface{}) *awstypes.TotalLocalStorageGB {
+func expandTotalLocalStorageGB(tfMap map[string]any) *awstypes.TotalLocalStorageGB {
 	if tfMap == nil {
 		return nil
 	}
@@ -1800,7 +1800,7 @@ func expandTotalLocalStorageGB(tfMap map[string]interface{}) *awstypes.TotalLoca
 	return apiObject
 }
 
-func expandVCPUCountRange(tfMap map[string]interface{}) *awstypes.VCpuCountRange {
+func expandVCPUCountRange(tfMap map[string]any) *awstypes.VCpuCountRange {
 	if tfMap == nil {
 		return nil
 	}
@@ -1818,26 +1818,26 @@ func expandVCPUCountRange(tfMap map[string]interface{}) *awstypes.VCpuCountRange
 	return apiObject
 }
 
-func expandSpotMaintenanceStrategies(l []interface{}) *awstypes.SpotMaintenanceStrategies {
+func expandSpotMaintenanceStrategies(l []any) *awstypes.SpotMaintenanceStrategies {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	fleetSpotMaintenanceStrategies := &awstypes.SpotMaintenanceStrategies{
-		CapacityRebalance: expandSpotCapacityRebalance(m["capacity_rebalance"].([]interface{})),
+		CapacityRebalance: expandSpotCapacityRebalance(m["capacity_rebalance"].([]any)),
 	}
 
 	return fleetSpotMaintenanceStrategies
 }
 
-func expandSpotCapacityRebalance(l []interface{}) *awstypes.SpotCapacityRebalance {
+func expandSpotCapacityRebalance(l []any) *awstypes.SpotCapacityRebalance {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	capacityRebalance := &awstypes.SpotCapacityRebalance{}
 
@@ -1861,8 +1861,8 @@ func launchSpecsToSet(ctx context.Context, conn *ec2.Client, launchSpecs []awsty
 	return specSet, nil
 }
 
-func launchSpecToMap(ctx context.Context, l awstypes.SpotFleetLaunchSpecification, rootDevName *string) map[string]interface{} {
-	m := make(map[string]interface{})
+func launchSpecToMap(ctx context.Context, l awstypes.SpotFleetLaunchSpecification, rootDevName *string) map[string]any {
+	m := make(map[string]any)
 
 	m["root_block_device"] = rootBlockDeviceToSet(l.BlockDeviceMappings, rootDevName)
 	m["ebs_block_device"] = ebsBlockDevicesToSet(l.BlockDeviceMappings, rootDevName)
@@ -1948,7 +1948,7 @@ func ebsBlockDevicesToSet(bdm []awstypes.BlockDeviceMapping, rootDevName *string
 
 	for _, val := range bdm {
 		if val.Ebs != nil {
-			m := make(map[string]interface{})
+			m := make(map[string]any)
 
 			ebs := val.Ebs
 
@@ -2004,7 +2004,7 @@ func ephemeralBlockDevicesToSet(bdm []awstypes.BlockDeviceMapping) *schema.Set {
 
 	for _, val := range bdm {
 		if val.VirtualName != nil {
-			m := make(map[string]interface{})
+			m := make(map[string]any)
 			m[names.AttrVirtualName] = aws.ToString(val.VirtualName)
 
 			if val.DeviceName != nil {
@@ -2024,7 +2024,7 @@ func rootBlockDeviceToSet(bdm []awstypes.BlockDeviceMapping, rootDevName *string
 	if rootDevName != nil {
 		for _, val := range bdm {
 			if aws.ToString(val.DeviceName) == aws.ToString(rootDevName) {
-				m := make(map[string]interface{})
+				m := make(map[string]any)
 				if val.Ebs.DeleteOnTermination != nil {
 					m[names.AttrDeleteOnTermination] = aws.ToBool(val.Ebs.DeleteOnTermination)
 				}
@@ -2061,22 +2061,22 @@ func rootBlockDeviceToSet(bdm []awstypes.BlockDeviceMapping, rootDevName *string
 	return set
 }
 
-func hashEphemeralBlockDevice(v interface{}) int {
+func hashEphemeralBlockDevice(v any) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m := v.(map[string]any)
 	buf.WriteString(fmt.Sprintf("%s-", m[names.AttrDeviceName].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m[names.AttrVirtualName].(string)))
 	return create.StringHashcode(buf.String())
 }
 
-func hashRootBlockDevice(v interface{}) int {
+func hashRootBlockDevice(v any) int {
 	// there can be only one root device; no need to hash anything
 	return 0
 }
 
-func hashLaunchSpecification(v interface{}) int {
+func hashLaunchSpecification(v any) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m := v.(map[string]any)
 	buf.WriteString(fmt.Sprintf("%s-", m["ami"].(string)))
 	if v, ok := m[names.AttrAvailabilityZone].(string); ok && v != "" {
 		buf.WriteString(fmt.Sprintf("%s-", v))
@@ -2089,9 +2089,9 @@ func hashLaunchSpecification(v interface{}) int {
 	return create.StringHashcode(buf.String())
 }
 
-func hashEBSBlockDevice(v interface{}) int {
+func hashEBSBlockDevice(v any) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m := v.(map[string]any)
 	if name, ok := m[names.AttrDeviceName]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", name.(string)))
 	}
@@ -2101,11 +2101,11 @@ func hashEBSBlockDevice(v interface{}) int {
 	return create.StringHashcode(buf.String())
 }
 
-func flattenLaunchTemplateConfig(apiObject awstypes.LaunchTemplateConfig) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenLaunchTemplateConfig(apiObject awstypes.LaunchTemplateConfig) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.LaunchTemplateSpecification; v != nil {
-		tfMap["launch_template_specification"] = []interface{}{flattenFleetLaunchTemplateSpecificationForSpotFleetRequest(v)}
+		tfMap["launch_template_specification"] = []any{flattenFleetLaunchTemplateSpecificationForSpotFleetRequest(v)}
 	}
 
 	if v := apiObject.Overrides; v != nil {
@@ -2115,12 +2115,12 @@ func flattenLaunchTemplateConfig(apiObject awstypes.LaunchTemplateConfig) map[st
 	return tfMap
 }
 
-func flattenLaunchTemplateConfigs(apiObjects []awstypes.LaunchTemplateConfig) []interface{} {
+func flattenLaunchTemplateConfigs(apiObjects []awstypes.LaunchTemplateConfig) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenLaunchTemplateConfig(apiObject))
@@ -2129,12 +2129,12 @@ func flattenLaunchTemplateConfigs(apiObjects []awstypes.LaunchTemplateConfig) []
 	return tfList
 }
 
-func flattenFleetLaunchTemplateSpecificationForSpotFleetRequest(apiObject *awstypes.FleetLaunchTemplateSpecification) map[string]interface{} {
+func flattenFleetLaunchTemplateSpecificationForSpotFleetRequest(apiObject *awstypes.FleetLaunchTemplateSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.LaunchTemplateId; v != nil {
 		tfMap[names.AttrID] = aws.ToString(v)
@@ -2151,15 +2151,15 @@ func flattenFleetLaunchTemplateSpecificationForSpotFleetRequest(apiObject *awsty
 	return tfMap
 }
 
-func flattenLaunchTemplateOverrides(apiObject awstypes.LaunchTemplateOverrides) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenLaunchTemplateOverrides(apiObject awstypes.LaunchTemplateOverrides) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.AvailabilityZone; v != nil {
 		tfMap[names.AttrAvailabilityZone] = aws.ToString(v)
 	}
 
 	if v := apiObject.InstanceRequirements; v != nil {
-		tfMap["instance_requirements"] = []interface{}{flattenInstanceRequirements(v)}
+		tfMap["instance_requirements"] = []any{flattenInstanceRequirements(v)}
 	}
 
 	if v := apiObject.InstanceType; v != "" {
@@ -2185,12 +2185,12 @@ func flattenLaunchTemplateOverrides(apiObject awstypes.LaunchTemplateOverrides) 
 	return tfMap
 }
 
-func flattenLaunchTemplateOverrideses(apiObjects []awstypes.LaunchTemplateOverrides) []interface{} {
+func flattenLaunchTemplateOverrideses(apiObjects []awstypes.LaunchTemplateOverrides) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenLaunchTemplateOverrides(apiObject))
@@ -2199,26 +2199,26 @@ func flattenLaunchTemplateOverrideses(apiObjects []awstypes.LaunchTemplateOverri
 	return tfList
 }
 
-func flattenSpotMaintenanceStrategies(spotMaintenanceStrategies *awstypes.SpotMaintenanceStrategies) []interface{} {
+func flattenSpotMaintenanceStrategies(spotMaintenanceStrategies *awstypes.SpotMaintenanceStrategies) []any {
 	if spotMaintenanceStrategies == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"capacity_rebalance": flattenSpotCapacityRebalance(spotMaintenanceStrategies.CapacityRebalance),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenSpotCapacityRebalance(spotCapacityRebalance *awstypes.SpotCapacityRebalance) []interface{} {
+func flattenSpotCapacityRebalance(spotCapacityRebalance *awstypes.SpotCapacityRebalance) []any {
 	if spotCapacityRebalance == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"replacement_strategy": spotCapacityRebalance.ReplacementStrategy,
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/ec2/ec2_spot_fleet_request_migrate.go
+++ b/internal/service/ec2/ec2_spot_fleet_request_migrate.go
@@ -11,7 +11,7 @@ import (
 )
 
 func spotFleetRequestMigrateState(
-	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found AWS Spot Fleet Request State v0; migrating to v1")

--- a/internal/service/ec2/ec2_spot_fleet_request_migrate_test.go
+++ b/internal/service/ec2/ec2_spot_fleet_request_migrate_test.go
@@ -19,7 +19,7 @@ func TestSpotFleetRequestMigrateState(t *testing.T) {
 		ID           string
 		Attributes   map[string]string
 		Expected     string
-		Meta         interface{}
+		Meta         any
 	}{
 		"v0_1": {
 			StateVersion: 0,

--- a/internal/service/ec2/ec2_spot_instance_request.go
+++ b/internal/service/ec2/ec2_spot_instance_request.go
@@ -142,7 +142,7 @@ func resourceSpotInstanceRequest() *schema.Resource {
 	}
 }
 
-func resourceSpotInstanceRequestCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotInstanceRequestCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -201,7 +201,7 @@ func resourceSpotInstanceRequestCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, iamPropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.RequestSpotInstances(ctx, &input)
 		},
 		func(err error) (bool, error) {
@@ -235,11 +235,11 @@ func resourceSpotInstanceRequestCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceSpotInstanceRequestRead(ctx, d, meta)...)
 }
 
-func resourceSpotInstanceRequestRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotInstanceRequestRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findSpotInstanceRequestByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -284,7 +284,7 @@ func resourceSpotInstanceRequestRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceSpotInstanceRequestUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotInstanceRequestUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -292,7 +292,7 @@ func resourceSpotInstanceRequestUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceSpotInstanceRequestRead(ctx, d, meta)...)
 }
 
-func resourceSpotInstanceRequestDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSpotInstanceRequestDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -319,7 +319,7 @@ func resourceSpotInstanceRequestDelete(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func readInstance(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func readInstance(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ec2_spot_price_data_source.go
+++ b/internal/service/ec2/ec2_spot_price_data_source.go
@@ -52,7 +52,7 @@ func dataSourceSpotPrice() *schema.Resource {
 	}
 }
 
-func dataSourceSpotPriceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSpotPriceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/filters.go
+++ b/internal/service/ec2/filters.go
@@ -176,8 +176,8 @@ func newCustomFilterList(s *schema.Set) []awstypes.Filter {
 		return []awstypes.Filter{}
 	}
 
-	return tfslices.ApplyToAll(s.List(), func(tfList interface{}) awstypes.Filter {
-		tfMap := tfList.(map[string]interface{})
+	return tfslices.ApplyToAll(s.List(), func(tfList any) awstypes.Filter {
+		tfMap := tfList.(map[string]any)
 		return newFilter(tfMap[names.AttrName].(string), flex.ExpandStringValueEmptySet(tfMap[names.AttrValues].(*schema.Set)))
 	})
 }

--- a/internal/service/ec2/filters_test.go
+++ b/internal/service/ec2/filters_test.go
@@ -126,11 +126,11 @@ func TestNewCustomFilterList(t *testing.T) {
 		return ret
 	}
 
-	filters.Add(map[string]interface{}{
+	filters.Add(map[string]any{
 		names.AttrName:   "foo",
 		names.AttrValues: valuesSet("bar", "baz"),
 	})
-	filters.Add(map[string]interface{}{
+	filters.Add(map[string]any{
 		names.AttrName:   "pizza",
 		names.AttrValues: valuesSet("cheese"),
 	})

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -3005,10 +3005,8 @@ func findVPCEndpointRouteTableAssociationExists(ctx context.Context, conn *ec2.C
 		return err
 	}
 
-	for _, vpcEndpointRouteTableID := range vpcEndpoint.RouteTableIds {
-		if vpcEndpointRouteTableID == routeTableID {
-			return nil
-		}
+	if slices.Contains(vpcEndpoint.RouteTableIds, routeTableID) {
+		return nil
 	}
 
 	return &retry.NotFoundError{
@@ -3043,10 +3041,8 @@ func findVPCEndpointSubnetAssociationExists(ctx context.Context, conn *ec2.Clien
 		return err
 	}
 
-	for _, vpcEndpointSubnetID := range vpcEndpoint.SubnetIds {
-		if vpcEndpointSubnetID == subnetID {
-			return nil
-		}
+	if slices.Contains(vpcEndpoint.SubnetIds, subnetID) {
+		return nil
 	}
 
 	return &retry.NotFoundError{

--- a/internal/service/ec2/ipam_.go
+++ b/internal/service/ec2/ipam_.go
@@ -108,12 +108,12 @@ func resourceIPAM() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.Sequence(
-			func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 				if diff.Id() == "" { // Create.
 					currentRegion := meta.(*conns.AWSClient).Region(ctx)
 
 					for _, v := range diff.Get("operating_regions").(*schema.Set).List() {
-						if v.(map[string]interface{})["region_name"].(string) == currentRegion {
+						if v.(map[string]any)["region_name"].(string) == currentRegion {
 							return nil
 						}
 					}
@@ -127,7 +127,7 @@ func resourceIPAM() *schema.Resource {
 	}
 }
 
-func resourceIPAMCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -164,7 +164,7 @@ func resourceIPAMCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceIPAMRead(ctx, d, meta)...)
 }
 
-func resourceIPAMRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -198,7 +198,7 @@ func resourceIPAMRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	return diags
 }
 
-func resourceIPAMUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -256,7 +256,7 @@ func resourceIPAMUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceIPAMRead(ctx, d, meta)...)
 }
 
-func resourceIPAMDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -286,63 +286,63 @@ func resourceIPAMDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func expandIPAMOperatingRegions(operatingRegions []interface{}) []awstypes.AddIpamOperatingRegion {
+func expandIPAMOperatingRegions(operatingRegions []any) []awstypes.AddIpamOperatingRegion {
 	regions := make([]awstypes.AddIpamOperatingRegion, 0, len(operatingRegions))
 	for _, regionRaw := range operatingRegions {
-		region := regionRaw.(map[string]interface{})
+		region := regionRaw.(map[string]any)
 		regions = append(regions, expandIPAMOperatingRegion(region))
 	}
 
 	return regions
 }
 
-func expandIPAMOperatingRegion(operatingRegion map[string]interface{}) awstypes.AddIpamOperatingRegion {
+func expandIPAMOperatingRegion(operatingRegion map[string]any) awstypes.AddIpamOperatingRegion {
 	region := awstypes.AddIpamOperatingRegion{
 		RegionName: aws.String(operatingRegion["region_name"].(string)),
 	}
 	return region
 }
 
-func flattenIPAMOperatingRegions(operatingRegions []awstypes.IpamOperatingRegion) []interface{} {
-	regions := []interface{}{}
+func flattenIPAMOperatingRegions(operatingRegions []awstypes.IpamOperatingRegion) []any {
+	regions := []any{}
 	for _, operatingRegion := range operatingRegions {
 		regions = append(regions, flattenIPAMOperatingRegion(operatingRegion))
 	}
 	return regions
 }
 
-func flattenIPAMOperatingRegion(operatingRegion awstypes.IpamOperatingRegion) map[string]interface{} {
-	region := make(map[string]interface{})
+func flattenIPAMOperatingRegion(operatingRegion awstypes.IpamOperatingRegion) map[string]any {
+	region := make(map[string]any)
 	region["region_name"] = aws.ToString(operatingRegion.RegionName)
 	return region
 }
 
-func expandIPAMOperatingRegionsUpdateAddRegions(operatingRegions []interface{}) []awstypes.AddIpamOperatingRegion {
+func expandIPAMOperatingRegionsUpdateAddRegions(operatingRegions []any) []awstypes.AddIpamOperatingRegion {
 	regionUpdates := make([]awstypes.AddIpamOperatingRegion, 0, len(operatingRegions))
 	for _, regionRaw := range operatingRegions {
-		region := regionRaw.(map[string]interface{})
+		region := regionRaw.(map[string]any)
 		regionUpdates = append(regionUpdates, expandIPAMOperatingRegionsUpdateAddRegion(region))
 	}
 	return regionUpdates
 }
 
-func expandIPAMOperatingRegionsUpdateAddRegion(operatingRegion map[string]interface{}) awstypes.AddIpamOperatingRegion {
+func expandIPAMOperatingRegionsUpdateAddRegion(operatingRegion map[string]any) awstypes.AddIpamOperatingRegion {
 	regionUpdate := awstypes.AddIpamOperatingRegion{
 		RegionName: aws.String(operatingRegion["region_name"].(string)),
 	}
 	return regionUpdate
 }
 
-func expandIPAMOperatingRegionsUpdateDeleteRegions(operatingRegions []interface{}) []awstypes.RemoveIpamOperatingRegion {
+func expandIPAMOperatingRegionsUpdateDeleteRegions(operatingRegions []any) []awstypes.RemoveIpamOperatingRegion {
 	regionUpdates := make([]awstypes.RemoveIpamOperatingRegion, 0, len(operatingRegions))
 	for _, regionRaw := range operatingRegions {
-		region := regionRaw.(map[string]interface{})
+		region := regionRaw.(map[string]any)
 		regionUpdates = append(regionUpdates, expandIPAMOperatingRegionsUpdateDeleteRegion(region))
 	}
 	return regionUpdates
 }
 
-func expandIPAMOperatingRegionsUpdateDeleteRegion(operatingRegion map[string]interface{}) awstypes.RemoveIpamOperatingRegion {
+func expandIPAMOperatingRegionsUpdateDeleteRegion(operatingRegion map[string]any) awstypes.RemoveIpamOperatingRegion {
 	regionUpdate := awstypes.RemoveIpamOperatingRegion{
 		RegionName: aws.String(operatingRegion["region_name"].(string)),
 	}

--- a/internal/service/ec2/ipam_organization_admin_account.go
+++ b/internal/service/ec2/ipam_organization_admin_account.go
@@ -63,7 +63,7 @@ const (
 	ipamServicePrincipal = "ipam.amazonaws.com"
 )
 
-func resourceIPAMOrganizationAdminAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMOrganizationAdminAccountCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -87,7 +87,7 @@ func resourceIPAMOrganizationAdminAccountCreate(ctx context.Context, d *schema.R
 	return append(diags, resourceIPAMOrganizationAdminAccountRead(ctx, d, meta)...)
 }
 
-func resourceIPAMOrganizationAdminAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMOrganizationAdminAccountRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).OrganizationsClient(ctx)
 
@@ -112,7 +112,7 @@ func resourceIPAMOrganizationAdminAccountRead(ctx context.Context, d *schema.Res
 	return diags
 }
 
-func resourceIPAMOrganizationAdminAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMOrganizationAdminAccountDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ipam_pool.go
+++ b/internal/service/ec2/ipam_pool.go
@@ -148,7 +148,7 @@ func resourceIPAMPool() *schema.Resource {
 	}
 }
 
-func resourceIPAMPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPoolCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -174,8 +174,8 @@ func resourceIPAMPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 		input.AllocationMinNetmaskLength = aws.Int32(int32(v.(int)))
 	}
 
-	if v, ok := d.GetOk("allocation_resource_tags"); ok && len(v.(map[string]interface{})) > 0 {
-		input.AllocationResourceTags = ipamResourceTags(tftags.New(ctx, v.(map[string]interface{})))
+	if v, ok := d.GetOk("allocation_resource_tags"); ok && len(v.(map[string]any)) > 0 {
+		input.AllocationResourceTags = ipamResourceTags(tftags.New(ctx, v.(map[string]any)))
 	}
 
 	if v, ok := d.GetOk("auto_import"); ok {
@@ -228,7 +228,7 @@ func resourceIPAMPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceIPAMPoolRead(ctx, d, meta)...)
 }
 
-func resourceIPAMPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPoolRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -265,7 +265,7 @@ func resourceIPAMPoolRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceIPAMPoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPoolUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -322,7 +322,7 @@ func resourceIPAMPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceIPAMPoolRead(ctx, d, meta)...)
 }
 
-func resourceIPAMPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPoolDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ipam_pool_cidr.go
+++ b/internal/service/ec2/ipam_pool_cidr.go
@@ -103,7 +103,7 @@ func resourceIPAMPoolCIDR() *schema.Resource {
 	}
 }
 
-func resourceIPAMPoolCIDRCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPoolCIDRCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -116,8 +116,8 @@ func resourceIPAMPoolCIDRCreate(ctx context.Context, d *schema.ResourceData, met
 		input.Cidr = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("cidr_authorization_context"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.CidrAuthorizationContext = expandIPAMCIDRAuthorizationContext(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("cidr_authorization_context"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.CidrAuthorizationContext = expandIPAMCIDRAuthorizationContext(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("netmask_length"); ok {
@@ -147,7 +147,7 @@ func resourceIPAMPoolCIDRCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceIPAMPoolCIDRRead(ctx, d, meta)...)
 }
 
-func resourceIPAMPoolCIDRRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPoolCIDRRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -175,7 +175,7 @@ func resourceIPAMPoolCIDRRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceIPAMPoolCIDRDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPoolCIDRDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -226,7 +226,7 @@ func ipamPoolCIDRParseResourceID(id string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func expandIPAMCIDRAuthorizationContext(tfMap map[string]interface{}) *awstypes.IpamCidrAuthorizationContext {
+func expandIPAMCIDRAuthorizationContext(tfMap map[string]any) *awstypes.IpamCidrAuthorizationContext {
 	if tfMap == nil {
 		return nil
 	}
@@ -244,7 +244,7 @@ func expandIPAMCIDRAuthorizationContext(tfMap map[string]interface{}) *awstypes.
 	return apiObject
 }
 
-func resourceIPAMPoolCIDRCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func resourceIPAMPoolCIDRCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	// cidr can be set by a value returned from IPAM or explicitly in config.
 	if diff.Id() != "" && diff.HasChange("cidr") {
 		// If netmask is set then cidr is derived from IPAM, ignore changes.

--- a/internal/service/ec2/ipam_pool_cidr_allocation.go
+++ b/internal/service/ec2/ipam_pool_cidr_allocation.go
@@ -99,7 +99,7 @@ func resourceIPAMPoolCIDRAllocation() *schema.Resource {
 	}
 }
 
-func resourceIPAMPoolCIDRAllocationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPoolCIDRAllocationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -134,7 +134,7 @@ func resourceIPAMPoolCIDRAllocationCreate(ctx context.Context, d *schema.Resourc
 	allocationID := aws.ToString(output.IpamPoolAllocation.IpamPoolAllocationId)
 	d.SetId(ipamPoolCIDRAllocationCreateResourceID(allocationID, ipamPoolID))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
 		return findIPAMPoolAllocationByTwoPartKey(ctx, conn, allocationID, ipamPoolID)
 	})
 
@@ -145,7 +145,7 @@ func resourceIPAMPoolCIDRAllocationCreate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceIPAMPoolCIDRAllocationRead(ctx, d, meta)...)
 }
 
-func resourceIPAMPoolCIDRAllocationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPoolCIDRAllocationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -189,7 +189,7 @@ func resourceIPAMPoolCIDRAllocationRead(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceIPAMPoolCIDRAllocationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPoolCIDRAllocationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ipam_pool_cidrs_data_source.go
+++ b/internal/service/ec2/ipam_pool_cidrs_data_source.go
@@ -52,7 +52,7 @@ func dataSourceIPAMPoolCIDRs() *schema.Resource {
 	}
 }
 
-func dataSourceIPAMPoolCIDRsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIPAMPoolCIDRsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -81,16 +81,16 @@ func dataSourceIPAMPoolCIDRsRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func flattenIPAMPoolCIDRs(c []awstypes.IpamPoolCidr) []interface{} {
-	cidrs := []interface{}{}
+func flattenIPAMPoolCIDRs(c []awstypes.IpamPoolCidr) []any {
+	cidrs := []any{}
 	for _, cidr := range c {
 		cidrs = append(cidrs, flattenIPAMPoolCIDR(cidr))
 	}
 	return cidrs
 }
 
-func flattenIPAMPoolCIDR(c awstypes.IpamPoolCidr) map[string]interface{} {
-	cidr := make(map[string]interface{})
+func flattenIPAMPoolCIDR(c awstypes.IpamPoolCidr) map[string]any {
+	cidr := make(map[string]any)
 	cidr["cidr"] = aws.ToString(c.Cidr)
 	cidr[names.AttrState] = c.State
 	return cidr

--- a/internal/service/ec2/ipam_pool_data_source.go
+++ b/internal/service/ec2/ipam_pool_data_source.go
@@ -106,7 +106,7 @@ func dataSourceIPAMPool() *schema.Resource {
 	}
 }
 
-func dataSourceIPAMPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIPAMPoolRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ipam_pools_data_source.go
+++ b/internal/service/ec2/ipam_pools_data_source.go
@@ -103,7 +103,7 @@ func dataSourceIPAMPools() *schema.Resource {
 	}
 }
 
-func dataSourceIPAMPoolsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIPAMPoolsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
@@ -130,16 +130,16 @@ func dataSourceIPAMPoolsRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func flattenIPAMPools(ctx context.Context, c []awstypes.IpamPool, ignoreTagsConfig *tftags.IgnoreConfig) []interface{} {
-	pools := []interface{}{}
+func flattenIPAMPools(ctx context.Context, c []awstypes.IpamPool, ignoreTagsConfig *tftags.IgnoreConfig) []any {
+	pools := []any{}
 	for _, pool := range c {
 		pools = append(pools, flattenIPAMPool(ctx, pool, ignoreTagsConfig))
 	}
 	return pools
 }
 
-func flattenIPAMPool(ctx context.Context, p awstypes.IpamPool, ignoreTagsConfig *tftags.IgnoreConfig) map[string]interface{} {
-	pool := make(map[string]interface{})
+func flattenIPAMPool(ctx context.Context, p awstypes.IpamPool, ignoreTagsConfig *tftags.IgnoreConfig) map[string]any {
+	pool := make(map[string]any)
 
 	pool["address_family"] = p.AddressFamily
 	pool["allocation_default_netmask_length"] = aws.ToInt32(p.AllocationDefaultNetmaskLength)

--- a/internal/service/ec2/ipam_preview_next_cidr.go
+++ b/internal/service/ec2/ipam_preview_next_cidr.go
@@ -66,7 +66,7 @@ func resourceIPAMPreviewNextCIDR() *schema.Resource {
 	}
 }
 
-func resourceIPAMPreviewNextCIDRCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPreviewNextCIDRCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	poolId := d.Get("ipam_pool_id").(string)
@@ -103,7 +103,7 @@ func resourceIPAMPreviewNextCIDRCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceIPAMPreviewNextCIDRRead(ctx, d, meta)...)
 }
 
-func resourceIPAMPreviewNextCIDRRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMPreviewNextCIDRRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	cidr, poolId, err := decodeIPAMPreviewNextCIDRID(d.Id())
 

--- a/internal/service/ec2/ipam_preview_next_cidr_data_source.go
+++ b/internal/service/ec2/ipam_preview_next_cidr_data_source.go
@@ -65,7 +65,7 @@ func dataSourceIPAMPreviewNextCIDR() *schema.Resource {
 	}
 }
 
-func dataSourceIPAMPreviewNextCIDRRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIPAMPreviewNextCIDRRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	poolId := d.Get("ipam_pool_id").(string)

--- a/internal/service/ec2/ipam_resource_discovery.go
+++ b/internal/service/ec2/ipam_resource_discovery.go
@@ -85,12 +85,12 @@ func resourceIPAMResourceDiscovery() *schema.Resource {
 
 		CustomizeDiff: customdiff.Sequence(
 			// user must define authn region within `operating_regions {}`
-			func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 				if diff.Id() == "" { // Create.
 					currentRegion := meta.(*conns.AWSClient).Region(ctx)
 
 					for _, v := range diff.Get("operating_regions").(*schema.Set).List() {
-						if v.(map[string]interface{})["region_name"].(string) == currentRegion {
+						if v.(map[string]any)["region_name"].(string) == currentRegion {
 							return nil
 						}
 					}
@@ -102,7 +102,7 @@ func resourceIPAMResourceDiscovery() *schema.Resource {
 	}
 }
 
-func resourceIPAMResourceDiscoveryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMResourceDiscoveryCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -131,7 +131,7 @@ func resourceIPAMResourceDiscoveryCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceIPAMResourceDiscoveryRead(ctx, d, meta)...)
 }
 
-func resourceIPAMResourceDiscoveryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMResourceDiscoveryRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -161,7 +161,7 @@ func resourceIPAMResourceDiscoveryRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceIPAMResourceDiscoveryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMResourceDiscoveryUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -211,7 +211,7 @@ func resourceIPAMResourceDiscoveryUpdate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceIPAMResourceDiscoveryRead(ctx, d, meta)...)
 }
 
-func resourceIPAMResourceDiscoveryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMResourceDiscoveryDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -236,46 +236,46 @@ func resourceIPAMResourceDiscoveryDelete(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func flattenIPAMResourceDiscoveryOperatingRegions(operatingRegions []awstypes.IpamOperatingRegion) []interface{} {
-	regions := []interface{}{}
+func flattenIPAMResourceDiscoveryOperatingRegions(operatingRegions []awstypes.IpamOperatingRegion) []any {
+	regions := []any{}
 	for _, operatingRegion := range operatingRegions {
 		regions = append(regions, flattenIPAMResourceDiscoveryOperatingRegion(operatingRegion))
 	}
 	return regions
 }
 
-func flattenIPAMResourceDiscoveryOperatingRegion(operatingRegion awstypes.IpamOperatingRegion) map[string]interface{} {
-	region := make(map[string]interface{})
+func flattenIPAMResourceDiscoveryOperatingRegion(operatingRegion awstypes.IpamOperatingRegion) map[string]any {
+	region := make(map[string]any)
 	region["region_name"] = aws.ToString(operatingRegion.RegionName)
 	return region
 }
 
-func expandIPAMResourceDiscoveryOperatingRegionsUpdateAddRegions(operatingRegions []interface{}) []awstypes.AddIpamOperatingRegion {
+func expandIPAMResourceDiscoveryOperatingRegionsUpdateAddRegions(operatingRegions []any) []awstypes.AddIpamOperatingRegion {
 	regionUpdates := make([]awstypes.AddIpamOperatingRegion, 0, len(operatingRegions))
 	for _, regionRaw := range operatingRegions {
-		region := regionRaw.(map[string]interface{})
+		region := regionRaw.(map[string]any)
 		regionUpdates = append(regionUpdates, expandIPAMResourceDiscoveryOperatingRegionsUpdateAddRegion(region))
 	}
 	return regionUpdates
 }
 
-func expandIPAMResourceDiscoveryOperatingRegionsUpdateAddRegion(operatingRegion map[string]interface{}) awstypes.AddIpamOperatingRegion {
+func expandIPAMResourceDiscoveryOperatingRegionsUpdateAddRegion(operatingRegion map[string]any) awstypes.AddIpamOperatingRegion {
 	regionUpdate := awstypes.AddIpamOperatingRegion{
 		RegionName: aws.String(operatingRegion["region_name"].(string)),
 	}
 	return regionUpdate
 }
 
-func expandIPAMResourceDiscoveryOperatingRegionsUpdateDeleteRegions(operatingRegions []interface{}) []awstypes.RemoveIpamOperatingRegion {
+func expandIPAMResourceDiscoveryOperatingRegionsUpdateDeleteRegions(operatingRegions []any) []awstypes.RemoveIpamOperatingRegion {
 	regionUpdates := make([]awstypes.RemoveIpamOperatingRegion, 0, len(operatingRegions))
 	for _, regionRaw := range operatingRegions {
-		region := regionRaw.(map[string]interface{})
+		region := regionRaw.(map[string]any)
 		regionUpdates = append(regionUpdates, expandIPAMResourceDiscoveryOperatingRegionsUpdateDeleteRegion(region))
 	}
 	return regionUpdates
 }
 
-func expandIPAMResourceDiscoveryOperatingRegionsUpdateDeleteRegion(operatingRegion map[string]interface{}) awstypes.RemoveIpamOperatingRegion {
+func expandIPAMResourceDiscoveryOperatingRegionsUpdateDeleteRegion(operatingRegion map[string]any) awstypes.RemoveIpamOperatingRegion {
 	regionUpdate := awstypes.RemoveIpamOperatingRegion{
 		RegionName: aws.String(operatingRegion["region_name"].(string)),
 	}

--- a/internal/service/ec2/ipam_resource_discovery_association.go
+++ b/internal/service/ec2/ipam_resource_discovery_association.go
@@ -81,7 +81,7 @@ func resourceIPAMResourceDiscoveryAssociation() *schema.Resource {
 	}
 }
 
-func resourceIPAMResourceDiscoveryAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMResourceDiscoveryAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -109,7 +109,7 @@ func resourceIPAMResourceDiscoveryAssociationCreate(ctx context.Context, d *sche
 	return append(diags, resourceIPAMResourceDiscoveryAssociationRead(ctx, d, meta)...)
 }
 
-func resourceIPAMResourceDiscoveryAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMResourceDiscoveryAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -139,7 +139,7 @@ func resourceIPAMResourceDiscoveryAssociationRead(ctx context.Context, d *schema
 	return diags
 }
 
-func resourceIPAMResourceDiscoveryAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMResourceDiscoveryAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -147,7 +147,7 @@ func resourceIPAMResourceDiscoveryAssociationUpdate(ctx context.Context, d *sche
 	return append(diags, resourceIPAMResourceDiscoveryAssociationRead(ctx, d, meta)...)
 }
 
-func resourceIPAMResourceDiscoveryAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMResourceDiscoveryAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/ipam_scope.go
+++ b/internal/service/ec2/ipam_scope.go
@@ -78,7 +78,7 @@ func resourceIPAMScope() *schema.Resource {
 	}
 }
 
-func resourceIPAMScopeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMScopeCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -107,7 +107,7 @@ func resourceIPAMScopeCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceIPAMScopeRead(ctx, d, meta)...)
 }
 
-func resourceIPAMScopeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMScopeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -137,7 +137,7 @@ func resourceIPAMScopeRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceIPAMScopeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMScopeUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -164,7 +164,7 @@ func resourceIPAMScopeUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceIPAMScopeRead(ctx, d, meta)...)
 }
 
-func resourceIPAMScopeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIPAMScopeDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/outposts_coip_pool_data_source.go
+++ b/internal/service/ec2/outposts_coip_pool_data_source.go
@@ -55,7 +55,7 @@ func dataSourceCoIPPool() *schema.Resource {
 	}
 }
 
-func dataSourceCoIPPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCoIPPoolRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -73,7 +73,7 @@ func dataSourceCoIPPoolRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	if tags, tagsOk := d.GetOk(names.AttrTags); tagsOk {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+			Tags(tftags.New(ctx, tags.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/outposts_coip_pools_data_source.go
+++ b/internal/service/ec2/outposts_coip_pools_data_source.go
@@ -40,14 +40,14 @@ func dataSourceCoIPPools() *schema.Resource {
 	}
 }
 
-func dataSourceCoIPPoolsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCoIPPoolsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := &ec2.DescribeCoipPoolsInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/outposts_local_gateway_data_source.go
+++ b/internal/service/ec2/outposts_local_gateway_data_source.go
@@ -54,7 +54,7 @@ func dataSourceLocalGateway() *schema.Resource {
 	}
 }
 
-func dataSourceLocalGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLocalGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -72,7 +72,7 @@ func dataSourceLocalGatewayRead(ctx context.Context, d *schema.ResourceData, met
 
 	if tags, tagsOk := d.GetOk(names.AttrTags); tagsOk {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+			Tags(tftags.New(ctx, tags.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/outposts_local_gateway_route.go
+++ b/internal/service/ec2/outposts_local_gateway_route.go
@@ -54,7 +54,7 @@ func resourceLocalGatewayRoute() *schema.Resource {
 	}
 }
 
-func resourceLocalGatewayRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLocalGatewayRouteCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -78,7 +78,7 @@ func resourceLocalGatewayRouteCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceLocalGatewayRouteRead(ctx, d, meta)...)
 }
 
-func resourceLocalGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLocalGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -90,7 +90,7 @@ func resourceLocalGatewayRouteRead(ctx context.Context, d *schema.ResourceData, 
 	const (
 		timeout = 1 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, timeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, timeout, func() (any, error) {
 		return findLocalGatewayRouteByTwoPartKey(ctx, conn, localGatewayRouteTableID, destination)
 	}, d.IsNewResource())
 
@@ -113,7 +113,7 @@ func resourceLocalGatewayRouteRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceLocalGatewayRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLocalGatewayRouteDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/outposts_local_gateway_route_table_data_source.go
+++ b/internal/service/ec2/outposts_local_gateway_route_table_data_source.go
@@ -56,7 +56,7 @@ func dataSourceLocalGatewayRouteTable() *schema.Resource {
 	}
 }
 
-func dataSourceLocalGatewayRouteTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLocalGatewayRouteTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -75,7 +75,7 @@ func dataSourceLocalGatewayRouteTableRead(ctx context.Context, d *schema.Resourc
 	)
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/outposts_local_gateway_route_table_vpc_association.go
+++ b/internal/service/ec2/outposts_local_gateway_route_table_vpc_association.go
@@ -55,7 +55,7 @@ func resourceLocalGatewayRouteTableVPCAssociation() *schema.Resource {
 	}
 }
 
-func resourceLocalGatewayRouteTableVPCAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLocalGatewayRouteTableVPCAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -80,7 +80,7 @@ func resourceLocalGatewayRouteTableVPCAssociationCreate(ctx context.Context, d *
 	return append(diags, resourceLocalGatewayRouteTableVPCAssociationRead(ctx, d, meta)...)
 }
 
-func resourceLocalGatewayRouteTableVPCAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLocalGatewayRouteTableVPCAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -105,7 +105,7 @@ func resourceLocalGatewayRouteTableVPCAssociationRead(ctx context.Context, d *sc
 	return diags
 }
 
-func resourceLocalGatewayRouteTableVPCAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLocalGatewayRouteTableVPCAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -113,7 +113,7 @@ func resourceLocalGatewayRouteTableVPCAssociationUpdate(ctx context.Context, d *
 	return append(diags, resourceLocalGatewayRouteTableVPCAssociationRead(ctx, d, meta)...)
 }
 
-func resourceLocalGatewayRouteTableVPCAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLocalGatewayRouteTableVPCAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/outposts_local_gateway_route_tables_data_source.go
+++ b/internal/service/ec2/outposts_local_gateway_route_tables_data_source.go
@@ -40,14 +40,14 @@ func dataSourceLocalGatewayRouteTables() *schema.Resource {
 	}
 }
 
-func dataSourceLocalGatewayRouteTablesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLocalGatewayRouteTablesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := &ec2.DescribeLocalGatewayRouteTablesInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/outposts_local_gateway_virtual_interface_data_source.go
+++ b/internal/service/ec2/outposts_local_gateway_virtual_interface_data_source.go
@@ -70,7 +70,7 @@ func dataSourceLocalGatewayVirtualInterface() *schema.Resource {
 	}
 }
 
-func dataSourceLocalGatewayVirtualInterfaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLocalGatewayVirtualInterfaceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -81,7 +81,7 @@ func dataSourceLocalGatewayVirtualInterfaceRead(ctx context.Context, d *schema.R
 	}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/outposts_local_gateway_virtual_interface_group_data_source.go
+++ b/internal/service/ec2/outposts_local_gateway_virtual_interface_group_data_source.go
@@ -51,7 +51,7 @@ func dataSourceLocalGatewayVirtualInterfaceGroup() *schema.Resource {
 	}
 }
 
-func dataSourceLocalGatewayVirtualInterfaceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLocalGatewayVirtualInterfaceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -68,7 +68,7 @@ func dataSourceLocalGatewayVirtualInterfaceGroupRead(ctx context.Context, d *sch
 	)
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/outposts_local_gateway_virtual_interface_groups_data_source.go
+++ b/internal/service/ec2/outposts_local_gateway_virtual_interface_groups_data_source.go
@@ -43,14 +43,14 @@ func dataSourceLocalGatewayVirtualInterfaceGroups() *schema.Resource {
 	}
 }
 
-func dataSourceLocalGatewayVirtualInterfaceGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLocalGatewayVirtualInterfaceGroupsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := &ec2.DescribeLocalGatewayVirtualInterfaceGroupsInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/outposts_local_gateways_data_source.go
+++ b/internal/service/ec2/outposts_local_gateways_data_source.go
@@ -40,14 +40,14 @@ func dataSourceLocalGateways() *schema.Resource {
 	}
 }
 
-func dataSourceLocalGatewaysRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLocalGatewaysRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := &ec2.DescribeLocalGatewaysInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -16,7 +16,7 @@ import (
 )
 
 func statusAvailabilityZoneGroupOptInStatus(ctx context.Context, conn *ec2.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findAvailabilityZoneGroupByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -32,7 +32,7 @@ func statusAvailabilityZoneGroupOptInStatus(ctx context.Context, conn *ec2.Clien
 }
 
 func statusCapacityReservation(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findCapacityReservationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -48,7 +48,7 @@ func statusCapacityReservation(ctx context.Context, conn *ec2.Client, id string)
 }
 
 func statusCarrierGateway(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findCarrierGatewayByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -64,7 +64,7 @@ func statusCarrierGateway(ctx context.Context, conn *ec2.Client, id string) retr
 }
 
 func statusFleet(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		// Don't call FindFleetByID as it maps useful status codes to NotFoundError.
 		output, err := findFleet(ctx, conn, &ec2.DescribeFleetsInput{
 			FleetIds: []string{id},
@@ -83,7 +83,7 @@ func statusFleet(ctx context.Context, conn *ec2.Client, id string) retry.StateRe
 }
 
 func statusHost(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findHostByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -99,7 +99,7 @@ func statusHost(ctx context.Context, conn *ec2.Client, id string) retry.StateRef
 }
 
 func statusInstance(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		// Don't call findInstanceByID as it maps useful status codes to NotFoundError.
 		output, err := findInstance(ctx, conn, &ec2.DescribeInstancesInput{
 			InstanceIds: []string{id},
@@ -118,7 +118,7 @@ func statusInstance(ctx context.Context, conn *ec2.Client, id string) retry.Stat
 }
 
 func statusInstanceIAMInstanceProfile(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		instance, err := findInstanceByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -144,7 +144,7 @@ func statusInstanceIAMInstanceProfile(ctx context.Context, conn *ec2.Client, id 
 }
 
 func statusInstanceCapacityReservationSpecificationEquals(ctx context.Context, conn *ec2.Client, id string, expectedValue *awstypes.CapacityReservationSpecification) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findInstanceByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -160,7 +160,7 @@ func statusInstanceCapacityReservationSpecificationEquals(ctx context.Context, c
 }
 
 func statusInstanceMaintenanceOptionsAutoRecovery(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findInstanceByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -180,7 +180,7 @@ func statusInstanceMaintenanceOptionsAutoRecovery(ctx context.Context, conn *ec2
 }
 
 func statusInstanceMetadataOptions(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findInstanceByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -200,7 +200,7 @@ func statusInstanceMetadataOptions(ctx context.Context, conn *ec2.Client, id str
 }
 
 func statusInstanceRootBlockDeviceDeleteOnTermination(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findInstanceByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -222,7 +222,7 @@ func statusInstanceRootBlockDeviceDeleteOnTermination(ctx context.Context, conn 
 }
 
 func statusLocalGatewayRoute(ctx context.Context, conn *ec2.Client, localGatewayRouteTableID, destinationCIDRBlock string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findLocalGatewayRouteByTwoPartKey(ctx, conn, localGatewayRouteTableID, destinationCIDRBlock)
 
 		if tfresource.NotFound(err) {
@@ -238,7 +238,7 @@ func statusLocalGatewayRoute(ctx context.Context, conn *ec2.Client, localGateway
 }
 
 func statusLocalGatewayRouteTableVPCAssociation(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findLocalGatewayRouteTableVPCAssociationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -254,7 +254,7 @@ func statusLocalGatewayRouteTableVPCAssociation(ctx context.Context, conn *ec2.C
 }
 
 func statusManagedPrefixListState(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findManagedPrefixListByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -270,7 +270,7 @@ func statusManagedPrefixListState(ctx context.Context, conn *ec2.Client, id stri
 }
 
 func statusPlacementGroup(ctx context.Context, conn *ec2.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findPlacementGroupByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -290,7 +290,7 @@ const (
 )
 
 func statusSecurityGroup(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSecurityGroupByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -306,7 +306,7 @@ func statusSecurityGroup(ctx context.Context, conn *ec2.Client, id string) retry
 }
 
 func statusSpotFleetActivityStatus(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSpotFleetRequestByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -322,7 +322,7 @@ func statusSpotFleetActivityStatus(ctx context.Context, conn *ec2.Client, id str
 }
 
 func statusSpotFleetRequest(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		// Don't call FindSpotFleetRequestByID as it maps useful status codes to NotFoundError.
 		output, err := findSpotFleetRequest(ctx, conn, &ec2.DescribeSpotFleetRequestsInput{
 			SpotFleetRequestIds: []string{id},
@@ -341,7 +341,7 @@ func statusSpotFleetRequest(ctx context.Context, conn *ec2.Client, id string) re
 }
 
 func statusSpotInstanceRequest(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSpotInstanceRequestByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -357,7 +357,7 @@ func statusSpotInstanceRequest(ctx context.Context, conn *ec2.Client, id string)
 }
 
 func statusSubnetState(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubnetByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -373,7 +373,7 @@ func statusSubnetState(ctx context.Context, conn *ec2.Client, id string) retry.S
 }
 
 func statusSubnetIPv6CIDRBlockAssociationState(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubnetIPv6CIDRBlockAssociationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -389,7 +389,7 @@ func statusSubnetIPv6CIDRBlockAssociationState(ctx context.Context, conn *ec2.Cl
 }
 
 func statusSubnetAssignIPv6AddressOnCreation(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubnetByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -405,7 +405,7 @@ func statusSubnetAssignIPv6AddressOnCreation(ctx context.Context, conn *ec2.Clie
 }
 
 func statusSubnetEnableDNS64(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubnetByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -421,7 +421,7 @@ func statusSubnetEnableDNS64(ctx context.Context, conn *ec2.Client, id string) r
 }
 
 func statusSubnetEnableLniAtDeviceIndex(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubnetByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -437,7 +437,7 @@ func statusSubnetEnableLniAtDeviceIndex(ctx context.Context, conn *ec2.Client, i
 }
 
 func statusSubnetEnableResourceNameDNSAAAARecordOnLaunch(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubnetByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -453,7 +453,7 @@ func statusSubnetEnableResourceNameDNSAAAARecordOnLaunch(ctx context.Context, co
 }
 
 func statusSubnetEnableResourceNameDNSARecordOnLaunch(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubnetByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -469,7 +469,7 @@ func statusSubnetEnableResourceNameDNSARecordOnLaunch(ctx context.Context, conn 
 }
 
 func statusSubnetMapCustomerOwnedIPOnLaunch(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubnetByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -485,7 +485,7 @@ func statusSubnetMapCustomerOwnedIPOnLaunch(ctx context.Context, conn *ec2.Clien
 }
 
 func statusSubnetMapPublicIPOnLaunch(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubnetByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -501,7 +501,7 @@ func statusSubnetMapPublicIPOnLaunch(ctx context.Context, conn *ec2.Client, id s
 }
 
 func statusSubnetPrivateDNSHostnameTypeOnLaunch(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubnetByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -517,7 +517,7 @@ func statusSubnetPrivateDNSHostnameTypeOnLaunch(ctx context.Context, conn *ec2.C
 }
 
 func statusVolume(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findEBSVolumeByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -533,7 +533,7 @@ func statusVolume(ctx context.Context, conn *ec2.Client, id string) retry.StateR
 }
 
 func statusVolumeAttachment(ctx context.Context, conn *ec2.Client, volumeID, instanceID, deviceName string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVolumeAttachment(ctx, conn, volumeID, instanceID, deviceName)
 
 		if tfresource.NotFound(err) {
@@ -549,7 +549,7 @@ func statusVolumeAttachment(ctx context.Context, conn *ec2.Client, volumeID, ins
 }
 
 func statusVolumeModification(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVolumeModificationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -565,7 +565,7 @@ func statusVolumeModification(ctx context.Context, conn *ec2.Client, id string) 
 }
 
 func statusVPC(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -581,7 +581,7 @@ func statusVPC(ctx context.Context, conn *ec2.Client, id string) retry.StateRefr
 }
 
 func statusVPCCIDRBlockAssociationState(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, _, err := findVPCCIDRBlockAssociationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -597,7 +597,7 @@ func statusVPCCIDRBlockAssociationState(ctx context.Context, conn *ec2.Client, i
 }
 
 func statusVPCIPv6CIDRBlockAssociation(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, _, err := findVPCIPv6CIDRBlockAssociationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -613,7 +613,7 @@ func statusVPCIPv6CIDRBlockAssociation(ctx context.Context, conn *ec2.Client, id
 }
 
 func statusVPCAttributeValue(ctx context.Context, conn *ec2.Client, id string, attribute awstypes.VpcAttributeName) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		attributeValue, err := findVPCAttribute(ctx, conn, id, attribute)
 
 		if tfresource.NotFound(err) {
@@ -629,7 +629,7 @@ func statusVPCAttributeValue(ctx context.Context, conn *ec2.Client, id string, a
 }
 
 func statusNetworkInterface(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findNetworkInterfaceByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -645,7 +645,7 @@ func statusNetworkInterface(ctx context.Context, conn *ec2.Client, id string) re
 }
 
 func statusNetworkInterfaceAttachment(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findNetworkInterfaceAttachmentByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -661,7 +661,7 @@ func statusNetworkInterfaceAttachment(ctx context.Context, conn *ec2.Client, id 
 }
 
 func statusNetworkInterfacePermission(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findNetworkInterfacePermissionByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -677,7 +677,7 @@ func statusNetworkInterfacePermission(ctx context.Context, conn *ec2.Client, id 
 }
 
 func statusVPCEndpoint(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCEndpointByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -697,7 +697,7 @@ const (
 )
 
 func statusRoute(ctx context.Context, conn *ec2.Client, routeFinder routeFinder, routeTableID, destination string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := routeFinder(ctx, conn, routeTableID, destination)
 
 		if tfresource.NotFound(err) {
@@ -717,7 +717,7 @@ const (
 )
 
 func statusRouteTable(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findRouteTableByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -733,7 +733,7 @@ func statusRouteTable(ctx context.Context, conn *ec2.Client, id string) retry.St
 }
 
 func statusRouteTableAssociation(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findRouteTableAssociationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -757,7 +757,7 @@ func statusRouteTableAssociation(ctx context.Context, conn *ec2.Client, id strin
 }
 
 func statusVPCEndpointServiceAvailable(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		// Don't call FindVPCEndpointServiceConfigurationByID as it maps useful status codes to NotFoundError.
 		output, err := findVPCEndpointServiceConfiguration(ctx, conn, &ec2.DescribeVpcEndpointServiceConfigurationsInput{
 			ServiceIds: []string{id},
@@ -776,7 +776,7 @@ func statusVPCEndpointServiceAvailable(ctx context.Context, conn *ec2.Client, id
 }
 
 func fetchVPCEndpointServiceDeletionStatus(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCEndpointServiceConfigurationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -796,7 +796,7 @@ const (
 )
 
 func statusVPCEndpointRouteTableAssociation(ctx context.Context, conn *ec2.Client, vpcEndpointID, routeTableID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		err := findVPCEndpointRouteTableAssociationExists(ctx, conn, vpcEndpointID, routeTableID)
 
 		if tfresource.NotFound(err) {
@@ -812,7 +812,7 @@ func statusVPCEndpointRouteTableAssociation(ctx context.Context, conn *ec2.Clien
 }
 
 func statusVPCEndpointConnectionVPCEndpoint(ctx context.Context, conn *ec2.Client, serviceID, vpcEndpointID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCEndpointConnectionByServiceIDAndVPCEndpointID(ctx, conn, serviceID, vpcEndpointID)
 
 		if tfresource.NotFound(err) {
@@ -828,7 +828,7 @@ func statusVPCEndpointConnectionVPCEndpoint(ctx context.Context, conn *ec2.Clien
 }
 
 func statusVPCEndpointServicePrivateDNSNameConfiguration(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCEndpointServicePrivateDNSNameConfigurationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -844,7 +844,7 @@ func statusVPCEndpointServicePrivateDNSNameConfiguration(ctx context.Context, co
 }
 
 func statusVPCPeeringConnectionActive(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		// Don't call findVPCPeeringConnectionByID as it maps useful status codes to NotFoundError.
 		output, err := findVPCPeeringConnection(ctx, conn, &ec2.DescribeVpcPeeringConnectionsInput{
 			VpcPeeringConnectionIds: []string{id},
@@ -863,7 +863,7 @@ func statusVPCPeeringConnectionActive(ctx context.Context, conn *ec2.Client, id 
 }
 
 func statusVPCPeeringConnectionDeleted(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCPeeringConnectionByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -879,7 +879,7 @@ func statusVPCPeeringConnectionDeleted(ctx context.Context, conn *ec2.Client, id
 }
 
 func statusClientVPNEndpoint(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findClientVPNEndpointByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -895,7 +895,7 @@ func statusClientVPNEndpoint(ctx context.Context, conn *ec2.Client, id string) r
 }
 
 func statusClientVPNEndpointClientConnectResponseOptions(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findClientVPNEndpointClientConnectResponseOptionsByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -911,7 +911,7 @@ func statusClientVPNEndpointClientConnectResponseOptions(ctx context.Context, co
 }
 
 func statusClientVPNAuthorizationRule(ctx context.Context, conn *ec2.Client, endpointID, targetNetworkCIDR, accessGroupID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findClientVPNAuthorizationRuleByThreePartKey(ctx, conn, endpointID, targetNetworkCIDR, accessGroupID)
 
 		if tfresource.NotFound(err) {
@@ -927,7 +927,7 @@ func statusClientVPNAuthorizationRule(ctx context.Context, conn *ec2.Client, end
 }
 
 func statusClientVPNNetworkAssociation(ctx context.Context, conn *ec2.Client, associationID, endpointID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findClientVPNNetworkAssociationByTwoPartKey(ctx, conn, associationID, endpointID)
 
 		if tfresource.NotFound(err) {
@@ -943,7 +943,7 @@ func statusClientVPNNetworkAssociation(ctx context.Context, conn *ec2.Client, as
 }
 
 func statusClientVPNRoute(ctx context.Context, conn *ec2.Client, endpointID, targetSubnetID, destinationCIDR string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findClientVPNRouteByThreePartKey(ctx, conn, endpointID, targetSubnetID, destinationCIDR)
 
 		if tfresource.NotFound(err) {
@@ -959,7 +959,7 @@ func statusClientVPNRoute(ctx context.Context, conn *ec2.Client, endpointID, tar
 }
 
 func statusVPNConnection(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPNConnectionByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -975,7 +975,7 @@ func statusVPNConnection(ctx context.Context, conn *ec2.Client, id string) retry
 }
 
 func statusVPNConnectionRoute(ctx context.Context, conn *ec2.Client, vpnConnectionID, cidrBlock string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPNConnectionRouteByTwoPartKey(ctx, conn, vpnConnectionID, cidrBlock)
 
 		if tfresource.NotFound(err) {
@@ -991,7 +991,7 @@ func statusVPNConnectionRoute(ctx context.Context, conn *ec2.Client, vpnConnecti
 }
 
 func statusVPNGateway(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPNGatewayByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1007,7 +1007,7 @@ func statusVPNGateway(ctx context.Context, conn *ec2.Client, id string) retry.St
 }
 
 func statusVPNGatewayVPCAttachment(ctx context.Context, conn *ec2.Client, vpnGatewayID, vpcID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPNGatewayVPCAttachmentByTwoPartKey(ctx, conn, vpnGatewayID, vpcID)
 
 		if tfresource.NotFound(err) {
@@ -1023,7 +1023,7 @@ func statusVPNGatewayVPCAttachment(ctx context.Context, conn *ec2.Client, vpnGat
 }
 
 func statusCustomerGateway(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findCustomerGatewayByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1039,7 +1039,7 @@ func statusCustomerGateway(ctx context.Context, conn *ec2.Client, id string) ret
 }
 
 func statusInternetGatewayAttachmentState(ctx context.Context, conn *ec2.Client, internetGatewayID, vpcID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findInternetGatewayAttachment(ctx, conn, internetGatewayID, vpcID)
 
 		if tfresource.NotFound(err) {
@@ -1055,7 +1055,7 @@ func statusInternetGatewayAttachmentState(ctx context.Context, conn *ec2.Client,
 }
 
 func statusIPAM(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findIPAMByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1071,7 +1071,7 @@ func statusIPAM(ctx context.Context, conn *ec2.Client, id string) retry.StateRef
 }
 
 func statusIPAMPool(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findIPAMPoolByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1087,7 +1087,7 @@ func statusIPAMPool(ctx context.Context, conn *ec2.Client, id string) retry.Stat
 }
 
 func statusIPAMPoolCIDR(ctx context.Context, conn *ec2.Client, cidrBlock, poolID, poolCIDRID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		if cidrBlock == "" {
 			output, err := findIPAMPoolCIDRByPoolCIDRIDAndPoolID(ctx, conn, poolCIDRID, poolID)
 
@@ -1117,7 +1117,7 @@ func statusIPAMPoolCIDR(ctx context.Context, conn *ec2.Client, cidrBlock, poolID
 }
 
 func statusIPAMResourceDiscovery(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findIPAMResourceDiscoveryByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1133,7 +1133,7 @@ func statusIPAMResourceDiscovery(ctx context.Context, conn *ec2.Client, id strin
 }
 
 func statusIPAMResourceDiscoveryAssociation(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findIPAMResourceDiscoveryAssociationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1149,7 +1149,7 @@ func statusIPAMResourceDiscoveryAssociation(ctx context.Context, conn *ec2.Clien
 }
 
 func statusIPAMScope(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findIPAMScopeByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1165,7 +1165,7 @@ func statusIPAMScope(ctx context.Context, conn *ec2.Client, id string) retry.Sta
 }
 
 func statusImage(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findImageByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1181,7 +1181,7 @@ func statusImage(ctx context.Context, conn *ec2.Client, id string) retry.StateRe
 }
 
 func statusImageBlockPublicAccess(ctx context.Context, conn *ec2.Client) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findImageBlockPublicAccessState(ctx, conn)
 
 		if tfresource.NotFound(err) {
@@ -1197,7 +1197,7 @@ func statusImageBlockPublicAccess(ctx context.Context, conn *ec2.Client) retry.S
 }
 
 func statusTransitGateway(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1213,7 +1213,7 @@ func statusTransitGateway(ctx context.Context, conn *ec2.Client, id string) retr
 }
 
 func statusTransitGatewayConnect(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayConnectByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1229,7 +1229,7 @@ func statusTransitGatewayConnect(ctx context.Context, conn *ec2.Client, id strin
 }
 
 func statusTransitGatewayConnectPeer(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayConnectPeerByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1245,7 +1245,7 @@ func statusTransitGatewayConnectPeer(ctx context.Context, conn *ec2.Client, id s
 }
 
 func statusTransitGatewayMulticastDomain(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayMulticastDomainByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1261,7 +1261,7 @@ func statusTransitGatewayMulticastDomain(ctx context.Context, conn *ec2.Client, 
 }
 
 func statusTransitGatewayMulticastDomainAssociation(ctx context.Context, conn *ec2.Client, multicastDomainID, attachmentID, subnetID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayMulticastDomainAssociationByThreePartKey(ctx, conn, multicastDomainID, attachmentID, subnetID)
 
 		if tfresource.NotFound(err) {
@@ -1277,7 +1277,7 @@ func statusTransitGatewayMulticastDomainAssociation(ctx context.Context, conn *e
 }
 
 func statusTransitGatewayPeeringAttachment(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		// Don't call findTransitGatewayPeeringAttachmentByID as it maps useful status codes to NotFoundError.
 		output, err := findTransitGatewayPeeringAttachment(ctx, conn, &ec2.DescribeTransitGatewayPeeringAttachmentsInput{
 			TransitGatewayAttachmentIds: []string{id},
@@ -1296,7 +1296,7 @@ func statusTransitGatewayPeeringAttachment(ctx context.Context, conn *ec2.Client
 }
 
 func statusTransitGatewayPrefixListReference(ctx context.Context, conn *ec2.Client, transitGatewayRouteTableID string, prefixListID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayPrefixListReferenceByTwoPartKey(ctx, conn, transitGatewayRouteTableID, prefixListID)
 
 		if tfresource.NotFound(err) {
@@ -1312,7 +1312,7 @@ func statusTransitGatewayPrefixListReference(ctx context.Context, conn *ec2.Clie
 }
 
 func statusTransitGatewayStaticRoute(ctx context.Context, conn *ec2.Client, transitGatewayRouteTableID, destination string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayStaticRoute(ctx, conn, transitGatewayRouteTableID, destination)
 
 		if tfresource.NotFound(err) {
@@ -1328,7 +1328,7 @@ func statusTransitGatewayStaticRoute(ctx context.Context, conn *ec2.Client, tran
 }
 
 func statusTransitGatewayRouteTable(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayRouteTableByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1344,7 +1344,7 @@ func statusTransitGatewayRouteTable(ctx context.Context, conn *ec2.Client, id st
 }
 
 func statusTransitGatewayPolicyTable(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayPolicyTableByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1360,7 +1360,7 @@ func statusTransitGatewayPolicyTable(ctx context.Context, conn *ec2.Client, id s
 }
 
 func statusTransitGatewayPolicyTableAssociation(ctx context.Context, conn *ec2.Client, transitGatewayPolicyTableID, transitGatewayAttachmentID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayPolicyTableAssociationByTwoPartKey(ctx, conn, transitGatewayPolicyTableID, transitGatewayAttachmentID)
 
 		if tfresource.NotFound(err) {
@@ -1376,7 +1376,7 @@ func statusTransitGatewayPolicyTableAssociation(ctx context.Context, conn *ec2.C
 }
 
 func statusTransitGatewayRouteTableAssociation(ctx context.Context, conn *ec2.Client, transitGatewayRouteTableID, transitGatewayAttachmentID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayRouteTableAssociationByTwoPartKey(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID)
 
 		if tfresource.NotFound(err) {
@@ -1392,7 +1392,7 @@ func statusTransitGatewayRouteTableAssociation(ctx context.Context, conn *ec2.Cl
 }
 
 func statusTransitGatewayRouteTablePropagation(ctx context.Context, conn *ec2.Client, transitGatewayRouteTableID string, transitGatewayAttachmentID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTransitGatewayRouteTablePropagationByTwoPartKey(ctx, conn, transitGatewayRouteTableID, transitGatewayAttachmentID)
 
 		if tfresource.NotFound(err) {
@@ -1408,7 +1408,7 @@ func statusTransitGatewayRouteTablePropagation(ctx context.Context, conn *ec2.Cl
 }
 
 func statusTransitGatewayVPCAttachment(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		// Don't call findTransitGatewayVPCAttachmentByID as it maps useful status codes to NotFoundError.
 		output, err := findTransitGatewayVPCAttachment(ctx, conn, &ec2.DescribeTransitGatewayVpcAttachmentsInput{
 			TransitGatewayAttachmentIds: []string{id},
@@ -1427,7 +1427,7 @@ func statusTransitGatewayVPCAttachment(ctx context.Context, conn *ec2.Client, id
 }
 
 func statusEIPDomainNameAttribute(ctx context.Context, conn *ec2.Client, allocationID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findEIPDomainNameAttributeByAllocationID(ctx, conn, allocationID)
 
 		if tfresource.NotFound(err) {
@@ -1447,7 +1447,7 @@ func statusEIPDomainNameAttribute(ctx context.Context, conn *ec2.Client, allocat
 }
 
 func statusSnapshotStorageTier(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSnapshotTierStatusBySnapshotID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1463,7 +1463,7 @@ func statusSnapshotStorageTier(ctx context.Context, conn *ec2.Client, id string)
 }
 
 func statusInstanceConnectEndpoint(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findInstanceConnectEndpointByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1479,7 +1479,7 @@ func statusInstanceConnectEndpoint(ctx context.Context, conn *ec2.Client, id str
 }
 
 func statusVerifiedAccessEndpoint(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVerifiedAccessEndpointByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1495,7 +1495,7 @@ func statusVerifiedAccessEndpoint(ctx context.Context, conn *ec2.Client, id stri
 }
 
 func statusFastSnapshotRestore(ctx context.Context, conn *ec2.Client, availabilityZone, snapshotID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findFastSnapshotRestoreByTwoPartKey(ctx, conn, availabilityZone, snapshotID)
 
 		if tfresource.NotFound(err) {
@@ -1511,7 +1511,7 @@ func statusFastSnapshotRestore(ctx context.Context, conn *ec2.Client, availabili
 }
 
 func statusEBSSnapshotImport(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findImportSnapshotTaskByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1527,7 +1527,7 @@ func statusEBSSnapshotImport(ctx context.Context, conn *ec2.Client, id string) r
 }
 
 func statusNATGatewayState(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findNATGatewayByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1543,7 +1543,7 @@ func statusNATGatewayState(ctx context.Context, conn *ec2.Client, id string) ret
 }
 
 func statusNATGatewayAddressByNATGatewayIDAndAllocationID(ctx context.Context, conn *ec2.Client, natGatewayID, allocationID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findNATGatewayAddressByNATGatewayIDAndAllocationID(ctx, conn, natGatewayID, allocationID)
 
 		if tfresource.NotFound(err) {
@@ -1559,7 +1559,7 @@ func statusNATGatewayAddressByNATGatewayIDAndAllocationID(ctx context.Context, c
 }
 
 func statusNATGatewayAddressByNATGatewayIDAndPrivateIP(ctx context.Context, conn *ec2.Client, natGatewayID, privateIP string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findNATGatewayAddressByNATGatewayIDAndPrivateIP(ctx, conn, natGatewayID, privateIP)
 
 		if tfresource.NotFound(err) {
@@ -1575,7 +1575,7 @@ func statusNATGatewayAddressByNATGatewayIDAndPrivateIP(ctx context.Context, conn
 }
 
 func statusNetworkInsightsAnalysis(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findNetworkInsightsAnalysisByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1591,7 +1591,7 @@ func statusNetworkInsightsAnalysis(ctx context.Context, conn *ec2.Client, id str
 }
 
 func statusVPCBlockPublicAccessOptions(ctx context.Context, conn *ec2.Client) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCBlockPublicAccessOptions(ctx, conn)
 
 		if tfresource.NotFound(err) {
@@ -1607,7 +1607,7 @@ func statusVPCBlockPublicAccessOptions(ctx context.Context, conn *ec2.Client) re
 }
 
 func statusVPCBlockPublicAccessExclusion(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCBlockPublicAccessExclusionByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/ec2/tags.go
+++ b/internal/service/ec2/tags.go
@@ -25,7 +25,7 @@ func createTags(ctx context.Context, conn *ec2.Client, identifier string, tags [
 
 	newTagsMap := keyValueTags(ctx, tags)
 
-	_, err := tfresource.RetryWhenAWSErrCodeContains(ctx, eventualConsistencyTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeContains(ctx, eventualConsistencyTimeout, func() (any, error) {
 		return nil, updateTags(ctx, conn, identifier, nil, newTagsMap, optFns...)
 	}, ".NotFound")
 
@@ -54,7 +54,7 @@ func getTagSpecificationsIn(ctx context.Context, resourceType awstypes.ResourceT
 }
 
 // tagSpecificationsFromMap returns the tag specifications for the given tag key/value map and resource type.
-func tagSpecificationsFromMap(ctx context.Context, m map[string]interface{}, t awstypes.ResourceType) []awstypes.TagSpecification {
+func tagSpecificationsFromMap(ctx context.Context, m map[string]any, t awstypes.ResourceType) []awstypes.TagSpecification {
 	if len(m) == 0 {
 		return nil
 	}

--- a/internal/service/ec2/transitgateway_.go
+++ b/internal/service/ec2/transitgateway_.go
@@ -48,11 +48,11 @@ func resourceTransitGateway() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.Sequence(
-			customdiff.ForceNewIfChange("default_route_table_association", func(_ context.Context, old, new, meta interface{}) bool {
+			customdiff.ForceNewIfChange("default_route_table_association", func(_ context.Context, old, new, meta any) bool {
 				// Only changes from disable to enable for feature_set should force a new resource.
 				return old.(string) == string(awstypes.DefaultRouteTableAssociationValueDisable) && new.(string) == string(awstypes.DefaultRouteTableAssociationValueEnable)
 			}),
-			customdiff.ForceNewIfChange("default_route_table_propagation", func(_ context.Context, old, new, meta interface{}) bool {
+			customdiff.ForceNewIfChange("default_route_table_propagation", func(_ context.Context, old, new, meta any) bool {
 				// Only changes from disable to enable for feature_set should force a new resource.
 				return old.(string) == string(awstypes.DefaultRouteTablePropagationValueDisable) && new.(string) == string(awstypes.DefaultRouteTablePropagationValueEnable)
 			}),
@@ -148,7 +148,7 @@ func resourceTransitGateway() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -193,7 +193,7 @@ func resourceTransitGatewayCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceTransitGatewayRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -229,7 +229,7 @@ func resourceTransitGatewayRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceTransitGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -296,7 +296,7 @@ func resourceTransitGatewayUpdate(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceTransitGatewayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -304,7 +304,7 @@ func resourceTransitGatewayDelete(ctx context.Context, d *schema.ResourceData, m
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
 		return conn.DeleteTransitGateway(ctx, &ec2.DeleteTransitGatewayInput{
 			TransitGatewayId: aws.String(d.Id()),
 		})

--- a/internal/service/ec2/transitgateway_attachment_data_source.go
+++ b/internal/service/ec2/transitgateway_attachment_data_source.go
@@ -74,7 +74,7 @@ func dataSourceTransitGatewayAttachment() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_attachments_data_source.go
+++ b/internal/service/ec2/transitgateway_attachments_data_source.go
@@ -38,7 +38,7 @@ func dataSourceTransitGatewayAttachments() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayAttachmentsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayAttachmentsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -50,7 +50,7 @@ func dataSourceTransitGatewayAttachmentsRead(ctx context.Context, d *schema.Reso
 
 	if v, ok := d.GetOk(names.AttrTags); ok {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, v.(map[string]interface{}))),
+			Tags(tftags.New(ctx, v.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/transitgateway_connect.go
+++ b/internal/service/ec2/transitgateway_connect.go
@@ -79,7 +79,7 @@ func resourceTransitGatewayConnect() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayConnectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayConnectCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -133,7 +133,7 @@ func resourceTransitGatewayConnectCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceTransitGatewayConnectRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayConnectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayConnectRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -204,7 +204,7 @@ func resourceTransitGatewayConnectRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceTransitGatewayConnectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayConnectUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -233,7 +233,7 @@ func resourceTransitGatewayConnectUpdate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceTransitGatewayConnectRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayConnectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayConnectDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)

--- a/internal/service/ec2/transitgateway_connect_data_source.go
+++ b/internal/service/ec2/transitgateway_connect_data_source.go
@@ -53,7 +53,7 @@ func dataSourceTransitGatewayConnect() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayConnectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayConnectRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_connect_peer.go
+++ b/internal/service/ec2/transitgateway_connect_peer.go
@@ -114,7 +114,7 @@ func resourceTransitGatewayConnectPeer() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayConnectPeerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayConnectPeerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -158,7 +158,7 @@ func resourceTransitGatewayConnectPeerCreate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceTransitGatewayConnectPeerRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayConnectPeerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayConnectPeerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -199,12 +199,12 @@ func resourceTransitGatewayConnectPeerRead(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceTransitGatewayConnectPeerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayConnectPeerUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceTransitGatewayConnectPeerRead(ctx, d, meta)
 }
 
-func resourceTransitGatewayConnectPeerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayConnectPeerDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)

--- a/internal/service/ec2/transitgateway_connect_peer_data_source.go
+++ b/internal/service/ec2/transitgateway_connect_peer_data_source.go
@@ -80,7 +80,7 @@ func dataSourceTransitGatewayConnectPeer() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayConnectPeerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayConnectPeerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_data_source.go
+++ b/internal/service/ec2/transitgateway_data_source.go
@@ -98,7 +98,7 @@ func dataSourceTransitGateway() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_dx_gateway_attachment_data_source.go
+++ b/internal/service/ec2/transitgateway_dx_gateway_attachment_data_source.go
@@ -51,7 +51,7 @@ func dataSourceTransitGatewayDxGatewayAttachment() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayDxGatewayAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayDxGatewayAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -67,7 +67,7 @@ func dataSourceTransitGatewayDxGatewayAttachmentRead(ctx context.Context, d *sch
 
 	if v, ok := d.GetOk(names.AttrTags); ok {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, v.(map[string]interface{}))),
+			Tags(tftags.New(ctx, v.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/transitgateway_multicast_domain.go
+++ b/internal/service/ec2/transitgateway_multicast_domain.go
@@ -82,7 +82,7 @@ func resourceTransitGatewayMulticastDomain() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayMulticastDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastDomainCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -113,7 +113,7 @@ func resourceTransitGatewayMulticastDomainCreate(ctx context.Context, d *schema.
 	return append(diags, resourceTransitGatewayMulticastDomainRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayMulticastDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastDomainRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -142,12 +142,12 @@ func resourceTransitGatewayMulticastDomainRead(ctx context.Context, d *schema.Re
 	return diags
 }
 
-func resourceTransitGatewayMulticastDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastDomainUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceTransitGatewayMulticastDomainRead(ctx, d, meta)
 }
 
-func resourceTransitGatewayMulticastDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastDomainDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)

--- a/internal/service/ec2/transitgateway_multicast_domain_association.go
+++ b/internal/service/ec2/transitgateway_multicast_domain_association.go
@@ -53,7 +53,7 @@ func resourceTransitGatewayMulticastDomainAssociation() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayMulticastDomainAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastDomainAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -83,7 +83,7 @@ func resourceTransitGatewayMulticastDomainAssociationCreate(ctx context.Context,
 	return append(diags, resourceTransitGatewayMulticastDomainAssociationRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayMulticastDomainAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastDomainAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -111,7 +111,7 @@ func resourceTransitGatewayMulticastDomainAssociationRead(ctx context.Context, d
 	return diags
 }
 
-func resourceTransitGatewayMulticastDomainAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastDomainAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_multicast_domain_data_source.go
+++ b/internal/service/ec2/transitgateway_multicast_domain_data_source.go
@@ -122,7 +122,7 @@ func dataSourceTransitGatewayMulticastDomain() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayMulticastDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayMulticastDomainRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -205,8 +205,8 @@ func dataSourceTransitGatewayMulticastDomainRead(ctx context.Context, d *schema.
 	return diags
 }
 
-func flattenTransitGatewayMulticastDomainAssociation(apiObject awstypes.TransitGatewayMulticastDomainAssociation) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenTransitGatewayMulticastDomainAssociation(apiObject awstypes.TransitGatewayMulticastDomainAssociation) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.Subnet.SubnetId; v != nil {
 		tfMap[names.AttrSubnetID] = aws.ToString(v)
@@ -219,12 +219,12 @@ func flattenTransitGatewayMulticastDomainAssociation(apiObject awstypes.TransitG
 	return tfMap
 }
 
-func flattenTransitGatewayMulticastDomainAssociations(apiObjects []awstypes.TransitGatewayMulticastDomainAssociation) []interface{} {
+func flattenTransitGatewayMulticastDomainAssociations(apiObjects []awstypes.TransitGatewayMulticastDomainAssociation) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenTransitGatewayMulticastDomainAssociation(apiObject))
@@ -233,8 +233,8 @@ func flattenTransitGatewayMulticastDomainAssociations(apiObjects []awstypes.Tran
 	return tfList
 }
 
-func flattenTransitGatewayMulticastGroup(apiObject awstypes.TransitGatewayMulticastGroup) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenTransitGatewayMulticastGroup(apiObject awstypes.TransitGatewayMulticastGroup) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.GroupIpAddress; v != nil {
 		tfMap["group_ip_address"] = aws.ToString(v)
@@ -247,12 +247,12 @@ func flattenTransitGatewayMulticastGroup(apiObject awstypes.TransitGatewayMultic
 	return tfMap
 }
 
-func flattenTransitGatewayMulticastGroups(apiObjects []awstypes.TransitGatewayMulticastGroup) []interface{} {
+func flattenTransitGatewayMulticastGroups(apiObjects []awstypes.TransitGatewayMulticastGroup) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenTransitGatewayMulticastGroup(apiObject))

--- a/internal/service/ec2/transitgateway_multicast_group_member.go
+++ b/internal/service/ec2/transitgateway_multicast_group_member.go
@@ -50,7 +50,7 @@ func resourceTransitGatewayMulticastGroupMember() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayMulticastGroupMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastGroupMemberCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -76,7 +76,7 @@ func resourceTransitGatewayMulticastGroupMemberCreate(ctx context.Context, d *sc
 	return append(diags, resourceTransitGatewayMulticastGroupMemberRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayMulticastGroupMemberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastGroupMemberRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -85,7 +85,7 @@ func resourceTransitGatewayMulticastGroupMemberRead(ctx context.Context, d *sche
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findTransitGatewayMulticastGroupMemberByThreePartKey(ctx, conn, multicastDomainID, groupIPAddress, eniID)
 	}, d.IsNewResource())
 
@@ -108,7 +108,7 @@ func resourceTransitGatewayMulticastGroupMemberRead(ctx context.Context, d *sche
 	return diags
 }
 
-func resourceTransitGatewayMulticastGroupMemberDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastGroupMemberDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -149,7 +149,7 @@ func deregisterTransitGatewayMulticastGroupMember(ctx context.Context, conn *ec2
 		return fmt.Errorf("deleting EC2 Transit Gateway Multicast Group Member (%s): %w", id, err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findTransitGatewayMulticastGroupMemberByThreePartKey(ctx, conn, multicastDomainID, groupIPAddress, eniID)
 	})
 

--- a/internal/service/ec2/transitgateway_multicast_group_source.go
+++ b/internal/service/ec2/transitgateway_multicast_group_source.go
@@ -50,7 +50,7 @@ func resourceTransitGatewayMulticastGroupSource() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayMulticastGroupSourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastGroupSourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -77,7 +77,7 @@ func resourceTransitGatewayMulticastGroupSourceCreate(ctx context.Context, d *sc
 	return append(diags, resourceTransitGatewayMulticastGroupSourceRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayMulticastGroupSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastGroupSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -87,7 +87,7 @@ func resourceTransitGatewayMulticastGroupSourceRead(ctx context.Context, d *sche
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findTransitGatewayMulticastGroupSourceByThreePartKey(ctx, conn, multicastDomainID, groupIPAddress, eniID)
 	}, d.IsNewResource())
 
@@ -110,7 +110,7 @@ func resourceTransitGatewayMulticastGroupSourceRead(ctx context.Context, d *sche
 	return diags
 }
 
-func resourceTransitGatewayMulticastGroupSourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayMulticastGroupSourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -152,7 +152,7 @@ func deregisterTransitGatewayMulticastGroupSource(ctx context.Context, conn *ec2
 		return fmt.Errorf("deleting EC2 Transit Gateway Multicast Group Source (%s): %w", id, err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findTransitGatewayMulticastGroupSourceByThreePartKey(ctx, conn, multicastDomainID, groupIPAddress, eniID)
 	})
 

--- a/internal/service/ec2/transitgateway_peering_attachment.go
+++ b/internal/service/ec2/transitgateway_peering_attachment.go
@@ -91,7 +91,7 @@ func resourceTransitGatewayPeeringAttachment() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayPeeringAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPeeringAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -108,7 +108,7 @@ func resourceTransitGatewayPeeringAttachmentCreate(ctx context.Context, d *schem
 	}
 
 	if v, ok := d.GetOk("options"); ok {
-		input.Options = expandCreateTransitGatewayPeeringAttachmentRequestOptions(v.([]interface{}))
+		input.Options = expandCreateTransitGatewayPeeringAttachmentRequestOptions(v.([]any))
 	}
 
 	output, err := conn.CreateTransitGatewayPeeringAttachment(ctx, input)
@@ -126,7 +126,7 @@ func resourceTransitGatewayPeeringAttachmentCreate(ctx context.Context, d *schem
 	return append(diags, resourceTransitGatewayPeeringAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayPeeringAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPeeringAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -166,7 +166,7 @@ func resourceTransitGatewayPeeringAttachmentRead(ctx context.Context, d *schema.
 	return diags
 }
 
-func resourceTransitGatewayPeeringAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPeeringAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -174,7 +174,7 @@ func resourceTransitGatewayPeeringAttachmentUpdate(ctx context.Context, d *schem
 	return append(diags, resourceTransitGatewayPeeringAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayPeeringAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPeeringAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -199,14 +199,14 @@ func resourceTransitGatewayPeeringAttachmentDelete(ctx context.Context, d *schem
 	return diags
 }
 
-func expandCreateTransitGatewayPeeringAttachmentRequestOptions(tfMap []interface{}) *awstypes.CreateTransitGatewayPeeringAttachmentRequestOptions {
+func expandCreateTransitGatewayPeeringAttachmentRequestOptions(tfMap []any) *awstypes.CreateTransitGatewayPeeringAttachmentRequestOptions {
 	if len(tfMap) == 0 || tfMap[0] == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.CreateTransitGatewayPeeringAttachmentRequestOptions{}
 
-	m := tfMap[0].(map[string]interface{})
+	m := tfMap[0].(map[string]any)
 
 	if v, ok := m["dynamic_routing"].(string); ok {
 		apiObject.DynamicRouting = awstypes.DynamicRoutingValue(v)
@@ -215,12 +215,12 @@ func expandCreateTransitGatewayPeeringAttachmentRequestOptions(tfMap []interface
 	return apiObject
 }
 
-func flattenTransitGatewayPeeringAttachmentOptions(apiObject *awstypes.TransitGatewayPeeringAttachmentOptions) []interface{} {
+func flattenTransitGatewayPeeringAttachmentOptions(apiObject *awstypes.TransitGatewayPeeringAttachmentOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	return []interface{}{map[string]interface{}{
+	return []any{map[string]any{
 		"dynamic_routing": apiObject.DynamicRouting,
 	}}
 }

--- a/internal/service/ec2/transitgateway_peering_attachment_accepter.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_accepter.go
@@ -61,7 +61,7 @@ func resourceTransitGatewayPeeringAttachmentAccepter() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayPeeringAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPeeringAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -90,7 +90,7 @@ func resourceTransitGatewayPeeringAttachmentAccepterCreate(ctx context.Context, 
 	return append(diags, resourceTransitGatewayPeeringAttachmentAccepterRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayPeeringAttachmentAccepterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPeeringAttachmentAccepterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -124,7 +124,7 @@ func resourceTransitGatewayPeeringAttachmentAccepterRead(ctx context.Context, d 
 	return diags
 }
 
-func resourceTransitGatewayPeeringAttachmentAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPeeringAttachmentAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -132,7 +132,7 @@ func resourceTransitGatewayPeeringAttachmentAccepterUpdate(ctx context.Context, 
 	return append(diags, resourceTransitGatewayPeeringAttachmentAccepterRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayPeeringAttachmentAccepterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPeeringAttachmentAccepterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_peering_attachment_data_source.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_data_source.go
@@ -67,7 +67,7 @@ func dataSourceTransitGatewayPeeringAttachment() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayPeeringAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayPeeringAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -83,7 +83,7 @@ func dataSourceTransitGatewayPeeringAttachmentRead(ctx context.Context, d *schem
 
 	if v, ok := d.GetOk(names.AttrTags); ok {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, v.(map[string]interface{}))),
+			Tags(tftags.New(ctx, v.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/transitgateway_peering_attachments_data_source.go
+++ b/internal/service/ec2/transitgateway_peering_attachments_data_source.go
@@ -38,7 +38,7 @@ func dataSourceTransitGatewayPeeringAttachments() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayPeeringAttachmentsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayPeeringAttachmentsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_policy_table.go
+++ b/internal/service/ec2/transitgateway_policy_table.go
@@ -58,7 +58,7 @@ func resourceTransitGatewayPolicyTable() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayPolicyTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPolicyTableCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -84,7 +84,7 @@ func resourceTransitGatewayPolicyTableCreate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceTransitGatewayPolicyTableRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayPolicyTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPolicyTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -116,7 +116,7 @@ func resourceTransitGatewayPolicyTableRead(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceTransitGatewayPolicyTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPolicyTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -124,7 +124,7 @@ func resourceTransitGatewayPolicyTableUpdate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceTransitGatewayPolicyTableRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayPolicyTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPolicyTableDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_policy_table_association.go
+++ b/internal/service/ec2/transitgateway_policy_table_association.go
@@ -58,7 +58,7 @@ func resourceTransitGatewayPolicyTableAssociation() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayPolicyTableAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPolicyTableAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -111,7 +111,7 @@ func resourceTransitGatewayPolicyTableAssociationCreate(ctx context.Context, d *
 	return append(diags, resourceTransitGatewayPolicyTableAssociationRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayPolicyTableAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPolicyTableAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -140,7 +140,7 @@ func resourceTransitGatewayPolicyTableAssociationRead(ctx context.Context, d *sc
 	return diags
 }
 
-func resourceTransitGatewayPolicyTableAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPolicyTableAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_prefix_list_reference.go
+++ b/internal/service/ec2/transitgateway_prefix_list_reference.go
@@ -63,7 +63,7 @@ func resourceTransitGatewayPrefixListReference() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayPrefixListReferenceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPrefixListReferenceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -101,7 +101,7 @@ func resourceTransitGatewayPrefixListReferenceCreate(ctx context.Context, d *sch
 	return append(diags, resourceTransitGatewayPrefixListReferenceRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayPrefixListReferenceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPrefixListReferenceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -135,7 +135,7 @@ func resourceTransitGatewayPrefixListReferenceRead(ctx context.Context, d *schem
 	return diags
 }
 
-func resourceTransitGatewayPrefixListReferenceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPrefixListReferenceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -170,7 +170,7 @@ func resourceTransitGatewayPrefixListReferenceUpdate(ctx context.Context, d *sch
 	return append(diags, resourceTransitGatewayPrefixListReferenceRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayPrefixListReferenceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayPrefixListReferenceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_route.go
+++ b/internal/service/ec2/transitgateway_route.go
@@ -64,7 +64,7 @@ func resourceTransitGatewayRoute() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -93,7 +93,7 @@ func resourceTransitGatewayRouteCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceTransitGatewayRouteRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -102,7 +102,7 @@ func resourceTransitGatewayRouteRead(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findTransitGatewayStaticRoute(ctx, conn, transitGatewayRouteTableID, destination)
 	}, d.IsNewResource())
 
@@ -131,7 +131,7 @@ func resourceTransitGatewayRouteRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceTransitGatewayRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_route_table.go
+++ b/internal/service/ec2/transitgateway_route_table.go
@@ -62,7 +62,7 @@ func resourceTransitGatewayRouteTable() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -87,7 +87,7 @@ func resourceTransitGatewayRouteTableCreate(ctx context.Context, d *schema.Resou
 	return append(diags, resourceTransitGatewayRouteTableRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayRouteTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -120,7 +120,7 @@ func resourceTransitGatewayRouteTableRead(ctx context.Context, d *schema.Resourc
 	return diags
 }
 
-func resourceTransitGatewayRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -128,7 +128,7 @@ func resourceTransitGatewayRouteTableUpdate(ctx context.Context, d *schema.Resou
 	return append(diags, resourceTransitGatewayRouteTableRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayRouteTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteTableDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_route_table_association.go
+++ b/internal/service/ec2/transitgateway_route_table_association.go
@@ -63,7 +63,7 @@ func resourceTransitGatewayRouteTableAssociation() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			func(_ context.Context, d *schema.ResourceDiff, meta any) error {
 				if !d.HasChange(names.AttrTransitGatewayAttachmentID) {
 					return nil
 				}
@@ -101,7 +101,7 @@ func resourceTransitGatewayRouteTableAssociation() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayRouteTableAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteTableAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -150,7 +150,7 @@ func resourceTransitGatewayRouteTableAssociationCreate(ctx context.Context, d *s
 	return append(diags, resourceTransitGatewayRouteTableAssociationRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayRouteTableAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteTableAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -179,7 +179,7 @@ func resourceTransitGatewayRouteTableAssociationRead(ctx context.Context, d *sch
 	return diags
 }
 
-func resourceTransitGatewayRouteTableAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteTableAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_route_table_associations_data_source.go
+++ b/internal/service/ec2/transitgateway_route_table_associations_data_source.go
@@ -42,7 +42,7 @@ func dataSourceTransitGatewayRouteTableAssociations() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayRouteTableAssociationsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayRouteTableAssociationsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_route_table_data_source.go
+++ b/internal/service/ec2/transitgateway_route_table_data_source.go
@@ -59,7 +59,7 @@ func dataSourceTransitGatewayRouteTable() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayRouteTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayRouteTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_route_table_propagation.go
+++ b/internal/service/ec2/transitgateway_route_table_propagation.go
@@ -57,7 +57,7 @@ func resourceTransitGatewayRouteTablePropagation() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayRouteTablePropagationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteTablePropagationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -84,7 +84,7 @@ func resourceTransitGatewayRouteTablePropagationCreate(ctx context.Context, d *s
 	return append(diags, resourceTransitGatewayRouteTablePropagationRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayRouteTablePropagationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteTablePropagationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -113,7 +113,7 @@ func resourceTransitGatewayRouteTablePropagationRead(ctx context.Context, d *sch
 	return diags
 }
 
-func resourceTransitGatewayRouteTablePropagationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayRouteTablePropagationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_route_table_propagations_data_source.go
+++ b/internal/service/ec2/transitgateway_route_table_propagations_data_source.go
@@ -42,7 +42,7 @@ func dataSourceTransitGatewayRouteTablePropagations() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayRouteTablePropagationsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayRouteTablePropagationsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_route_table_routes_data_source.go
+++ b/internal/service/ec2/transitgateway_route_table_routes_data_source.go
@@ -60,7 +60,7 @@ func dataSourceTransitGatewayRouteTableRoutes() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayRouteTableRoutesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayRouteTableRoutesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -78,9 +78,9 @@ func dataSourceTransitGatewayRouteTableRoutesRead(ctx context.Context, d *schema
 
 	d.SetId(tgwRouteTableID)
 
-	routes := []interface{}{}
+	routes := []any{}
 	for _, route := range output {
-		routes = append(routes, map[string]interface{}{
+		routes = append(routes, map[string]any{
 			"destination_cidr_block": aws.ToString(route.DestinationCidrBlock),
 			"prefix_list_id":         aws.ToString(route.PrefixListId),
 			names.AttrState:          route.State,

--- a/internal/service/ec2/transitgateway_route_tables_data_source.go
+++ b/internal/service/ec2/transitgateway_route_tables_data_source.go
@@ -38,14 +38,14 @@ func dataSourceTransitGatewayRouteTables() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayRouteTablesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayRouteTablesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := &ec2.DescribeTransitGatewayRouteTablesInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -852,7 +852,7 @@ func testAccCheckTransitGatewayRecreated(i, j *awstypes.TransitGateway) resource
 	}
 }
 
-func testAccCheckTransitGatewayAssociationDefaultRouteTableAttachmentAssociated(ctx context.Context, transitGateway *awstypes.TransitGateway, transitGatewayAttachment interface{}) resource.TestCheckFunc {
+func testAccCheckTransitGatewayAssociationDefaultRouteTableAttachmentAssociated(ctx context.Context, transitGateway *awstypes.TransitGateway, transitGatewayAttachment any) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		transitGatewayRouteTableID := aws.ToString(transitGateway.Options.AssociationDefaultRouteTableId)
 
@@ -880,7 +880,7 @@ func testAccCheckTransitGatewayAssociationDefaultRouteTableAttachmentAssociated(
 	}
 }
 
-func testAccCheckTransitGatewayAssociationDefaultRouteTableAttachmentNotAssociated(ctx context.Context, transitGateway *awstypes.TransitGateway, transitGatewayAttachment interface{}) resource.TestCheckFunc {
+func testAccCheckTransitGatewayAssociationDefaultRouteTableAttachmentNotAssociated(ctx context.Context, transitGateway *awstypes.TransitGateway, transitGatewayAttachment any) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		transitGatewayRouteTableID := aws.ToString(transitGateway.Options.AssociationDefaultRouteTableId)
 
@@ -912,7 +912,7 @@ func testAccCheckTransitGatewayAssociationDefaultRouteTableAttachmentNotAssociat
 	}
 }
 
-func testAccCheckTransitGatewayPropagationDefaultRouteTableAttachmentPropagated(ctx context.Context, transitGateway *awstypes.TransitGateway, transitGatewayAttachment interface{}) resource.TestCheckFunc {
+func testAccCheckTransitGatewayPropagationDefaultRouteTableAttachmentPropagated(ctx context.Context, transitGateway *awstypes.TransitGateway, transitGatewayAttachment any) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		transitGatewayRouteTableID := aws.ToString(transitGateway.Options.PropagationDefaultRouteTableId)
 
@@ -940,7 +940,7 @@ func testAccCheckTransitGatewayPropagationDefaultRouteTableAttachmentPropagated(
 	}
 }
 
-func testAccCheckTransitGatewayPropagationDefaultRouteTableAttachmentNotPropagated(ctx context.Context, transitGateway *awstypes.TransitGateway, transitGatewayAttachment interface{}) resource.TestCheckFunc {
+func testAccCheckTransitGatewayPropagationDefaultRouteTableAttachmentNotPropagated(ctx context.Context, transitGateway *awstypes.TransitGateway, transitGatewayAttachment any) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		transitGatewayRouteTableID := aws.ToString(transitGateway.Options.PropagationDefaultRouteTableId)
 

--- a/internal/service/ec2/transitgateway_vpc_attachment.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment.go
@@ -106,7 +106,7 @@ func resourceTransitGatewayVPCAttachment() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayVPCAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayVPCAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -170,7 +170,7 @@ func resourceTransitGatewayVPCAttachmentCreate(ctx context.Context, d *schema.Re
 	return append(diags, resourceTransitGatewayVPCAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayVPCAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayVPCAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -248,7 +248,7 @@ func resourceTransitGatewayVPCAttachmentRead(ctx context.Context, d *schema.Reso
 	return diags
 }
 
-func resourceTransitGatewayVPCAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayVPCAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -308,7 +308,7 @@ func resourceTransitGatewayVPCAttachmentUpdate(ctx context.Context, d *schema.Re
 	return diags
 }
 
-func resourceTransitGatewayVPCAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayVPCAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_vpc_attachment_accepter.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_accepter.go
@@ -88,7 +88,7 @@ func resourceTransitGatewayVPCAttachmentAccepter() *schema.Resource {
 	}
 }
 
-func resourceTransitGatewayVPCAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayVPCAttachmentAccepterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -132,7 +132,7 @@ func resourceTransitGatewayVPCAttachmentAccepterCreate(ctx context.Context, d *s
 	return append(diags, resourceTransitGatewayVPCAttachmentAccepterRead(ctx, d, meta)...)
 }
 
-func resourceTransitGatewayVPCAttachmentAccepterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayVPCAttachmentAccepterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -199,7 +199,7 @@ func resourceTransitGatewayVPCAttachmentAccepterRead(ctx context.Context, d *sch
 	return diags
 }
 
-func resourceTransitGatewayVPCAttachmentAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayVPCAttachmentAccepterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -227,7 +227,7 @@ func resourceTransitGatewayVPCAttachmentAccepterUpdate(ctx context.Context, d *s
 	return diags
 }
 
-func resourceTransitGatewayVPCAttachmentAccepterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTransitGatewayVPCAttachmentAccepterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_vpc_attachment_data_source.go
+++ b/internal/service/ec2/transitgateway_vpc_attachment_data_source.go
@@ -80,7 +80,7 @@ func dataSourceTransitGatewayVPCAttachment() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayVPCAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayVPCAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/transitgateway_vpc_attachments_data_source.go
+++ b/internal/service/ec2/transitgateway_vpc_attachments_data_source.go
@@ -36,7 +36,7 @@ func dataSourceTransitGatewayVPCAttachments() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayVPCAttachmentsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayVPCAttachmentsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)

--- a/internal/service/ec2/transitgateway_vpn_attachment_data_source.go
+++ b/internal/service/ec2/transitgateway_vpn_attachment_data_source.go
@@ -45,7 +45,7 @@ func dataSourceTransitGatewayVPNAttachment() *schema.Resource {
 	}
 }
 
-func dataSourceTransitGatewayVPNAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTransitGatewayVPNAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -61,7 +61,7 @@ func dataSourceTransitGatewayVPNAttachmentRead(ctx context.Context, d *schema.Re
 
 	if v, ok := d.GetOk(names.AttrTags); ok {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, v.(map[string]interface{}))),
+			Tags(tftags.New(ctx, v.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/validate.go
+++ b/internal/service/ec2/validate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/YakDriver/regexache"
 )
 
-func validSecurityGroupRuleDescription(v interface{}, k string) (ws []string, errors []error) {
+func validSecurityGroupRuleDescription(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 255 {
 		errors = append(errors, fmt.Errorf(
@@ -30,7 +30,7 @@ func validSecurityGroupRuleDescription(v interface{}, k string) (ws []string, er
 
 // validNestedExactlyOneOf is called on the map representing a nested schema element
 // Once ExactlyOneOf is supported for nested elements, this should be deprecated.
-func validNestedExactlyOneOf(m map[string]interface{}, valid []string) error {
+func validNestedExactlyOneOf(m map[string]any, valid []string) error {
 	specified := make([]string, 0)
 	for _, k := range valid {
 		if v, ok := m[k].(string); ok && v != "" {

--- a/internal/service/ec2/verifiedaccess_endpoint.go
+++ b/internal/service/ec2/verifiedaccess_endpoint.go
@@ -183,7 +183,7 @@ func resourceVerifiedAccessEndpoint() *schema.Resource {
 	}
 }
 
-func resourceVerifiedAccessEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessEndpointCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -202,12 +202,12 @@ func resourceVerifiedAccessEndpointCreate(ctx context.Context, d *schema.Resourc
 		input.Description = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("load_balancer_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.LoadBalancerOptions = expandCreateVerifiedAccessEndpointLoadBalancerOptions(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("load_balancer_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.LoadBalancerOptions = expandCreateVerifiedAccessEndpointLoadBalancerOptions(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("network_interface_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.NetworkInterfaceOptions = expandCreateVerifiedAccessEndpointEniOptions(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("network_interface_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.NetworkInterfaceOptions = expandCreateVerifiedAccessEndpointEniOptions(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("policy_document"); ok {
@@ -218,8 +218,8 @@ func resourceVerifiedAccessEndpointCreate(ctx context.Context, d *schema.Resourc
 		input.SecurityGroupIds = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("sse_specification"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.SseSpecification = expandCreateVerifiedAccessEndpointSseSpecification(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("sse_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.SseSpecification = expandCreateVerifiedAccessEndpointSseSpecification(v.([]any)[0].(map[string]any))
 	}
 
 	output, err := conn.CreateVerifiedAccessEndpoint(ctx, input)
@@ -237,7 +237,7 @@ func resourceVerifiedAccessEndpointCreate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceVerifiedAccessEndpointRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessEndpointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -284,7 +284,7 @@ func resourceVerifiedAccessEndpointRead(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceVerifiedAccessEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -299,14 +299,14 @@ func resourceVerifiedAccessEndpointUpdate(ctx context.Context, d *schema.Resourc
 		}
 
 		if d.HasChanges("load_balancer_options") {
-			if v, ok := d.GetOk("load_balancer_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.LoadBalancerOptions = expandModifyVerifiedAccessEndpointLoadBalancerOptions(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("load_balancer_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.LoadBalancerOptions = expandModifyVerifiedAccessEndpointLoadBalancerOptions(v.([]any)[0].(map[string]any))
 			}
 		}
 
 		if d.HasChanges("network_interface_options") {
-			if v, ok := d.GetOk("network_interface_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.NetworkInterfaceOptions = expandModifyVerifiedAccessEndpointEniOptions(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("network_interface_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.NetworkInterfaceOptions = expandModifyVerifiedAccessEndpointEniOptions(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -347,7 +347,7 @@ func resourceVerifiedAccessEndpointUpdate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceVerifiedAccessEndpointRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessEndpointDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -373,12 +373,12 @@ func resourceVerifiedAccessEndpointDelete(ctx context.Context, d *schema.Resourc
 	return diags
 }
 
-func flattenVerifiedAccessEndpointLoadBalancerOptions(apiObject *types.VerifiedAccessEndpointLoadBalancerOptions) []interface{} {
+func flattenVerifiedAccessEndpointLoadBalancerOptions(apiObject *types.VerifiedAccessEndpointLoadBalancerOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfmap := map[string]interface{}{}
+	tfmap := map[string]any{}
 
 	if v := apiObject.LoadBalancerArn; v != nil {
 		tfmap["load_balancer_arn"] = aws.ToString(v)
@@ -396,15 +396,15 @@ func flattenVerifiedAccessEndpointLoadBalancerOptions(apiObject *types.VerifiedA
 		tfmap[names.AttrSubnetIDs] = aws.StringSlice(v)
 	}
 
-	return []interface{}{tfmap}
+	return []any{tfmap}
 }
 
-func flattenVerifiedAccessEndpointEniOptions(apiObject *types.VerifiedAccessEndpointEniOptions) []interface{} {
+func flattenVerifiedAccessEndpointEniOptions(apiObject *types.VerifiedAccessEndpointEniOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfmap := map[string]interface{}{}
+	tfmap := map[string]any{}
 
 	if v := apiObject.NetworkInterfaceId; v != nil {
 		tfmap[names.AttrNetworkInterfaceID] = aws.ToString(v)
@@ -418,15 +418,15 @@ func flattenVerifiedAccessEndpointEniOptions(apiObject *types.VerifiedAccessEndp
 		tfmap[names.AttrProtocol] = v
 	}
 
-	return []interface{}{tfmap}
+	return []any{tfmap}
 }
 
-func flattenVerifiedAccessSseSpecificationRequest(apiObject *types.VerifiedAccessSseSpecificationResponse) []interface{} {
+func flattenVerifiedAccessSseSpecificationRequest(apiObject *types.VerifiedAccessSseSpecificationResponse) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfmap := map[string]interface{}{}
+	tfmap := map[string]any{}
 
 	if v := apiObject.CustomerManagedKeyEnabled; v != nil {
 		tfmap["customer_managed_key_enabled"] = aws.ToBool(v)
@@ -436,10 +436,10 @@ func flattenVerifiedAccessSseSpecificationRequest(apiObject *types.VerifiedAcces
 		tfmap[names.AttrKMSKeyARN] = aws.ToString(v)
 	}
 
-	return []interface{}{tfmap}
+	return []any{tfmap}
 }
 
-func expandCreateVerifiedAccessEndpointLoadBalancerOptions(tfMap map[string]interface{}) *types.CreateVerifiedAccessEndpointLoadBalancerOptions {
+func expandCreateVerifiedAccessEndpointLoadBalancerOptions(tfMap map[string]any) *types.CreateVerifiedAccessEndpointLoadBalancerOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -465,7 +465,7 @@ func expandCreateVerifiedAccessEndpointLoadBalancerOptions(tfMap map[string]inte
 	return apiobject
 }
 
-func expandCreateVerifiedAccessEndpointEniOptions(tfMap map[string]interface{}) *types.CreateVerifiedAccessEndpointEniOptions {
+func expandCreateVerifiedAccessEndpointEniOptions(tfMap map[string]any) *types.CreateVerifiedAccessEndpointEniOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -486,7 +486,7 @@ func expandCreateVerifiedAccessEndpointEniOptions(tfMap map[string]interface{}) 
 	return apiobject
 }
 
-func expandModifyVerifiedAccessEndpointLoadBalancerOptions(tfMap map[string]interface{}) *types.ModifyVerifiedAccessEndpointLoadBalancerOptions {
+func expandModifyVerifiedAccessEndpointLoadBalancerOptions(tfMap map[string]any) *types.ModifyVerifiedAccessEndpointLoadBalancerOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -508,7 +508,7 @@ func expandModifyVerifiedAccessEndpointLoadBalancerOptions(tfMap map[string]inte
 	return apiObject
 }
 
-func expandModifyVerifiedAccessEndpointEniOptions(tfMap map[string]interface{}) *types.ModifyVerifiedAccessEndpointEniOptions {
+func expandModifyVerifiedAccessEndpointEniOptions(tfMap map[string]any) *types.ModifyVerifiedAccessEndpointEniOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -525,7 +525,7 @@ func expandModifyVerifiedAccessEndpointEniOptions(tfMap map[string]interface{}) 
 	return apiObject
 }
 
-func expandCreateVerifiedAccessEndpointSseSpecification(tfMap map[string]interface{}) *types.VerifiedAccessSseSpecificationRequest {
+func expandCreateVerifiedAccessEndpointSseSpecification(tfMap map[string]any) *types.VerifiedAccessSseSpecificationRequest {
 	if tfMap == nil {
 		return nil
 	}

--- a/internal/service/ec2/verifiedaccess_group.go
+++ b/internal/service/ec2/verifiedaccess_group.go
@@ -99,7 +99,7 @@ func resourceVerifiedAccessGroup() *schema.Resource {
 	}
 }
 
-func resourceVerifiedAccessGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -117,8 +117,8 @@ func resourceVerifiedAccessGroupCreate(ctx context.Context, d *schema.ResourceDa
 		input.PolicyDocument = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("sse_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.SseSpecification = expandVerifiedAccessSseSpecificationRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("sse_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.SseSpecification = expandVerifiedAccessSseSpecificationRequest(v.([]any)[0].(map[string]any))
 	}
 
 	output, err := conn.CreateVerifiedAccessGroup(ctx, input)
@@ -132,7 +132,7 @@ func resourceVerifiedAccessGroupCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceVerifiedAccessGroupRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -177,7 +177,7 @@ func resourceVerifiedAccessGroupRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceVerifiedAccessGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -221,8 +221,8 @@ func resourceVerifiedAccessGroupUpdate(ctx context.Context, d *schema.ResourceDa
 			VerifiedAccessGroupId: aws.String(d.Id()),
 		}
 
-		if v, ok := d.GetOk("sse_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			in.SseSpecification = expandVerifiedAccessSseSpecificationRequest(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("sse_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			in.SseSpecification = expandVerifiedAccessSseSpecificationRequest(v.([]any)[0].(map[string]any))
 		}
 
 		_, err := conn.ModifyVerifiedAccessGroupPolicy(ctx, in)
@@ -235,7 +235,7 @@ func resourceVerifiedAccessGroupUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceVerifiedAccessGroupRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -257,7 +257,7 @@ func resourceVerifiedAccessGroupDelete(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func expandVerifiedAccessSseSpecificationRequest(tfMap map[string]interface{}) *types.VerifiedAccessSseSpecificationRequest {
+func expandVerifiedAccessSseSpecificationRequest(tfMap map[string]any) *types.VerifiedAccessSseSpecificationRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -275,12 +275,12 @@ func expandVerifiedAccessSseSpecificationRequest(tfMap map[string]interface{}) *
 	return apiObject
 }
 
-func flattenVerifiedAccessSseSpecificationResponse(apiObject *types.VerifiedAccessSseSpecificationResponse) []interface{} {
+func flattenVerifiedAccessSseSpecificationResponse(apiObject *types.VerifiedAccessSseSpecificationResponse) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CustomerManagedKeyEnabled; v != nil {
 		tfMap["customer_managed_key_enabled"] = aws.ToBool(v)
@@ -290,5 +290,5 @@ func flattenVerifiedAccessSseSpecificationResponse(apiObject *types.VerifiedAcce
 		tfMap[names.AttrKMSKeyARN] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/ec2/verifiedaccess_instance.go
+++ b/internal/service/ec2/verifiedaccess_instance.go
@@ -87,7 +87,7 @@ func resourceVerifiedAccessInstance() *schema.Resource {
 	}
 }
 
-func resourceVerifiedAccessInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -115,7 +115,7 @@ func resourceVerifiedAccessInstanceCreate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceVerifiedAccessInstanceRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -149,7 +149,7 @@ func resourceVerifiedAccessInstanceRead(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceVerifiedAccessInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -173,7 +173,7 @@ func resourceVerifiedAccessInstanceUpdate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceVerifiedAccessInstanceRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -195,12 +195,12 @@ func resourceVerifiedAccessInstanceDelete(ctx context.Context, d *schema.Resourc
 	return diags
 }
 
-func flattenVerifiedAccessTrustProviders(apiObjects []types.VerifiedAccessTrustProviderCondensed) []interface{} {
+func flattenVerifiedAccessTrustProviders(apiObjects []types.VerifiedAccessTrustProviderCondensed) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		v := flattenVerifiedAccessTrustProvider(apiObject)
@@ -213,8 +213,8 @@ func flattenVerifiedAccessTrustProviders(apiObjects []types.VerifiedAccessTrustP
 	return tfList
 }
 
-func flattenVerifiedAccessTrustProvider(apiObject types.VerifiedAccessTrustProviderCondensed) map[string]interface{} {
-	tfMap := map[string]interface{}{
+func flattenVerifiedAccessTrustProvider(apiObject types.VerifiedAccessTrustProviderCondensed) map[string]any {
+	tfMap := map[string]any{
 		"device_trust_provider_type": string(apiObject.DeviceTrustProviderType),
 		"trust_provider_type":        string(apiObject.TrustProviderType),
 		"user_trust_provider_type":   string(apiObject.UserTrustProviderType),

--- a/internal/service/ec2/verifiedaccess_instance_logging_configuration.go
+++ b/internal/service/ec2/verifiedaccess_instance_logging_configuration.go
@@ -130,7 +130,7 @@ func resourceVerifiedAccessInstanceLoggingConfiguration() *schema.Resource {
 	}
 }
 
-func resourceVerifiedAccessInstanceLoggingConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceLoggingConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -142,7 +142,7 @@ func resourceVerifiedAccessInstanceLoggingConfigurationCreate(ctx context.Contex
 	}
 
 	input := &ec2.ModifyVerifiedAccessInstanceLoggingConfigurationInput{
-		AccessLogs:               expandVerifiedAccessInstanceAccessLogs(d.Get("access_logs").([]interface{})),
+		AccessLogs:               expandVerifiedAccessInstanceAccessLogs(d.Get("access_logs").([]any)),
 		ClientToken:              aws.String(uuid), // can't use aws.String(id.UniqueId()), because it's not a valid uuid
 		VerifiedAccessInstanceId: aws.String(vaiID),
 	}
@@ -158,7 +158,7 @@ func resourceVerifiedAccessInstanceLoggingConfigurationCreate(ctx context.Contex
 	return append(diags, resourceVerifiedAccessInstanceLoggingConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessInstanceLoggingConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceLoggingConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -188,7 +188,7 @@ func resourceVerifiedAccessInstanceLoggingConfigurationRead(ctx context.Context,
 	return diags
 }
 
-func resourceVerifiedAccessInstanceLoggingConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceLoggingConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -201,7 +201,7 @@ func resourceVerifiedAccessInstanceLoggingConfigurationUpdate(ctx context.Contex
 		}
 
 		input := &ec2.ModifyVerifiedAccessInstanceLoggingConfigurationInput{
-			AccessLogs:               expandVerifiedAccessInstanceAccessLogs(d.Get("access_logs").([]interface{})),
+			AccessLogs:               expandVerifiedAccessInstanceAccessLogs(d.Get("access_logs").([]any)),
 			ClientToken:              aws.String(uuid), // can't use aws.String(id.UniqueId()), because it's not a valid uuid
 			VerifiedAccessInstanceId: aws.String(vaiID),
 		}
@@ -216,7 +216,7 @@ func resourceVerifiedAccessInstanceLoggingConfigurationUpdate(ctx context.Contex
 	return append(diags, resourceVerifiedAccessInstanceLoggingConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessInstanceLoggingConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceLoggingConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -265,19 +265,19 @@ func resourceVerifiedAccessInstanceLoggingConfigurationDelete(ctx context.Contex
 	return diags
 }
 
-func expandVerifiedAccessInstanceAccessLogs(accessLogs []interface{}) *types.VerifiedAccessLogOptions {
+func expandVerifiedAccessInstanceAccessLogs(accessLogs []any) *types.VerifiedAccessLogOptions {
 	if len(accessLogs) == 0 || accessLogs[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := accessLogs[0].(map[string]interface{})
+	tfMap, ok := accessLogs[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	result := &types.VerifiedAccessLogOptions{}
 
-	if v, ok := tfMap[names.AttrCloudWatchLogs].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrCloudWatchLogs].([]any); ok && len(v) > 0 {
 		result.CloudWatchLogs = expandVerifiedAccessLogCloudWatchLogs(v)
 	}
 
@@ -285,7 +285,7 @@ func expandVerifiedAccessInstanceAccessLogs(accessLogs []interface{}) *types.Ver
 		result.IncludeTrustContext = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["kinesis_data_firehose"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["kinesis_data_firehose"].([]any); ok && len(v) > 0 {
 		result.KinesisDataFirehose = expandVerifiedAccessLogKinesisDataFirehose(v)
 	}
 
@@ -293,19 +293,19 @@ func expandVerifiedAccessInstanceAccessLogs(accessLogs []interface{}) *types.Ver
 		result.LogVersion = aws.String(v)
 	}
 
-	if v, ok := tfMap["s3"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["s3"].([]any); ok && len(v) > 0 {
 		result.S3 = expandVerifiedAccessLogS3(v)
 	}
 
 	return result
 }
 
-func expandVerifiedAccessLogCloudWatchLogs(cloudWatchLogs []interface{}) *types.VerifiedAccessLogCloudWatchLogsDestinationOptions {
+func expandVerifiedAccessLogCloudWatchLogs(cloudWatchLogs []any) *types.VerifiedAccessLogCloudWatchLogsDestinationOptions {
 	if len(cloudWatchLogs) == 0 || cloudWatchLogs[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := cloudWatchLogs[0].(map[string]interface{})
+	tfMap, ok := cloudWatchLogs[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -321,12 +321,12 @@ func expandVerifiedAccessLogCloudWatchLogs(cloudWatchLogs []interface{}) *types.
 	return result
 }
 
-func expandVerifiedAccessLogKinesisDataFirehose(kinesisDataFirehose []interface{}) *types.VerifiedAccessLogKinesisDataFirehoseDestinationOptions {
+func expandVerifiedAccessLogKinesisDataFirehose(kinesisDataFirehose []any) *types.VerifiedAccessLogKinesisDataFirehoseDestinationOptions {
 	if len(kinesisDataFirehose) == 0 || kinesisDataFirehose[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := kinesisDataFirehose[0].(map[string]interface{})
+	tfMap, ok := kinesisDataFirehose[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -342,12 +342,12 @@ func expandVerifiedAccessLogKinesisDataFirehose(kinesisDataFirehose []interface{
 	return result
 }
 
-func expandVerifiedAccessLogS3(s3 []interface{}) *types.VerifiedAccessLogS3DestinationOptions {
+func expandVerifiedAccessLogS3(s3 []any) *types.VerifiedAccessLogS3DestinationOptions {
 	if len(s3) == 0 || s3[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := s3[0].(map[string]interface{})
+	tfMap, ok := s3[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -375,8 +375,8 @@ func expandVerifiedAccessLogS3(s3 []interface{}) *types.VerifiedAccessLogS3Desti
 	return result
 }
 
-func flattenVerifiedAccessInstanceAccessLogs(apiObject *types.VerifiedAccessLogs) []interface{} {
-	tfMap := map[string]interface{}{}
+func flattenVerifiedAccessInstanceAccessLogs(apiObject *types.VerifiedAccessLogs) []any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.CloudWatchLogs; v != nil {
 		tfMap[names.AttrCloudWatchLogs] = flattenVerifiedAccessLogCloudWatchLogs(v)
@@ -398,11 +398,11 @@ func flattenVerifiedAccessInstanceAccessLogs(apiObject *types.VerifiedAccessLogs
 		tfMap["s3"] = flattenVerifiedAccessLogS3(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenVerifiedAccessLogCloudWatchLogs(apiObject *types.VerifiedAccessLogCloudWatchLogsDestination) []interface{} {
-	tfMap := map[string]interface{}{
+func flattenVerifiedAccessLogCloudWatchLogs(apiObject *types.VerifiedAccessLogCloudWatchLogsDestination) []any {
+	tfMap := map[string]any{
 		names.AttrEnabled: apiObject.Enabled,
 	}
 
@@ -410,11 +410,11 @@ func flattenVerifiedAccessLogCloudWatchLogs(apiObject *types.VerifiedAccessLogCl
 		tfMap["log_group"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenVerifiedAccessLogKinesisDataFirehose(apiObject *types.VerifiedAccessLogKinesisDataFirehoseDestination) []interface{} {
-	tfMap := map[string]interface{}{
+func flattenVerifiedAccessLogKinesisDataFirehose(apiObject *types.VerifiedAccessLogKinesisDataFirehoseDestination) []any {
+	tfMap := map[string]any{
 		names.AttrEnabled: apiObject.Enabled,
 	}
 
@@ -422,11 +422,11 @@ func flattenVerifiedAccessLogKinesisDataFirehose(apiObject *types.VerifiedAccess
 		tfMap["delivery_stream"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenVerifiedAccessLogS3(apiObject *types.VerifiedAccessLogS3Destination) []interface{} {
-	tfMap := map[string]interface{}{
+func flattenVerifiedAccessLogS3(apiObject *types.VerifiedAccessLogS3Destination) []any {
+	tfMap := map[string]any{
 		names.AttrEnabled: apiObject.Enabled,
 	}
 
@@ -442,5 +442,5 @@ func flattenVerifiedAccessLogS3(apiObject *types.VerifiedAccessLogS3Destination)
 		tfMap[names.AttrPrefix] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/ec2/verifiedaccess_instance_trust_provider_attachment.go
+++ b/internal/service/ec2/verifiedaccess_instance_trust_provider_attachment.go
@@ -46,7 +46,7 @@ func resourceVerifiedAccessInstanceTrustProviderAttachment() *schema.Resource {
 	}
 }
 
-func resourceVerifiedAccessInstanceTrustProviderAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceTrustProviderAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -70,7 +70,7 @@ func resourceVerifiedAccessInstanceTrustProviderAttachmentCreate(ctx context.Con
 	return append(diags, resourceVerifiedAccessInstanceTrustProviderAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessInstanceTrustProviderAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceTrustProviderAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -97,7 +97,7 @@ func resourceVerifiedAccessInstanceTrustProviderAttachmentRead(ctx context.Conte
 	return diags
 }
 
-func resourceVerifiedAccessInstanceTrustProviderAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessInstanceTrustProviderAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/verifiedaccess_trust_provider.go
+++ b/internal/service/ec2/verifiedaccess_trust_provider.go
@@ -139,7 +139,7 @@ func resourceVerifiedAccessTrustProvider() *schema.Resource {
 	}
 }
 
-func resourceVerifiedAccessTrustProviderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessTrustProviderCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -154,16 +154,16 @@ func resourceVerifiedAccessTrustProviderCreate(ctx context.Context, d *schema.Re
 		input.Description = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("device_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DeviceOptions = expandCreateVerifiedAccessTrustProviderDeviceOptions(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("device_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DeviceOptions = expandCreateVerifiedAccessTrustProviderDeviceOptions(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("device_trust_provider_type"); ok {
 		input.DeviceTrustProviderType = types.DeviceTrustProviderType(v.(string))
 	}
 
-	if v, ok := d.GetOk("oidc_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.OidcOptions = expandCreateVerifiedAccessTrustProviderOIDCOptions(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("oidc_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.OidcOptions = expandCreateVerifiedAccessTrustProviderOIDCOptions(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("user_trust_provider_type"); ok {
@@ -181,7 +181,7 @@ func resourceVerifiedAccessTrustProviderCreate(ctx context.Context, d *schema.Re
 	return append(diags, resourceVerifiedAccessTrustProviderRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessTrustProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessTrustProviderRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -222,7 +222,7 @@ func resourceVerifiedAccessTrustProviderRead(ctx context.Context, d *schema.Reso
 	return diags
 }
 
-func resourceVerifiedAccessTrustProviderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessTrustProviderUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -237,8 +237,8 @@ func resourceVerifiedAccessTrustProviderUpdate(ctx context.Context, d *schema.Re
 		}
 
 		if d.HasChange("oidc_options") {
-			if v, ok := d.GetOk("oidc_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.OidcOptions = expandModifyVerifiedAccessTrustProviderOIDCOptions(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("oidc_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.OidcOptions = expandModifyVerifiedAccessTrustProviderOIDCOptions(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -252,7 +252,7 @@ func resourceVerifiedAccessTrustProviderUpdate(ctx context.Context, d *schema.Re
 	return append(diags, resourceVerifiedAccessTrustProviderRead(ctx, d, meta)...)
 }
 
-func resourceVerifiedAccessTrustProviderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVerifiedAccessTrustProviderDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -274,26 +274,26 @@ func resourceVerifiedAccessTrustProviderDelete(ctx context.Context, d *schema.Re
 	return diags
 }
 
-func flattenDeviceOptions(apiObject *types.DeviceOptions) []interface{} {
+func flattenDeviceOptions(apiObject *types.DeviceOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.TenantId; v != nil {
 		tfMap["tenant_id"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenOIDCOptions(apiObject *types.OidcOptions, clientSecret string) []interface{} {
+func flattenOIDCOptions(apiObject *types.OidcOptions, clientSecret string) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrClientSecret: clientSecret,
 	}
 
@@ -316,10 +316,10 @@ func flattenOIDCOptions(apiObject *types.OidcOptions, clientSecret string) []int
 		tfMap["user_info_endpoint"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandCreateVerifiedAccessTrustProviderDeviceOptions(tfMap map[string]interface{}) *types.CreateVerifiedAccessTrustProviderDeviceOptions {
+func expandCreateVerifiedAccessTrustProviderDeviceOptions(tfMap map[string]any) *types.CreateVerifiedAccessTrustProviderDeviceOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -333,7 +333,7 @@ func expandCreateVerifiedAccessTrustProviderDeviceOptions(tfMap map[string]inter
 	return apiObject
 }
 
-func expandCreateVerifiedAccessTrustProviderOIDCOptions(tfMap map[string]interface{}) *types.CreateVerifiedAccessTrustProviderOidcOptions {
+func expandCreateVerifiedAccessTrustProviderOIDCOptions(tfMap map[string]any) *types.CreateVerifiedAccessTrustProviderOidcOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -365,7 +365,7 @@ func expandCreateVerifiedAccessTrustProviderOIDCOptions(tfMap map[string]interfa
 	return apiObject
 }
 
-func expandModifyVerifiedAccessTrustProviderOIDCOptions(tfMap map[string]interface{}) *types.ModifyVerifiedAccessTrustProviderOidcOptions {
+func expandModifyVerifiedAccessTrustProviderOIDCOptions(tfMap map[string]any) *types.ModifyVerifiedAccessTrustProviderOidcOptions {
 	if tfMap == nil {
 		return nil
 	}

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -183,7 +183,7 @@ func resourceVPC() *schema.Resource {
 	}
 }
 
-func resourceVPCCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -222,7 +222,7 @@ func resourceVPCCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	// "UnsupportedOperation: The operation AllocateIpamPoolCidr is not supported. Account 123456789012 is not monitored by IPAM ipam-07b079e3392782a55."
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, ec2PropagationTimeout, func() (any, error) {
 		return conn.CreateVpc(ctx, input)
 	}, errCodeUnsupportedOperation, "is not monitored by IPAM")
 
@@ -262,11 +262,11 @@ func resourceVPCCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return append(diags, resourceVPCRead(ctx, d, meta)...)
 }
 
-func resourceVPCRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findVPCByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -296,7 +296,7 @@ func resourceVPCRead(ctx context.Context, d *schema.ResourceData, meta interface
 	d.Set("instance_tenancy", vpc.InstanceTenancy)
 	d.Set(names.AttrOwnerID, ownerID)
 
-	if v, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	if v, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findVPCAttribute(ctx, conn, d.Id(), types.VpcAttributeNameEnableDnsHostnames)
 	}, d.IsNewResource()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC (%s) Attribute (%s): %s", d.Id(), types.VpcAttributeNameEnableDnsHostnames, err)
@@ -304,7 +304,7 @@ func resourceVPCRead(ctx context.Context, d *schema.ResourceData, meta interface
 		d.Set("enable_dns_hostnames", v)
 	}
 
-	if v, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	if v, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findVPCAttribute(ctx, conn, d.Id(), types.VpcAttributeNameEnableDnsSupport)
 	}, d.IsNewResource()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC (%s) Attribute (%s): %s", d.Id(), types.VpcAttributeNameEnableDnsSupport, err)
@@ -312,7 +312,7 @@ func resourceVPCRead(ctx context.Context, d *schema.ResourceData, meta interface
 		d.Set("enable_dns_support", v)
 	}
 
-	if v, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	if v, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findVPCAttribute(ctx, conn, d.Id(), types.VpcAttributeNameEnableNetworkAddressUsageMetrics)
 	}, d.IsNewResource()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC (%s) Attribute (%s): %s", d.Id(), types.VpcAttributeNameEnableNetworkAddressUsageMetrics, err)
@@ -386,7 +386,7 @@ func resourceVPCRead(ctx context.Context, d *schema.ResourceData, meta interface
 	return diags
 }
 
-func resourceVPCUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -449,7 +449,7 @@ func resourceVPCUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return append(diags, resourceVPCRead(ctx, d, meta)...)
 }
 
-func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -458,7 +458,7 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	log.Printf("[INFO] Deleting EC2 VPC: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return conn.DeleteVpc(ctx, input)
 	}, errCodeDependencyViolation)
 
@@ -470,7 +470,7 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		return sdkdiag.AppendErrorf(diags, "deleting EC2 VPC (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return findVPCByID(ctx, conn, d.Id())
 	})
 
@@ -492,7 +492,7 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		const (
 			timeout = 35 * time.Minute // IPAM eventual consistency. It can take ~30 min to release allocations.
 		)
-		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (interface{}, error) {
+		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
 			return findIPAMPoolAllocationsForVPC(ctx, conn, ipamPoolID, d.Id())
 		})
 
@@ -504,12 +504,12 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceVPCImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVPCImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	d.Set("assign_generated_ipv6_cidr_block", false)
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceVPCCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func resourceVPCCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if diff.HasChange("assign_generated_ipv6_cidr_block") {
 		if err := diff.SetNewComputed("ipv6_association_id"); err != nil {
 			return fmt.Errorf("setting ipv6_association_id to computed: %s", err)

--- a/internal/service/ec2/vpc_data_source.go
+++ b/internal/service/ec2/vpc_data_source.go
@@ -121,7 +121,7 @@ func dataSourceVPC() *schema.Resource {
 	}
 }
 
-func dataSourceVPCRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVPCRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -205,9 +205,9 @@ func dataSourceVPCRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		d.Set("main_route_table_id", v.RouteTableId)
 	}
 
-	cidrAssociations := []interface{}{}
+	cidrAssociations := []any{}
 	for _, v := range vpc.CidrBlockAssociationSet {
-		association := map[string]interface{}{
+		association := map[string]any{
 			names.AttrAssociationID: aws.ToString(v.AssociationId),
 			names.AttrCIDRBlock:     aws.ToString(v.CidrBlock),
 			names.AttrState:         aws.ToString(aws.String(string(v.CidrBlockState.State))),

--- a/internal/service/ec2/vpc_default_network_acl.go
+++ b/internal/service/ec2/vpc_default_network_acl.go
@@ -35,7 +35,7 @@ func resourceDefaultNetworkACL() *schema.Resource {
 		DeleteWithoutTimeout: schema.NoopContext,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set("default_network_acl_id", d.Id())
 
 				return []*schema.ResourceData{d}, nil
@@ -98,7 +98,7 @@ func resourceDefaultNetworkACL() *schema.Resource {
 	}
 }
 
-func resourceDefaultNetworkACLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { // nosemgrep:ci.semgrep.tags.calling-UpdateTags-in-resource-create
+func resourceDefaultNetworkACLCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics { // nosemgrep:ci.semgrep.tags.calling-UpdateTags-in-resource-create
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -138,7 +138,7 @@ func resourceDefaultNetworkACLCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceNetworkACLRead(ctx, d, meta)...)
 }
 
-func resourceDefaultNetworkACLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDefaultNetworkACLUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_default_route_table.go
+++ b/internal/service/ec2/vpc_default_route_table.go
@@ -141,7 +141,7 @@ func resourceDefaultRouteTable() *schema.Resource {
 	}
 }
 
-func resourceDefaultRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDefaultRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -228,7 +228,7 @@ func resourceDefaultRouteTableCreate(ctx context.Context, d *schema.ResourceData
 	// Add new routes.
 	if v, ok := d.GetOk("route"); ok && v.(*schema.Set).Len() > 0 {
 		for _, v := range v.(*schema.Set).List() {
-			v := v.(map[string]interface{})
+			v := v.(map[string]any)
 
 			if err := routeTableAddRoute(ctx, conn, d.Id(), v, d.Timeout(schema.TimeoutCreate)); err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
@@ -243,7 +243,7 @@ func resourceDefaultRouteTableCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceDefaultRouteTableRead(ctx, d, meta)...)
 }
 
-func resourceDefaultRouteTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDefaultRouteTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	d.Set("default_route_table_id", d.Id())
 
 	// Re-use regular AWS Route Table READ.
@@ -251,7 +251,7 @@ func resourceDefaultRouteTableRead(ctx context.Context, d *schema.ResourceData, 
 	return resourceRouteTableRead(ctx, d, meta) // nosemgrep:ci.semgrep.pluginsdk.append-Read-to-diags
 }
 
-func resourceDefaultRouteTableImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDefaultRouteTableImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	routeTable, err := findMainRouteTableByVPCID(ctx, conn, d.Id())

--- a/internal/service/ec2/vpc_default_security_group.go
+++ b/internal/service/ec2/vpc_default_security_group.go
@@ -79,7 +79,7 @@ func resourceDefaultSecurityGroup() *schema.Resource {
 	}
 }
 
-func resourceDefaultSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { // nosemgrep:ci.semgrep.tags.calling-UpdateTags-in-resource-create
+func resourceDefaultSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics { // nosemgrep:ci.semgrep.tags.calling-UpdateTags-in-resource-create
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)

--- a/internal/service/ec2/vpc_default_subnet.go
+++ b/internal/service/ec2/vpc_default_subnet.go
@@ -163,7 +163,7 @@ func resourceDefaultSubnet() *schema.Resource {
 	}
 }
 
-func resourceDefaultSubnetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { // nosemgrep:ci.semgrep.tags.calling-UpdateTags-in-resource-create
+func resourceDefaultSubnetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics { // nosemgrep:ci.semgrep.tags.calling-UpdateTags-in-resource-create
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -253,7 +253,7 @@ func resourceDefaultSubnetCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceSubnetRead(ctx, d, meta)...)
 }
 
-func resourceDefaultSubnetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDefaultSubnetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if d.Get(names.AttrForceDestroy).(bool) {
 		return append(diags, resourceSubnetDelete(ctx, d, meta)...)

--- a/internal/service/ec2/vpc_default_vpc.go
+++ b/internal/service/ec2/vpc_default_vpc.go
@@ -149,7 +149,7 @@ func resourceDefaultVPC() *schema.Resource {
 	}
 }
 
-func resourceDefaultVPCCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { // nosemgrep:ci.semgrep.tags.calling-UpdateTags-in-resource-create
+func resourceDefaultVPCCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics { // nosemgrep:ci.semgrep.tags.calling-UpdateTags-in-resource-create
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -279,7 +279,7 @@ func resourceDefaultVPCCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceVPCRead(ctx, d, meta)...)
 }
 
-func resourceDefaultVPCDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDefaultVPCDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if d.Get(names.AttrForceDestroy).(bool) {
 		return append(diags, resourceVPCDelete(ctx, d, meta)...)

--- a/internal/service/ec2/vpc_default_vpc_dhcp_options.go
+++ b/internal/service/ec2/vpc_default_vpc_dhcp_options.go
@@ -79,7 +79,7 @@ func resourceDefaultVPCDHCPOptions() *schema.Resource {
 	}
 }
 
-func resourceDefaultVPCDHCPOptionsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDefaultVPCDHCPOptionsCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_dhcp_options.go
+++ b/internal/service/ec2/vpc_dhcp_options.go
@@ -103,7 +103,7 @@ var (
 	})
 )
 
-func resourceVPCDHCPOptionsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCDHCPOptionsCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -129,11 +129,11 @@ func resourceVPCDHCPOptionsCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceVPCDHCPOptionsRead(ctx, d, meta)...)
 }
 
-func resourceVPCDHCPOptionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCDHCPOptionsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findDHCPOptionsByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -171,7 +171,7 @@ func resourceVPCDHCPOptionsRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceVPCDHCPOptionsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCDHCPOptionsUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -179,7 +179,7 @@ func resourceVPCDHCPOptionsUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceVPCDHCPOptionsRead(ctx, d, meta)...)
 }
 
-func resourceVPCDHCPOptionsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCDHCPOptionsDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -217,7 +217,7 @@ func resourceVPCDHCPOptionsDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	log.Printf("[INFO] Deleting EC2 DHCP Options Set: %s", d.Id())
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return conn.DeleteDhcpOptions(ctx, input)
 	}, errCodeDependencyViolation)
 
@@ -270,7 +270,7 @@ func (m *dhcpOptionsMap) dhcpConfigurationsToResourceData(dhcpConfigurations []a
 		switch currentValue.(type) {
 		case string:
 			d.Set(tfName, dhcpConfiguration.Values[0].Value)
-		case []interface{}:
+		case []any:
 			var values []string
 			for _, v := range dhcpConfiguration.Values {
 				if v.Value != nil {
@@ -300,7 +300,7 @@ func (m *dhcpOptionsMap) resourceDataToDHCPConfigurations(d *schema.ResourceData
 					Values: []string{v},
 				})
 			}
-		case []interface{}:
+		case []any:
 			var values []string
 			for _, item := range v {
 				if str, ok := item.(string); ok && str != "" {

--- a/internal/service/ec2/vpc_dhcp_options_association.go
+++ b/internal/service/ec2/vpc_dhcp_options_association.go
@@ -46,7 +46,7 @@ func resourceVPCDHCPOptionsAssociation() *schema.Resource {
 	}
 }
 
-func resourceVPCDHCPOptionsAssociationPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCDHCPOptionsAssociationPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -70,7 +70,7 @@ func resourceVPCDHCPOptionsAssociationPut(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceVPCDHCPOptionsAssociationRead(ctx, d, meta)...)
 }
 
-func resourceVPCDHCPOptionsAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCDHCPOptionsAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -80,7 +80,7 @@ func resourceVPCDHCPOptionsAssociationRead(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "reading EC2 VPC DHCP Options Set Association (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return nil, findVPCDHCPOptionsAssociation(ctx, conn, vpcID, dhcpOptionsID)
 	}, d.IsNewResource())
 
@@ -100,7 +100,7 @@ func resourceVPCDHCPOptionsAssociationRead(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceVPCDHCPOptionsAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCDHCPOptionsAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -135,7 +135,7 @@ func resourceVPCDHCPOptionsAssociationDelete(ctx context.Context, d *schema.Reso
 	return diags
 }
 
-func resourceVPCDHCPOptionsAssociationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVPCDHCPOptionsAssociationImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	vpc, err := findVPCByID(ctx, conn, d.Id())

--- a/internal/service/ec2/vpc_dhcp_options_data_source.go
+++ b/internal/service/ec2/vpc_dhcp_options_data_source.go
@@ -76,7 +76,7 @@ func dataSourceVPCDHCPOptions() *schema.Resource {
 	}
 }
 
-func dataSourceVPCDHCPOptionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVPCDHCPOptionsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)

--- a/internal/service/ec2/vpc_egress_only_internet_gateway.go
+++ b/internal/service/ec2/vpc_egress_only_internet_gateway.go
@@ -47,7 +47,7 @@ func resourceEgressOnlyInternetGateway() *schema.Resource {
 	}
 }
 
-func resourceEgressOnlyInternetGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEgressOnlyInternetGatewayCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -68,11 +68,11 @@ func resourceEgressOnlyInternetGatewayCreate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceEgressOnlyInternetGatewayRead(ctx, d, meta)...)
 }
 
-func resourceEgressOnlyInternetGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEgressOnlyInternetGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findEgressOnlyInternetGatewayByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -99,7 +99,7 @@ func resourceEgressOnlyInternetGatewayRead(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceEgressOnlyInternetGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEgressOnlyInternetGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -107,7 +107,7 @@ func resourceEgressOnlyInternetGatewayUpdate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceEgressOnlyInternetGatewayRead(ctx, d, meta)...)
 }
 
-func resourceEgressOnlyInternetGatewayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEgressOnlyInternetGatewayDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_endpoint.go
+++ b/internal/service/ec2/vpc_endpoint.go
@@ -124,7 +124,7 @@ func resourceVPCEndpoint() *schema.Resource {
 				ValidateFunc:          validation.StringIsJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -236,7 +236,7 @@ func resourceVPCEndpoint() *schema.Resource {
 	}
 }
 
-func resourceVPCEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -250,13 +250,13 @@ func resourceVPCEndpointCreate(ctx context.Context, d *schema.ResourceData, meta
 		VpcId:             aws.String(d.Get(names.AttrVPCID).(string)),
 	}
 
-	if v, ok := d.GetOk("dns_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+	if v, ok := d.GetOk("dns_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		// PrivateDnsOnlyForInboundResolverEndpoint is only supported for services
 		// that support both gateway and interface endpoints, i.e. S3.
 		if isAmazonS3VPCEndpoint(serviceName) {
-			input.DnsOptions = expandDNSOptionsSpecificationWithPrivateDNSOnly(v.([]interface{})[0].(map[string]interface{}))
+			input.DnsOptions = expandDNSOptionsSpecificationWithPrivateDNSOnly(v.([]any)[0].(map[string]any))
 		} else {
-			input.DnsOptions = expandDNSOptionsSpecification(v.([]interface{})[0].(map[string]interface{}))
+			input.DnsOptions = expandDNSOptionsSpecification(v.([]any)[0].(map[string]any))
 		}
 	}
 
@@ -336,7 +336,7 @@ func resourceVPCEndpointCreate(ctx context.Context, d *schema.ResourceData, meta
 		err := createTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceVPCEndpointRead(ctx, d, meta)...)
 		}
 
@@ -348,7 +348,7 @@ func resourceVPCEndpointCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceVPCEndpointRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -370,7 +370,7 @@ func resourceVPCEndpointRead(ctx context.Context, d *schema.ResourceData, meta i
 		return sdkdiag.AppendErrorf(diags, "setting dns_entry: %s", err)
 	}
 	if vpce.DnsOptions != nil {
-		if err := d.Set("dns_options", []interface{}{flattenDNSOptions(vpce.DnsOptions)}); err != nil {
+		if err := d.Set("dns_options", []any{flattenDNSOptions(vpce.DnsOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting dns_options: %s", err)
 		}
 	} else {
@@ -445,7 +445,7 @@ func resourceVPCEndpointRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceVPCEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -461,8 +461,8 @@ func resourceVPCEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		if d.HasChange("dns_options") {
-			if v, ok := d.GetOk("dns_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				tfMap := v.([]interface{})[0].(map[string]interface{})
+			if v, ok := d.GetOk("dns_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				tfMap := v.([]any)[0].(map[string]any)
 				// PrivateDnsOnlyForInboundResolverEndpoint is only supported for services
 				// that support both gateway and interface endpoints, i.e. S3.
 				if isAmazonS3VPCEndpoint(d.Get(names.AttrServiceName).(string)) {
@@ -524,7 +524,7 @@ func resourceVPCEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceVPCEndpointRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -609,7 +609,7 @@ func isAmazonS3VPCEndpoint(serviceName string) bool {
 	return ok
 }
 
-func expandDNSOptionsSpecification(tfMap map[string]interface{}) *awstypes.DnsOptionsSpecification {
+func expandDNSOptionsSpecification(tfMap map[string]any) *awstypes.DnsOptionsSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -623,7 +623,7 @@ func expandDNSOptionsSpecification(tfMap map[string]interface{}) *awstypes.DnsOp
 	return apiObject
 }
 
-func expandDNSOptionsSpecificationWithPrivateDNSOnly(tfMap map[string]interface{}) *awstypes.DnsOptionsSpecification {
+func expandDNSOptionsSpecificationWithPrivateDNSOnly(tfMap map[string]any) *awstypes.DnsOptionsSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -641,7 +641,7 @@ func expandDNSOptionsSpecificationWithPrivateDNSOnly(tfMap map[string]interface{
 	return apiObject
 }
 
-func expandSubnetConfiguration(tfMap map[string]interface{}) *awstypes.SubnetConfiguration {
+func expandSubnetConfiguration(tfMap map[string]any) *awstypes.SubnetConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -663,7 +663,7 @@ func expandSubnetConfiguration(tfMap map[string]interface{}) *awstypes.SubnetCon
 	return apiObject
 }
 
-func expandSubnetConfigurations(tfList []interface{}) []awstypes.SubnetConfiguration {
+func expandSubnetConfigurations(tfList []any) []awstypes.SubnetConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -671,7 +671,7 @@ func expandSubnetConfigurations(tfList []interface{}) []awstypes.SubnetConfigura
 	var apiObjects []awstypes.SubnetConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -689,12 +689,12 @@ func expandSubnetConfigurations(tfList []interface{}) []awstypes.SubnetConfigura
 	return apiObjects
 }
 
-func flattenDNSEntry(apiObject *awstypes.DnsEntry) map[string]interface{} {
+func flattenDNSEntry(apiObject *awstypes.DnsEntry) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.DnsName; v != nil {
 		tfMap[names.AttrDNSName] = aws.ToString(v)
@@ -707,12 +707,12 @@ func flattenDNSEntry(apiObject *awstypes.DnsEntry) map[string]interface{} {
 	return tfMap
 }
 
-func flattenDNSEntries(apiObjects []awstypes.DnsEntry) []interface{} {
+func flattenDNSEntries(apiObjects []awstypes.DnsEntry) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenDNSEntry(&apiObject))
@@ -721,12 +721,12 @@ func flattenDNSEntries(apiObjects []awstypes.DnsEntry) []interface{} {
 	return tfList
 }
 
-func flattenDNSOptions(apiObject *awstypes.DnsOptions) map[string]interface{} {
+func flattenDNSOptions(apiObject *awstypes.DnsOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"dns_record_ip_type": string(apiObject.DnsRecordIpType),
 	}
 
@@ -773,12 +773,12 @@ func flattenAddAndRemoveStringValueLists(d *schema.ResourceData, key string) ([]
 	return add, del
 }
 
-func flattenSubnetConfiguration(apiObject *subnetConfiguration) map[string]interface{} {
+func flattenSubnetConfiguration(apiObject *subnetConfiguration) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ipv4; v != nil {
 		tfMap["ipv4"] = aws.ToString(v)
@@ -795,12 +795,12 @@ func flattenSubnetConfiguration(apiObject *subnetConfiguration) map[string]inter
 	return tfMap
 }
 
-func flattenSubnetConfigurations(apiObjects []subnetConfiguration) []interface{} {
+func flattenSubnetConfigurations(apiObjects []subnetConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenSubnetConfiguration(&apiObject))

--- a/internal/service/ec2/vpc_endpoint_connection_accepter.go
+++ b/internal/service/ec2/vpc_endpoint_connection_accepter.go
@@ -50,7 +50,7 @@ func resourceVPCEndpointConnectionAccepter() *schema.Resource {
 	}
 }
 
-func resourceVPCEndpointConnectionAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointConnectionAccepterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -77,7 +77,7 @@ func resourceVPCEndpointConnectionAccepterCreate(ctx context.Context, d *schema.
 	return append(diags, resourceVPCEndpointConnectionAccepterRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointConnectionAccepterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointConnectionAccepterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -105,7 +105,7 @@ func resourceVPCEndpointConnectionAccepterRead(ctx context.Context, d *schema.Re
 	return diags
 }
 
-func resourceVPCEndpointConnectionAccepterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointConnectionAccepterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_endpoint_connection_notification.go
+++ b/internal/service/ec2/vpc_endpoint_connection_notification.go
@@ -69,7 +69,7 @@ func resourceVPCEndpointConnectionNotification() *schema.Resource {
 	}
 }
 
-func resourceVPCEndpointConnectionNotificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointConnectionNotificationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -98,7 +98,7 @@ func resourceVPCEndpointConnectionNotificationCreate(ctx context.Context, d *sch
 	return append(diags, resourceVPCEndpointConnectionNotificationRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointConnectionNotificationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointConnectionNotificationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -124,7 +124,7 @@ func resourceVPCEndpointConnectionNotificationRead(ctx context.Context, d *schem
 	return diags
 }
 
-func resourceVPCEndpointConnectionNotificationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointConnectionNotificationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -149,7 +149,7 @@ func resourceVPCEndpointConnectionNotificationUpdate(ctx context.Context, d *sch
 	return append(diags, resourceVPCEndpointConnectionNotificationRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointConnectionNotificationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointConnectionNotificationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_endpoint_data_source.go
+++ b/internal/service/ec2/vpc_endpoint_data_source.go
@@ -145,7 +145,7 @@ func dataSourceVPCEndpoint() *schema.Resource {
 	}
 }
 
-func dataSourceVPCEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVPCEndpointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
@@ -165,7 +165,7 @@ func dataSourceVPCEndpointRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 	input.Filters = append(input.Filters, newCustomFilterList(
 		d.Get(names.AttrFilter).(*schema.Set),
@@ -189,7 +189,7 @@ func dataSourceVPCEndpointRead(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "setting dns_entry: %s", err)
 	}
 	if vpce.DnsOptions != nil {
-		if err := d.Set("dns_options", []interface{}{flattenDNSOptions(vpce.DnsOptions)}); err != nil {
+		if err := d.Set("dns_options", []any{flattenDNSOptions(vpce.DnsOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting dns_options: %s", err)
 		}
 	} else {

--- a/internal/service/ec2/vpc_endpoint_policy.go
+++ b/internal/service/ec2/vpc_endpoint_policy.go
@@ -41,7 +41,7 @@ func resourceVPCEndpointPolicy() *schema.Resource {
 				ValidateFunc:          validation.StringIsJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -60,7 +60,7 @@ func resourceVPCEndpointPolicy() *schema.Resource {
 	}
 }
 
-func resourceVPCEndpointPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointPolicyPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -95,7 +95,7 @@ func resourceVPCEndpointPolicyPut(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceVPCEndpointPolicyRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -129,7 +129,7 @@ func resourceVPCEndpointPolicyRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceVPCEndpointPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_endpoint_route_table_association.go
+++ b/internal/service/ec2/vpc_endpoint_route_table_association.go
@@ -45,7 +45,7 @@ func resourceVPCEndpointRouteTableAssociation() *schema.Resource {
 	}
 }
 
-func resourceVPCEndpointRouteTableAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointRouteTableAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -76,7 +76,7 @@ func resourceVPCEndpointRouteTableAssociationCreate(ctx context.Context, d *sche
 	return append(diags, resourceVPCEndpointRouteTableAssociationRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointRouteTableAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointRouteTableAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -85,7 +85,7 @@ func resourceVPCEndpointRouteTableAssociationRead(ctx context.Context, d *schema
 	// Human friendly ID for error messages since d.Id() is non-descriptive
 	id := fmt.Sprintf("%s/%s", endpointID, routeTableID)
 
-	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return nil, findVPCEndpointRouteTableAssociationExists(ctx, conn, endpointID, routeTableID)
 	}, d.IsNewResource())
 
@@ -102,7 +102,7 @@ func resourceVPCEndpointRouteTableAssociationRead(ctx context.Context, d *schema
 	return diags
 }
 
-func resourceVPCEndpointRouteTableAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointRouteTableAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -136,7 +136,7 @@ func resourceVPCEndpointRouteTableAssociationDelete(ctx context.Context, d *sche
 	return diags
 }
 
-func resourceVPCEndpointRouteTableAssociationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVPCEndpointRouteTableAssociationImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("wrong format of import ID (%s), use: 'vpc-endpoint-id/route-table-id'", d.Id())

--- a/internal/service/ec2/vpc_endpoint_security_group_association.go
+++ b/internal/service/ec2/vpc_endpoint_security_group_association.go
@@ -51,7 +51,7 @@ func resourceVPCEndpointSecurityGroupAssociation() *schema.Resource {
 	}
 }
 
-func resourceVPCEndpointSecurityGroupAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointSecurityGroupAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -113,7 +113,7 @@ func resourceVPCEndpointSecurityGroupAssociationCreate(ctx context.Context, d *s
 	return append(diags, resourceVPCEndpointSecurityGroupAssociationRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointSecurityGroupAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointSecurityGroupAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -137,7 +137,7 @@ func resourceVPCEndpointSecurityGroupAssociationRead(ctx context.Context, d *sch
 	return diags
 }
 
-func resourceVPCEndpointSecurityGroupAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointSecurityGroupAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -212,7 +212,7 @@ func deleteVPCEndpointSecurityGroupAssociation(ctx context.Context, conn *ec2.Cl
 	return nil
 }
 
-func resourceVPCEndpointSecurityGroupAssociationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVPCEndpointSecurityGroupAssociationImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("wrong format of import ID (%s), use: 'vpc-endpoint-id/security-group-id'", d.Id())

--- a/internal/service/ec2/vpc_endpoint_service.go
+++ b/internal/service/ec2/vpc_endpoint_service.go
@@ -159,7 +159,7 @@ func resourceVPCEndpointService() *schema.Resource {
 	}
 }
 
-func resourceVPCEndpointServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointServiceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -215,7 +215,7 @@ func resourceVPCEndpointServiceCreate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceVPCEndpointServiceRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointServiceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -248,7 +248,7 @@ func resourceVPCEndpointServiceRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("private_dns_name", svcCfg.PrivateDnsName)
 	// The EC2 API can return a XML structure with no elements.
 	if tfMap := flattenPrivateDNSNameConfiguration(svcCfg.PrivateDnsNameConfiguration); len(tfMap) > 0 {
-		if err := d.Set("private_dns_name_configuration", []interface{}{tfMap}); err != nil {
+		if err := d.Set("private_dns_name_configuration", []any{tfMap}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting private_dns_name_configuration: %s", err)
 		}
 	} else {
@@ -277,7 +277,7 @@ func resourceVPCEndpointServiceRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceVPCEndpointServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -326,7 +326,7 @@ func resourceVPCEndpointServiceUpdate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceVPCEndpointServiceRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointServiceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -365,12 +365,12 @@ func flattenAllowedPrincipals(apiObjects []awstypes.AllowedPrincipal) []string {
 	})
 }
 
-func flattenPrivateDNSNameConfiguration(apiObject *awstypes.PrivateDnsNameConfiguration) map[string]interface{} {
+func flattenPrivateDNSNameConfiguration(apiObject *awstypes.PrivateDnsNameConfiguration) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Name; v != nil {
 		tfMap[names.AttrName] = aws.ToString(v)

--- a/internal/service/ec2/vpc_endpoint_service_allowed_principal.go
+++ b/internal/service/ec2/vpc_endpoint_service_allowed_principal.go
@@ -39,7 +39,7 @@ func resourceVPCEndpointServiceAllowedPrincipal() *schema.Resource {
 	}
 }
 
-func resourceVPCEndpointServiceAllowedPrincipalCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointServiceAllowedPrincipalCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -65,7 +65,7 @@ func resourceVPCEndpointServiceAllowedPrincipalCreate(ctx context.Context, d *sc
 	return append(diags, resourceVPCEndpointServiceAllowedPrincipalRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointServiceAllowedPrincipalRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointServiceAllowedPrincipalRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -89,7 +89,7 @@ func resourceVPCEndpointServiceAllowedPrincipalRead(ctx context.Context, d *sche
 	return diags
 }
 
-func resourceVPCEndpointServiceAllowedPrincipalDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointServiceAllowedPrincipalDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_endpoint_service_data_source.go
+++ b/internal/service/ec2/vpc_endpoint_service_data_source.go
@@ -114,7 +114,7 @@ func dataSourceVPCEndpointService() *schema.Resource {
 	}
 }
 
-func dataSourceVPCEndpointServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVPCEndpointServiceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
@@ -145,7 +145,7 @@ func dataSourceVPCEndpointServiceRead(ctx context.Context, d *schema.ResourceDat
 
 	if v, ok := d.GetOk(names.AttrTags); ok {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, v.(map[string]interface{}))))...)
+			Tags(tftags.New(ctx, v.(map[string]any))))...)
 	}
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/vpc_endpoint_subnet_association.go
+++ b/internal/service/ec2/vpc_endpoint_subnet_association.go
@@ -52,7 +52,7 @@ func resourceVPCEndpointSubnetAssociation() *schema.Resource {
 	}
 }
 
-func resourceVPCEndpointSubnetAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointSubnetAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -78,7 +78,7 @@ func resourceVPCEndpointSubnetAssociationCreate(ctx context.Context, d *schema.R
 		Delay:   1 * time.Minute,
 		Timeout: 3 * time.Minute,
 		Target:  []string{"ok"},
-		Refresh: func() (interface{}, string, error) {
+		Refresh: func() (any, string, error) {
 			output, err := conn.ModifyVpcEndpoint(ctx, input)
 
 			return output, "ok", err
@@ -101,7 +101,7 @@ func resourceVPCEndpointSubnetAssociationCreate(ctx context.Context, d *schema.R
 	return append(diags, resourceVPCEndpointSubnetAssociationRead(ctx, d, meta)...)
 }
 
-func resourceVPCEndpointSubnetAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointSubnetAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -125,7 +125,7 @@ func resourceVPCEndpointSubnetAssociationRead(ctx context.Context, d *schema.Res
 	return diags
 }
 
-func resourceVPCEndpointSubnetAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCEndpointSubnetAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -159,7 +159,7 @@ func resourceVPCEndpointSubnetAssociationDelete(ctx context.Context, d *schema.R
 	return diags
 }
 
-func resourceVPCEndpointSubnetAssociationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVPCEndpointSubnetAssociationImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("wrong format of import ID (%s), use: 'vpc-endpoint-id/subnet-id'", d.Id())

--- a/internal/service/ec2/vpc_flow_log.go
+++ b/internal/service/ec2/vpc_flow_log.go
@@ -166,7 +166,7 @@ func resourceFlowLog() *schema.Resource {
 	}
 }
 
-func resourceLogFlowCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLogFlowCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -218,8 +218,8 @@ func resourceLogFlowCreate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
-	if v, ok := d.GetOk("destination_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DestinationOptions = expandDestinationOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("destination_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DestinationOptions = expandDestinationOptionsRequest(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("deliver_cross_account_role"); ok {
@@ -246,7 +246,7 @@ func resourceLogFlowCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.MaxAggregationInterval = aws.Int32(int32(v.(int)))
 	}
 
-	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, iamPropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, iamPropagationTimeout, func() (any, error) {
 		return conn.CreateFlowLogs(ctx, input)
 	}, errCodeInvalidParameter, "Unable to assume given IAM role")
 
@@ -263,7 +263,7 @@ func resourceLogFlowCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceLogFlowRead(ctx, d, meta)...)
 }
 
-func resourceLogFlowRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLogFlowRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -289,7 +289,7 @@ func resourceLogFlowRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set(names.AttrARN, arn)
 	d.Set("deliver_cross_account_role", fl.DeliverCrossAccountRole)
 	if fl.DestinationOptions != nil {
-		if err := d.Set("destination_options", []interface{}{flattenDestinationOptionsResponse(fl.DestinationOptions)}); err != nil {
+		if err := d.Set("destination_options", []any{flattenDestinationOptionsResponse(fl.DestinationOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting destination_options: %s", err)
 		}
 	} else {
@@ -324,7 +324,7 @@ func resourceLogFlowRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceLogFlowUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLogFlowUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -332,7 +332,7 @@ func resourceLogFlowUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceLogFlowRead(ctx, d, meta)...)
 }
 
-func resourceLogFlowDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLogFlowDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -357,7 +357,7 @@ func resourceLogFlowDelete(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func expandDestinationOptionsRequest(tfMap map[string]interface{}) *awstypes.DestinationOptionsRequest {
+func expandDestinationOptionsRequest(tfMap map[string]any) *awstypes.DestinationOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -379,8 +379,8 @@ func expandDestinationOptionsRequest(tfMap map[string]interface{}) *awstypes.Des
 	return apiObject
 }
 
-func flattenDestinationOptionsResponse(apiObject *awstypes.DestinationOptionsResponse) map[string]interface{} {
-	tfMap := map[string]interface{}{
+func flattenDestinationOptionsResponse(apiObject *awstypes.DestinationOptionsResponse) map[string]any {
+	tfMap := map[string]any{
 		"file_format": apiObject.FileFormat,
 	}
 

--- a/internal/service/ec2/vpc_internet_gateway.go
+++ b/internal/service/ec2/vpc_internet_gateway.go
@@ -64,7 +64,7 @@ func resourceInternetGateway() *schema.Resource {
 	}
 }
 
-func resourceInternetGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInternetGatewayCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -90,11 +90,11 @@ func resourceInternetGatewayCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceInternetGatewayRead(ctx, d, meta)...)
 }
 
-func resourceInternetGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInternetGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findInternetGatewayByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -132,7 +132,7 @@ func resourceInternetGatewayRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceInternetGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInternetGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -155,7 +155,7 @@ func resourceInternetGatewayUpdate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceInternetGatewayRead(ctx, d, meta)...)
 }
 
-func resourceInternetGatewayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInternetGatewayDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -173,7 +173,7 @@ func resourceInternetGatewayDelete(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	log.Printf("[INFO] Deleting Internet Gateway: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return conn.DeleteInternetGateway(ctx, input)
 	}, errCodeDependencyViolation)
 
@@ -195,7 +195,7 @@ func attachInternetGateway(ctx context.Context, conn *ec2.Client, internetGatewa
 	}
 
 	log.Printf("[INFO] Attaching EC2 Internet Gateway: %#v", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
 		return conn.AttachInternetGateway(ctx, input)
 	}, errCodeInvalidInternetGatewayIDNotFound)
 
@@ -219,7 +219,7 @@ func detachInternetGateway(ctx context.Context, conn *ec2.Client, internetGatewa
 	}
 
 	log.Printf("[INFO] Detaching EC2 Internet Gateway: %#v", input)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
 		return conn.DetachInternetGateway(ctx, input)
 	}, errCodeDependencyViolation)
 

--- a/internal/service/ec2/vpc_internet_gateway_attachment.go
+++ b/internal/service/ec2/vpc_internet_gateway_attachment.go
@@ -50,7 +50,7 @@ func resourceInternetGatewayAttachment() *schema.Resource {
 	}
 }
 
-func resourceInternetGatewayAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInternetGatewayAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -66,7 +66,7 @@ func resourceInternetGatewayAttachmentCreate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceInternetGatewayAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceInternetGatewayAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInternetGatewayAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -76,7 +76,7 @@ func resourceInternetGatewayAttachmentRead(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findInternetGatewayAttachment(ctx, conn, igwID, vpcID)
 	}, d.IsNewResource())
 
@@ -98,7 +98,7 @@ func resourceInternetGatewayAttachmentRead(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceInternetGatewayAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInternetGatewayAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_internet_gateway_data_source.go
+++ b/internal/service/ec2/vpc_internet_gateway_data_source.go
@@ -66,7 +66,7 @@ func dataSourceInternetGateway() *schema.Resource {
 	}
 }
 
-func dataSourceInternetGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInternetGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
@@ -84,7 +84,7 @@ func dataSourceInternetGatewayRead(ctx context.Context, d *schema.ResourceData, 
 		"internet-gateway-id": internetGatewayId.(string),
 	})
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+		Tags(tftags.New(ctx, tags.(map[string]any))),
 	)...)
 	input.Filters = append(input.Filters, newCustomFilterList(
 		filter.(*schema.Set),
@@ -122,10 +122,10 @@ func dataSourceInternetGatewayRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func flattenInternetGatewayAttachments(igwAttachments []awstypes.InternetGatewayAttachment) []map[string]interface{} {
-	attachments := make([]map[string]interface{}, 0, len(igwAttachments))
+func flattenInternetGatewayAttachments(igwAttachments []awstypes.InternetGatewayAttachment) []map[string]any {
+	attachments := make([]map[string]any, 0, len(igwAttachments))
 	for _, a := range igwAttachments {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 		m[names.AttrState] = string(a.State)
 		m[names.AttrVPCID] = aws.ToString(a.VpcId)
 		attachments = append(attachments, m)

--- a/internal/service/ec2/vpc_ipv4_cidr_block_association.go
+++ b/internal/service/ec2/vpc_ipv4_cidr_block_association.go
@@ -31,7 +31,7 @@ func resourceVPCIPv4CIDRBlockAssociation() *schema.Resource {
 		DeleteWithoutTimeout: resourceVPCIPv4CIDRBlockAssociationDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				switch parts := strings.Split(d.Id(), ","); len(parts) {
 				case 1:
 					break
@@ -50,7 +50,7 @@ func resourceVPCIPv4CIDRBlockAssociation() *schema.Resource {
 			},
 		},
 
-		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, v any) error {
 			// cidr_block can be set by a value returned from IPAM or explicitly in config.
 			if diff.Id() != "" && diff.HasChange(names.AttrCIDRBlock) {
 				// If netmask is set then cidr_block is derived from IPAM, ignore changes.
@@ -95,7 +95,7 @@ func resourceVPCIPv4CIDRBlockAssociation() *schema.Resource {
 	}
 }
 
-func resourceVPCIPv4CIDRBlockAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCIPv4CIDRBlockAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -131,7 +131,7 @@ func resourceVPCIPv4CIDRBlockAssociationCreate(ctx context.Context, d *schema.Re
 	return append(diags, resourceVPCIPv4CIDRBlockAssociationRead(ctx, d, meta)...)
 }
 
-func resourceVPCIPv4CIDRBlockAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCIPv4CIDRBlockAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -153,7 +153,7 @@ func resourceVPCIPv4CIDRBlockAssociationRead(ctx context.Context, d *schema.Reso
 	return diags
 }
 
-func resourceVPCIPv4CIDRBlockAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCIPv4CIDRBlockAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_ipv4_cidr_block_association_test.go
+++ b/internal/service/ec2/vpc_ipv4_cidr_block_association_test.go
@@ -276,7 +276,7 @@ func testAccCheckVPCIPv4CIDRBlockAssociationWaitVPCAllocationDeleted(ctx context
 		const (
 			timeout = 35 * time.Minute // IPAM eventual consistency. It can take ~30 min to release allocations.
 		)
-		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (interface{}, error) {
+		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
 			return tfec2.FindIPAMPoolAllocationsForVPC(ctx, conn, rsIPAMPool.Primary.ID, rsVPC.Primary.ID)
 		})
 

--- a/internal/service/ec2/vpc_ipv6_cidr_block_association.go
+++ b/internal/service/ec2/vpc_ipv6_cidr_block_association.go
@@ -31,7 +31,7 @@ func resourceVPCIPv6CIDRBlockAssociation() *schema.Resource {
 		DeleteWithoutTimeout: resourceVPCIPv6CIDRBlockAssociationDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				switch parts := strings.Split(d.Id(), ","); len(parts) {
 				case 1:
 					break
@@ -50,7 +50,7 @@ func resourceVPCIPv6CIDRBlockAssociation() *schema.Resource {
 			},
 		},
 
-		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, v any) error {
 			// ipv6_cidr_block can be set by a value returned from IPAM or explicitly in config.
 			if diff.Id() != "" && diff.HasChange("ipv6_cidr_block") {
 				// If netmask is set then ipv6_cidr_block is derived from IPAM, ignore changes.
@@ -118,7 +118,7 @@ func resourceVPCIPv6CIDRBlockAssociation() *schema.Resource {
 	}
 }
 
-func resourceVPCIPv6CIDRBlockAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCIPv6CIDRBlockAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -162,7 +162,7 @@ func resourceVPCIPv6CIDRBlockAssociationCreate(ctx context.Context, d *schema.Re
 	return append(diags, resourceVPCIPv6CIDRBlockAssociationRead(ctx, d, meta)...)
 }
 
-func resourceVPCIPv6CIDRBlockAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCIPv6CIDRBlockAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -191,7 +191,7 @@ func resourceVPCIPv6CIDRBlockAssociationRead(ctx context.Context, d *schema.Reso
 	return diags
 }
 
-func resourceVPCIPv6CIDRBlockAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCIPv6CIDRBlockAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_main_route_table_association.go
+++ b/internal/service/ec2/vpc_main_route_table_association.go
@@ -53,7 +53,7 @@ func resourceMainRouteTableAssociation() *schema.Resource {
 	}
 }
 
-func resourceMainRouteTableAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMainRouteTableAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -87,7 +87,7 @@ func resourceMainRouteTableAssociationCreate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceMainRouteTableAssociationRead(ctx, d, meta)...)
 }
 
-func resourceMainRouteTableAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMainRouteTableAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -106,7 +106,7 @@ func resourceMainRouteTableAssociationRead(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceMainRouteTableAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMainRouteTableAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -134,7 +134,7 @@ func resourceMainRouteTableAssociationUpdate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceMainRouteTableAssociationRead(ctx, d, meta)...)
 }
 
-func resourceMainRouteTableAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMainRouteTableAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_managed_prefix_list.go
+++ b/internal/service/ec2/vpc_managed_prefix_list.go
@@ -39,7 +39,7 @@ func resourceManagedPrefixList() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.Sequence(
-			customdiff.ComputedIf(names.AttrVersion, func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf(names.AttrVersion, func(ctx context.Context, diff *schema.ResourceDiff, meta any) bool {
 				return diff.HasChange("entry")
 			}),
 		),
@@ -98,7 +98,7 @@ func resourceManagedPrefixList() *schema.Resource {
 	}
 }
 
-func resourceManagedPrefixListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceManagedPrefixListCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -131,7 +131,7 @@ func resourceManagedPrefixListCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceManagedPrefixListRead(ctx, d, meta)...)
 }
 
-func resourceManagedPrefixListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceManagedPrefixListRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -169,7 +169,7 @@ func resourceManagedPrefixListRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceManagedPrefixListUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceManagedPrefixListUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -301,7 +301,7 @@ func resourceManagedPrefixListUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceManagedPrefixListRead(ctx, d, meta)...)
 }
 
-func resourceManagedPrefixListDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceManagedPrefixListDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -347,7 +347,7 @@ func updateMaxEntry(ctx context.Context, conn *ec2.Client, id string, maxEntries
 	return nil
 }
 
-func expandAddPrefixListEntry(tfMap map[string]interface{}) awstypes.AddPrefixListEntry {
+func expandAddPrefixListEntry(tfMap map[string]any) awstypes.AddPrefixListEntry {
 	apiObject := awstypes.AddPrefixListEntry{}
 
 	if v, ok := tfMap["cidr"].(string); ok && v != "" {
@@ -361,7 +361,7 @@ func expandAddPrefixListEntry(tfMap map[string]interface{}) awstypes.AddPrefixLi
 	return apiObject
 }
 
-func expandAddPrefixListEntries(tfList []interface{}) []awstypes.AddPrefixListEntry {
+func expandAddPrefixListEntries(tfList []any) []awstypes.AddPrefixListEntry {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -369,7 +369,7 @@ func expandAddPrefixListEntries(tfList []interface{}) []awstypes.AddPrefixListEn
 	var apiObjects []awstypes.AddPrefixListEntry
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -381,7 +381,7 @@ func expandAddPrefixListEntries(tfList []interface{}) []awstypes.AddPrefixListEn
 	return apiObjects
 }
 
-func expandRemovePrefixListEntry(tfMap map[string]interface{}) awstypes.RemovePrefixListEntry {
+func expandRemovePrefixListEntry(tfMap map[string]any) awstypes.RemovePrefixListEntry {
 	apiObject := awstypes.RemovePrefixListEntry{}
 
 	if v, ok := tfMap["cidr"].(string); ok && v != "" {
@@ -391,7 +391,7 @@ func expandRemovePrefixListEntry(tfMap map[string]interface{}) awstypes.RemovePr
 	return apiObject
 }
 
-func expandRemovePrefixListEntries(tfList []interface{}) []awstypes.RemovePrefixListEntry {
+func expandRemovePrefixListEntries(tfList []any) []awstypes.RemovePrefixListEntry {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -399,7 +399,7 @@ func expandRemovePrefixListEntries(tfList []interface{}) []awstypes.RemovePrefix
 	var apiObjects []awstypes.RemovePrefixListEntry
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -411,8 +411,8 @@ func expandRemovePrefixListEntries(tfList []interface{}) []awstypes.RemovePrefix
 	return apiObjects
 }
 
-func flattenPrefixListEntry(apiObject awstypes.PrefixListEntry) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenPrefixListEntry(apiObject awstypes.PrefixListEntry) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.Cidr; v != nil {
 		tfMap["cidr"] = aws.ToString(v)
@@ -425,12 +425,12 @@ func flattenPrefixListEntry(apiObject awstypes.PrefixListEntry) map[string]inter
 	return tfMap
 }
 
-func flattenPrefixListEntries(apiObjects []awstypes.PrefixListEntry) []interface{} {
+func flattenPrefixListEntries(apiObjects []awstypes.PrefixListEntry) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenPrefixListEntry(apiObject))

--- a/internal/service/ec2/vpc_managed_prefix_list_data_source.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_data_source.go
@@ -80,7 +80,7 @@ func dataSourceManagedPrefixList() *schema.Resource {
 	}
 }
 
-func dataSourceManagedPrefixListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceManagedPrefixListRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)

--- a/internal/service/ec2/vpc_managed_prefix_list_entry.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_entry.go
@@ -56,7 +56,7 @@ func resourceManagedPrefixListEntry() *schema.Resource {
 	}
 }
 
-func resourceManagedPrefixListEntryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceManagedPrefixListEntryCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -71,7 +71,7 @@ func resourceManagedPrefixListEntryCreate(ctx context.Context, d *schema.Resourc
 		addPrefixListEntry.Description = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
 		mutexKey := fmt.Sprintf("vpc-managed-prefix-list-%s", plID)
 		conns.GlobalMutexKV.Lock(mutexKey)
 		defer conns.GlobalMutexKV.Unlock(mutexKey)
@@ -104,7 +104,7 @@ func resourceManagedPrefixListEntryCreate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceManagedPrefixListEntryRead(ctx, d, meta)...)
 }
 
-func resourceManagedPrefixListEntryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceManagedPrefixListEntryRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -115,7 +115,7 @@ func resourceManagedPrefixListEntryRead(ctx context.Context, d *schema.ResourceD
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, managedPrefixListEntryCreateTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, managedPrefixListEntryCreateTimeout, func() (any, error) {
 		return findManagedPrefixListEntryByIDAndCIDR(ctx, conn, plID, cidr)
 	}, d.IsNewResource())
 
@@ -137,7 +137,7 @@ func resourceManagedPrefixListEntryRead(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceManagedPrefixListEntryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceManagedPrefixListEntryDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -148,7 +148,7 @@ func resourceManagedPrefixListEntryDelete(ctx context.Context, d *schema.Resourc
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
 		mutexKey := fmt.Sprintf("vpc-managed-prefix-list-%s", plID)
 		conns.GlobalMutexKV.Lock(mutexKey)
 		defer conns.GlobalMutexKV.Unlock(mutexKey)
@@ -185,7 +185,7 @@ func resourceManagedPrefixListEntryDelete(ctx context.Context, d *schema.Resourc
 	return diags
 }
 
-func resourceManagedPrefixListEntryImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceManagedPrefixListEntryImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	plID, cidr, err := managedPrefixListEntryParseResourceID(d.Id())
 
 	if err != nil {

--- a/internal/service/ec2/vpc_managed_prefix_lists_data_source.go
+++ b/internal/service/ec2/vpc_managed_prefix_lists_data_source.go
@@ -33,7 +33,7 @@ func dataSourceManagedPrefixLists() *schema.Resource {
 	}
 }
 
-func dataSourceManagedPrefixListsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceManagedPrefixListsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -41,7 +41,7 @@ func dataSourceManagedPrefixListsRead(ctx context.Context, d *schema.ResourceDat
 	input := &ec2.DescribeManagedPrefixListsInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/vpc_migrate.go
+++ b/internal/service/ec2/vpc_migrate.go
@@ -11,7 +11,7 @@ import (
 )
 
 func vpcMigrateState(
-	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found AWS VPC State v0; migrating to v1")

--- a/internal/service/ec2/vpc_migrate_test.go
+++ b/internal/service/ec2/vpc_migrate_test.go
@@ -19,7 +19,7 @@ func TestVPCMigrateState(t *testing.T) {
 		ID           string
 		Attributes   map[string]string
 		Expected     string
-		Meta         interface{}
+		Meta         any
 	}{
 		"v0_1": {
 			StateVersion: 0,

--- a/internal/service/ec2/vpc_nat_gateway.go
+++ b/internal/service/ec2/vpc_nat_gateway.go
@@ -110,7 +110,7 @@ func resourceNATGateway() *schema.Resource {
 	}
 }
 
-func resourceNATGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNATGatewayCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -162,7 +162,7 @@ func resourceNATGatewayCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceNATGatewayRead(ctx, d, meta)...)
 }
 
-func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -209,7 +209,7 @@ func resourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -329,7 +329,7 @@ func resourceNATGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceNATGatewayRead(ctx, d, meta)...)
 }
 
-func resourceNATGatewayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNATGatewayDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -354,7 +354,7 @@ func resourceNATGatewayDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceNATGatewayCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+func resourceNATGatewayCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 	switch connectivityType := awstypes.ConnectivityType(diff.Get("connectivity_type").(string)); connectivityType {
 	case awstypes.ConnectivityTypePrivate:
 		if _, ok := diff.GetOk("allocation_id"); ok {

--- a/internal/service/ec2/vpc_nat_gateway_data_source.go
+++ b/internal/service/ec2/vpc_nat_gateway_data_source.go
@@ -92,7 +92,7 @@ func dataSourceNATGateway() *schema.Resource {
 	}
 }
 
-func dataSourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	var diags diag.Diagnostics
 
@@ -114,7 +114,7 @@ func dataSourceNATGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	if tags, ok := d.GetOk(names.AttrTags); ok {
 		input.Filter = append(input.Filter, newTagFilterList(
-			Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+			Tags(tftags.New(ctx, tags.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/vpc_nat_gateways_data_source.go
+++ b/internal/service/ec2/vpc_nat_gateways_data_source.go
@@ -42,7 +42,7 @@ func dataSourceNATGateways() *schema.Resource {
 	}
 }
 
-func dataSourceNATGatewaysRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceNATGatewaysRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -59,7 +59,7 @@ func dataSourceNATGatewaysRead(ctx context.Context, d *schema.ResourceData, meta
 
 	if tags, ok := d.GetOk(names.AttrTags); ok {
 		input.Filter = append(input.Filter, newTagFilterList(
-			Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+			Tags(tftags.New(ctx, tags.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/vpc_network_acl.go
+++ b/internal/service/ec2/vpc_network_acl.go
@@ -41,7 +41,7 @@ func resourceNetworkACL() *schema.Resource {
 		DeleteWithoutTimeout: resourceNetworkACLDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 				nacl, err := findNetworkACLByID(ctx, conn, d.Id())
@@ -141,7 +141,7 @@ func networkACLRuleNestedBlock() *schema.Resource {
 			names.AttrProtocol: {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+				ValidateFunc: func(v any, k string) (ws []string, errors []error) {
 					_, err := networkACLProtocolNumber(v.(string))
 
 					if err != nil {
@@ -165,7 +165,7 @@ func networkACLRuleNestedBlock() *schema.Resource {
 	}
 }
 
-func resourceNetworkACLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkACLCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -190,11 +190,11 @@ func resourceNetworkACLCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceNetworkACLRead(ctx, d, meta)...)
 }
 
-func resourceNetworkACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkACLRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findNetworkACLByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -256,7 +256,7 @@ func resourceNetworkACLRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceNetworkACLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkACLUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -267,7 +267,7 @@ func resourceNetworkACLUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceNetworkACLRead(ctx, d, meta)...)
 }
 
-func resourceNetworkACLDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkACLDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -282,7 +282,7 @@ func resourceNetworkACLDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "reading EC2 Network ACL (%s): %s", d.Id(), err)
 	}
 
-	var subnetIDs []interface{}
+	var subnetIDs []any
 	for _, v := range nacl.Associations {
 		subnetIDs = append(subnetIDs, aws.ToString(v.SubnetId))
 	}
@@ -297,7 +297,7 @@ func resourceNetworkACLDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	log.Printf("[INFO] Deleting EC2 Network ACL: %s", d.Id())
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (any, error) {
 		return conn.DeleteNetworkAcl(ctx, input)
 	}, errCodeDependencyViolation)
 
@@ -381,10 +381,10 @@ func modifyNetworkACLAttributesOnUpdate(ctx context.Context, conn *ec2.Client, d
 	return nil
 }
 
-func networkACLRuleHash(v interface{}) int {
+func networkACLRuleHash(v any) int {
 	var buf bytes.Buffer
 
-	tfMap := v.(map[string]interface{})
+	tfMap := v.(map[string]any)
 	buf.WriteString(fmt.Sprintf("%d-", tfMap["from_port"].(int)))
 	buf.WriteString(fmt.Sprintf("%d-", tfMap["to_port"].(int)))
 	buf.WriteString(fmt.Sprintf("%d-", tfMap["rule_no"].(int)))
@@ -411,7 +411,7 @@ func networkACLRuleHash(v interface{}) int {
 	return create.StringHashcode(buf.String())
 }
 
-func createNetworkACLEntries(ctx context.Context, conn *ec2.Client, naclID string, tfList []interface{}, egress bool) error {
+func createNetworkACLEntries(ctx context.Context, conn *ec2.Client, naclID string, tfList []any, egress bool) error {
 	naclEntries := expandNetworkACLEntries(tfList, egress)
 
 	for _, naclEntry := range naclEntries {
@@ -448,7 +448,7 @@ func createNetworkACLEntries(ctx context.Context, conn *ec2.Client, naclID strin
 	return nil
 }
 
-func deleteNetworkACLEntriesList(ctx context.Context, conn *ec2.Client, naclID string, tfList []interface{}, egress bool) error {
+func deleteNetworkACLEntriesList(ctx context.Context, conn *ec2.Client, naclID string, tfList []any, egress bool) error {
 	return deleteNetworkACLEntries(ctx, conn, naclID, expandNetworkACLEntries(tfList, egress))
 }
 
@@ -491,7 +491,7 @@ func updateNetworkACLEntries(ctx context.Context, conn *ec2.Client, naclID strin
 	return nil
 }
 
-func expandNetworkACLEntry(tfMap map[string]interface{}, egress bool) *awstypes.NetworkAclEntry {
+func expandNetworkACLEntry(tfMap map[string]any, egress bool) *awstypes.NetworkAclEntry {
 	if tfMap == nil {
 		return nil
 	}
@@ -552,7 +552,7 @@ func expandNetworkACLEntry(tfMap map[string]interface{}, egress bool) *awstypes.
 	return apiObject
 }
 
-func expandNetworkACLEntries(tfList []interface{}, egress bool) []awstypes.NetworkAclEntry {
+func expandNetworkACLEntries(tfList []any, egress bool) []awstypes.NetworkAclEntry {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -560,7 +560,7 @@ func expandNetworkACLEntries(tfList []interface{}, egress bool) []awstypes.Netwo
 	var apiObjects []awstypes.NetworkAclEntry
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -578,8 +578,8 @@ func expandNetworkACLEntries(tfList []interface{}, egress bool) []awstypes.Netwo
 	return apiObjects
 }
 
-func flattenNetworkACLEntry(apiObject awstypes.NetworkAclEntry) map[string]interface{} {
-	tfMap := map[string]interface{}{
+func flattenNetworkACLEntry(apiObject awstypes.NetworkAclEntry) map[string]any {
+	tfMap := map[string]any{
 		names.AttrAction: apiObject.RuleAction,
 	}
 
@@ -631,12 +631,12 @@ func flattenNetworkACLEntry(apiObject awstypes.NetworkAclEntry) map[string]inter
 	return tfMap
 }
 
-func flattenNetworkACLEntries(apiObjects []awstypes.NetworkAclEntry) []interface{} {
+func flattenNetworkACLEntries(apiObjects []awstypes.NetworkAclEntry) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenNetworkACLEntry(apiObject))

--- a/internal/service/ec2/vpc_network_acl_association.go
+++ b/internal/service/ec2/vpc_network_acl_association.go
@@ -45,7 +45,7 @@ func resourceNetworkACLAssociation() *schema.Resource {
 	}
 }
 
-func resourceNetworkACLAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkACLAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -60,11 +60,11 @@ func resourceNetworkACLAssociationCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceNetworkACLAssociationRead(ctx, d, meta)...)
 }
 
-func resourceNetworkACLAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkACLAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findNetworkACLAssociationByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -86,7 +86,7 @@ func resourceNetworkACLAssociationRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceNetworkACLAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkACLAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -135,7 +135,7 @@ func networkACLAssociationCreate(ctx context.Context, conn *ec2.Client, naclID, 
 	}
 
 	log.Printf("[DEBUG] Creating EC2 Network ACL Association: %#v", input)
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (any, error) {
 		return conn.ReplaceNetworkAclAssociation(ctx, input)
 	}, errCodeInvalidAssociationIDNotFound)
 
@@ -147,7 +147,7 @@ func networkACLAssociationCreate(ctx context.Context, conn *ec2.Client, naclID, 
 }
 
 // networkACLAssociationsCreate creates associations between the specified NACL and subnets.
-func networkACLAssociationsCreate(ctx context.Context, conn *ec2.Client, naclID string, subnetIDs []interface{}) error {
+func networkACLAssociationsCreate(ctx context.Context, conn *ec2.Client, naclID string, subnetIDs []any) error {
 	for _, v := range subnetIDs {
 		subnetID := v.(string)
 		_, err := networkACLAssociationCreate(ctx, conn, naclID, subnetID)
@@ -189,7 +189,7 @@ func networkACLAssociationDelete(ctx context.Context, conn *ec2.Client, associat
 
 // networkACLAssociationsDelete deletes the specified NACL associations for the specified subnets.
 // Each subnet's current association is replaced by an association with the specified VPC's default NACL.
-func networkACLAssociationsDelete(ctx context.Context, conn *ec2.Client, vpcID string, subnetIDs []interface{}) error {
+func networkACLAssociationsDelete(ctx context.Context, conn *ec2.Client, vpcID string, subnetIDs []any) error {
 	defaultNACL, err := findVPCDefaultNetworkACL(ctx, conn, vpcID)
 
 	if err != nil {

--- a/internal/service/ec2/vpc_network_acl_rule.go
+++ b/internal/service/ec2/vpc_network_acl_rule.go
@@ -89,7 +89,7 @@ func resourceNetworkACLRule() *schema.Resource {
 
 					return old == new
 				},
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+				ValidateFunc: func(v any, k string) (ws []string, errors []error) {
 					_, err := networkACLProtocolNumber(v.(string))
 
 					if err != nil {
@@ -122,7 +122,7 @@ func resourceNetworkACLRule() *schema.Resource {
 	}
 }
 
-func resourceNetworkACLRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkACLRuleCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -187,7 +187,7 @@ func resourceNetworkACLRuleCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceNetworkACLRuleRead(ctx, d, meta)...)
 }
 
-func resourceNetworkACLRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkACLRuleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -195,7 +195,7 @@ func resourceNetworkACLRuleRead(ctx context.Context, d *schema.ResourceData, met
 	naclID := d.Get("network_acl_id").(string)
 	ruleNumber := d.Get("rule_number").(int)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findNetworkACLEntryByThreePartKey(ctx, conn, naclID, egress, ruleNumber)
 	}, d.IsNewResource())
 
@@ -242,7 +242,7 @@ func resourceNetworkACLRuleRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceNetworkACLRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkACLRuleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -265,7 +265,7 @@ func resourceNetworkACLRuleDelete(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceNetworkACLRuleImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceNetworkACLRuleImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), networkACLRuleImportIDSeparator)
 
 	if len(parts) != 4 || parts[0] == "" || parts[1] == "" || parts[2] == "" || parts[3] == "" {

--- a/internal/service/ec2/vpc_network_acls_data_source.go
+++ b/internal/service/ec2/vpc_network_acls_data_source.go
@@ -42,7 +42,7 @@ func dataSourceNetworkACLs() *schema.Resource {
 	}
 }
 
-func dataSourceNetworkACLsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceNetworkACLsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -57,7 +57,7 @@ func dataSourceNetworkACLsRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/vpc_network_insights_analysis.go
+++ b/internal/service/ec2/vpc_network_insights_analysis.go
@@ -1410,7 +1410,7 @@ func networkInsightsAnalysisExplanationsSchema() *schema.Schema {
 	}
 }
 
-func resourceNetworkInsightsAnalysisCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInsightsAnalysisCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1440,7 +1440,7 @@ func resourceNetworkInsightsAnalysisCreate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceNetworkInsightsAnalysisRead(ctx, d, meta)...)
 }
 
-func resourceNetworkInsightsAnalysisRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInsightsAnalysisRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1482,12 +1482,12 @@ func resourceNetworkInsightsAnalysisRead(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceNetworkInsightsAnalysisUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInsightsAnalysisUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceNetworkInsightsAnalysisRead(ctx, d, meta)
 }
 
-func resourceNetworkInsightsAnalysisDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInsightsAnalysisDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1508,30 +1508,30 @@ func resourceNetworkInsightsAnalysisDelete(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func flattenAdditionalDetail(apiObject *awstypes.AdditionalDetail) map[string]interface{} {
+func flattenAdditionalDetail(apiObject *awstypes.AdditionalDetail) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AdditionalDetailType; v != nil {
 		tfMap["additional_detail_type"] = aws.ToString(v)
 	}
 
 	if v := apiObject.Component; v != nil {
-		tfMap["component"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["component"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	return tfMap
 }
 
-func flattenAdditionalDetails(apiObjects []awstypes.AdditionalDetail) []interface{} {
+func flattenAdditionalDetails(apiObjects []awstypes.AdditionalDetail) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenAdditionalDetail(&apiObject))
@@ -1540,12 +1540,12 @@ func flattenAdditionalDetails(apiObjects []awstypes.AdditionalDetail) []interfac
 	return tfList
 }
 
-func flattenAlternatePathHint(apiObject *awstypes.AlternatePathHint) map[string]interface{} {
+func flattenAlternatePathHint(apiObject *awstypes.AlternatePathHint) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ComponentArn; v != nil {
 		tfMap["component_arn"] = aws.ToString(v)
@@ -1558,12 +1558,12 @@ func flattenAlternatePathHint(apiObject *awstypes.AlternatePathHint) map[string]
 	return tfMap
 }
 
-func flattenAlternatePathHints(apiObjects []awstypes.AlternatePathHint) []interface{} {
+func flattenAlternatePathHints(apiObjects []awstypes.AlternatePathHint) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenAlternatePathHint(&apiObject))
@@ -1572,12 +1572,12 @@ func flattenAlternatePathHints(apiObjects []awstypes.AlternatePathHint) []interf
 	return tfList
 }
 
-func flattenAnalysisAclRule(apiObject *awstypes.AnalysisAclRule) map[string]interface{} { // nosemgrep:ci.caps2-in-func-name
+func flattenAnalysisAclRule(apiObject *awstypes.AnalysisAclRule) map[string]any { // nosemgrep:ci.caps2-in-func-name
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Cidr; v != nil {
 		tfMap["cidr"] = aws.ToString(v)
@@ -1588,7 +1588,7 @@ func flattenAnalysisAclRule(apiObject *awstypes.AnalysisAclRule) map[string]inte
 	}
 
 	if v := apiObject.PortRange; v != nil {
-		tfMap["port_range"] = []interface{}{flattenPortRange(v)}
+		tfMap["port_range"] = []any{flattenPortRange(v)}
 	}
 
 	if v := apiObject.Protocol; v != nil {
@@ -1606,12 +1606,12 @@ func flattenAnalysisAclRule(apiObject *awstypes.AnalysisAclRule) map[string]inte
 	return tfMap
 }
 
-func flattenAnalysisLoadBalancerListener(apiObject *awstypes.AnalysisLoadBalancerListener) map[string]interface{} {
+func flattenAnalysisLoadBalancerListener(apiObject *awstypes.AnalysisLoadBalancerListener) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.InstancePort; v != nil {
 		tfMap["instance_port"] = aws.ToInt32(v)
@@ -1624,12 +1624,12 @@ func flattenAnalysisLoadBalancerListener(apiObject *awstypes.AnalysisLoadBalance
 	return tfMap
 }
 
-func flattenAnalysisComponent(apiObject *awstypes.AnalysisComponent) map[string]interface{} {
+func flattenAnalysisComponent(apiObject *awstypes.AnalysisComponent) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Arn; v != nil {
 		tfMap[names.AttrARN] = aws.ToString(v)
@@ -1646,12 +1646,12 @@ func flattenAnalysisComponent(apiObject *awstypes.AnalysisComponent) map[string]
 	return tfMap
 }
 
-func flattenAnalysisComponents(apiObjects []awstypes.AnalysisComponent) []interface{} {
+func flattenAnalysisComponents(apiObjects []awstypes.AnalysisComponent) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenAnalysisComponent(&apiObject))
@@ -1660,12 +1660,12 @@ func flattenAnalysisComponents(apiObjects []awstypes.AnalysisComponent) []interf
 	return tfList
 }
 
-func flattenAnalysisLoadBalancerTarget(apiObject *awstypes.AnalysisLoadBalancerTarget) map[string]interface{} {
+func flattenAnalysisLoadBalancerTarget(apiObject *awstypes.AnalysisLoadBalancerTarget) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Address; v != nil {
 		tfMap[names.AttrAddress] = aws.ToString(v)
@@ -1676,7 +1676,7 @@ func flattenAnalysisLoadBalancerTarget(apiObject *awstypes.AnalysisLoadBalancerT
 	}
 
 	if v := apiObject.Instance; v != nil {
-		tfMap["instance"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["instance"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.Port; v != nil {
@@ -1686,12 +1686,12 @@ func flattenAnalysisLoadBalancerTarget(apiObject *awstypes.AnalysisLoadBalancerT
 	return tfMap
 }
 
-func flattenAnalysisPacketHeader(apiObject *awstypes.AnalysisPacketHeader) map[string]interface{} {
+func flattenAnalysisPacketHeader(apiObject *awstypes.AnalysisPacketHeader) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.DestinationAddresses; v != nil {
 		tfMap["destination_addresses"] = v
@@ -1716,12 +1716,12 @@ func flattenAnalysisPacketHeader(apiObject *awstypes.AnalysisPacketHeader) map[s
 	return tfMap
 }
 
-func flattenAnalysisRouteTableRoute(apiObject *awstypes.AnalysisRouteTableRoute) map[string]interface{} {
+func flattenAnalysisRouteTableRoute(apiObject *awstypes.AnalysisRouteTableRoute) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.DestinationCidr; v != nil {
 		tfMap["destination_cidr"] = aws.ToString(v)
@@ -1766,19 +1766,19 @@ func flattenAnalysisRouteTableRoute(apiObject *awstypes.AnalysisRouteTableRoute)
 	return tfMap
 }
 
-func flattenAnalysisSecurityGroupRule(apiObject *awstypes.AnalysisSecurityGroupRule) map[string]interface{} {
+func flattenAnalysisSecurityGroupRule(apiObject *awstypes.AnalysisSecurityGroupRule) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Cidr; v != nil {
 		tfMap["cidr"] = aws.ToString(v)
 	}
 
 	if v := apiObject.PortRange; v != nil {
-		tfMap["port_range"] = []interface{}{flattenPortRange(v)}
+		tfMap["port_range"] = []any{flattenPortRange(v)}
 	}
 
 	if v := apiObject.PrefixListId; v != nil {
@@ -1796,19 +1796,19 @@ func flattenAnalysisSecurityGroupRule(apiObject *awstypes.AnalysisSecurityGroupR
 	return tfMap
 }
 
-func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} {
+func flattenExplanation(apiObject *awstypes.Explanation) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Acl; v != nil {
-		tfMap["acl"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["acl"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.AclRule; v != nil {
-		tfMap["acl_rule"] = []interface{}{flattenAnalysisAclRule(v)}
+		tfMap["acl_rule"] = []any{flattenAnalysisAclRule(v)}
 	}
 
 	if v := apiObject.Address; v != nil {
@@ -1820,7 +1820,7 @@ func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} 
 	}
 
 	if v := apiObject.AttachedTo; v != nil {
-		tfMap["attached_to"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["attached_to"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.AvailabilityZones; v != nil {
@@ -1832,23 +1832,23 @@ func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} 
 	}
 
 	if v := apiObject.ClassicLoadBalancerListener; v != nil {
-		tfMap["classic_load_balancer_listener"] = []interface{}{flattenAnalysisLoadBalancerListener(v)}
+		tfMap["classic_load_balancer_listener"] = []any{flattenAnalysisLoadBalancerListener(v)}
 	}
 
 	if v := apiObject.Component; v != nil {
-		tfMap["component"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["component"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.CustomerGateway; v != nil {
-		tfMap["customer_gateway"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["customer_gateway"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.Destination; v != nil {
-		tfMap[names.AttrDestination] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap[names.AttrDestination] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.DestinationVpc; v != nil {
-		tfMap["destination_vpc"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["destination_vpc"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.Direction; v != nil {
@@ -1856,7 +1856,7 @@ func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} 
 	}
 
 	if v := apiObject.ElasticLoadBalancerListener; v != nil {
-		tfMap["elastic_load_balancer_listener"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["elastic_load_balancer_listener"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.ExplanationCode; v != nil {
@@ -1864,11 +1864,11 @@ func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} 
 	}
 
 	if v := apiObject.IngressRouteTable; v != nil {
-		tfMap["ingress_route_table"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["ingress_route_table"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.InternetGateway; v != nil {
-		tfMap["internet_gateway"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["internet_gateway"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.LoadBalancerArn; v != nil {
@@ -1880,11 +1880,11 @@ func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} 
 	}
 
 	if v := apiObject.LoadBalancerTarget; v != nil {
-		tfMap["load_balancer_target"] = []interface{}{flattenAnalysisLoadBalancerTarget(v)}
+		tfMap["load_balancer_target"] = []any{flattenAnalysisLoadBalancerTarget(v)}
 	}
 
 	if v := apiObject.LoadBalancerTargetGroup; v != nil {
-		tfMap["load_balancer_target_group"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["load_balancer_target_group"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.LoadBalancerTargetGroups; v != nil {
@@ -1900,11 +1900,11 @@ func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} 
 	}
 
 	if v := apiObject.NatGateway; v != nil {
-		tfMap["nat_gateway"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["nat_gateway"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.NetworkInterface; v != nil {
-		tfMap["network_interface"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["network_interface"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.PacketField; v != nil {
@@ -1920,7 +1920,7 @@ func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} 
 	}
 
 	if v := apiObject.PrefixList; v != nil {
-		tfMap["prefix_list"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["prefix_list"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.Protocols; v != nil {
@@ -1928,19 +1928,19 @@ func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} 
 	}
 
 	if v := apiObject.RouteTable; v != nil {
-		tfMap["route_table"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["route_table"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.RouteTableRoute; v != nil {
-		tfMap["route_table_route"] = []interface{}{flattenAnalysisRouteTableRoute(v)}
+		tfMap["route_table_route"] = []any{flattenAnalysisRouteTableRoute(v)}
 	}
 
 	if v := apiObject.SecurityGroup; v != nil {
-		tfMap["security_group"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["security_group"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.SecurityGroupRule; v != nil {
-		tfMap["security_group_rule"] = []interface{}{flattenAnalysisSecurityGroupRule(v)}
+		tfMap["security_group_rule"] = []any{flattenAnalysisSecurityGroupRule(v)}
 	}
 
 	if v := apiObject.SecurityGroups; v != nil {
@@ -1948,7 +1948,7 @@ func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} 
 	}
 
 	if v := apiObject.SourceVpc; v != nil {
-		tfMap["source_vpc"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["source_vpc"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.State; v != nil {
@@ -1956,58 +1956,58 @@ func flattenExplanation(apiObject *awstypes.Explanation) map[string]interface{} 
 	}
 
 	if v := apiObject.Subnet; v != nil {
-		tfMap["subnet"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["subnet"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.SubnetRouteTable; v != nil {
-		tfMap["subnet_route_table"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["subnet_route_table"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.TransitGateway; v != nil {
-		tfMap["transit_gateway"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["transit_gateway"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.TransitGatewayAttachment; v != nil {
-		tfMap["transit_gateway_attachment"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["transit_gateway_attachment"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.TransitGatewayRouteTable; v != nil {
-		tfMap["transit_gateway_route_table"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["transit_gateway_route_table"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.TransitGatewayRouteTableRoute; v != nil {
-		tfMap["transit_gateway_route_table_route"] = []interface{}{flattenTransitGatewayRouteTableRoute(v)}
+		tfMap["transit_gateway_route_table_route"] = []any{flattenTransitGatewayRouteTableRoute(v)}
 	}
 
 	if v := apiObject.Vpc; v != nil {
-		tfMap["vpc"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["vpc"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.VpcEndpoint; v != nil {
-		tfMap["vpc_endpoint"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["vpc_endpoint"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.VpcPeeringConnection; v != nil {
-		tfMap["vpc_peering_connection"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["vpc_peering_connection"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.VpnConnection; v != nil {
-		tfMap["vpn_connection"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["vpn_connection"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.VpnGateway; v != nil {
-		tfMap["vpn_gateway"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["vpn_gateway"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	return tfMap
 }
 
-func flattenExplanations(apiObjects []awstypes.Explanation) []interface{} {
+func flattenExplanations(apiObjects []awstypes.Explanation) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenExplanation(&apiObject))
@@ -2016,15 +2016,15 @@ func flattenExplanations(apiObjects []awstypes.Explanation) []interface{} {
 	return tfList
 }
 
-func flattenPathComponent(apiObject *awstypes.PathComponent) map[string]interface{} {
+func flattenPathComponent(apiObject *awstypes.PathComponent) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AclRule; v != nil {
-		tfMap["acl_rule"] = []interface{}{flattenAnalysisAclRule(v)}
+		tfMap["acl_rule"] = []any{flattenAnalysisAclRule(v)}
 	}
 
 	if v := apiObject.AdditionalDetails; v != nil {
@@ -2032,27 +2032,27 @@ func flattenPathComponent(apiObject *awstypes.PathComponent) map[string]interfac
 	}
 
 	if v := apiObject.Component; v != nil {
-		tfMap["component"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["component"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.DestinationVpc; v != nil {
-		tfMap["destination_vpc"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["destination_vpc"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.InboundHeader; v != nil {
-		tfMap["inbound_header"] = []interface{}{flattenAnalysisPacketHeader(v)}
+		tfMap["inbound_header"] = []any{flattenAnalysisPacketHeader(v)}
 	}
 
 	if v := apiObject.OutboundHeader; v != nil {
-		tfMap["outbound_header"] = []interface{}{flattenAnalysisPacketHeader(v)}
+		tfMap["outbound_header"] = []any{flattenAnalysisPacketHeader(v)}
 	}
 
 	if v := apiObject.RouteTableRoute; v != nil {
-		tfMap["route_table_route"] = []interface{}{flattenAnalysisRouteTableRoute(v)}
+		tfMap["route_table_route"] = []any{flattenAnalysisRouteTableRoute(v)}
 	}
 
 	if v := apiObject.SecurityGroupRule; v != nil {
-		tfMap["security_group_rule"] = []interface{}{flattenAnalysisSecurityGroupRule(v)}
+		tfMap["security_group_rule"] = []any{flattenAnalysisSecurityGroupRule(v)}
 	}
 
 	if v := apiObject.SequenceNumber; v != nil {
@@ -2060,34 +2060,34 @@ func flattenPathComponent(apiObject *awstypes.PathComponent) map[string]interfac
 	}
 
 	if v := apiObject.SourceVpc; v != nil {
-		tfMap["source_vpc"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["source_vpc"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.Subnet; v != nil {
-		tfMap["subnet"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["subnet"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.TransitGateway; v != nil {
-		tfMap["transit_gateway"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["transit_gateway"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	if v := apiObject.TransitGatewayRouteTableRoute; v != nil {
-		tfMap["transit_gateway_route_table_route"] = []interface{}{flattenTransitGatewayRouteTableRoute(v)}
+		tfMap["transit_gateway_route_table_route"] = []any{flattenTransitGatewayRouteTableRoute(v)}
 	}
 
 	if v := apiObject.Vpc; v != nil {
-		tfMap["vpc"] = []interface{}{flattenAnalysisComponent(v)}
+		tfMap["vpc"] = []any{flattenAnalysisComponent(v)}
 	}
 
 	return tfMap
 }
 
-func flattenPathComponents(apiObjects []awstypes.PathComponent) []interface{} {
+func flattenPathComponents(apiObjects []awstypes.PathComponent) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenPathComponent(&apiObject))
@@ -2096,12 +2096,12 @@ func flattenPathComponents(apiObjects []awstypes.PathComponent) []interface{} {
 	return tfList
 }
 
-func flattenPortRange(apiObject *awstypes.PortRange) map[string]interface{} {
+func flattenPortRange(apiObject *awstypes.PortRange) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.From; v != nil {
 		tfMap["from"] = aws.ToInt32(v)
@@ -2114,12 +2114,12 @@ func flattenPortRange(apiObject *awstypes.PortRange) map[string]interface{} {
 	return tfMap
 }
 
-func flattenPortRanges(apiObjects []awstypes.PortRange) []interface{} {
+func flattenPortRanges(apiObjects []awstypes.PortRange) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenPortRange(&apiObject))
@@ -2128,12 +2128,12 @@ func flattenPortRanges(apiObjects []awstypes.PortRange) []interface{} {
 	return tfList
 }
 
-func flattenTransitGatewayRouteTableRoute(apiObject *awstypes.TransitGatewayRouteTableRoute) map[string]interface{} {
+func flattenTransitGatewayRouteTableRoute(apiObject *awstypes.TransitGatewayRouteTableRoute) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AttachmentId; v != nil {
 		tfMap["attachment_id"] = aws.ToString(v)

--- a/internal/service/ec2/vpc_network_insights_analysis_data_source.go
+++ b/internal/service/ec2/vpc_network_insights_analysis_data_source.go
@@ -91,7 +91,7 @@ func dataSourceNetworkInsightsAnalysis() *schema.Resource {
 	}
 }
 
-func dataSourceNetworkInsightsAnalysisRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceNetworkInsightsAnalysisRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_network_insights_path.go
+++ b/internal/service/ec2/vpc_network_insights_path.go
@@ -89,7 +89,7 @@ func resourceNetworkInsightsPath() *schema.Resource {
 	}
 }
 
-func resourceNetworkInsightsPathCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInsightsPathCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -127,7 +127,7 @@ func resourceNetworkInsightsPathCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceNetworkInsightsPathRead(ctx, d, meta)...)
 }
 
-func resourceNetworkInsightsPathRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInsightsPathRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -158,17 +158,17 @@ func resourceNetworkInsightsPathRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceNetworkInsightsPathUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInsightsPathUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceNetworkInsightsPathRead(ctx, d, meta)
 }
 
-func resourceNetworkInsightsPathDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInsightsPathDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting EC2 Network Insights Path: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (any, error) {
 		return conn.DeleteNetworkInsightsPath(ctx, &ec2.DeleteNetworkInsightsPathInput{
 			NetworkInsightsPathId: aws.String(d.Id()),
 		})

--- a/internal/service/ec2/vpc_network_insights_path_data_source.go
+++ b/internal/service/ec2/vpc_network_insights_path_data_source.go
@@ -72,7 +72,7 @@ func dataSourceNetworkInsightsPath() *schema.Resource {
 	}
 }
 
-func dataSourceNetworkInsightsPathRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceNetworkInsightsPathRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -215,7 +215,7 @@ func resourceNetworkInterface() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.Sequence(
-			customdiff.ForceNewIf("private_ips", func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ForceNewIf("private_ips", func(_ context.Context, d *schema.ResourceDiff, meta any) bool {
 				privateIPListEnabled := d.Get("private_ip_list_enabled").(bool)
 				if privateIPListEnabled {
 					return false
@@ -224,7 +224,7 @@ func resourceNetworkInterface() *schema.Resource {
 				if new != nil {
 					oldPrimaryIP := ""
 					if v, ok := d.GetOk("private_ip_list"); ok {
-						for _, ip := range v.([]interface{}) {
+						for _, ip := range v.([]any) {
 							oldPrimaryIP = ip.(string)
 							break
 						}
@@ -241,11 +241,11 @@ func resourceNetworkInterface() *schema.Resource {
 					return false
 				}
 			}),
-			customdiff.ForceNewIf("enable_primary_ipv6", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ForceNewIf("enable_primary_ipv6", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				o, n := diff.GetChange("enable_primary_ipv6")
 				return o.(bool) && !n.(bool) // can be enabled but not disabled without recreate
 			}),
-			customdiff.ForceNewIf("private_ip_list", func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ForceNewIf("private_ip_list", func(_ context.Context, d *schema.ResourceDiff, meta any) bool {
 				privateIPListEnabled := d.Get("private_ip_list_enabled").(bool)
 				if !privateIPListEnabled {
 					return false
@@ -254,11 +254,11 @@ func resourceNetworkInterface() *schema.Resource {
 				if old != nil && new != nil {
 					oldPrimaryIP := ""
 					newPrimaryIP := ""
-					for _, ip := range old.([]interface{}) {
+					for _, ip := range old.([]any) {
 						oldPrimaryIP = ip.(string)
 						break
 					}
-					for _, ip := range new.([]interface{}) {
+					for _, ip := range new.([]any) {
 						newPrimaryIP = ip.(string)
 						break
 					}
@@ -269,7 +269,7 @@ func resourceNetworkInterface() *schema.Resource {
 					return false
 				}
 			}),
-			customdiff.ComputedIf("private_ips", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("private_ips", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				if !diff.Get("private_ip_list_enabled").(bool) {
 					// it is not computed if we are actively updating it
 					if diff.HasChange("private_ips") {
@@ -281,7 +281,7 @@ func resourceNetworkInterface() *schema.Resource {
 					return diff.HasChange("private_ip_list")
 				}
 			}),
-			customdiff.ComputedIf("private_ips_count", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("private_ips_count", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				if !diff.Get("private_ip_list_enabled").(bool) {
 					// it is not computed if we are actively updating it
 					if diff.HasChange("private_ips_count") {
@@ -295,7 +295,7 @@ func resourceNetworkInterface() *schema.Resource {
 					return diff.HasChange("private_ip_list")
 				}
 			}),
-			customdiff.ComputedIf("private_ip_list", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("private_ip_list", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				if diff.Get("private_ip_list_enabled").(bool) {
 					// if the list is controlling it does not need to be computed
 					return false
@@ -304,7 +304,7 @@ func resourceNetworkInterface() *schema.Resource {
 					return diff.HasChange("private_ips") || diff.HasChange("private_ips_count") || diff.HasChange("private_ip_list")
 				}
 			}),
-			customdiff.ComputedIf("ipv6_addresses", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("ipv6_addresses", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				if !diff.Get("ipv6_address_list_enabled").(bool) {
 					// it is not computed if we are actively updating it
 					if diff.HasChange("private_ips") {
@@ -316,7 +316,7 @@ func resourceNetworkInterface() *schema.Resource {
 					return diff.HasChange("ipv6_address_list")
 				}
 			}),
-			customdiff.ComputedIf("ipv6_address_count", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("ipv6_address_count", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				if !diff.Get("ipv6_address_list_enabled").(bool) {
 					// it is not computed if we are actively updating it
 					if diff.HasChange("ipv6_address_count") {
@@ -330,7 +330,7 @@ func resourceNetworkInterface() *schema.Resource {
 					return diff.HasChange("ipv6_address_list")
 				}
 			}),
-			customdiff.ComputedIf("ipv6_address_list", func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("ipv6_address_list", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				if diff.Get("ipv6_address_list_enabled").(bool) {
 					// if the list is controlling it does not need to be computed
 					return false
@@ -343,7 +343,7 @@ func resourceNetworkInterface() *schema.Resource {
 	}
 }
 
-func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -394,8 +394,8 @@ func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if d.Get("private_ip_list_enabled").(bool) {
-		if v, ok := d.GetOk("private_ip_list"); ok && len(v.([]interface{})) > 0 {
-			input.PrivateIpAddresses = expandPrivateIPAddressSpecifications(v.([]interface{}))
+		if v, ok := d.GetOk("private_ip_list"); ok && len(v.([]any)) > 0 {
+			input.PrivateIpAddresses = expandPrivateIPAddressSpecifications(v.([]any))
 		}
 	} else {
 		if v, ok := d.GetOk("private_ips"); ok && v.(*schema.Set).Len() > 0 {
@@ -410,7 +410,7 @@ func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 				}
 			}
 			// truncate the list
-			countLimitedIPs := make([]interface{}, totalPrivateIPs)
+			countLimitedIPs := make([]any, totalPrivateIPs)
 			for i, ip := range privateIPs {
 				countLimitedIPs[i] = ip.(string)
 				if i == totalPrivateIPs-1 {
@@ -489,7 +489,7 @@ func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if v, ok := d.GetOk("attachment"); ok && v.(*schema.Set).Len() > 0 {
-		attachment := v.(*schema.Set).List()[0].(map[string]interface{})
+		attachment := v.(*schema.Set).List()[0].(map[string]any)
 
 		_, err := attachNetworkInterface(ctx, conn, d.Id(), attachment["instance"].(string), attachment["device_index"].(int), networkInterfaceAttachedTimeout)
 
@@ -501,11 +501,11 @@ func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceNetworkInterfaceRead(ctx, d, meta)...)
 }
 
-func resourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findNetworkInterfaceByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -531,7 +531,7 @@ func resourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData, m
 	}.String()
 	d.Set(names.AttrARN, arn)
 	if eni.Attachment != nil {
-		if err := d.Set("attachment", []interface{}{flattenNetworkInterfaceAttachment(eni.Attachment)}); err != nil {
+		if err := d.Set("attachment", []any{flattenNetworkInterfaceAttachment(eni.Attachment)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting attachment: %s", err)
 		}
 	} else {
@@ -582,7 +582,7 @@ func resourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	privateIPsNetChange := 0
@@ -591,7 +591,7 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 		oa, na := d.GetChange("attachment")
 
 		if oa != nil && oa.(*schema.Set).Len() > 0 {
-			attachment := oa.(*schema.Set).List()[0].(map[string]interface{})
+			attachment := oa.(*schema.Set).List()[0].(map[string]any)
 
 			if err := detachNetworkInterface(ctx, conn, d.Id(), attachment["attachment_id"].(string), networkInterfaceDetachedTimeout); err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
@@ -599,7 +599,7 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 
 		if na != nil && na.(*schema.Set).Len() > 0 {
-			attachment := na.(*schema.Set).List()[0].(map[string]interface{})
+			attachment := na.(*schema.Set).List()[0].(map[string]any)
 
 			if _, err := attachNetworkInterface(ctx, conn, d.Id(), attachment["instance"].(string), attachment["device_index"].(int), networkInterfaceAttachedTimeout); err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
@@ -661,10 +661,10 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 		if n == nil {
 			n = make([]string, 0)
 		}
-		if len(o.([]interface{}))-1 > 0 {
-			privateIPsToUnassign := make([]interface{}, len(o.([]interface{}))-1)
+		if len(o.([]any))-1 > 0 {
+			privateIPsToUnassign := make([]any, len(o.([]any))-1)
 			idx := 0
-			for i, ip := range o.([]interface{}) {
+			for i, ip := range o.([]any) {
 				// skip primary private ip address
 				if i == 0 {
 					continue
@@ -687,12 +687,12 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 
 		// Assign each ip one-by-one in order to retain order
-		for i, ip := range n.([]interface{}) {
+		for i, ip := range n.([]any) {
 			// skip primary private ip address
 			if i == 0 {
 				continue
 			}
-			privateIPToAssign := []interface{}{ip}
+			privateIPToAssign := []any{ip}
 
 			input := &ec2.AssignPrivateIpAddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
@@ -916,9 +916,9 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 
 		// Unassign old IPV6 addresses
-		if len(o.([]interface{})) > 0 {
-			unassignIPs := make([]interface{}, len(o.([]interface{})))
-			copy(unassignIPs, o.([]interface{}))
+		if len(o.([]any)) > 0 {
+			unassignIPs := make([]any, len(o.([]any)))
+			copy(unassignIPs, o.([]any))
 
 			input := &ec2.UnassignIpv6AddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
@@ -933,8 +933,8 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 
 		// Assign each ip one-by-one in order to retain order
-		for _, ip := range n.([]interface{}) {
-			privateIPToAssign := []interface{}{ip}
+		for _, ip := range n.([]any) {
+			privateIPToAssign := []any{ip}
 
 			input := &ec2.AssignIpv6AddressesInput{
 				NetworkInterfaceId: aws.String(d.Id()),
@@ -1065,12 +1065,12 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceNetworkInterfaceRead(ctx, d, meta)...)
 }
 
-func resourceNetworkInterfaceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfaceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	if v, ok := d.GetOk("attachment"); ok && v.(*schema.Set).Len() > 0 {
-		attachment := v.(*schema.Set).List()[0].(map[string]interface{})
+		attachment := v.(*schema.Set).List()[0].(map[string]any)
 
 		if err := detachNetworkInterface(ctx, conn, d.Id(), attachment["attachment_id"].(string), networkInterfaceDetachedTimeout); err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
@@ -1156,12 +1156,12 @@ func detachNetworkInterface(ctx context.Context, conn *ec2.Client, networkInterf
 	return nil
 }
 
-func flattenNetworkInterfaceAssociation(apiObject *types.NetworkInterfaceAssociation) map[string]interface{} {
+func flattenNetworkInterfaceAssociation(apiObject *types.NetworkInterfaceAssociation) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AllocationId; v != nil {
 		tfMap["allocation_id"] = aws.ToString(v)
@@ -1194,12 +1194,12 @@ func flattenNetworkInterfaceAssociation(apiObject *types.NetworkInterfaceAssocia
 	return tfMap
 }
 
-func flattenNetworkInterfaceAttachment(apiObject *types.NetworkInterfaceAttachment) map[string]interface{} {
+func flattenNetworkInterfaceAttachment(apiObject *types.NetworkInterfaceAttachment) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AttachmentId; v != nil {
 		tfMap["attachment_id"] = aws.ToString(v)
@@ -1228,7 +1228,7 @@ func expandPrivateIPAddressSpecification(tfString string) *types.PrivateIpAddres
 	return apiObject
 }
 
-func expandPrivateIPAddressSpecifications(tfList []interface{}) []types.PrivateIpAddressSpecification {
+func expandPrivateIPAddressSpecifications(tfList []any) []types.PrivateIpAddressSpecification {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1270,7 +1270,7 @@ func expandInstanceIPv6Address(tfString string) *types.InstanceIpv6Address {
 	return apiObject
 }
 
-func expandInstanceIPv6Addresses(tfList []interface{}) []types.InstanceIpv6Address {
+func expandInstanceIPv6Addresses(tfList []any) []types.InstanceIpv6Address {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1364,7 +1364,7 @@ func expandIPv4PrefixSpecificationRequest(tfString string) *types.Ipv4PrefixSpec
 	return apiObject
 }
 
-func expandIPv4PrefixSpecificationRequests(tfList []interface{}) []types.Ipv4PrefixSpecificationRequest {
+func expandIPv4PrefixSpecificationRequests(tfList []any) []types.Ipv4PrefixSpecificationRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1402,7 +1402,7 @@ func expandIPv6PrefixSpecificationRequest(tfString string) *types.Ipv6PrefixSpec
 	return apiObject
 }
 
-func expandIPv6PrefixSpecificationRequests(tfList []interface{}) []types.Ipv6PrefixSpecificationRequest {
+func expandIPv6PrefixSpecificationRequests(tfList []any) []types.Ipv6PrefixSpecificationRequest {
 	if len(tfList) == 0 {
 		return nil
 	}

--- a/internal/service/ec2/vpc_network_interface_attachment.go
+++ b/internal/service/ec2/vpc_network_interface_attachment.go
@@ -53,7 +53,7 @@ func resourceNetworkInterfaceAttachment() *schema.Resource {
 	}
 }
 
-func resourceNetworkInterfaceAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfaceAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -75,7 +75,7 @@ func resourceNetworkInterfaceAttachmentCreate(ctx context.Context, d *schema.Res
 	return append(diags, resourceNetworkInterfaceAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceNetworkInterfaceAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfaceAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -100,7 +100,7 @@ func resourceNetworkInterfaceAttachmentRead(ctx context.Context, d *schema.Resou
 	return diags
 }
 
-func resourceNetworkInterfaceAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfaceAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_network_interface_data_source.go
+++ b/internal/service/ec2/vpc_network_interface_data_source.go
@@ -166,7 +166,7 @@ func dataSourceNetworkInterface() *schema.Resource {
 	}
 }
 
-func dataSourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -197,14 +197,14 @@ func dataSourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData,
 	}.String()
 	d.Set(names.AttrARN, arn)
 	if eni.Association != nil {
-		if err := d.Set("association", []interface{}{flattenNetworkInterfaceAssociation(eni.Association)}); err != nil {
+		if err := d.Set("association", []any{flattenNetworkInterfaceAssociation(eni.Association)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting association: %s", err)
 		}
 	} else {
 		d.Set("association", nil)
 	}
 	if eni.Attachment != nil {
-		if err := d.Set("attachment", []interface{}{flattenNetworkInterfaceAttachmentForDataSource(eni.Attachment)}); err != nil {
+		if err := d.Set("attachment", []any{flattenNetworkInterfaceAttachmentForDataSource(eni.Attachment)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting attachment: %s", err)
 		}
 	} else {
@@ -230,12 +230,12 @@ func dataSourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func flattenNetworkInterfaceAttachmentForDataSource(apiObject *types.NetworkInterfaceAttachment) map[string]interface{} {
+func flattenNetworkInterfaceAttachmentForDataSource(apiObject *types.NetworkInterfaceAttachment) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AttachmentId; v != nil {
 		tfMap["attachment_id"] = aws.ToString(v)

--- a/internal/service/ec2/vpc_network_interface_sg_attachment.go
+++ b/internal/service/ec2/vpc_network_interface_sg_attachment.go
@@ -54,7 +54,7 @@ func resourceNetworkInterfaceSGAttachment() *schema.Resource {
 	}
 }
 
-func resourceNetworkInterfaceSGAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfaceSGAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -99,13 +99,13 @@ func resourceNetworkInterfaceSGAttachmentCreate(ctx context.Context, d *schema.R
 	return append(diags, resourceNetworkInterfaceSGAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceNetworkInterfaceSGAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfaceSGAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	networkInterfaceID := d.Get(names.AttrNetworkInterfaceID).(string)
 	sgID := d.Get("security_group_id").(string)
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, maxDuration(ec2PropagationTimeout, d.Timeout(schema.TimeoutRead)), func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, maxDuration(ec2PropagationTimeout, d.Timeout(schema.TimeoutRead)), func() (any, error) {
 		return findNetworkInterfaceSecurityGroup(ctx, conn, networkInterfaceID, sgID)
 	}, d.IsNewResource())
 
@@ -135,7 +135,7 @@ func maxDuration(a, b time.Duration) time.Duration {
 	return b
 }
 
-func resourceNetworkInterfaceSGAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkInterfaceSGAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -186,7 +186,7 @@ func resourceNetworkInterfaceSGAttachmentDelete(ctx context.Context, d *schema.R
 	return diags
 }
 
-func resourceNetworkInterfaceSGAttachmentImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceNetworkInterfaceSGAttachmentImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "_")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("Unexpected format for import: %s. Please use '<NetworkInterfaceId>_<SecurityGroupID>", d.Id())

--- a/internal/service/ec2/vpc_network_interfaces_data_source.go
+++ b/internal/service/ec2/vpc_network_interfaces_data_source.go
@@ -38,14 +38,14 @@ func dataSourceNetworkInterfaces() *schema.Resource {
 	}
 }
 
-func dataSourceNetworkInterfacesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceNetworkInterfacesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := &ec2.DescribeNetworkInterfacesInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/vpc_network_performance_metric_subscription.go
+++ b/internal/service/ec2/vpc_network_performance_metric_subscription.go
@@ -61,7 +61,7 @@ func resourceNetworkPerformanceMetricSubscription() *schema.Resource {
 	}
 }
 
-func resourceNetworkPerformanceMetricSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkPerformanceMetricSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -88,7 +88,7 @@ func resourceNetworkPerformanceMetricSubscriptionCreate(ctx context.Context, d *
 	return append(diags, resourceNetworkPerformanceMetricSubscriptionRead(ctx, d, meta)...)
 }
 
-func resourceNetworkPerformanceMetricSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkPerformanceMetricSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -118,7 +118,7 @@ func resourceNetworkPerformanceMetricSubscriptionRead(ctx context.Context, d *sc
 	return diags
 }
 
-func resourceNetworkPerformanceMetricSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNetworkPerformanceMetricSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_peering_connection.go
+++ b/internal/service/ec2/vpc_peering_connection.go
@@ -100,7 +100,7 @@ var vpcPeeringConnectionOptionsSchema = &schema.Schema{
 	},
 }
 
-func resourceVPCPeeringConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCPeeringConnectionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -152,7 +152,7 @@ func resourceVPCPeeringConnectionCreate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceVPCPeeringConnectionRead(ctx, d, meta)...)
 }
 
-func resourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -184,7 +184,7 @@ func resourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if vpcPeeringConnection.AccepterVpcInfo.PeeringOptions != nil {
-		if err := d.Set("accepter", []interface{}{flattenVPCPeeringConnectionOptionsDescription(vpcPeeringConnection.AccepterVpcInfo.PeeringOptions)}); err != nil {
+		if err := d.Set("accepter", []any{flattenVPCPeeringConnectionOptionsDescription(vpcPeeringConnection.AccepterVpcInfo.PeeringOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting accepter: %s", err)
 		}
 	} else {
@@ -192,7 +192,7 @@ func resourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if vpcPeeringConnection.RequesterVpcInfo.PeeringOptions != nil {
-		if err := d.Set("requester", []interface{}{flattenVPCPeeringConnectionOptionsDescription(vpcPeeringConnection.RequesterVpcInfo.PeeringOptions)}); err != nil {
+		if err := d.Set("requester", []any{flattenVPCPeeringConnectionOptionsDescription(vpcPeeringConnection.RequesterVpcInfo.PeeringOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting requester: %s", err)
 		}
 	} else {
@@ -204,7 +204,7 @@ func resourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceVPCPeeringConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCPeeringConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -231,7 +231,7 @@ func resourceVPCPeeringConnectionUpdate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceVPCPeeringConnectionRead(ctx, d, meta)...)
 }
 
-func resourceVPCPeeringConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCPeeringConnectionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -286,14 +286,14 @@ func modifyVPCPeeringConnectionOptions(ctx context.Context, conn *ec2.Client, d 
 	var accepterPeeringConnectionOptions, requesterPeeringConnectionOptions *awstypes.PeeringConnectionOptionsRequest
 
 	if key := "accepter"; d.HasChange(key) {
-		if v, ok := d.GetOk(key); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			accepterPeeringConnectionOptions = expandPeeringConnectionOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk(key); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			accepterPeeringConnectionOptions = expandPeeringConnectionOptionsRequest(v.([]any)[0].(map[string]any))
 		}
 	}
 
 	if key := "requester"; d.HasChange(key) {
-		if v, ok := d.GetOk(key); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			requesterPeeringConnectionOptions = expandPeeringConnectionOptionsRequest(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk(key); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			requesterPeeringConnectionOptions = expandPeeringConnectionOptionsRequest(v.([]any)[0].(map[string]any))
 		}
 	}
 
@@ -358,7 +358,7 @@ func vpcPeeringConnectionOptionsEqual(o1 *awstypes.VpcPeeringConnectionOptionsDe
 	return aws.ToBool(o1.AllowDnsResolutionFromRemoteVpc) == aws.ToBool(o2.AllowDnsResolutionFromRemoteVpc)
 }
 
-func expandPeeringConnectionOptionsRequest(tfMap map[string]interface{}) *awstypes.PeeringConnectionOptionsRequest {
+func expandPeeringConnectionOptionsRequest(tfMap map[string]any) *awstypes.PeeringConnectionOptionsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -372,12 +372,12 @@ func expandPeeringConnectionOptionsRequest(tfMap map[string]interface{}) *awstyp
 	return apiObject
 }
 
-func flattenVPCPeeringConnectionOptionsDescription(apiObject *awstypes.VpcPeeringConnectionOptionsDescription) map[string]interface{} {
+func flattenVPCPeeringConnectionOptionsDescription(apiObject *awstypes.VpcPeeringConnectionOptionsDescription) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AllowDnsResolutionFromRemoteVpc; v != nil {
 		tfMap["allow_remote_vpc_dns_resolution"] = aws.ToBool(v)

--- a/internal/service/ec2/vpc_peering_connection_accepter.go
+++ b/internal/service/ec2/vpc_peering_connection_accepter.go
@@ -32,7 +32,7 @@ func resourceVPCPeeringConnectionAccepter() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) (result []*schema.ResourceData, err error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, m any) (result []*schema.ResourceData, err error) {
 				d.Set("vpc_peering_connection_id", d.Id())
 
 				return []*schema.ResourceData{d}, nil
@@ -84,7 +84,7 @@ func resourceVPCPeeringConnectionAccepter() *schema.Resource {
 	}
 }
 
-func resourceVPCPeeringAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCPeeringAccepterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_peering_connection_data_source.go
+++ b/internal/service/ec2/vpc_peering_connection_data_source.go
@@ -142,7 +142,7 @@ func dataSourceVPCPeeringConnection() *schema.Resource {
 	}
 }
 
-func dataSourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
@@ -167,7 +167,7 @@ func dataSourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceD
 
 	if tags, tagsOk := d.GetOk(names.AttrTags); tagsOk {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+			Tags(tftags.New(ctx, tags.(map[string]any))),
 		)...)
 	}
 
@@ -191,9 +191,9 @@ func dataSourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceD
 	d.Set(names.AttrOwnerID, vpcPeeringConnection.RequesterVpcInfo.OwnerId)
 	d.Set(names.AttrCIDRBlock, vpcPeeringConnection.RequesterVpcInfo.CidrBlock)
 
-	cidrBlockSet := []interface{}{}
+	cidrBlockSet := []any{}
 	for _, v := range vpcPeeringConnection.RequesterVpcInfo.CidrBlockSet {
-		cidrBlockSet = append(cidrBlockSet, map[string]interface{}{
+		cidrBlockSet = append(cidrBlockSet, map[string]any{
 			names.AttrCIDRBlock: aws.ToString(v.CidrBlock),
 		})
 	}
@@ -201,9 +201,9 @@ func dataSourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceD
 		return sdkdiag.AppendErrorf(diags, "setting cidr_block_set: %s", err)
 	}
 
-	ipv6CidrBlockSet := []interface{}{}
+	ipv6CidrBlockSet := []any{}
 	for _, v := range vpcPeeringConnection.RequesterVpcInfo.Ipv6CidrBlockSet {
-		ipv6CidrBlockSet = append(ipv6CidrBlockSet, map[string]interface{}{
+		ipv6CidrBlockSet = append(ipv6CidrBlockSet, map[string]any{
 			"ipv6_cidr_block": aws.ToString(v.Ipv6CidrBlock),
 		})
 	}
@@ -216,9 +216,9 @@ func dataSourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceD
 	d.Set("peer_owner_id", vpcPeeringConnection.AccepterVpcInfo.OwnerId)
 	d.Set("peer_cidr_block", vpcPeeringConnection.AccepterVpcInfo.CidrBlock)
 
-	peerCidrBlockSet := []interface{}{}
+	peerCidrBlockSet := []any{}
 	for _, v := range vpcPeeringConnection.AccepterVpcInfo.CidrBlockSet {
-		peerCidrBlockSet = append(peerCidrBlockSet, map[string]interface{}{
+		peerCidrBlockSet = append(peerCidrBlockSet, map[string]any{
 			names.AttrCIDRBlock: aws.ToString(v.CidrBlock),
 		})
 	}
@@ -226,9 +226,9 @@ func dataSourceVPCPeeringConnectionRead(ctx context.Context, d *schema.ResourceD
 		return sdkdiag.AppendErrorf(diags, "setting peer_cidr_block_set: %s", err)
 	}
 
-	peerIpv6CidrBlockSet := []interface{}{}
+	peerIpv6CidrBlockSet := []any{}
 	for _, v := range vpcPeeringConnection.AccepterVpcInfo.Ipv6CidrBlockSet {
-		peerIpv6CidrBlockSet = append(peerIpv6CidrBlockSet, map[string]interface{}{
+		peerIpv6CidrBlockSet = append(peerIpv6CidrBlockSet, map[string]any{
 			"ipv6_cidr_block": aws.ToString(v.Ipv6CidrBlock),
 		})
 	}

--- a/internal/service/ec2/vpc_peering_connection_options.go
+++ b/internal/service/ec2/vpc_peering_connection_options.go
@@ -37,7 +37,7 @@ func resourceVPCPeeringConnectionOptions() *schema.Resource {
 	}
 }
 
-func resourceVPCPeeringConnectionOptionsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCPeeringConnectionOptionsCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -57,7 +57,7 @@ func resourceVPCPeeringConnectionOptionsCreate(ctx context.Context, d *schema.Re
 	return append(diags, resourceVPCPeeringConnectionOptionsRead(ctx, d, meta)...)
 }
 
-func resourceVPCPeeringConnectionOptionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCPeeringConnectionOptionsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -76,7 +76,7 @@ func resourceVPCPeeringConnectionOptionsRead(ctx context.Context, d *schema.Reso
 	d.Set("vpc_peering_connection_id", vpcPeeringConnection.VpcPeeringConnectionId)
 
 	if vpcPeeringConnection.AccepterVpcInfo.PeeringOptions != nil {
-		if err := d.Set("accepter", []interface{}{flattenVPCPeeringConnectionOptionsDescription(vpcPeeringConnection.AccepterVpcInfo.PeeringOptions)}); err != nil {
+		if err := d.Set("accepter", []any{flattenVPCPeeringConnectionOptionsDescription(vpcPeeringConnection.AccepterVpcInfo.PeeringOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting accepter: %s", err)
 		}
 	} else {
@@ -84,7 +84,7 @@ func resourceVPCPeeringConnectionOptionsRead(ctx context.Context, d *schema.Reso
 	}
 
 	if vpcPeeringConnection.RequesterVpcInfo.PeeringOptions != nil {
-		if err := d.Set("requester", []interface{}{flattenVPCPeeringConnectionOptionsDescription(vpcPeeringConnection.RequesterVpcInfo.PeeringOptions)}); err != nil {
+		if err := d.Set("requester", []any{flattenVPCPeeringConnectionOptionsDescription(vpcPeeringConnection.RequesterVpcInfo.PeeringOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting requester: %s", err)
 		}
 	} else {
@@ -94,7 +94,7 @@ func resourceVPCPeeringConnectionOptionsRead(ctx context.Context, d *schema.Reso
 	return diags
 }
 
-func resourceVPCPeeringConnectionOptionsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCPeeringConnectionOptionsUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -111,7 +111,7 @@ func resourceVPCPeeringConnectionOptionsUpdate(ctx context.Context, d *schema.Re
 	return append(diags, resourceVPCPeeringConnectionOptionsRead(ctx, d, meta)...)
 }
 
-func resourceVPCPeeringConnectionOptionsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCPeeringConnectionOptionsDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var
 	// Don't do anything with the underlying VPC Peering Connection.
 	diags diag.Diagnostics

--- a/internal/service/ec2/vpc_peering_connections_data_source.go
+++ b/internal/service/ec2/vpc_peering_connections_data_source.go
@@ -38,14 +38,14 @@ func dataSourceVPCPeeringConnections() *schema.Resource {
 	}
 }
 
-func dataSourceVPCPeeringConnectionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVPCPeeringConnectionsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	input := &ec2.DescribeVpcPeeringConnectionsInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 	input.Filters = append(input.Filters, newCustomFilterList(
 		d.Get(names.AttrFilter).(*schema.Set),

--- a/internal/service/ec2/vpc_prefix_list_data_source.go
+++ b/internal/service/ec2/vpc_prefix_list_data_source.go
@@ -46,7 +46,7 @@ func dataSourcePrefixList() *schema.Resource {
 	}
 }
 
-func dataSourcePrefixListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourcePrefixListRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_route.go
+++ b/internal/service/ec2/vpc_route.go
@@ -181,7 +181,7 @@ func resourceRoute() *schema.Resource {
 	}
 }
 
-func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -254,7 +254,7 @@ func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate),
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateRoute(ctx, input)
 		},
 		errCodeInvalidParameterException,
@@ -279,7 +279,7 @@ func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceRouteRead(ctx, d, meta)...)
 }
 
-func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -302,7 +302,7 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	routeTableID := d.Get("route_table_id").(string)
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return routeFinder(ctx, conn, routeTableID, destination)
 	}, d.IsNewResource())
 
@@ -344,7 +344,7 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -425,7 +425,7 @@ func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceRouteRead(ctx, d, meta)...)
 }
 
-func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -458,7 +458,7 @@ func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta inter
 
 	log.Printf("[DEBUG] Deleting Route: %v", input)
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete),
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.DeleteRoute(ctx, input)
 		},
 		errCodeInvalidParameterException,
@@ -484,7 +484,7 @@ func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceRouteImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceRouteImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	idParts := strings.Split(d.Id(), "_")
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format of ID (%q), expected ROUTETABLEID_DESTINATION", d.Id())

--- a/internal/service/ec2/vpc_route_data_source.go
+++ b/internal/service/ec2/vpc_route_data_source.go
@@ -108,7 +108,7 @@ func dataSourceRoute() *schema.Resource {
 	}
 }
 
-func dataSourceRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_route_table.go
+++ b/internal/service/ec2/vpc_route_table.go
@@ -166,7 +166,7 @@ func resourceRouteTable() *schema.Resource {
 	}
 }
 
-func resourceRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -200,7 +200,7 @@ func resourceRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	if v, ok := d.GetOk("route"); ok && v.(*schema.Set).Len() > 0 {
 		for _, v := range v.(*schema.Set).List() {
-			v := v.(map[string]interface{})
+			v := v.(map[string]any)
 
 			if err := routeTableAddRoute(ctx, conn, d.Id(), v, d.Timeout(schema.TimeoutCreate)); err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
@@ -211,11 +211,11 @@ func resourceRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceRouteTableRead(ctx, d, meta)...)
 }
 
-func resourceRouteTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findRouteTableByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -258,7 +258,7 @@ func resourceRouteTableRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -290,7 +290,7 @@ func resourceRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		o, n := d.GetChange("route")
 
 		for _, new := range n.(*schema.Set).List() {
-			vNew := new.(map[string]interface{})
+			vNew := new.(map[string]any)
 
 			_, newDestination := routeTableRouteDestinationAttribute(vNew)
 			_, newTarget := routeTableRouteTargetAttribute(vNew)
@@ -298,7 +298,7 @@ func resourceRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			addRoute := true
 
 			for _, old := range o.(*schema.Set).List() {
-				vOld := old.(map[string]interface{})
+				vOld := old.(map[string]any)
 
 				_, oldDestination := routeTableRouteDestinationAttribute(vOld)
 				_, oldTarget := routeTableRouteTargetAttribute(vOld)
@@ -322,14 +322,14 @@ func resourceRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 
 		for _, old := range o.(*schema.Set).List() {
-			vOld := old.(map[string]interface{})
+			vOld := old.(map[string]any)
 
 			_, oldDestination := routeTableRouteDestinationAttribute(vOld)
 
 			delRoute := true
 
 			for _, new := range n.(*schema.Set).List() {
-				vNew := new.(map[string]interface{})
+				vNew := new.(map[string]any)
 
 				_, newDestination := routeTableRouteDestinationAttribute(vNew)
 
@@ -349,7 +349,7 @@ func resourceRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceRouteTableRead(ctx, d, meta)...)
 }
 
-func resourceRouteTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteTableDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -393,9 +393,9 @@ func resourceRouteTableDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceRouteTableHash(v interface{}) int {
+func resourceRouteTableHash(v any) int {
 	var buf bytes.Buffer
-	m, castOk := v.(map[string]interface{})
+	m, castOk := v.(map[string]any)
 	if !castOk {
 		return 0
 	}
@@ -458,7 +458,7 @@ func resourceRouteTableHash(v interface{}) int {
 }
 
 // routeTableAddRoute adds a route to the specified route table.
-func routeTableAddRoute(ctx context.Context, conn *ec2.Client, routeTableID string, tfMap map[string]interface{}, timeout time.Duration) error {
+func routeTableAddRoute(ctx context.Context, conn *ec2.Client, routeTableID string, tfMap map[string]any, timeout time.Duration) error {
 	if err := validNestedExactlyOneOf(tfMap, routeTableValidDestinations); err != nil {
 		return fmt.Errorf("creating route: %w", err)
 	}
@@ -495,7 +495,7 @@ func routeTableAddRoute(ctx context.Context, conn *ec2.Client, routeTableID stri
 		// created by AWS so probably doesn't need a retry but just to be sure
 		// we provide a small one
 		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, time.Second*15,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return routeFinder(ctx, conn, routeTableID, destination)
 			},
 			errCodeInvalidRouteNotFound,
@@ -513,7 +513,7 @@ func routeTableAddRoute(ctx context.Context, conn *ec2.Client, routeTableID stri
 	}
 
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateRoute(ctx, input)
 		},
 		errCodeInvalidParameterException,
@@ -532,7 +532,7 @@ func routeTableAddRoute(ctx context.Context, conn *ec2.Client, routeTableID stri
 }
 
 // routeTableDeleteRoute deletes a route from the specified route table.
-func routeTableDeleteRoute(ctx context.Context, conn *ec2.Client, routeTableID string, tfMap map[string]interface{}, timeout time.Duration) error {
+func routeTableDeleteRoute(ctx context.Context, conn *ec2.Client, routeTableID string, tfMap map[string]any, timeout time.Duration) error {
 	destinationAttributeKey, destination := routeTableRouteDestinationAttribute(tfMap)
 
 	input := &ec2.DeleteRouteInput{
@@ -573,7 +573,7 @@ func routeTableDeleteRoute(ctx context.Context, conn *ec2.Client, routeTableID s
 }
 
 // routeTableUpdateRoute updates a route in the specified route table.
-func routeTableUpdateRoute(ctx context.Context, conn *ec2.Client, routeTableID string, tfMap map[string]interface{}, timeout time.Duration) error {
+func routeTableUpdateRoute(ctx context.Context, conn *ec2.Client, routeTableID string, tfMap map[string]any, timeout time.Duration) error {
 	if err := validNestedExactlyOneOf(tfMap, routeTableValidDestinations); err != nil {
 		return fmt.Errorf("updating route: %w", err)
 	}
@@ -644,7 +644,7 @@ func routeTableEnableVGWRoutePropagation(ctx context.Context, conn *ec2.Client, 
 	}
 
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.EnableVgwRoutePropagation(ctx, input)
 		},
 		errCodeGatewayNotAttached,
@@ -657,7 +657,7 @@ func routeTableEnableVGWRoutePropagation(ctx context.Context, conn *ec2.Client, 
 	return nil
 }
 
-func expandCreateRouteInput(tfMap map[string]interface{}) *ec2.CreateRouteInput {
+func expandCreateRouteInput(tfMap map[string]any) *ec2.CreateRouteInput {
 	if tfMap == nil {
 		return nil
 	}
@@ -719,7 +719,7 @@ func expandCreateRouteInput(tfMap map[string]interface{}) *ec2.CreateRouteInput 
 	return apiObject
 }
 
-func expandReplaceRouteInput(tfMap map[string]interface{}) *ec2.ReplaceRouteInput {
+func expandReplaceRouteInput(tfMap map[string]any) *ec2.ReplaceRouteInput {
 	if tfMap == nil {
 		return nil
 	}
@@ -785,12 +785,12 @@ func expandReplaceRouteInput(tfMap map[string]interface{}) *ec2.ReplaceRouteInpu
 	return apiObject
 }
 
-func flattenRoute(apiObject *awstypes.Route) map[string]interface{} {
+func flattenRoute(apiObject *awstypes.Route) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.DestinationCidrBlock; v != nil {
 		tfMap[names.AttrCIDRBlock] = aws.ToString(v)
@@ -847,12 +847,12 @@ func flattenRoute(apiObject *awstypes.Route) map[string]interface{} {
 	return tfMap
 }
 
-func flattenRoutes(ctx context.Context, conn *ec2.Client, d *schema.ResourceData, apiObjects []awstypes.Route) []interface{} {
+func flattenRoutes(ctx context.Context, conn *ec2.Client, d *schema.ResourceData, apiObjects []awstypes.Route) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if gatewayID := aws.ToString(apiObject.GatewayId); gatewayID == gatewayIDVPCLattice {
@@ -902,7 +902,7 @@ func flattenRoutes(ctx context.Context, conn *ec2.Client, d *schema.ResourceData
 func hasLocalConfig(d *schema.ResourceData, apiObject awstypes.Route) bool {
 	if v, ok := d.GetOk("route"); ok && v.(*schema.Set).Len() > 0 {
 		for _, v := range v.(*schema.Set).List() {
-			v := v.(map[string]interface{})
+			v := v.(map[string]any)
 			if v[names.AttrCIDRBlock].(string) != aws.ToString(apiObject.DestinationCidrBlock) &&
 				v["destination_prefix_list_id"] != aws.ToString(apiObject.DestinationPrefixListId) &&
 				v["ipv6_cidr_block"] != aws.ToString(apiObject.DestinationIpv6CidrBlock) {
@@ -919,7 +919,7 @@ func hasLocalConfig(d *schema.ResourceData, apiObject awstypes.Route) bool {
 }
 
 // routeTableRouteDestinationAttribute returns the attribute key and value of the route table route's destination.
-func routeTableRouteDestinationAttribute(m map[string]interface{}) (string, string) {
+func routeTableRouteDestinationAttribute(m map[string]any) (string, string) {
 	for _, key := range routeTableValidDestinations {
 		if v, ok := m[key].(string); ok && v != "" {
 			return key, v
@@ -930,7 +930,7 @@ func routeTableRouteDestinationAttribute(m map[string]interface{}) (string, stri
 }
 
 // routeTableRouteTargetAttribute returns the attribute key and value of the route table route's target.
-func routeTableRouteTargetAttribute(m map[string]interface{}) (string, string) { //nolint:unparam
+func routeTableRouteTargetAttribute(m map[string]any) (string, string) { //nolint:unparam
 	for _, key := range routeTableValidTargets {
 		if v, ok := m[key].(string); ok && v != "" {
 			return key, v

--- a/internal/service/ec2/vpc_route_table_association.go
+++ b/internal/service/ec2/vpc_route_table_association.go
@@ -60,7 +60,7 @@ func resourceRouteTableAssociation() *schema.Resource {
 	}
 }
 
-func resourceRouteTableAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteTableAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -78,7 +78,7 @@ func resourceRouteTableAssociationCreate(ctx context.Context, d *schema.Resource
 	}
 
 	output, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.AssociateRouteTable(ctx, input)
 		},
 		errCodeInvalidRouteTableIDNotFound,
@@ -97,11 +97,11 @@ func resourceRouteTableAssociationCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceRouteTableAssociationRead(ctx, d, meta)...)
 }
 
-func resourceRouteTableAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteTableAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findRouteTableAssociationByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -124,7 +124,7 @@ func resourceRouteTableAssociationRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceRouteTableAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteTableAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -160,7 +160,7 @@ func resourceRouteTableAssociationUpdate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceRouteTableAssociationRead(ctx, d, meta)...)
 }
 
-func resourceRouteTableAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteTableAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -170,7 +170,7 @@ func resourceRouteTableAssociationDelete(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceRouteTableAssociationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceRouteTableAssociationImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("Unexpected format for import: %s. Use 'subnet ID/route table ID' or 'gateway ID/route table ID", d.Id())

--- a/internal/service/ec2/vpc_route_table_data_source.go
+++ b/internal/service/ec2/vpc_route_table_data_source.go
@@ -186,7 +186,7 @@ func dataSourceRouteTable() *schema.Resource {
 	}
 }
 
-func dataSourceRouteTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceRouteTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
@@ -211,7 +211,7 @@ func dataSourceRouteTableRead(ctx context.Context, d *schema.ResourceData, meta 
 		},
 	)
 	req.Filters = append(req.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+		Tags(tftags.New(ctx, tags.(map[string]any))),
 	)...)
 	req.Filters = append(req.Filters, newCustomFilterList(
 		filter.(*schema.Set),
@@ -262,8 +262,8 @@ func dataSourceRouteTableRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func dataSourceRoutesRead(ctx context.Context, conn *ec2.Client, ec2Routes []awstypes.Route) []map[string]interface{} {
-	routes := make([]map[string]interface{}, 0, len(ec2Routes))
+func dataSourceRoutesRead(ctx context.Context, conn *ec2.Client, ec2Routes []awstypes.Route) []map[string]any {
+	routes := make([]map[string]any, 0, len(ec2Routes))
 	// Loop through the routes and add them to the set
 	for _, r := range ec2Routes {
 		if gatewayID := aws.ToString(r.GatewayId); gatewayID == gatewayIDLocal || gatewayID == gatewayIDVPCLattice {
@@ -292,7 +292,7 @@ func dataSourceRoutesRead(ctx context.Context, conn *ec2.Client, ec2Routes []aws
 			}
 		}
 
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 
 		if r.DestinationCidrBlock != nil {
 			m[names.AttrCIDRBlock] = aws.ToString(r.DestinationCidrBlock)
@@ -343,11 +343,11 @@ func dataSourceRoutesRead(ctx context.Context, conn *ec2.Client, ec2Routes []aws
 	return routes
 }
 
-func dataSourceAssociationsRead(ec2Assocations []awstypes.RouteTableAssociation) []map[string]interface{} {
-	associations := make([]map[string]interface{}, 0, len(ec2Assocations))
+func dataSourceAssociationsRead(ec2Assocations []awstypes.RouteTableAssociation) []map[string]any {
+	associations := make([]map[string]any, 0, len(ec2Assocations))
 	// Loop through the routes and add them to the set
 	for _, a := range ec2Assocations {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 		m["route_table_id"] = aws.ToString(a.RouteTableId)
 		m["route_table_association_id"] = aws.ToString(a.RouteTableAssociationId)
 		// GH[11134]

--- a/internal/service/ec2/vpc_route_tables_data_source.go
+++ b/internal/service/ec2/vpc_route_tables_data_source.go
@@ -42,7 +42,7 @@ func dataSourceRouteTables() *schema.Resource {
 	}
 }
 
-func dataSourceRouteTablesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceRouteTablesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -57,7 +57,7 @@ func dataSourceRouteTablesRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -185,7 +185,7 @@ var (
 	}
 )
 
-func resourceSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -265,7 +265,7 @@ func resourceSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceSecurityGroupUpdate(ctx, d, meta)...)
 }
 
-func resourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -321,7 +321,7 @@ func resourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -347,7 +347,7 @@ func resourceSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceSecurityGroupRead(ctx, d, meta)...)
 }
 
-func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -378,7 +378,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(
 		ctx,
 		firstShortRetry, // short initial attempt followed by full length attempt
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{
 				GroupId: aws.String(d.Id()),
 			})
@@ -398,7 +398,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 		_, err = tfresource.RetryWhenAWSErrCodeEquals(
 			ctx,
 			remainingRetry,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.DeleteSecurityGroup(ctx, &ec2.DeleteSecurityGroupInput{
 					GroupId: aws.String(d.Id()),
 				})
@@ -415,7 +415,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "deleting Security Group (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findSecurityGroupByID(ctx, conn, d.Id())
 	})
 
@@ -580,9 +580,9 @@ func relatedSGs(ctx context.Context, conn *ec2.Client, id string) ([]string, err
 	return relatedSGs, nil
 }
 
-func securityGroupRuleHash(v interface{}) int {
+func securityGroupRuleHash(v any) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m := v.(map[string]any)
 	buf.WriteString(fmt.Sprintf("%d-", m["from_port"].(int)))
 	buf.WriteString(fmt.Sprintf("%d-", m["to_port"].(int)))
 	p := protocolForValue(m[names.AttrProtocol].(string))
@@ -592,7 +592,7 @@ func securityGroupRuleHash(v interface{}) int {
 	// We need to make sure to sort the strings below so that we always
 	// generate the same hash code no matter what is in the set.
 	if v, ok := m["cidr_blocks"]; ok {
-		vs := v.([]interface{})
+		vs := v.([]any)
 		s := make([]string, len(vs))
 		for i, raw := range vs {
 			s[i] = raw.(string)
@@ -604,7 +604,7 @@ func securityGroupRuleHash(v interface{}) int {
 		}
 	}
 	if v, ok := m["ipv6_cidr_blocks"]; ok {
-		vs := v.([]interface{})
+		vs := v.([]any)
 		s := make([]string, len(vs))
 		for i, raw := range vs {
 			s[i] = raw.(string)
@@ -616,7 +616,7 @@ func securityGroupRuleHash(v interface{}) int {
 		}
 	}
 	if v, ok := m["prefix_list_ids"]; ok {
-		vs := v.([]interface{})
+		vs := v.([]any)
 		s := make([]string, len(vs))
 		for i, raw := range vs {
 			s[i] = raw.(string)
@@ -646,8 +646,8 @@ func securityGroupRuleHash(v interface{}) int {
 	return create.StringHashcode(buf.String())
 }
 
-func securityGroupIPPermGather(groupId string, permissions []awstypes.IpPermission, ownerId *string) []map[string]interface{} {
-	ruleMap := make(map[string]map[string]interface{})
+func securityGroupIPPermGather(groupId string, permissions []awstypes.IpPermission, ownerId *string) []map[string]any {
+	ruleMap := make(map[string]map[string]any)
 	for _, perm := range permissions {
 		if len(perm.IpRanges) > 0 {
 			for _, ip := range perm.IpRanges {
@@ -725,7 +725,7 @@ func securityGroupIPPermGather(groupId string, permissions []awstypes.IpPermissi
 		}
 	}
 
-	rules := make([]map[string]interface{}, 0, len(ruleMap))
+	rules := make([]map[string]any, 0, len(ruleMap))
 	for _, m := range ruleMap {
 		rules = append(rules, m)
 	}
@@ -821,11 +821,11 @@ func updateSecurityGroupRules(ctx context.Context, conn *ec2.Client, d *schema.R
 // group rules and returns EC2 API compatible objects. This function will error
 // if it finds invalid permissions input, namely a protocol of "-1" with either
 // to_port or from_port set to a non-zero value.
-func expandIPPerms(group *awstypes.SecurityGroup, configured []interface{}) ([]awstypes.IpPermission, error) {
+func expandIPPerms(group *awstypes.SecurityGroup, configured []any) ([]awstypes.IpPermission, error) {
 	perms := make([]awstypes.IpPermission, len(configured))
 	for i, mRaw := range configured {
 		var perm awstypes.IpPermission
-		m := mRaw.(map[string]interface{})
+		m := mRaw.(map[string]any)
 
 		perm.IpProtocol = aws.String(protocolForValue(m[names.AttrProtocol].(string)))
 
@@ -873,20 +873,20 @@ func expandIPPerms(group *awstypes.SecurityGroup, configured []interface{}) ([]a
 		}
 
 		if raw, ok := m["cidr_blocks"]; ok {
-			list := raw.([]interface{})
+			list := raw.([]any)
 			for _, v := range list {
 				perm.IpRanges = append(perm.IpRanges, awstypes.IpRange{CidrIp: aws.String(v.(string))})
 			}
 		}
 		if raw, ok := m["ipv6_cidr_blocks"]; ok {
-			list := raw.([]interface{})
+			list := raw.([]any)
 			for _, v := range list {
 				perm.Ipv6Ranges = append(perm.Ipv6Ranges, awstypes.Ipv6Range{CidrIpv6: aws.String(v.(string))})
 			}
 		}
 
 		if raw, ok := m["prefix_list_ids"]; ok {
-			list := raw.([]interface{})
+			list := raw.([]any)
 			for _, v := range list {
 				perm.PrefixListIds = append(perm.PrefixListIds, awstypes.PrefixListId{PrefixListId: aws.String(v.(string))})
 			}
@@ -962,15 +962,15 @@ func flattenSecurityGroups(list []awstypes.UserIdGroupPair, ownerId *string) []*
 //
 // If no match is found, we'll write the remote rule to state and let the graph
 // sort things out
-func matchRules(rType string, local []interface{}, remote []map[string]interface{}) []map[string]interface{} {
+func matchRules(rType string, local []any, remote []map[string]any) []map[string]any {
 	// For each local ip or security_group, we need to match against the remote
 	// ruleSet until all ips or security_groups are found
 
 	// saves represents the rules that have been identified to be saved to state,
 	// in the appropriate d.Set("{ingress,egress}") call.
-	var saves []map[string]interface{}
+	var saves []map[string]any
 	for _, raw := range local {
-		l := raw.(map[string]interface{})
+		l := raw.(map[string]any)
 
 		var selfVal bool
 		if v, ok := l["self"]; ok {
@@ -1003,15 +1003,15 @@ func matchRules(rType string, local []interface{}, remote []map[string]interface
 				// actual counts
 				lcRaw, ok := l["cidr_blocks"]
 				if ok {
-					numExpectedCidrs = len(l["cidr_blocks"].([]interface{}))
+					numExpectedCidrs = len(l["cidr_blocks"].([]any))
 				}
 				liRaw, ok := l["ipv6_cidr_blocks"]
 				if ok {
-					numExpectedIpv6Cidrs = len(l["ipv6_cidr_blocks"].([]interface{}))
+					numExpectedIpv6Cidrs = len(l["ipv6_cidr_blocks"].([]any))
 				}
 				lpRaw, ok := l["prefix_list_ids"]
 				if ok {
-					numExpectedPrefixLists = len(l["prefix_list_ids"].([]interface{}))
+					numExpectedPrefixLists = len(l["prefix_list_ids"].([]any))
 				}
 				lsRaw, ok := l[names.AttrSecurityGroups]
 				if ok {
@@ -1055,9 +1055,9 @@ func matchRules(rType string, local []interface{}, remote []map[string]interface
 				}
 
 				// match CIDRs by converting both to sets, and using Set methods
-				var localCidrs []interface{}
+				var localCidrs []any
 				if lcRaw != nil {
-					localCidrs = lcRaw.([]interface{})
+					localCidrs = lcRaw.([]any)
 				}
 				localCidrSet := schema.NewSet(schema.HashString, localCidrs)
 
@@ -1069,7 +1069,7 @@ func matchRules(rType string, local []interface{}, remote []map[string]interface
 					remoteCidrs = rcRaw.([]string)
 				}
 				// convert remote cidrs to a set, for easy comparisons
-				var list []interface{}
+				var list []any
 				for _, s := range remoteCidrs {
 					list = append(list, s)
 				}
@@ -1083,9 +1083,9 @@ func matchRules(rType string, local []interface{}, remote []map[string]interface
 				}
 
 				//IPV6 CIDRs
-				var localIpv6Cidrs []interface{}
+				var localIpv6Cidrs []any
 				if liRaw != nil {
-					localIpv6Cidrs = liRaw.([]interface{})
+					localIpv6Cidrs = liRaw.([]any)
 				}
 				localIpv6CidrSet := schema.NewSet(schema.HashString, localIpv6Cidrs)
 
@@ -1093,7 +1093,7 @@ func matchRules(rType string, local []interface{}, remote []map[string]interface
 				if riRaw != nil {
 					remoteIpv6Cidrs = riRaw.([]string)
 				}
-				var listIpv6 []interface{}
+				var listIpv6 []any
 				for _, s := range remoteIpv6Cidrs {
 					listIpv6 = append(listIpv6, s)
 				}
@@ -1106,9 +1106,9 @@ func matchRules(rType string, local []interface{}, remote []map[string]interface
 				}
 
 				// match prefix lists by converting both to sets, and using Set methods
-				var localPrefixLists []interface{}
+				var localPrefixLists []any
 				if lpRaw != nil {
-					localPrefixLists = lpRaw.([]interface{})
+					localPrefixLists = lpRaw.([]any)
 				}
 				localPrefixListsSet := schema.NewSet(schema.HashString, localPrefixLists)
 
@@ -1275,10 +1275,10 @@ func matchRules(rType string, local []interface{}, remote []map[string]interface
 
 // Duplicate ingress/egress block structure and fill out all
 // the required fields
-func resourceSecurityGroupCopyRule(src map[string]interface{}, self bool, k string, v interface{}) map[string]interface{} {
+func resourceSecurityGroupCopyRule(src map[string]any, self bool, k string, v any) map[string]any {
 	var keys_to_copy = []string{names.AttrDescription, "from_port", "to_port", names.AttrProtocol}
 
-	dst := make(map[string]interface{})
+	dst := make(map[string]any)
 	for _, key := range keys_to_copy {
 		if val, ok := src[key]; ok {
 			dst[key] = val
@@ -1300,13 +1300,13 @@ func resourceSecurityGroupCopyRule(src map[string]interface{}, self bool, k stri
 //
 // For more detail, see comments for
 // securityGroupExpandRules()
-func securityGroupCollapseRules(ruleset string, rules []interface{}) []interface{} {
+func securityGroupCollapseRules(ruleset string, rules []any) []any {
 	var keys_to_collapse = []string{"cidr_blocks", "ipv6_cidr_blocks", "prefix_list_ids", names.AttrSecurityGroups}
 
-	collapsed := make(map[string]map[string]interface{})
+	collapsed := make(map[string]map[string]any)
 
 	for _, rule := range rules {
-		r := rule.(map[string]interface{})
+		r := rule.(map[string]any)
 
 		ruleHash := idCollapseHash(ruleset, r[names.AttrProtocol].(string), int32(r["to_port"].(int)), int32(r["from_port"].(int)), r[names.AttrDescription].(string))
 
@@ -1325,7 +1325,7 @@ func securityGroupCollapseRules(ruleset string, rules []interface{}) []interface
 					if key == names.AttrSecurityGroups {
 						collapsed[ruleHash][key] = collapsed[ruleHash][key].(*schema.Set).Union(r[key].(*schema.Set))
 					} else {
-						collapsed[ruleHash][key] = append(collapsed[ruleHash][key].([]interface{}), r[key].([]interface{})...)
+						collapsed[ruleHash][key] = append(collapsed[ruleHash][key].([]any), r[key].([]any)...)
 					}
 				} else {
 					collapsed[ruleHash][key] = r[key]
@@ -1334,7 +1334,7 @@ func securityGroupCollapseRules(ruleset string, rules []interface{}) []interface
 		}
 	}
 
-	values := make([]interface{}, 0, len(collapsed))
+	values := make([]any, 0, len(collapsed))
 	for _, val := range collapsed {
 		values = append(values, val)
 	}
@@ -1392,7 +1392,7 @@ func securityGroupExpandRules(rules *schema.Set) *schema.Set {
 	normalized := schema.NewSet(securityGroupRuleHash, nil)
 
 	for _, rawRule := range rules.List() {
-		rule := rawRule.(map[string]interface{})
+		rule := rawRule.(map[string]any)
 
 		if v, ok := rule["self"]; ok && v.(bool) {
 			new_rule := resourceSecurityGroupCopyRule(rule, true, "", nil)
@@ -1401,20 +1401,20 @@ func securityGroupExpandRules(rules *schema.Set) *schema.Set {
 		for _, key := range keys_to_expand {
 			item, exists := rule[key]
 			if exists {
-				var list []interface{}
+				var list []any
 				if key == names.AttrSecurityGroups {
 					list = item.(*schema.Set).List()
 				} else {
-					list = item.([]interface{})
+					list = item.([]any)
 				}
 				for _, v := range list {
-					var new_rule map[string]interface{}
+					var new_rule map[string]any
 					if key == names.AttrSecurityGroups {
 						new_v := schema.NewSet(schema.HashString, nil)
 						new_v.Add(v)
 						new_rule = resourceSecurityGroupCopyRule(rule, false, key, new_v)
 					} else {
-						new_v := make([]interface{}, 0)
+						new_v := make([]any, 0)
 						new_v = append(new_v, v)
 						new_rule = resourceSecurityGroupCopyRule(rule, false, key, new_v)
 					}
@@ -1454,7 +1454,7 @@ func idHash(rType, protocol string, toPort, fromPort int32, self bool) string {
 }
 
 // protocolStateFunc ensures we only store a string in any protocol field
-func protocolStateFunc(v interface{}) string {
+func protocolStateFunc(v any) string {
 	switch v := v.(type) {
 	case string:
 		p := protocolForValue(v)
@@ -1515,7 +1515,7 @@ var securityGroupProtocolIntegers = map[string]int{
 	"all":    -1,
 }
 
-func initSecurityGroupRule(ruleMap map[string]map[string]interface{}, perm awstypes.IpPermission, desc string) map[string]interface{} {
+func initSecurityGroupRule(ruleMap map[string]map[string]any, perm awstypes.IpPermission, desc string) map[string]any {
 	var fromPort, toPort int32
 	if v := perm.FromPort; v != nil {
 		fromPort = aws.ToInt32(v)
@@ -1526,7 +1526,7 @@ func initSecurityGroupRule(ruleMap map[string]map[string]interface{}, perm awsty
 	k := fmt.Sprintf("%s-%d-%d-%s", aws.ToString(perm.IpProtocol), fromPort, toPort, desc)
 	rule, ok := ruleMap[k]
 	if !ok {
-		rule = make(map[string]interface{})
+		rule = make(map[string]any)
 		ruleMap[k] = rule
 	}
 	rule[names.AttrProtocol] = aws.ToString(perm.IpProtocol)

--- a/internal/service/ec2/vpc_security_group_data_source.go
+++ b/internal/service/ec2/vpc_security_group_data_source.go
@@ -61,7 +61,7 @@ func dataSourceSecurityGroup() *schema.Resource {
 	}
 }
 
-func dataSourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -80,7 +80,7 @@ func dataSourceSecurityGroupRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/vpc_security_group_ingress_rule.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule.go
@@ -362,7 +362,7 @@ func (r *securityGroupRuleResource) Delete(ctx context.Context, request resource
 		return
 	}
 
-	tflog.Debug(ctx, "deleting VPC Security Group Rule", map[string]interface{}{
+	tflog.Debug(ctx, "deleting VPC Security Group Rule", map[string]any{
 		names.AttrID: data.ID.ValueString(),
 	})
 	err := r.securityGroupRule.delete(ctx, &data)

--- a/internal/service/ec2/vpc_security_group_migrate.go
+++ b/internal/service/ec2/vpc_security_group_migrate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func securityGroupMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func securityGroupMigrateState(v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found Security Group State v0; migrating to v1")

--- a/internal/service/ec2/vpc_security_group_migrate_test.go
+++ b/internal/service/ec2/vpc_security_group_migrate_test.go
@@ -19,7 +19,7 @@ func TestSecurityGroupMigrateState(t *testing.T) {
 		StateVersion int
 		Attributes   map[string]string
 		Expected     map[string]string
-		Meta         interface{}
+		Meta         any
 	}{
 		"v0": {
 			StateVersion: 0,
@@ -59,7 +59,7 @@ func TestSecurityGroupMigrateState_empty(t *testing.T) {
 	t.Parallel()
 
 	var is *terraform.InstanceState
-	var meta interface{}
+	var meta any
 
 	// should handle nil
 	is, err := tfec2.SecurityGroupMigrateState(0, is, meta)

--- a/internal/service/ec2/vpc_security_group_rule.go
+++ b/internal/service/ec2/vpc_security_group_rule.go
@@ -157,7 +157,7 @@ func resourceSecurityGroupRule() *schema.Resource {
 	}
 }
 
-func resourceSecurityGroupRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityGroupRuleCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -227,7 +227,7 @@ information and instructions for recovery. Error: %s`, securityGroupID, err)
 		return sdkdiag.AppendErrorf(diags, "authorizing Security Group (%s) Rule (%s): %s", securityGroupID, id, err)
 	}
 
-	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
 		sg, err := findSecurityGroupByID(ctx, conn, securityGroupID)
 
 		if err != nil {
@@ -260,7 +260,7 @@ information and instructions for recovery. Error: %s`, securityGroupID, err)
 	return diags
 }
 
-func resourceSecurityGroupRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityGroupRuleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -335,7 +335,7 @@ func resourceSecurityGroupRuleRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceSecurityGroupRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityGroupRuleUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -381,7 +381,7 @@ func resourceSecurityGroupRuleUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceSecurityGroupRuleRead(ctx, d, meta)...)
 }
 
-func resourceSecurityGroupRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityGroupRuleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -428,7 +428,7 @@ func resourceSecurityGroupRuleDelete(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceSecurityGroupRuleImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+func resourceSecurityGroupRuleImport(_ context.Context, d *schema.ResourceData, _ any) ([]*schema.ResourceData, error) {
 	invalidIDError := func(msg string) error {
 		return fmt.Errorf("unexpected format for ID (%q), expected SECURITYGROUPID_TYPE_PROTOCOL_FROMPORT_TOPORT_SOURCE[_SOURCE]*: %s", d.Id(), msg)
 	}
@@ -775,24 +775,24 @@ func expandIPPermission(d *schema.ResourceData, sg *awstypes.SecurityGroup) awst
 		apiObject.ToPort = aws.Int32(int32(d.Get("to_port").(int)))
 	}
 
-	if v, ok := d.GetOk("cidr_blocks"); ok && len(v.([]interface{})) > 0 {
-		for _, v := range v.([]interface{}) {
+	if v, ok := d.GetOk("cidr_blocks"); ok && len(v.([]any)) > 0 {
+		for _, v := range v.([]any) {
 			apiObject.IpRanges = append(apiObject.IpRanges, awstypes.IpRange{
 				CidrIp: aws.String(v.(string)),
 			})
 		}
 	}
 
-	if v, ok := d.GetOk("ipv6_cidr_blocks"); ok && len(v.([]interface{})) > 0 {
-		for _, v := range v.([]interface{}) {
+	if v, ok := d.GetOk("ipv6_cidr_blocks"); ok && len(v.([]any)) > 0 {
+		for _, v := range v.([]any) {
 			apiObject.Ipv6Ranges = append(apiObject.Ipv6Ranges, awstypes.Ipv6Range{
 				CidrIpv6: aws.String(v.(string)),
 			})
 		}
 	}
 
-	if v, ok := d.GetOk("prefix_list_ids"); ok && len(v.([]interface{})) > 0 {
-		for _, v := range v.([]interface{}) {
+	if v, ok := d.GetOk("prefix_list_ids"); ok && len(v.([]any)) > 0 {
+		for _, v := range v.([]any) {
 			apiObject.PrefixListIds = append(apiObject.PrefixListIds, awstypes.PrefixListId{
 				PrefixListId: aws.String(v.(string)),
 			})

--- a/internal/service/ec2/vpc_security_group_rule_migrate.go
+++ b/internal/service/ec2/vpc_security_group_rule_migrate.go
@@ -16,7 +16,7 @@ import (
 )
 
 func securityGroupRuleMigrateState(
-	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found AWS Security Group State v0; migrating to v1")

--- a/internal/service/ec2/vpc_security_group_rule_migrate_test.go
+++ b/internal/service/ec2/vpc_security_group_rule_migrate_test.go
@@ -20,7 +20,7 @@ func TestSecurityGroupRuleMigrateState(t *testing.T) {
 		ID           string
 		Attributes   map[string]string
 		Expected     string
-		Meta         interface{}
+		Meta         any
 	}{
 		"v0_1": {
 			StateVersion: 0,

--- a/internal/service/ec2/vpc_security_group_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_rule_test.go
@@ -1640,7 +1640,7 @@ func testAccSecurityGroupRuleImportGetAttrs(attrs map[string]string, key string)
 		if err != nil {
 			return nil, err
 		}
-		for i := 0; i < count; i++ {
+		for i := range count {
 			values = append(values, attrs[fmt.Sprintf("%s.%d", key, i)])
 		}
 	}

--- a/internal/service/ec2/vpc_security_group_rules_matching_test.go
+++ b/internal/service/ec2/vpc_security_group_rules_matching_test.go
@@ -17,63 +17,63 @@ func TestRulesMixedMatching(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		local  []interface{}
-		remote []map[string]interface{}
-		saves  []map[string]interface{}
+		local  []any
+		remote []map[string]any
+		saves  []map[string]any
 	}{
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":              80,
 					"to_port":                8000,
 					names.AttrProtocol:       "tcp",
-					"cidr_blocks":            []interface{}{"172.8.0.0/16", "10.0.0.0/16"},
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					"cidr_blocks":            []any{"172.8.0.0/16", "10.0.0.0/16"},
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":              int32(80),
 					"to_port":                int32(8000),
 					names.AttrProtocol:       "tcp",
 					"cidr_blocks":            []string{"172.8.0.0/16", "10.0.0.0/16"},
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":              80,
 					"to_port":                8000,
 					names.AttrProtocol:       "tcp",
 					"cidr_blocks":            []string{"172.8.0.0/16", "10.0.0.0/16"},
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
 		},
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":              80,
 					"to_port":                8000,
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":              int32(80),
 					"to_port":                int32(8000),
 					names.AttrProtocol:       "tcp",
 					"cidr_blocks":            []string{"172.8.0.0/16", "10.0.0.0/16"},
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":              80,
 					"to_port":                8000,
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 				{
 					"from_port":        int32(80),
@@ -84,15 +84,15 @@ func TestRulesMixedMatching(t *testing.T) {
 			},
 		},
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"172.8.0.0/16", "10.0.0.0/16"},
+					"cidr_blocks":      []any{"172.8.0.0/16", "10.0.0.0/16"},
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -100,7 +100,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					"cidr_blocks":      []string{"172.8.0.0/16", "10.0.0.0/16"},
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        80,
 					"to_port":          8000,
@@ -110,47 +110,47 @@ func TestRulesMixedMatching(t *testing.T) {
 			},
 		},
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":              80,
 					"to_port":                8000,
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":              int32(80),
 					"to_port":                int32(8000),
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":              80,
 					"to_port":                8000,
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
 		},
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"172.8.0.0/16"},
+					"cidr_blocks":      []any{"172.8.0.0/16"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"192.168.0.0/16"},
+					"cidr_blocks":      []any{"192.168.0.0/16"},
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -158,7 +158,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					"cidr_blocks":      []string{"172.8.0.0/16", "192.168.0.0/16"},
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        80,
 					"to_port":          8000,
@@ -174,8 +174,8 @@ func TestRulesMixedMatching(t *testing.T) {
 			},
 		},
 		{
-			local: []interface{}{},
-			remote: []map[string]interface{}{
+			local: []any{},
+			remote: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -183,7 +183,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					"cidr_blocks":      []string{"172.8.0.0/16", "10.0.0.0/16"},
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -194,21 +194,21 @@ func TestRulesMixedMatching(t *testing.T) {
 		},
 		// test lower/ uppercase handling
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "TCP",
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
 					names.AttrProtocol: "tcp",
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        80,
 					"to_port":          8000,
@@ -218,15 +218,15 @@ func TestRulesMixedMatching(t *testing.T) {
 		},
 		// local and remote differ
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"172.8.0.0/16"},
+					"cidr_blocks":      []any{"172.8.0.0/16"},
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -237,7 +237,7 @@ func TestRulesMixedMatching(t *testing.T) {
 			// Because this is the remote rule being saved, we need to check for int32
 			// encoding. We could convert this code, but ultimately Terraform doesn't
 			// care it's for the reflect.DeepEqual in this test
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -248,15 +248,15 @@ func TestRulesMixedMatching(t *testing.T) {
 		},
 		// local with more rules and the remote (the remote should then be saved)
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"172.8.0.0/16", "10.8.0.0/16", "192.168.0.0/16"},
+					"cidr_blocks":      []any{"172.8.0.0/16", "10.8.0.0/16", "192.168.0.0/16"},
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -264,7 +264,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					"cidr_blocks":      []string{"172.8.0.0/16", "192.168.0.0/16"},
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -276,27 +276,27 @@ func TestRulesMixedMatching(t *testing.T) {
 		// 3 local rules
 		// this should trigger a diff (not shown)
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"172.8.0.0/16"},
+					"cidr_blocks":      []any{"172.8.0.0/16"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"10.8.0.0/16"},
+					"cidr_blocks":      []any{"10.8.0.0/16"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"192.168.0.0/16"},
+					"cidr_blocks":      []any{"192.168.0.0/16"},
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -304,7 +304,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					"cidr_blocks":      []string{"172.8.0.0/16", "192.168.0.0/16"},
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        80,
 					"to_port":          8000,
@@ -322,15 +322,15 @@ func TestRulesMixedMatching(t *testing.T) {
 		// a local rule with 2 cidrs, remote has 4 cidrs, should be saved to match
 		// the local but also an extra rule found
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"172.8.0.0/16", "10.8.0.0/16"},
+					"cidr_blocks":      []any{"172.8.0.0/16", "10.8.0.0/16"},
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -338,7 +338,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					"cidr_blocks":      []string{"172.8.0.0/16", "192.168.0.0/16", "10.8.0.0/16", "206.8.0.0/16"},
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        80,
 					"to_port":          8000,
@@ -355,63 +355,63 @@ func TestRulesMixedMatching(t *testing.T) {
 		},
 		// testing some SGS
 		{
-			local: []interface{}{},
-			remote: []map[string]interface{}{
+			local: []any{},
+			remote: []map[string]any{
 				{
 					"from_port":              int32(22),
 					"to_port":                int32(22),
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876"}),
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					// we're saving the remote, so it will be int32 encoded
 					"from_port":              int32(22),
 					"to_port":                int32(22),
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876"}),
 				},
 			},
 		},
 		// two local blocks that match a single remote group, but are saved as two
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":              22,
 					"to_port":                22,
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876"}),
 				},
-				map[string]interface{}{
+				map[string]any{
 					"from_port":              22,
 					"to_port":                22,
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-4444"}),
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(22),
 					"to_port":          int32(22),
 					names.AttrProtocol: "tcp",
 					names.AttrSecurityGroups: schema.NewSet(
 						schema.HashString,
-						[]interface{}{
+						[]any{
 							"sg-9876",
 							"sg-4444",
 						},
 					),
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        22,
 					"to_port":          22,
 					names.AttrProtocol: "tcp",
 					names.AttrSecurityGroups: schema.NewSet(
 						schema.HashString,
-						[]interface{}{
+						[]any{
 							"sg-9876",
 						},
 					),
@@ -422,7 +422,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					names.AttrProtocol: "tcp",
 					names.AttrSecurityGroups: schema.NewSet(
 						schema.HashString,
-						[]interface{}{
+						[]any{
 							"sg-4444",
 						},
 					),
@@ -431,16 +431,16 @@ func TestRulesMixedMatching(t *testing.T) {
 		},
 		// test self with other rules
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":              22,
 					"to_port":                22,
 					names.AttrProtocol:       "tcp",
 					"self":                   true,
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(22),
 					"to_port":          int32(22),
@@ -448,7 +448,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					"self":             true,
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        int32(22),
 					"to_port":          int32(22),
@@ -459,15 +459,15 @@ func TestRulesMixedMatching(t *testing.T) {
 		},
 		// test self
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":        22,
 					"to_port":          22,
 					names.AttrProtocol: "tcp",
 					"self":             true,
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(22),
 					"to_port":          int32(22),
@@ -475,7 +475,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					"self":             true,
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        int32(22),
 					"to_port":          int32(22),
@@ -485,15 +485,15 @@ func TestRulesMixedMatching(t *testing.T) {
 			},
 		},
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":              22,
 					"to_port":                22,
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":        int32(22),
 					"to_port":          int32(22),
@@ -501,7 +501,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					"self":             true,
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        int32(22),
 					"to_port":          int32(22),
@@ -512,30 +512,30 @@ func TestRulesMixedMatching(t *testing.T) {
 		},
 		// mix of sgs and cidrs
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"172.8.0.0/16", "10.8.0.0/16", "192.168.0.0/16"},
+					"cidr_blocks":      []any{"172.8.0.0/16", "10.8.0.0/16", "192.168.0.0/16"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"from_port":              80,
 					"to_port":                8000,
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":              int32(80),
 					"to_port":                int32(8000),
 					names.AttrProtocol:       "tcp",
 					"cidr_blocks":            []string{"172.8.0.0/16", "192.168.0.0/16"},
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        int32(80),
 					"to_port":          int32(8000),
@@ -546,36 +546,36 @@ func TestRulesMixedMatching(t *testing.T) {
 					"from_port":              int32(80),
 					"to_port":                int32(8000),
 					names.AttrProtocol:       "tcp",
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
 		},
 		{
-			local: []interface{}{
-				map[string]interface{}{
+			local: []any{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
-					"cidr_blocks":      []interface{}{"172.8.0.0/16", "10.8.0.0/16", "192.168.0.0/16"},
+					"cidr_blocks":      []any{"172.8.0.0/16", "10.8.0.0/16", "192.168.0.0/16"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"from_port":        80,
 					"to_port":          8000,
 					names.AttrProtocol: "tcp",
 					"self":             true,
 				},
 			},
-			remote: []map[string]interface{}{
+			remote: []map[string]any{
 				{
 					"from_port":              int32(80),
 					"to_port":                int32(8000),
 					names.AttrProtocol:       "tcp",
 					"cidr_blocks":            []string{"172.8.0.0/16", "192.168.0.0/16"},
 					"self":                   true,
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
-			saves: []map[string]interface{}{
+			saves: []map[string]any{
 				{
 					"from_port":        80,
 					"to_port":          8000,
@@ -587,7 +587,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					"to_port":                int32(8000),
 					names.AttrProtocol:       "tcp",
 					"cidr_blocks":            []string{"172.8.0.0/16", "192.168.0.0/16"},
-					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{"sg-9876", "sg-4444"}),
+					names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{"sg-9876", "sg-4444"}),
 				},
 			},
 		},
@@ -624,7 +624,7 @@ func TestRulesMixedMatching(t *testing.T) {
 					case []string:
 						numExpectedCidrs = len(s["cidr_blocks"].([]string))
 					default:
-						numExpectedCidrs = len(s["cidr_blocks"].([]interface{}))
+						numExpectedCidrs = len(s["cidr_blocks"].([]any))
 					}
 				}
 				if _, ok := s[names.AttrSecurityGroups]; ok {
@@ -657,7 +657,7 @@ func TestRulesMixedMatching(t *testing.T) {
 				}
 
 				// convert save cidrs to set
-				var lcs []interface{}
+				var lcs []any
 				if _, ok := s["cidr_blocks"]; ok {
 					switch s["cidr_blocks"].(type) {
 					case []string:
@@ -665,13 +665,13 @@ func TestRulesMixedMatching(t *testing.T) {
 							lcs = append(lcs, c)
 						}
 					default:
-						lcs = append(lcs, s["cidr_blocks"].([]interface{})...)
+						lcs = append(lcs, s["cidr_blocks"].([]any)...)
 					}
 				}
 				savesCidrs := schema.NewSet(schema.HashString, lcs)
 
 				// convert cs cidrs to set
-				var cslcs []interface{}
+				var cslcs []any
 				if _, ok := cs["cidr_blocks"]; ok {
 					for _, c := range cs["cidr_blocks"].([]string) {
 						cslcs = append(cslcs, c)

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -32,7 +32,7 @@ func TestProtocolStateFunc(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		input    interface{}
+		input    any
 		expected string
 	}{
 		{
@@ -169,7 +169,7 @@ func TestProtocolForValue(t *testing.T) {
 	}
 }
 
-func calcSecurityGroupChecksum(rules []interface{}) int {
+func calcSecurityGroupChecksum(rules []any) int {
 	sum := 0
 	for _, rule := range rules {
 		sum += tfec2.SecurityGroupRuleHash(rule)
@@ -180,184 +180,184 @@ func calcSecurityGroupChecksum(rules []interface{}) int {
 func TestSecurityGroupExpandCollapseRules(t *testing.T) {
 	t.Parallel()
 
-	expected_compact_list := []interface{}{
-		map[string]interface{}{
+	expected_compact_list := []any{
+		map[string]any{
 			names.AttrProtocol:    "tcp",
 			"from_port":           int(443),
 			"to_port":             int(443),
 			names.AttrDescription: "block with description",
 			"self":                true,
-			"cidr_blocks": []interface{}{
+			"cidr_blocks": []any{
 				"10.0.0.1/32",
 				"10.0.0.2/32",
 				"10.0.0.3/32",
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "tcp",
 			"from_port":           int(443),
 			"to_port":             int(443),
 			names.AttrDescription: "block with another description",
 			"self":                false,
-			"cidr_blocks": []interface{}{
+			"cidr_blocks": []any{
 				"192.168.0.1/32",
 				"192.168.0.2/32",
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "-1",
 			"from_port":           int(8000),
 			"to_port":             int(8080),
 			names.AttrDescription: "",
 			"self":                false,
-			"ipv6_cidr_blocks": []interface{}{
+			"ipv6_cidr_blocks": []any{
 				"fd00::1/128",
 				"fd00::2/128",
 			},
-			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{
+			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{
 				"sg-11111",
 				"sg-22222",
 				"sg-33333",
 			}),
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "udp",
 			"from_port":           int(10000),
 			"to_port":             int(10000),
 			names.AttrDescription: "",
 			"self":                false,
-			"prefix_list_ids": []interface{}{
+			"prefix_list_ids": []any{
 				"pl-111111",
 				"pl-222222",
 			},
 		},
 	}
 
-	expected_expanded_list := []interface{}{
-		map[string]interface{}{
+	expected_expanded_list := []any{
+		map[string]any{
 			names.AttrProtocol:    "tcp",
 			"from_port":           int(443),
 			"to_port":             int(443),
 			names.AttrDescription: "block with description",
 			"self":                true,
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "tcp",
 			"from_port":           int(443),
 			"to_port":             int(443),
 			names.AttrDescription: "block with description",
 			"self":                false,
-			"cidr_blocks": []interface{}{
+			"cidr_blocks": []any{
 				"10.0.0.1/32",
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "tcp",
 			"from_port":           int(443),
 			"to_port":             int(443),
 			names.AttrDescription: "block with description",
 			"self":                false,
-			"cidr_blocks": []interface{}{
+			"cidr_blocks": []any{
 				"10.0.0.2/32",
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "tcp",
 			"from_port":           int(443),
 			"to_port":             int(443),
 			names.AttrDescription: "block with description",
 			"self":                false,
-			"cidr_blocks": []interface{}{
+			"cidr_blocks": []any{
 				"10.0.0.3/32",
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "tcp",
 			"from_port":           int(443),
 			"to_port":             int(443),
 			names.AttrDescription: "block with another description",
 			"self":                false,
-			"cidr_blocks": []interface{}{
+			"cidr_blocks": []any{
 				"192.168.0.1/32",
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "tcp",
 			"from_port":           int(443),
 			"to_port":             int(443),
 			names.AttrDescription: "block with another description",
 			"self":                false,
-			"cidr_blocks": []interface{}{
+			"cidr_blocks": []any{
 				"192.168.0.2/32",
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "-1",
 			"from_port":           int(8000),
 			"to_port":             int(8080),
 			names.AttrDescription: "",
 			"self":                false,
-			"ipv6_cidr_blocks": []interface{}{
+			"ipv6_cidr_blocks": []any{
 				"fd00::1/128",
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "-1",
 			"from_port":           int(8000),
 			"to_port":             int(8080),
 			names.AttrDescription: "",
 			"self":                false,
-			"ipv6_cidr_blocks": []interface{}{
+			"ipv6_cidr_blocks": []any{
 				"fd00::2/128",
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "-1",
 			"from_port":           int(8000),
 			"to_port":             int(8080),
 			names.AttrDescription: "",
 			"self":                false,
-			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{
+			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{
 				"sg-11111",
 			}),
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "-1",
 			"from_port":           int(8000),
 			"to_port":             int(8080),
 			names.AttrDescription: "",
 			"self":                false,
-			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{
+			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{
 				"sg-22222",
 			}),
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "-1",
 			"from_port":           int(8000),
 			"to_port":             int(8080),
 			names.AttrDescription: "",
 			"self":                false,
-			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{
+			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{
 				"sg-33333",
 			}),
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "udp",
 			"from_port":           int(10000),
 			"to_port":             int(10000),
 			names.AttrDescription: "",
 			"self":                false,
-			"prefix_list_ids": []interface{}{
+			"prefix_list_ids": []any{
 				"pl-111111",
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol:    "udp",
 			"from_port":           int(10000),
 			"to_port":             int(10000),
 			names.AttrDescription: "",
 			"self":                false,
-			"prefix_list_ids": []interface{}{
+			"prefix_list_ids": []any{
 				"pl-222222",
 			},
 		},
@@ -435,7 +435,7 @@ func TestSecurityGroupIPPermGather(t *testing.T) {
 		},
 	}
 
-	local := []map[string]interface{}{
+	local := []map[string]any{
 		{
 			names.AttrProtocol:    "tcp",
 			"from_port":           int64(1),
@@ -448,7 +448,7 @@ func TestSecurityGroupIPPermGather(t *testing.T) {
 			names.AttrProtocol: "tcp",
 			"from_port":        int64(80),
 			"to_port":          int64(80),
-			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{
+			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{
 				"sg-22222",
 			}),
 		},
@@ -457,7 +457,7 @@ func TestSecurityGroupIPPermGather(t *testing.T) {
 			"from_port":        int64(0),
 			"to_port":          int64(0),
 			"prefix_list_ids":  []string{"pl-12345678"},
-			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []interface{}{
+			names.AttrSecurityGroups: schema.NewSet(schema.HashString, []any{
 				"sg-22222",
 			}),
 			names.AttrDescription: "desc",
@@ -497,19 +497,19 @@ func TestExpandIPPerms(t *testing.T) {
 
 	hash := schema.HashString
 
-	expanded := []interface{}{
-		map[string]interface{}{
+	expanded := []any{
+		map[string]any{
 			names.AttrProtocol: "icmp",
 			"from_port":        1,
 			"to_port":          -1,
-			"cidr_blocks":      []interface{}{"0.0.0.0/0"},
-			names.AttrSecurityGroups: schema.NewSet(hash, []interface{}{
+			"cidr_blocks":      []any{"0.0.0.0/0"},
+			names.AttrSecurityGroups: schema.NewSet(hash, []any{
 				"sg-11111",
 				"foo/sg-22222",
 			}),
 			names.AttrDescription: "desc",
 		},
-		map[string]interface{}{
+		map[string]any{
 			names.AttrProtocol: "icmp",
 			"from_port":        1,
 			"to_port":          -1,
@@ -614,13 +614,13 @@ func TestExpandIPPerms_NegOneProtocol(t *testing.T) {
 
 	hash := schema.HashString
 
-	expanded := []interface{}{
-		map[string]interface{}{
+	expanded := []any{
+		map[string]any{
 			names.AttrProtocol: "-1",
 			"from_port":        0,
 			"to_port":          0,
-			"cidr_blocks":      []interface{}{"0.0.0.0/0"},
-			names.AttrSecurityGroups: schema.NewSet(hash, []interface{}{
+			"cidr_blocks":      []any{"0.0.0.0/0"},
+			names.AttrSecurityGroups: schema.NewSet(hash, []any{
 				"sg-11111",
 				"foo/sg-22222",
 			}),
@@ -680,13 +680,13 @@ func TestExpandIPPerms_NegOneProtocol(t *testing.T) {
 
 	// Now test the error case. This *should* error when either from_port
 	// or to_port is not zero, but protocol is "-1".
-	errorCase := []interface{}{
-		map[string]interface{}{
+	errorCase := []any{
+		map[string]any{
 			names.AttrProtocol: "-1",
 			"from_port":        0,
 			"to_port":          65535,
-			"cidr_blocks":      []interface{}{"0.0.0.0/0"},
-			names.AttrSecurityGroups: schema.NewSet(hash, []interface{}{
+			"cidr_blocks":      []any{"0.0.0.0/0"},
+			names.AttrSecurityGroups: schema.NewSet(hash, []any{
 				"sg-11111",
 				"foo/sg-22222",
 			}),
@@ -708,13 +708,13 @@ func TestExpandIPPerms_AllProtocol(t *testing.T) {
 
 	hash := schema.HashString
 
-	expanded := []interface{}{
-		map[string]interface{}{
+	expanded := []any{
+		map[string]any{
 			names.AttrProtocol: "all",
 			"from_port":        0,
 			"to_port":          0,
-			"cidr_blocks":      []interface{}{"0.0.0.0/0"},
-			names.AttrSecurityGroups: schema.NewSet(hash, []interface{}{
+			"cidr_blocks":      []any{"0.0.0.0/0"},
+			names.AttrSecurityGroups: schema.NewSet(hash, []any{
 				"sg-11111",
 				"foo/sg-22222",
 			}),
@@ -774,13 +774,13 @@ func TestExpandIPPerms_AllProtocol(t *testing.T) {
 
 	// Now test the error case. This *should* error when either from_port
 	// or to_port is not zero, but protocol is "all".
-	errorCase := []interface{}{
-		map[string]interface{}{
+	errorCase := []any{
+		map[string]any{
 			names.AttrProtocol: "all",
 			"from_port":        0,
 			"to_port":          65535,
-			"cidr_blocks":      []interface{}{"0.0.0.0/0"},
-			names.AttrSecurityGroups: schema.NewSet(hash, []interface{}{
+			"cidr_blocks":      []any{"0.0.0.0/0"},
+			names.AttrSecurityGroups: schema.NewSet(hash, []any{
 				"sg-11111",
 				"foo/sg-22222",
 			}),

--- a/internal/service/ec2/vpc_security_group_vpc_association.go
+++ b/internal/service/ec2/vpc_security_group_vpc_association.go
@@ -242,7 +242,7 @@ func waitSecurityGroupVPCAssociationDeleted(ctx context.Context, conn *ec2.Clien
 }
 
 func statusSecurityGroupVPCAssociation(ctx context.Context, conn *ec2.Client, groupId string, vpcId string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		out, err := FindSecurityGroupVPCAssociationByTwoPartKey(ctx, conn, groupId, vpcId)
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/ec2/vpc_security_groups_data_source.go
+++ b/internal/service/ec2/vpc_security_groups_data_source.go
@@ -50,7 +50,7 @@ func dataSourceSecurityGroups() *schema.Resource {
 	}
 }
 
-func dataSourceSecurityGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSecurityGroupsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -58,7 +58,7 @@ func dataSourceSecurityGroupsRead(ctx context.Context, d *schema.ResourceData, m
 	input := &ec2.DescribeSecurityGroupsInput{}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(

--- a/internal/service/ec2/vpc_subnet.go
+++ b/internal/service/ec2/vpc_subnet.go
@@ -159,7 +159,7 @@ func resourceSubnet() *schema.Resource {
 	}
 }
 
-func resourceSubnetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -227,11 +227,11 @@ func resourceSubnetCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceSubnetRead(ctx, d, meta)...)
 }
 
-func resourceSubnetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findSubnetByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -289,7 +289,7 @@ func resourceSubnetRead(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func resourceSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -363,7 +363,7 @@ func resourceSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceSubnetRead(ctx, d, meta)...)
 }
 
-func resourceSubnetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -375,7 +375,7 @@ func resourceSubnetDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "deleting ENIs for EC2 Subnet (%s): %s", d.Id(), err)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return conn.DeleteSubnet(ctx, &ec2.DeleteSubnetInput{
 			SubnetId: aws.String(d.Id()),
 		})

--- a/internal/service/ec2/vpc_subnet_cidr_reservation.go
+++ b/internal/service/ec2/vpc_subnet_cidr_reservation.go
@@ -30,7 +30,7 @@ func resourceSubnetCIDRReservation() *schema.Resource {
 		ReadWithoutTimeout:   resourceSubnetCIDRReservationRead,
 		DeleteWithoutTimeout: resourceSubnetCIDRReservationDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), ":")
 				if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 					return nil, fmt.Errorf("unexpected format of ID (%q), expected SUBNET_ID:RESERVATION_ID", d.Id())
@@ -76,7 +76,7 @@ func resourceSubnetCIDRReservation() *schema.Resource {
 	}
 }
 
-func resourceSubnetCIDRReservationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetCIDRReservationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -102,7 +102,7 @@ func resourceSubnetCIDRReservationCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceSubnetCIDRReservationRead(ctx, d, meta)...)
 }
 
-func resourceSubnetCIDRReservationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetCIDRReservationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -127,7 +127,7 @@ func resourceSubnetCIDRReservationRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceSubnetCIDRReservationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetCIDRReservationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_subnet_data_source.go
+++ b/internal/service/ec2/vpc_subnet_data_source.go
@@ -137,7 +137,7 @@ func dataSourceSubnet() *schema.Resource {
 	}
 }
 
-func dataSourceSubnetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSubnetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -177,7 +177,7 @@ func dataSourceSubnetRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if tags, tagsOk := d.GetOk(names.AttrTags); tagsOk {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+			Tags(tftags.New(ctx, tags.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/vpc_subnet_migrate.go
+++ b/internal/service/ec2/vpc_subnet_migrate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func subnetMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func subnetMigrateState(v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found AWS Subnet State v0; migrating to v1")

--- a/internal/service/ec2/vpc_subnet_migrate_test.go
+++ b/internal/service/ec2/vpc_subnet_migrate_test.go
@@ -19,7 +19,7 @@ func TestSubnetMigrateState(t *testing.T) {
 		ID           string
 		Attributes   map[string]string
 		Expected     string
-		Meta         interface{}
+		Meta         any
 	}{
 		"v0_1_without_value": {
 			StateVersion: 0,

--- a/internal/service/ec2/vpc_subnets_data_source.go
+++ b/internal/service/ec2/vpc_subnets_data_source.go
@@ -38,7 +38,7 @@ func dataSourceSubnets() *schema.Resource {
 	}
 }
 
-func dataSourceSubnetsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSubnetsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -46,7 +46,7 @@ func dataSourceSubnetsRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	if tags, tagsOk := d.GetOk(names.AttrTags); tagsOk {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+			Tags(tftags.New(ctx, tags.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/vpc_traffic_mirror_filter.go
+++ b/internal/service/ec2/vpc_traffic_mirror_filter.go
@@ -66,7 +66,7 @@ func resourceTrafficMirrorFilter() *schema.Resource {
 	}
 }
 
-func resourceTrafficMirrorFilterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorFilterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -103,7 +103,7 @@ func resourceTrafficMirrorFilterCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceTrafficMirrorFilterRead(ctx, d, meta)...)
 }
 
-func resourceTrafficMirrorFilterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorFilterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -135,7 +135,7 @@ func resourceTrafficMirrorFilterRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceTrafficMirrorFilterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorFilterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -164,7 +164,7 @@ func resourceTrafficMirrorFilterUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceTrafficMirrorFilterRead(ctx, d, meta)...)
 }
 
-func resourceTrafficMirrorFilterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorFilterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_traffic_mirror_filter_rule.go
+++ b/internal/service/ec2/vpc_traffic_mirror_filter_rule.go
@@ -122,7 +122,7 @@ func resourceTrafficMirrorFilterRule() *schema.Resource {
 	}
 }
 
-func resourceTrafficMirrorFilterRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorFilterRuleCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -140,16 +140,16 @@ func resourceTrafficMirrorFilterRuleCreate(ctx context.Context, d *schema.Resour
 		input.Description = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("destination_port_range"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DestinationPortRange = expandTrafficMirrorPortRangeRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("destination_port_range"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DestinationPortRange = expandTrafficMirrorPortRangeRequest(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrProtocol); ok {
 		input.Protocol = aws.Int32(int32(v.(int)))
 	}
 
-	if v, ok := d.GetOk("source_port_range"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.SourcePortRange = expandTrafficMirrorPortRangeRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("source_port_range"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.SourcePortRange = expandTrafficMirrorPortRangeRequest(v.([]any)[0].(map[string]any))
 	}
 
 	output, err := conn.CreateTrafficMirrorFilterRule(ctx, input)
@@ -163,7 +163,7 @@ func resourceTrafficMirrorFilterRuleCreate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceTrafficMirrorFilterRuleRead(ctx, d, meta)...)
 }
 
-func resourceTrafficMirrorFilterRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorFilterRuleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -190,7 +190,7 @@ func resourceTrafficMirrorFilterRuleRead(ctx context.Context, d *schema.Resource
 	d.Set(names.AttrDescription, rule.Description)
 	d.Set("destination_cidr_block", rule.DestinationCidrBlock)
 	if rule.DestinationPortRange != nil {
-		if err := d.Set("destination_port_range", []interface{}{flattenTrafficMirrorPortRange(rule.DestinationPortRange)}); err != nil {
+		if err := d.Set("destination_port_range", []any{flattenTrafficMirrorPortRange(rule.DestinationPortRange)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting destination_port_range: %s", err)
 		}
 	} else {
@@ -201,7 +201,7 @@ func resourceTrafficMirrorFilterRuleRead(ctx context.Context, d *schema.Resource
 	d.Set("rule_number", rule.RuleNumber)
 	d.Set("source_cidr_block", rule.SourceCidrBlock)
 	if rule.SourcePortRange != nil {
-		if err := d.Set("source_port_range", []interface{}{flattenTrafficMirrorPortRange(rule.SourcePortRange)}); err != nil {
+		if err := d.Set("source_port_range", []any{flattenTrafficMirrorPortRange(rule.SourcePortRange)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting source_port_range: %s", err)
 		}
 	} else {
@@ -213,7 +213,7 @@ func resourceTrafficMirrorFilterRuleRead(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceTrafficMirrorFilterRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorFilterRuleUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -236,8 +236,8 @@ func resourceTrafficMirrorFilterRuleUpdate(ctx context.Context, d *schema.Resour
 	}
 
 	if d.HasChange("destination_port_range") {
-		if v, ok := d.GetOk("destination_port_range"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.DestinationPortRange = expandTrafficMirrorPortRangeRequest(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("destination_port_range"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.DestinationPortRange = expandTrafficMirrorPortRangeRequest(v.([]any)[0].(map[string]any))
 			// Modify request that adds port range seems to fail if protocol is not set in the request.
 			input.Protocol = aws.Int32(int32(d.Get(names.AttrProtocol).(int)))
 		} else {
@@ -266,8 +266,8 @@ func resourceTrafficMirrorFilterRuleUpdate(ctx context.Context, d *schema.Resour
 	}
 
 	if d.HasChange("source_port_range") {
-		if v, ok := d.GetOk("source_port_range"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.SourcePortRange = expandTrafficMirrorPortRangeRequest(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("source_port_range"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.SourcePortRange = expandTrafficMirrorPortRangeRequest(v.([]any)[0].(map[string]any))
 			// Modify request that adds port range seems to fail if protocol is not set in the request.
 			input.Protocol = aws.Int32(int32(d.Get(names.AttrProtocol).(int)))
 		} else {
@@ -292,7 +292,7 @@ func resourceTrafficMirrorFilterRuleUpdate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceTrafficMirrorFilterRuleRead(ctx, d, meta)...)
 }
 
-func resourceTrafficMirrorFilterRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorFilterRuleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -313,7 +313,7 @@ func resourceTrafficMirrorFilterRuleDelete(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceTrafficMirrorFilterRuleImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceTrafficMirrorFilterRuleImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), ":", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return nil, fmt.Errorf("unexpected format (%q), expected <filter-id>:<rule-id>", d.Id())
@@ -325,7 +325,7 @@ func resourceTrafficMirrorFilterRuleImport(ctx context.Context, d *schema.Resour
 	return []*schema.ResourceData{d}, nil
 }
 
-func expandTrafficMirrorPortRangeRequest(tfMap map[string]interface{}) *awstypes.TrafficMirrorPortRangeRequest {
+func expandTrafficMirrorPortRangeRequest(tfMap map[string]any) *awstypes.TrafficMirrorPortRangeRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -343,12 +343,12 @@ func expandTrafficMirrorPortRangeRequest(tfMap map[string]interface{}) *awstypes
 	return apiObject
 }
 
-func flattenTrafficMirrorPortRange(apiObject *awstypes.TrafficMirrorPortRange) map[string]interface{} {
+func flattenTrafficMirrorPortRange(apiObject *awstypes.TrafficMirrorPortRange) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.FromPort; v != nil {
 		tfMap["from_port"] = aws.ToInt32(v)

--- a/internal/service/ec2/vpc_traffic_mirror_session.go
+++ b/internal/service/ec2/vpc_traffic_mirror_session.go
@@ -85,7 +85,7 @@ func resourceTrafficMirrorSession() *schema.Resource {
 	}
 }
 
-func resourceTrafficMirrorSessionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorSessionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -124,7 +124,7 @@ func resourceTrafficMirrorSessionCreate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceTrafficMirrorSessionRead(ctx, d, meta)...)
 }
 
-func resourceTrafficMirrorSessionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorSessionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -163,7 +163,7 @@ func resourceTrafficMirrorSessionRead(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceTrafficMirrorSessionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorSessionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -224,7 +224,7 @@ func resourceTrafficMirrorSessionUpdate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceTrafficMirrorSessionRead(ctx, d, meta)...)
 }
 
-func resourceTrafficMirrorSessionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorSessionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_traffic_mirror_target.go
+++ b/internal/service/ec2/vpc_traffic_mirror_target.go
@@ -89,7 +89,7 @@ func resourceTrafficMirrorTarget() *schema.Resource {
 	}
 }
 
-func resourceTrafficMirrorTargetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorTargetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -125,7 +125,7 @@ func resourceTrafficMirrorTargetCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceTrafficMirrorTargetRead(ctx, d, meta)...)
 }
 
-func resourceTrafficMirrorTargetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorTargetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -161,7 +161,7 @@ func resourceTrafficMirrorTargetRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceTrafficMirrorTargetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorTargetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only
@@ -169,7 +169,7 @@ func resourceTrafficMirrorTargetUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceTrafficMirrorTargetRead(ctx, d, meta)...)
 }
 
-func resourceTrafficMirrorTargetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficMirrorTargetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpc_vpcs_data_source.go
+++ b/internal/service/ec2/vpc_vpcs_data_source.go
@@ -38,7 +38,7 @@ func dataSourceVPCs() *schema.Resource {
 	}
 }
 
-func dataSourceVPCsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVPCsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -46,7 +46,7 @@ func dataSourceVPCsRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	if tags, tagsOk := d.GetOk(names.AttrTags); tagsOk {
 		input.Filters = append(input.Filters, newTagFilterList(
-			Tags(tftags.New(ctx, tags.(map[string]interface{}))),
+			Tags(tftags.New(ctx, tags.(map[string]any))),
 		)...)
 	}
 

--- a/internal/service/ec2/vpnclient_authorization_rule.go
+++ b/internal/service/ec2/vpnclient_authorization_rule.go
@@ -74,7 +74,7 @@ func resourceClientVPNAuthorizationRule() *schema.Resource {
 	}
 }
 
-func resourceClientVPNAuthorizationRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNAuthorizationRuleCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -116,7 +116,7 @@ func resourceClientVPNAuthorizationRuleCreate(ctx context.Context, d *schema.Res
 	return append(diags, resourceClientVPNAuthorizationRuleRead(ctx, d, meta)...)
 }
 
-func resourceClientVPNAuthorizationRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNAuthorizationRuleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -146,7 +146,7 @@ func resourceClientVPNAuthorizationRuleRead(ctx context.Context, d *schema.Resou
 	return diags
 }
 
-func resourceClientVPNAuthorizationRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNAuthorizationRuleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpnclient_endpoint.go
+++ b/internal/service/ec2/vpnclient_endpoint.go
@@ -234,7 +234,7 @@ func resourceClientVPNEndpoint() *schema.Resource {
 	}
 }
 
-func resourceClientVPNEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNEndpointCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -252,16 +252,16 @@ func resourceClientVPNEndpointCreate(ctx context.Context, d *schema.ResourceData
 		input.AuthenticationOptions = expandClientVPNAuthenticationRequests(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("client_connect_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ClientConnectOptions = expandClientConnectOptions(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("client_connect_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ClientConnectOptions = expandClientConnectOptions(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("client_login_banner_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ClientLoginBannerOptions = expandClientLoginBannerOptions(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("client_login_banner_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ClientLoginBannerOptions = expandClientLoginBannerOptions(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("connection_log_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ConnectionLogOptions = expandConnectionLogOptions(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("connection_log_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ConnectionLogOptions = expandConnectionLogOptions(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
@@ -272,8 +272,8 @@ func resourceClientVPNEndpointCreate(ctx context.Context, d *schema.ResourceData
 		input.DisconnectOnSessionTimeout = aws.Bool(v.(bool))
 	}
 
-	if v, ok := d.GetOk("dns_servers"); ok && len(v.([]interface{})) > 0 {
-		input.DnsServers = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("dns_servers"); ok && len(v.([]any)) > 0 {
+		input.DnsServers = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrSecurityGroupIDs); ok {
@@ -303,7 +303,7 @@ func resourceClientVPNEndpointCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceClientVPNEndpointRead(ctx, d, meta)...)
 }
 
-func resourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -332,21 +332,21 @@ func resourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData, 
 	}
 	d.Set("client_cidr_block", ep.ClientCidrBlock)
 	if ep.ClientConnectOptions != nil {
-		if err := d.Set("client_connect_options", []interface{}{flattenClientConnectResponseOptions(ep.ClientConnectOptions)}); err != nil {
+		if err := d.Set("client_connect_options", []any{flattenClientConnectResponseOptions(ep.ClientConnectOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting client_connect_options: %s", err)
 		}
 	} else {
 		d.Set("client_connect_options", nil)
 	}
 	if ep.ClientLoginBannerOptions != nil {
-		if err := d.Set("client_login_banner_options", []interface{}{flattenClientLoginBannerResponseOptions(ep.ClientLoginBannerOptions)}); err != nil {
+		if err := d.Set("client_login_banner_options", []any{flattenClientLoginBannerResponseOptions(ep.ClientLoginBannerOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting client_login_banner_options: %s", err)
 		}
 	} else {
 		d.Set("client_login_banner_options", nil)
 	}
 	if ep.ConnectionLogOptions != nil {
-		if err := d.Set("connection_log_options", []interface{}{flattenConnectionLogResponseOptions(ep.ConnectionLogOptions)}); err != nil {
+		if err := d.Set("connection_log_options", []any{flattenConnectionLogResponseOptions(ep.ConnectionLogOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting connection_log_options: %s", err)
 		}
 	} else {
@@ -375,7 +375,7 @@ func resourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceClientVPNEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -388,20 +388,20 @@ func resourceClientVPNEndpointUpdate(ctx context.Context, d *schema.ResourceData
 		if d.HasChange("client_connect_options") {
 			waitForClientConnectResponseOptionsUpdate = true
 
-			if v, ok := d.GetOk("client_connect_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.ClientConnectOptions = expandClientConnectOptions(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("client_connect_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.ClientConnectOptions = expandClientConnectOptions(v.([]any)[0].(map[string]any))
 			}
 		}
 
 		if d.HasChange("client_login_banner_options") {
-			if v, ok := d.GetOk("client_login_banner_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.ClientLoginBannerOptions = expandClientLoginBannerOptions(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("client_login_banner_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.ClientLoginBannerOptions = expandClientLoginBannerOptions(v.([]any)[0].(map[string]any))
 			}
 		}
 
 		if d.HasChange("connection_log_options") {
-			if v, ok := d.GetOk("connection_log_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.ConnectionLogOptions = expandConnectionLogOptions(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("connection_log_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.ConnectionLogOptions = expandConnectionLogOptions(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -414,7 +414,7 @@ func resourceClientVPNEndpointUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if d.HasChange("dns_servers") {
-			dnsServers := d.Get("dns_servers").([]interface{})
+			dnsServers := d.Get("dns_servers").([]any)
 			enabled := len(dnsServers) > 0
 
 			input.DnsServers = &awstypes.DnsServersOptionsModifyStructure{
@@ -469,7 +469,7 @@ func resourceClientVPNEndpointUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceClientVPNEndpointRead(ctx, d, meta)...)
 }
 
-func resourceClientVPNEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNEndpointDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -494,7 +494,7 @@ func resourceClientVPNEndpointDelete(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func expandClientVPNAuthenticationRequest(tfMap map[string]interface{}) *awstypes.ClientVpnAuthenticationRequest {
+func expandClientVPNAuthenticationRequest(tfMap map[string]any) *awstypes.ClientVpnAuthenticationRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -537,7 +537,7 @@ func expandClientVPNAuthenticationRequest(tfMap map[string]interface{}) *awstype
 	return apiObject
 }
 
-func expandClientVPNAuthenticationRequests(tfList []interface{}) []awstypes.ClientVpnAuthenticationRequest {
+func expandClientVPNAuthenticationRequests(tfList []any) []awstypes.ClientVpnAuthenticationRequest {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -545,7 +545,7 @@ func expandClientVPNAuthenticationRequests(tfList []interface{}) []awstypes.Clie
 	var apiObjects []awstypes.ClientVpnAuthenticationRequest
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -563,8 +563,8 @@ func expandClientVPNAuthenticationRequests(tfList []interface{}) []awstypes.Clie
 	return apiObjects
 }
 
-func flattenClientVPNAuthentication(apiObject awstypes.ClientVpnAuthentication) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenClientVPNAuthentication(apiObject awstypes.ClientVpnAuthentication) map[string]any {
+	tfMap := map[string]any{}
 	tfMap[names.AttrType] = apiObject.Type
 
 	if apiObject.MutualAuthentication != nil {
@@ -588,12 +588,12 @@ func flattenClientVPNAuthentication(apiObject awstypes.ClientVpnAuthentication) 
 	return tfMap
 }
 
-func flattenClientVPNAuthentications(apiObjects []awstypes.ClientVpnAuthentication) []interface{} {
+func flattenClientVPNAuthentications(apiObjects []awstypes.ClientVpnAuthentication) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenClientVPNAuthentication(apiObject))
@@ -602,7 +602,7 @@ func flattenClientVPNAuthentications(apiObjects []awstypes.ClientVpnAuthenticati
 	return tfList
 }
 
-func expandClientConnectOptions(tfMap map[string]interface{}) *awstypes.ClientConnectOptions {
+func expandClientConnectOptions(tfMap map[string]any) *awstypes.ClientConnectOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -625,12 +625,12 @@ func expandClientConnectOptions(tfMap map[string]interface{}) *awstypes.ClientCo
 	return apiObject
 }
 
-func flattenClientConnectResponseOptions(apiObject *awstypes.ClientConnectResponseOptions) map[string]interface{} {
+func flattenClientConnectResponseOptions(apiObject *awstypes.ClientConnectResponseOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Enabled; v != nil {
 		tfMap[names.AttrEnabled] = v
@@ -643,7 +643,7 @@ func flattenClientConnectResponseOptions(apiObject *awstypes.ClientConnectRespon
 	return tfMap
 }
 
-func expandClientLoginBannerOptions(tfMap map[string]interface{}) *awstypes.ClientLoginBannerOptions {
+func expandClientLoginBannerOptions(tfMap map[string]any) *awstypes.ClientLoginBannerOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -666,12 +666,12 @@ func expandClientLoginBannerOptions(tfMap map[string]interface{}) *awstypes.Clie
 	return apiObject
 }
 
-func flattenClientLoginBannerResponseOptions(apiObject *awstypes.ClientLoginBannerResponseOptions) map[string]interface{} {
+func flattenClientLoginBannerResponseOptions(apiObject *awstypes.ClientLoginBannerResponseOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.BannerText; v != nil {
 		tfMap["banner_text"] = aws.ToString(v)
@@ -684,7 +684,7 @@ func flattenClientLoginBannerResponseOptions(apiObject *awstypes.ClientLoginBann
 	return tfMap
 }
 
-func expandConnectionLogOptions(tfMap map[string]interface{}) *awstypes.ConnectionLogOptions {
+func expandConnectionLogOptions(tfMap map[string]any) *awstypes.ConnectionLogOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -711,12 +711,12 @@ func expandConnectionLogOptions(tfMap map[string]interface{}) *awstypes.Connecti
 	return apiObject
 }
 
-func flattenConnectionLogResponseOptions(apiObject *awstypes.ConnectionLogResponseOptions) map[string]interface{} {
+func flattenConnectionLogResponseOptions(apiObject *awstypes.ConnectionLogResponseOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CloudwatchLogGroup; v != nil {
 		tfMap["cloudwatch_log_group"] = aws.ToString(v)

--- a/internal/service/ec2/vpnclient_endpoint_data_source.go
+++ b/internal/service/ec2/vpnclient_endpoint_data_source.go
@@ -182,7 +182,7 @@ func dataSourceClientVPNEndpoint() *schema.Resource {
 	}
 }
 
-func dataSourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -193,7 +193,7 @@ func dataSourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 
 	input.Filters = append(input.Filters, newCustomFilterList(
@@ -224,14 +224,14 @@ func dataSourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData
 	}
 	d.Set("client_cidr_block", ep.ClientCidrBlock)
 	if ep.ClientConnectOptions != nil {
-		if err := d.Set("client_connect_options", []interface{}{flattenClientConnectResponseOptions(ep.ClientConnectOptions)}); err != nil {
+		if err := d.Set("client_connect_options", []any{flattenClientConnectResponseOptions(ep.ClientConnectOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting client_connect_options: %s", err)
 		}
 	} else {
 		d.Set("client_connect_options", nil)
 	}
 	if ep.ClientLoginBannerOptions != nil {
-		if err := d.Set("client_login_banner_options", []interface{}{flattenClientLoginBannerResponseOptions(ep.ClientLoginBannerOptions)}); err != nil {
+		if err := d.Set("client_login_banner_options", []any{flattenClientLoginBannerResponseOptions(ep.ClientLoginBannerOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting client_login_banner_options: %s", err)
 		}
 	} else {
@@ -239,7 +239,7 @@ func dataSourceClientVPNEndpointRead(ctx context.Context, d *schema.ResourceData
 	}
 	d.Set("client_vpn_endpoint_id", ep.ClientVpnEndpointId)
 	if ep.ConnectionLogOptions != nil {
-		if err := d.Set("connection_log_options", []interface{}{flattenConnectionLogResponseOptions(ep.ConnectionLogOptions)}); err != nil {
+		if err := d.Set("connection_log_options", []any{flattenConnectionLogResponseOptions(ep.ConnectionLogOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting connection_log_options: %s", err)
 		}
 	} else {

--- a/internal/service/ec2/vpnclient_network_association.go
+++ b/internal/service/ec2/vpnclient_network_association.go
@@ -61,7 +61,7 @@ func resourceClientVPNNetworkAssociation() *schema.Resource {
 	}
 }
 
-func resourceClientVPNNetworkAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNNetworkAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -87,7 +87,7 @@ func resourceClientVPNNetworkAssociationCreate(ctx context.Context, d *schema.Re
 	return append(diags, resourceClientVPNNetworkAssociationRead(ctx, d, meta)...)
 }
 
-func resourceClientVPNNetworkAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNNetworkAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -112,7 +112,7 @@ func resourceClientVPNNetworkAssociationRead(ctx context.Context, d *schema.Reso
 	return diags
 }
 
-func resourceClientVPNNetworkAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNNetworkAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -140,7 +140,7 @@ func resourceClientVPNNetworkAssociationDelete(ctx context.Context, d *schema.Re
 	return diags
 }
 
-func resourceClientVPNNetworkAssociationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceClientVPNNetworkAssociationImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), ",")
 
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {

--- a/internal/service/ec2/vpnclient_route.go
+++ b/internal/service/ec2/vpnclient_route.go
@@ -73,7 +73,7 @@ func resourceClientVPNRoute() *schema.Resource {
 	}
 }
 
-func resourceClientVPNRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNRouteCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -92,7 +92,7 @@ func resourceClientVPNRouteCreate(ctx context.Context, d *schema.ResourceData, m
 		input.Description = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (any, error) {
 		return conn.CreateClientVpnRoute(ctx, input)
 	}, errCodeInvalidClientVPNActiveAssociationNotFound)
 
@@ -109,7 +109,7 @@ func resourceClientVPNRouteCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceClientVPNRouteRead(ctx, d, meta)...)
 }
 
-func resourceClientVPNRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -140,7 +140,7 @@ func resourceClientVPNRouteRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceClientVPNRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClientVPNRouteDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpnsite_connection.go
+++ b/internal/service/ec2/vpnsite_connection.go
@@ -673,7 +673,7 @@ var (
 	defaultVPNTunnelOptionsStartupAction          = vpnTunnelOptionsStartupActionAdd
 )
 
-func resourceVPNConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNConnectionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -708,7 +708,7 @@ func resourceVPNConnectionCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceVPNConnectionRead(ctx, d, meta)...)
 }
 
-func resourceVPNConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNConnectionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -845,7 +845,7 @@ func resourceVPNConnectionRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceVPNConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -932,7 +932,7 @@ func resourceVPNConnectionUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceVPNConnectionRead(ctx, d, meta)...)
 }
 
-func resourceVPNConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNConnectionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -1025,8 +1025,8 @@ func expandVPNTunnelOptionsSpecification(d *schema.ResourceData, prefix string) 
 		}
 	}
 
-	if v, ok := d.GetOk(prefix + "log_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.LogOptions = expandVPNTunnelLogOptionsSpecification(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk(prefix + "log_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.LogOptions = expandVPNTunnelLogOptionsSpecification(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk(prefix + "phase1_dh_group_numbers"); ok {
@@ -1104,21 +1104,21 @@ func expandVPNTunnelOptionsSpecification(d *schema.ResourceData, prefix string) 
 	return apiObject
 }
 
-func expandVPNTunnelLogOptionsSpecification(tfMap map[string]interface{}) *awstypes.VpnTunnelLogOptionsSpecification {
+func expandVPNTunnelLogOptionsSpecification(tfMap map[string]any) *awstypes.VpnTunnelLogOptionsSpecification {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.VpnTunnelLogOptionsSpecification{}
 
-	if v, ok := tfMap["cloudwatch_log_options"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.CloudWatchLogOptions = expandCloudWatchLogOptionsSpecification(v[0].(map[string]interface{}))
+	if v, ok := tfMap["cloudwatch_log_options"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.CloudWatchLogOptions = expandCloudWatchLogOptionsSpecification(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandCloudWatchLogOptionsSpecification(tfMap map[string]interface{}) *awstypes.CloudWatchLogOptionsSpecification {
+func expandCloudWatchLogOptionsSpecification(tfMap map[string]any) *awstypes.CloudWatchLogOptionsSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -1192,8 +1192,8 @@ func expandModifyVPNTunnelOptionsSpecification(d *schema.ResourceData, prefix st
 	}
 
 	if key := prefix + "log_options"; d.HasChange(key) {
-		if v, ok := d.GetOk(key); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			apiObject.LogOptions = expandVPNTunnelLogOptionsSpecification(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk(key); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			apiObject.LogOptions = expandVPNTunnelLogOptionsSpecification(v.([]any)[0].(map[string]any))
 		}
 
 		hasChange = true
@@ -1371,7 +1371,7 @@ func flattenTunnelOption(d *schema.ResourceData, prefix string, apiObject awstyp
 	s = nil
 
 	if apiObject.LogOptions != nil {
-		if err := d.Set(prefix+"log_options", []interface{}{flattenVPNTunnelLogOptions(apiObject.LogOptions)}); err != nil {
+		if err := d.Set(prefix+"log_options", []any{flattenVPNTunnelLogOptions(apiObject.LogOptions)}); err != nil {
 			return fmt.Errorf("setting %s: %w", prefix+"log_options", err)
 		}
 	} else {
@@ -1425,8 +1425,8 @@ func flattenTunnelOption(d *schema.ResourceData, prefix string, apiObject awstyp
 	return nil
 }
 
-func flattenVPNStaticRoute(apiObject awstypes.VpnStaticRoute) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenVPNStaticRoute(apiObject awstypes.VpnStaticRoute) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.DestinationCidrBlock; v != nil {
 		tfMap["destination_cidr_block"] = aws.ToString(v)
@@ -1438,12 +1438,12 @@ func flattenVPNStaticRoute(apiObject awstypes.VpnStaticRoute) map[string]interfa
 	return tfMap
 }
 
-func flattenVPNStaticRoutes(apiObjects []awstypes.VpnStaticRoute) []interface{} {
+func flattenVPNStaticRoutes(apiObjects []awstypes.VpnStaticRoute) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenVPNStaticRoute(apiObject))
@@ -1452,26 +1452,26 @@ func flattenVPNStaticRoutes(apiObjects []awstypes.VpnStaticRoute) []interface{} 
 	return tfList
 }
 
-func flattenVPNTunnelLogOptions(apiObject *awstypes.VpnTunnelLogOptions) map[string]interface{} {
+func flattenVPNTunnelLogOptions(apiObject *awstypes.VpnTunnelLogOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CloudWatchLogOptions; v != nil {
-		tfMap["cloudwatch_log_options"] = []interface{}{flattenCloudWatchLogOptions(v)}
+		tfMap["cloudwatch_log_options"] = []any{flattenCloudWatchLogOptions(v)}
 	}
 
 	return tfMap
 }
 
-func flattenCloudWatchLogOptions(apiObject *awstypes.CloudWatchLogOptions) map[string]interface{} {
+func flattenCloudWatchLogOptions(apiObject *awstypes.CloudWatchLogOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.LogEnabled; v != nil {
 		enabled := aws.ToBool(v)
@@ -1492,8 +1492,8 @@ func flattenCloudWatchLogOptions(apiObject *awstypes.CloudWatchLogOptions) map[s
 	return tfMap
 }
 
-func flattenVGWTelemetry(apiObject awstypes.VgwTelemetry) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenVGWTelemetry(apiObject awstypes.VgwTelemetry) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.AcceptedRouteCount; v != nil {
 		tfMap["accepted_route_count"] = aws.ToInt32(v)
@@ -1520,12 +1520,12 @@ func flattenVGWTelemetry(apiObject awstypes.VgwTelemetry) map[string]interface{}
 	return tfMap
 }
 
-func flattenVGWTelemetries(apiObjects []awstypes.VgwTelemetry) []interface{} {
+func flattenVGWTelemetries(apiObjects []awstypes.VgwTelemetry) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenVGWTelemetry(apiObject))
@@ -1660,7 +1660,7 @@ func validVPNConnectionTunnelInsideIPv6CIDR() schema.SchemaValidateFunc {
 }
 
 // customizeDiffValidateOutsideIPAddressType validates that if provided `outside_ip_address_type` is `PrivateIpv4` then `transport_transit_gateway_attachment_id` must be provided
-func customizeDiffValidateOutsideIPAddressType(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func customizeDiffValidateOutsideIPAddressType(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if v, ok := diff.GetOk("outside_ip_address_type"); !ok || v.(string) == outsideIPAddressTypePublicIPv4 {
 		return nil
 	}

--- a/internal/service/ec2/vpnsite_connection_route.go
+++ b/internal/service/ec2/vpnsite_connection_route.go
@@ -41,7 +41,7 @@ func resourceVPNConnectionRoute() *schema.Resource {
 	}
 }
 
-func resourceVPNConnectionRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNConnectionRouteCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -68,7 +68,7 @@ func resourceVPNConnectionRouteCreate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceVPNConnectionRouteRead(ctx, d, meta)...)
 }
 
-func resourceVPNConnectionRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNConnectionRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -95,7 +95,7 @@ func resourceVPNConnectionRouteRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceVPNConnectionRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNConnectionRouteDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpnsite_customer_gateway.go
+++ b/internal/service/ec2/vpnsite_customer_gateway.go
@@ -89,7 +89,7 @@ func resourceCustomerGateway() *schema.Resource {
 	}
 }
 
-func resourceCustomerGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomerGatewayCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -145,7 +145,7 @@ func resourceCustomerGatewayCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceCustomerGatewayRead(ctx, d, meta)...)
 }
 
-func resourceCustomerGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomerGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -181,12 +181,12 @@ func resourceCustomerGatewayRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceCustomerGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomerGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceCustomerGatewayRead(ctx, d, meta)
 }
 
-func resourceCustomerGatewayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomerGatewayDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpnsite_customer_gateway_data_source.go
+++ b/internal/service/ec2/vpnsite_customer_gateway_data_source.go
@@ -72,7 +72,7 @@ func dataSourceCustomerGateway() *schema.Resource {
 	}
 }
 
-func dataSourceCustomerGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCustomerGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpnsite_gateway.go
+++ b/internal/service/ec2/vpnsite_gateway.go
@@ -67,7 +67,7 @@ func resourceVPNGateway() *schema.Resource {
 	}
 }
 
-func resourceVPNGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNGatewayCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -102,11 +102,11 @@ func resourceVPNGatewayCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceVPNGatewayRead(ctx, d, meta)...)
 }
 
-func resourceVPNGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
 		return findVPNGatewayByID(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -146,7 +146,7 @@ func resourceVPNGatewayRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceVPNGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -169,7 +169,7 @@ func resourceVPNGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceVPNGatewayRead(ctx, d, meta)...)
 }
 
-func resourceVPNGatewayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNGatewayDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -183,7 +183,7 @@ func resourceVPNGatewayDelete(ctx context.Context, d *schema.ResourceData, meta 
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
 		return conn.DeleteVpnGateway(ctx, &ec2.DeleteVpnGatewayInput{
 			VpnGatewayId: aws.String(d.Id()),
 		})
@@ -210,7 +210,7 @@ func attachVPNGatewayToVPC(ctx context.Context, conn *ec2.Client, vpnGatewayID, 
 		VpnGatewayId: aws.String(vpnGatewayID),
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, ec2PropagationTimeout, func() (any, error) {
 		return conn.AttachVpnGateway(ctx, &input)
 	}, errCodeInvalidVPNGatewayIDNotFound)
 

--- a/internal/service/ec2/vpnsite_gateway_attachment.go
+++ b/internal/service/ec2/vpnsite_gateway_attachment.go
@@ -40,7 +40,7 @@ func resourceVPNGatewayAttachment() *schema.Resource {
 	}
 }
 
-func resourceVPNGatewayAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNGatewayAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -69,7 +69,7 @@ func resourceVPNGatewayAttachmentCreate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceVPNGatewayAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceVPNGatewayAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNGatewayAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -91,7 +91,7 @@ func resourceVPNGatewayAttachmentRead(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceVPNGatewayAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNGatewayAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/vpnsite_gateway_data_source.go
+++ b/internal/service/ec2/vpnsite_gateway_data_source.go
@@ -69,7 +69,7 @@ func dataSourceVPNGateway() *schema.Resource {
 	}
 }
 
-func dataSourceVPNGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVPNGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -101,7 +101,7 @@ func dataSourceVPNGatewayRead(ctx context.Context, d *schema.ResourceData, meta 
 		)...)
 	}
 	input.Filters = append(input.Filters, newTagFilterList(
-		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))),
+		Tags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))),
 	)...)
 	input.Filters = append(input.Filters, newCustomFilterList(
 		d.Get(names.AttrFilter).(*schema.Set),

--- a/internal/service/ec2/vpnsite_gateway_route_propagation.go
+++ b/internal/service/ec2/vpnsite_gateway_route_propagation.go
@@ -43,7 +43,7 @@ func resourceVPNGatewayRoutePropagation() *schema.Resource {
 	}
 }
 
-func resourceVPNGatewayRoutePropagationEnable(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNGatewayRoutePropagationEnable(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -60,7 +60,7 @@ func resourceVPNGatewayRoutePropagationEnable(ctx context.Context, d *schema.Res
 	return append(diags, resourceVPNGatewayRoutePropagationRead(ctx, d, meta)...)
 }
 
-func resourceVPNGatewayRoutePropagationDisable(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNGatewayRoutePropagationDisable(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -79,7 +79,7 @@ func resourceVPNGatewayRoutePropagationDisable(ctx context.Context, d *schema.Re
 	return sdkdiag.AppendFromErr(diags, err)
 }
 
-func resourceVPNGatewayRoutePropagationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPNGatewayRoutePropagationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 

--- a/internal/service/ec2/wavelength_carrier_gateway.go
+++ b/internal/service/ec2/wavelength_carrier_gateway.go
@@ -57,7 +57,7 @@ func resourceCarrierGateway() *schema.Resource {
 	}
 }
 
-func resourceCarrierGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCarrierGatewayCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -82,7 +82,7 @@ func resourceCarrierGatewayCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceCarrierGatewayRead(ctx, d, meta)...)
 }
 
-func resourceCarrierGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCarrierGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
@@ -115,7 +115,7 @@ func resourceCarrierGatewayRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceCarrierGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCarrierGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -123,7 +123,7 @@ func resourceCarrierGatewayUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceCarrierGatewayRead(ctx, d, meta)...)
 }
 
-func resourceCarrierGatewayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCarrierGatewayDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EC2Client(ctx)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make smoke
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2025/03/12 17:00:12 Initializing Terraform AWS Provider...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMPolicy_policy
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (12.50s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (12.66s)
--- PASS: TestAccIAMRole_disappears (17.29s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (17.36s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (17.37s)
--- PASS: TestAccIAMRole_basic (18.34s)
--- PASS: TestAccIAMRole_namePrefix (19.06s)
--- PASS: TestAccIAMRolePolicy_basic (19.08s)
--- PASS: TestAccIAMPolicy_basic (19.34s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (20.28s)
--- PASS: TestAccIAMInstanceProfile_basic (24.18s)
--- PASS: TestAccIAMPolicy_policy (27.07s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (27.44s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (34.83s)
--- PASS: TestAccIAMPolicy_tags (53.08s)
--- PASS: TestAccIAMInstanceProfile_tags (74.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	78.792s
2025/03/12 17:01:52 Initializing Terraform AWS Provider...
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_multiple
--- PASS: TestAccLogsGroup_multiple (11.29s)
--- PASS: TestAccLogsGroup_basic (13.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	17.931s
2025/03/12 17:02:11 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPC_tenancy
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPCSecurityGroup_egressMode
--- PASS: TestAccVPCSubnet_basic (20.18s)
--- PASS: TestAccVPCRouteTable_basic (20.70s)
--- PASS: TestAccVPCSecurityGroup_basic (23.14s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (23.17s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (24.72s)
--- PASS: TestAccVPCDataSource_basic (29.06s)
--- PASS: TestAccVPCSecurityGroup_egressMode (43.42s)
--- PASS: TestAccVPC_tenancy (43.93s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (51.82s)
--- PASS: TestAccVPCSecurityGroupRule_race (167.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	181.045s
2025/03/12 17:02:02 Initializing Terraform AWS Provider...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (22.45s)
--- PASS: TestAccECSService_basic (68.77s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	73.327s
2025/03/12 17:02:06 Initializing Terraform AWS Provider...
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (20.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	29.524s
2025/03/12 17:02:15 Initializing Terraform AWS Provider...
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (23.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	40.810s
2025/03/12 17:05:23 Initializing Terraform AWS Provider...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (29.69s)
--- PASS: TestAccLambdaFunction_basic (40.44s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	45.088s
2025/03/12 17:05:28 Initializing Terraform AWS Provider...
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaRegionDataSource_basic (8.10s)
--- PASS: TestAccMetaPartitionDataSource_basic (8.14s)
--- PASS: TestAccMetaRegionDataSource_endpoint (9.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	18.188s
2025/03/12 17:05:32 Initializing Terraform AWS Provider...
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_Latency_basic
--- PASS: TestAccRoute53ZoneDataSource_name (88.74s)
--- PASS: TestAccRoute53Record_Latency_basic (168.49s)
--- PASS: TestAccRoute53Record_basic (178.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	191.242s
2025/03/12 17:05:49 Initializing Terraform AWS Provider...
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketPolicy_basic
--- PASS: TestAccS3Object_basic (18.68s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (19.10s)
--- PASS: TestAccS3Bucket_Basic_basic (19.26s)
--- PASS: TestAccS3BucketPolicy_basic (19.27s)
--- PASS: TestAccS3BucketACL_updateACL (32.11s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (33.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	61.186s
2025/03/12 17:05:41 Initializing Terraform AWS Provider...
=== RUN   TestAccSSMParameterEphemeral_basic
=== PAUSE TestAccSSMParameterEphemeral_basic
=== CONT  TestAccSSMParameterEphemeral_basic
--- PASS: TestAccSSMParameterEphemeral_basic (11.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	31.443s
2025/03/12 17:05:36 Initializing Terraform AWS Provider...
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_basic (13.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	28.825s
2025/03/12 17:05:45 Initializing Terraform AWS Provider...
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (8.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	32.033s
```
