### PR TITLE
[Bug fix] fix expanding process for operation_preferences.region_order in CloudFormation StackSet

### DIFF
--- a/.changelog/41810.txt
+++ b/.changelog/41810.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+resource/aws_cloudformation_stack_set: fix the expanding process of `region_order` in `operation_preferences` block
+resource/aws_cloudformation_stack_instances: fix the expanding process of `region_order` in `operation_preferences` block
+resource/aws_cloudformation_stack_set_instances: fix the expanding process of `region_order` in `operation_preferences` block
+```

--- a/.changelog/41810.txt
+++ b/.changelog/41810.txt
@@ -1,5 +1,11 @@
 ```release-note:bug
-resource/aws_cloudformation_stack_set: fix the expanding process of `region_order` in `operation_preferences` block
-resource/aws_cloudformation_stack_instances: fix the expanding process of `region_order` in `operation_preferences` block
-resource/aws_cloudformation_stack_set_instances: fix the expanding process of `region_order` in `operation_preferences` block
+resource/aws_cloudformation_stack_set: Fix `region_order` in `operation_preferences` block not being correctly passed to AWS API
+```
+
+```release-note:bug
+resource/aws_cloudformation_stack_instances: Fix `region_order` in `operation_preferences` block not being correctly passed to AWS API
+```
+
+```release-note:bug
+resource/aws_cloudformation_stack_set_instances: Fix `region_order` in `operation_preferences` block not being correctly passed to AWS API
 ```

--- a/internal/service/cloudformation/stack_instances_test.go
+++ b/internal/service/cloudformation/stack_instances_test.go
@@ -472,6 +472,43 @@ func TestAccCloudFormationStackInstances_concurrencyMode(t *testing.T) {
 	})
 }
 
+func TestAccCloudFormationStackInstances_regionOrder(t *testing.T) {
+	ctx := acctest.Context(t)
+	var stackInstances tfcloudformation.StackInstances
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudformation_stack_instances.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckStackSet(ctx, t)
+			acctest.PreCheckOrganizationsEnabled(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+			acctest.PreCheckIAMServiceLinkedRole(ctx, t, "/aws-service-role/stacksets.cloudformation.amazonaws.com")
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFormationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckStackInstancesForOrganizationalUnitDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStackInstancesConfig_regionOrder(rName, []string{acctest.Region(), acctest.AlternateRegion()}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckStackInstancesForOrganizationalUnitExists(ctx, resourceName, stackInstances),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.concurrency_mode", "SOFT_FAILURE_TOLERANCE"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.failure_tolerance_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_count", "10"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.max_concurrent_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_concurrency_type", "SEQUENTIAL"),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_order.0", acctest.Region()),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_order.1", acctest.AlternateRegion()),
+				),
+			},
+		},
+	})
+}
+
 // https://github.com/hashicorp/terraform-provider-aws/issues/32536.
 func TestAccCloudFormationStackInstances_delegatedAdministrator(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -920,7 +957,7 @@ resource "aws_cloudformation_stack_instances" "test" {
 `, value1, value2))
 }
 
-func testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName string) string {
+func testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName string, autoDeployment bool) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -1019,7 +1056,7 @@ resource "aws_cloudformation_stack_set" "test" {
   permission_model = "SERVICE_MANAGED"
 
   auto_deployment {
-    enabled                          = true
+    enabled                          = %[3]t
     retain_stacks_on_account_removal = false
   }
 
@@ -1033,11 +1070,11 @@ TEMPLATE
     ignore_changes = [administration_role_arn]
   }
 }
-`, rName, testAccStackSetTemplateBodyVPC(rName))
+`, rName, testAccStackSetTemplateBodyVPC(rName), autoDeployment)
 }
 
 func testAccStackInstancesConfig_deploymentTargets(rName string) string {
-	return acctest.ConfigCompose(testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName), `
+	return acctest.ConfigCompose(testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName, true), `
 resource "aws_cloudformation_stack_instances" "test" {
   stack_set_name = aws_cloudformation_stack_set.test.name
 
@@ -1053,7 +1090,7 @@ resource "aws_cloudformation_stack_instances" "test" {
 }
 
 func testAccStackInstancesConfig_DeploymentTargets_emptyOU(rName string) string {
-	return acctest.ConfigCompose(testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName, true), fmt.Sprintf(`
 resource "aws_organizations_organizational_unit" "test" {
   name      = %[1]q
   parent_id = data.aws_organizations_organization.test.roots[0].id
@@ -1072,7 +1109,7 @@ resource "aws_cloudformation_stack_instances" "test" {
 }
 
 func testAccStackInstancesConfig_operationPreferences(rName string) string {
-	return acctest.ConfigCompose(testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName), `
+	return acctest.ConfigCompose(testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName, true), `
 resource "aws_cloudformation_stack_instances" "test" {
   stack_set_name = aws_cloudformation_stack_set.test.name
 
@@ -1091,7 +1128,7 @@ resource "aws_cloudformation_stack_instances" "test" {
 }
 
 func testAccStackInstancesConfig_concurrencyMode(rName string) string {
-	return acctest.ConfigCompose(testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName), `
+	return acctest.ConfigCompose(testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName, true), `
 resource "aws_cloudformation_stack_instances" "test" {
   stack_set_name = aws_cloudformation_stack_set.test.name
 
@@ -1108,6 +1145,29 @@ resource "aws_cloudformation_stack_instances" "test" {
   depends_on = [aws_iam_role_policy.Administration, aws_iam_role_policy.Execution]
 }
 `)
+}
+
+func testAccStackInstancesConfig_regionOrder(rName string, regionOrder []string) string {
+	return acctest.ConfigCompose(testAccStackInstancesBaseConfig_ServiceManagedStackSet(rName, false),
+		fmt.Sprintf(`
+resource "aws_cloudformation_stack_instances" "test" {
+  stack_set_name = aws_cloudformation_stack_set.test.name
+
+  operation_preferences {
+    failure_tolerance_count = 1
+    max_concurrent_count    = 10
+    concurrency_mode        = "SOFT_FAILURE_TOLERANCE"
+    region_concurrency_type = "SEQUENTIAL"
+    region_order            = ["%[1]s"]
+  }
+
+  deployment_targets {
+    organizational_unit_ids = [data.aws_organizations_organization.test.roots[0].id]
+  }
+
+  depends_on = [aws_iam_role_policy.Administration, aws_iam_role_policy.Execution]
+}
+`, strings.Join(regionOrder, `", "`)))
 }
 
 func testAccStackInstancesConfig_delegatedAdministrator(rName string) string {

--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -6,6 +6,7 @@ package cloudformation_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -828,6 +829,46 @@ func TestAccCloudFormationStackSet_autoDeploymentDisabled(t *testing.T) {
 	})
 }
 
+func TestAccCloudFormationStackSet_regionOrder(t *testing.T) {
+	ctx := acctest.Context(t)
+	var stackSet awstypes.StackSet
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudformation_stack_set.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckStackSet(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFormationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckStackSetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStackSetConfig_regionOrder(rName, []string{acctest.Region(), acctest.AlternateRegion()}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStackSetExists(ctx, resourceName, &stackSet),
+					resource.TestCheckResourceAttr(resourceName, "auto_deployment.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auto_deployment.0.enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_order.0", acctest.Region()),
+					resource.TestCheckResourceAttr(resourceName, "operation_preferences.0.region_order.1", acctest.AlternateRegion()),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"call_as",
+					"template_url",
+					"operation_preferences",
+				},
+			},
+		},
+	})
+}
+
 // https://github.com/hashicorp/terraform-provider-aws/issues/32536.
 // Prerequisites:
 // * Organizations management account
@@ -1482,6 +1523,30 @@ resource "aws_cloudformation_stack_set" "test" {
 TEMPLATE
 }
 `, rName, testAccStackSetTemplateBodyVPC(rName), enabled, retainStacksOnAccountRemoval)
+}
+
+func testAccStackSetConfig_regionOrder(rName string, regionOrder []string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudformation_stack_set" "test" {
+  name             = %[1]q
+  permission_model = "SERVICE_MANAGED"
+
+  auto_deployment {
+    enabled                          = false
+  }
+
+  operation_preferences {
+    failure_tolerance_count = 1
+    max_concurrent_count    = 10
+    region_concurrency_type = "SEQUENTIAL"
+	region_order            = ["%[3]s"]
+  }
+
+  template_body = <<TEMPLATE
+%[2]s
+TEMPLATE
+}
+`, rName, testAccStackSetTemplateBodyVPC(rName), strings.Join(regionOrder, "\", \""))
 }
 
 // Initialize all the providers used by delegated administrator acceptance tests.

--- a/internal/service/cloudformation/stack_set_test.go
+++ b/internal/service/cloudformation/stack_set_test.go
@@ -1532,14 +1532,14 @@ resource "aws_cloudformation_stack_set" "test" {
   permission_model = "SERVICE_MANAGED"
 
   auto_deployment {
-    enabled                          = false
+    enabled = false
   }
 
   operation_preferences {
     failure_tolerance_count = 1
     max_concurrent_count    = 10
     region_concurrency_type = "SEQUENTIAL"
-	region_order            = ["%[3]s"]
+    region_order            = ["%[3]s"]
   }
 
   template_body = <<TEMPLATE

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -466,8 +465,10 @@ func expandOperationPreferences(tfMap map[string]any) *awstypes.StackSetOperatio
 	if v, ok := tfMap["region_concurrency_type"].(string); ok && v != "" {
 		apiObject.RegionConcurrencyType = awstypes.RegionConcurrencyType(v)
 	}
-	if v, ok := tfMap["region_order"].(*schema.Set); ok && v.Len() > 0 {
-		apiObject.RegionOrder = flex.ExpandStringValueSet(v)
+	if v, ok := tfMap["region_order"].([]interface{}); ok && len(v) > 0 {
+		for _, region := range v {
+			apiObject.RegionOrder = append(apiObject.RegionOrder, region.(string))
+		}
 	}
 
 	if ftc, ftp := aws.ToInt32(apiObject.FailureToleranceCount), aws.ToInt32(apiObject.FailureTolerancePercentage); ftp == 0 {

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -465,7 +465,7 @@ func expandOperationPreferences(tfMap map[string]any) *awstypes.StackSetOperatio
 	if v, ok := tfMap["region_concurrency_type"].(string); ok && v != "" {
 		apiObject.RegionConcurrencyType = awstypes.RegionConcurrencyType(v)
 	}
-	if v, ok := tfMap["region_order"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["region_order"].([]any); ok && len(v) > 0 {
 		for _, region := range v {
 			apiObject.RegionOrder = append(apiObject.RegionOrder, region.(string))
 		}

--- a/internal/service/cloudformation/type.go
+++ b/internal/service/cloudformation/type.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -466,9 +467,7 @@ func expandOperationPreferences(tfMap map[string]any) *awstypes.StackSetOperatio
 		apiObject.RegionConcurrencyType = awstypes.RegionConcurrencyType(v)
 	}
 	if v, ok := tfMap["region_order"].([]any); ok && len(v) > 0 {
-		for _, region := range v {
-			apiObject.RegionOrder = append(apiObject.RegionOrder, region.(string))
-		}
+		apiObject.RegionOrder = flex.ExpandStringValueList(v)
 	}
 
 	if ftc, ftp := aws.ToInt32(apiObject.FailureToleranceCount), aws.ToInt32(apiObject.FailureTolerancePercentage); ftp == 0 {


### PR DESCRIPTION
### Description
* To resolve the issue reported by #41767. 
* fix a process of expanding (i.e. deserializing from terraform configuration) "region_order" in operation_preferences used in `aws_cloudformation_stack_set`, `aws_cloudformation_stack_instances` and `aws_cloudformation_stack_set_instance`.
  * It used to be deserialized as TypeSet, but it should be an ordered list. 
https://github.com/tabito-hara/terraform-provider-aws/commit/bff75ff005d56e0a5d3a7241c5c908f2f3c7b5c8
  The original one:
   ```go
	if v, ok := tfMap["region_order"].(*schema.Set); ok && v.Len() > 0 {
		apiObject.RegionOrder = flex.ExpandStringValueSet(v)
	}
   ```
   It has been modified as:
   ```go
	if v, ok := tfMap["region_order"].([]any); ok && len(v) > 0 {
		apiObject.RegionOrder = flex.ExpandStringValueList(v)
	}
   ```

* Add acctests for the `region_order` attribute.  
  * Note that passing the newly added tests does not necessarily mean that processes related to `region_order` are correctly implemented. (Even without the modifications in this branch, the acctests still pass.) However, these tests help observe changes in behavior, such as modifications to the request body of actions.  
    * The `operational_preferences` block (which includes `region_order`) is not refreshed during Terraform's read process; it exists solely as an internal attribute within Terraform.  
      * The acctests only verify that `region_order` is correctly retained in the Terraform state (`tfstate`), not that the resource is created according to the configuration specified in the `operation_preference` block.  
        * These are not resource attributes but rather operational configurations specified for a particular execution.  
        * As a result, actions that describe resource attributes do not return these attributes.  
        * `DescribeStackSetOperation` returns attributes in `operational_preferences`, but only during operations. This action describes the operational configuration of a specific operation, requiring an `operationId` to request it.  

* `region_order` is effective only when `auto_deployment` is set to `false`. In tests related to `region_order`, `auto_deployment` is explicitly set to `false`.  

#### Verification
The following acctests were conducted with TF_LOG=DEBUG environment variables.

```
TF_LOG=DEBUG  make testacc TESTS=TestAccCloudFormationStackSetInstance_regionOrder PKG=cloudformation 
```
* Without the modification, the request body of `CreateStackInstances` in TestAccCloudFormationStackSetInstance_regionOrder is as follows:
 ```
  http.request.body=
  | Action=CreateStackInstances&CallAs=SELF&DeploymentTargets.OrganizationalUnitIds.member.1=r-rcxe&OperationId=terraform-20250312215258287600000004&OperationPreferences.ConcurrencyMode=SOFT_FAILURE_TOLERANCE&OperationPreferences.FailureToleranceCount=1&OperationPreferences.MaxConcurrentCount=10&OperationPreferences.RegionConcurrencyType=SEQUENTIAL&Regions.member.1=us-west-2&StackSetName=tf-acc-test-2172309617782508679&Version=2010-05-15
```
You do not find "OperationPreferences.RegionOrder" in the request parameters.

And the response of `DescribeStackSetOperation`, called to check progress in the test, includes empty RegionOrder as follows:
```
  |       <OperationPreferences>
  |         <RegionOrder/>
  |         <RegionConcurrencyType>SEQUENTIAL</RegionConcurrencyType>
  |         <FailureToleranceCount>1</FailureToleranceCount>
  |         <MaxConcurrentCount>10</MaxConcurrentCount>
  |       </OperationPreferences>
``` 
`RegionOrder` is empty.

On the other hand, with the modification of this branch, "OperationPreferences.RegionOrder" is included in the request body of `CreateStackInstances`:
```
  http.request.body=
  | Action=CreateStackInstances&CallAs=SELF&DeploymentTargets.OrganizationalUnitIds.member.1=r-rcxe&OperationId=terraform-20250312214525917300000004&OperationPreferences.ConcurrencyMode=SOFT_FAILURE_TOLERANCE&OperationPreferences.FailureToleranceCount=1&OperationPreferences.MaxConcurrentCount=10&OperationPreferences.RegionConcurrencyType=SEQUENTIAL&OperationPreferences.RegionOrder.member.1=us-west-2&OperationPreferences.RegionOrder.member.2=us-east-1&Regions.member.1=us-west-2&StackSetName=tf-acc-test-491068053307654715&Version=2010-05-15
```

the response of `DescribeStackSetOperation` shows `RegionOrders` as expected.

```
  |       <OperationPreferences>
  |         <RegionOrder>
  |           <member>us-west-2</member>
  |           <member>us-east-1</member>
  |         </RegionOrder>
  |         <RegionConcurrencyType>SEQUENTIAL</RegionConcurrencyType>
  |         <FailureToleranceCount>1</FailureToleranceCount>
  |         <MaxConcurrentCount>10</MaxConcurrentCount>
  |       </OperationPreferences>

```

You can find the same result in running `TestAccCloudFormationStackInstances_regionOrder`.


### Relations
Closes #41767 

### References
[Cloudformation API Reference -- StackSetOperationPreferences](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_StackSetOperationPreferences.html)

### Output from Acceptance Testing
#### CloudFormationStackSet
```console
$ AWS_ALTERNATE_PROFILE=admin-non-org AWS_PROFILE=admin make testacc TESTS=TestAccCloudFormationStackSet_ PKG=cloudformation
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/cloudformation/... -v -count 1 -parallel 20 -run='TestAccCloudFormationStackSet_'  -timeout 360m -vet=off
2025/03/13 22:45:05 Initializing Terraform AWS Provider...
=== RUN   TestAccCloudFormationStackSet_basic
=== PAUSE TestAccCloudFormationStackSet_basic
=== RUN   TestAccCloudFormationStackSet_disappears
=== PAUSE TestAccCloudFormationStackSet_disappears
=== RUN   TestAccCloudFormationStackSet_administrationRoleARN
=== PAUSE TestAccCloudFormationStackSet_administrationRoleARN
=== RUN   TestAccCloudFormationStackSet_description
=== PAUSE TestAccCloudFormationStackSet_description
=== RUN   TestAccCloudFormationStackSet_executionRoleName
=== PAUSE TestAccCloudFormationStackSet_executionRoleName
=== RUN   TestAccCloudFormationStackSet_managedExecution
=== PAUSE TestAccCloudFormationStackSet_managedExecution
=== RUN   TestAccCloudFormationStackSet_name
=== PAUSE TestAccCloudFormationStackSet_name
=== RUN   TestAccCloudFormationStackSet_operationPreferences
=== PAUSE TestAccCloudFormationStackSet_operationPreferences
=== RUN   TestAccCloudFormationStackSet_parameters
=== PAUSE TestAccCloudFormationStackSet_parameters
=== RUN   TestAccCloudFormationStackSet_Parameters_default
    stack_set_test.go:479: this resource does not currently ignore unconfigured CloudFormation template parameters with the Default property
--- SKIP: TestAccCloudFormationStackSet_Parameters_default (0.00s)
=== RUN   TestAccCloudFormationStackSet_Parameters_noEcho
    stack_set_test.go:533: this resource does not currently ignore CloudFormation template parameters with the NoEcho property
--- SKIP: TestAccCloudFormationStackSet_Parameters_noEcho (0.00s)
=== RUN   TestAccCloudFormationStackSet_PermissionModel_serviceManaged
    stack_set_test.go:579: API does not support enabling Organizations access (in particular, creating the Stack Sets IAM Service-Linked Role)
--- SKIP: TestAccCloudFormationStackSet_PermissionModel_serviceManaged (0.00s)
=== RUN   TestAccCloudFormationStackSet_tags
=== PAUSE TestAccCloudFormationStackSet_tags
=== RUN   TestAccCloudFormationStackSet_templateBody
=== PAUSE TestAccCloudFormationStackSet_templateBody
=== RUN   TestAccCloudFormationStackSet_templateURL
=== PAUSE TestAccCloudFormationStackSet_templateURL
=== RUN   TestAccCloudFormationStackSet_autoDeploymentEnabled
=== PAUSE TestAccCloudFormationStackSet_autoDeploymentEnabled
=== RUN   TestAccCloudFormationStackSet_autoDeploymentDisabled
=== PAUSE TestAccCloudFormationStackSet_autoDeploymentDisabled
=== RUN   TestAccCloudFormationStackSet_regionOrder
=== PAUSE TestAccCloudFormationStackSet_regionOrder
=== RUN   TestAccCloudFormationStackSet_delegatedAdministrator
=== PAUSE TestAccCloudFormationStackSet_delegatedAdministrator
=== CONT  TestAccCloudFormationStackSet_basic
=== CONT  TestAccCloudFormationStackSet_executionRoleName
=== CONT  TestAccCloudFormationStackSet_name
=== CONT  TestAccCloudFormationStackSet_parameters
=== CONT  TestAccCloudFormationStackSet_disappears
=== CONT  TestAccCloudFormationStackSet_managedExecution
=== CONT  TestAccCloudFormationStackSet_autoDeploymentEnabled
=== CONT  TestAccCloudFormationStackSet_administrationRoleARN
=== CONT  TestAccCloudFormationStackSet_description
=== CONT  TestAccCloudFormationStackSet_operationPreferences
=== CONT  TestAccCloudFormationStackSet_templateURL
=== CONT  TestAccCloudFormationStackSet_templateBody
=== CONT  TestAccCloudFormationStackSet_tags
=== CONT  TestAccCloudFormationStackSet_regionOrder
=== CONT  TestAccCloudFormationStackSet_delegatedAdministrator
=== CONT  TestAccCloudFormationStackSet_autoDeploymentDisabled
=== NAME  TestAccCloudFormationStackSet_delegatedAdministrator
    stack_set_test.go:890: this AWS account must not be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSet_delegatedAdministrator (12.99s)
--- PASS: TestAccCloudFormationStackSet_autoDeploymentDisabled (66.50s)
--- PASS: TestAccCloudFormationStackSet_managedExecution (70.15s)
--- PASS: TestAccCloudFormationStackSet_regionOrder (72.63s)
--- PASS: TestAccCloudFormationStackSet_autoDeploymentEnabled (81.47s)
--- PASS: TestAccCloudFormationStackSet_basic (82.63s)
--- PASS: TestAccCloudFormationStackSet_disappears (86.52s)
--- PASS: TestAccCloudFormationStackSet_administrationRoleARN (100.46s)
--- PASS: TestAccCloudFormationStackSet_executionRoleName (110.16s)
--- PASS: TestAccCloudFormationStackSet_description (110.23s)
--- PASS: TestAccCloudFormationStackSet_templateBody (114.18s)
--- PASS: TestAccCloudFormationStackSet_name (130.64s)
--- PASS: TestAccCloudFormationStackSet_templateURL (134.55s)
--- PASS: TestAccCloudFormationStackSet_tags (142.28s)
--- PASS: TestAccCloudFormationStackSet_parameters (164.80s)
--- PASS: TestAccCloudFormationStackSet_operationPreferences (221.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     226.907s
```

#### CloudFormationStackInstances
```console
$ AWS_ALTERNATE_PROFILE=admin-non-org AWS_PROFILE=admin make testacc TESTS=TestAccCloudFormationStackInstances PKG=cloudformation
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/cloudformation/... -v -count 1 -parallel 20 -run='TestAccCloudFormationStackInstances'  -timeout 360m -vet=off
2025/03/13 09:19:21 Initializing Terraform AWS Provider...
=== RUN   TestAccCloudFormationStackInstances_basic
=== PAUSE TestAccCloudFormationStackInstances_basic
=== RUN   TestAccCloudFormationStackInstances_disappears
=== PAUSE TestAccCloudFormationStackInstances_disappears
=== RUN   TestAccCloudFormationStackInstances_Disappears_stackSet
=== PAUSE TestAccCloudFormationStackInstances_Disappears_stackSet
=== RUN   TestAccCloudFormationStackInstances_Multi_increaseRegions
=== PAUSE TestAccCloudFormationStackInstances_Multi_increaseRegions
=== RUN   TestAccCloudFormationStackInstances_Multi_decreaseRegions
=== PAUSE TestAccCloudFormationStackInstances_Multi_decreaseRegions
=== RUN   TestAccCloudFormationStackInstances_Multi_swapRegions
=== PAUSE TestAccCloudFormationStackInstances_Multi_swapRegions
=== RUN   TestAccCloudFormationStackInstances_parameterOverrides
=== PAUSE TestAccCloudFormationStackInstances_parameterOverrides
=== RUN   TestAccCloudFormationStackInstances_deploymentTargets
=== PAUSE TestAccCloudFormationStackInstances_deploymentTargets
=== RUN   TestAccCloudFormationStackInstances_DeploymentTargets_emptyOU
=== PAUSE TestAccCloudFormationStackInstances_DeploymentTargets_emptyOU
=== RUN   TestAccCloudFormationStackInstances_operationPreferences
=== PAUSE TestAccCloudFormationStackInstances_operationPreferences
=== RUN   TestAccCloudFormationStackInstances_concurrencyMode
=== PAUSE TestAccCloudFormationStackInstances_concurrencyMode
=== RUN   TestAccCloudFormationStackInstances_regionOrder
=== PAUSE TestAccCloudFormationStackInstances_regionOrder
=== RUN   TestAccCloudFormationStackInstances_delegatedAdministrator
=== PAUSE TestAccCloudFormationStackInstances_delegatedAdministrator
=== CONT  TestAccCloudFormationStackInstances_basic
=== CONT  TestAccCloudFormationStackInstances_deploymentTargets
=== CONT  TestAccCloudFormationStackInstances_concurrencyMode
=== CONT  TestAccCloudFormationStackInstances_parameterOverrides
=== CONT  TestAccCloudFormationStackInstances_Multi_decreaseRegions
=== CONT  TestAccCloudFormationStackInstances_Multi_increaseRegions
=== CONT  TestAccCloudFormationStackInstances_Multi_swapRegions
=== CONT  TestAccCloudFormationStackInstances_Disappears_stackSet
=== CONT  TestAccCloudFormationStackInstances_disappears
=== CONT  TestAccCloudFormationStackInstances_delegatedAdministrator
=== CONT  TestAccCloudFormationStackInstances_regionOrder
=== CONT  TestAccCloudFormationStackInstances_DeploymentTargets_emptyOU
=== CONT  TestAccCloudFormationStackInstances_operationPreferences
=== NAME  TestAccCloudFormationStackInstances_delegatedAdministrator
    stack_instances_test.go:525: this AWS account must not be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackInstances_delegatedAdministrator (4.72s)
--- PASS: TestAccCloudFormationStackInstances_regionOrder (95.67s)
--- PASS: TestAccCloudFormationStackInstances_operationPreferences (100.25s)
--- PASS: TestAccCloudFormationStackInstances_Disappears_stackSet (100.60s)
--- PASS: TestAccCloudFormationStackInstances_concurrencyMode (100.80s)
--- PASS: TestAccCloudFormationStackInstances_DeploymentTargets_emptyOU (103.03s)
--- PASS: TestAccCloudFormationStackInstances_deploymentTargets (132.38s)
--- PASS: TestAccCloudFormationStackInstances_Multi_increaseRegions (143.40s)
--- PASS: TestAccCloudFormationStackInstances_Multi_swapRegions (149.88s)
--- PASS: TestAccCloudFormationStackInstances_parameterOverrides (207.62s)
--- PASS: TestAccCloudFormationStackInstances_basic (244.95s)
--- PASS: TestAccCloudFormationStackInstances_disappears (268.16s)
--- PASS: TestAccCloudFormationStackInstances_Multi_decreaseRegions (298.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     303.806s
```

#### CloudFormationStackSetInstance
```console
 AWS_ALTERNATE_PROFILE=admin-non-org AWS_PROFILE=admin make testacc TESTS=TestAccCloudFormationStackSetInstance PKG=cloudformation              
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/cloudformation/... -v -count 1 -parallel 20 -run='TestAccCloudFormationStackSetInstance'  -timeout 360m -vet=off
2025/03/13 09:29:11 Initializing Terraform AWS Provider...
=== RUN   TestAccCloudFormationStackSetInstance_basic
=== PAUSE TestAccCloudFormationStackSetInstance_basic
=== RUN   TestAccCloudFormationStackSetInstance_disappears
=== PAUSE TestAccCloudFormationStackSetInstance_disappears
=== RUN   TestAccCloudFormationStackSetInstance_Disappears_stackSet
=== PAUSE TestAccCloudFormationStackSetInstance_Disappears_stackSet
=== RUN   TestAccCloudFormationStackSetInstance_parameterOverrides
=== PAUSE TestAccCloudFormationStackSetInstance_parameterOverrides
=== RUN   TestAccCloudFormationStackSetInstance_deploymentTargets
=== PAUSE TestAccCloudFormationStackSetInstance_deploymentTargets
=== RUN   TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU
=== PAUSE TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU
=== RUN   TestAccCloudFormationStackSetInstance_operationPreferences
=== PAUSE TestAccCloudFormationStackSetInstance_operationPreferences
=== RUN   TestAccCloudFormationStackSetInstance_concurrencyMode
=== PAUSE TestAccCloudFormationStackSetInstance_concurrencyMode
=== RUN   TestAccCloudFormationStackSetInstance_regionOrder
=== PAUSE TestAccCloudFormationStackSetInstance_regionOrder
=== RUN   TestAccCloudFormationStackSetInstance_delegatedAdministrator
=== PAUSE TestAccCloudFormationStackSetInstance_delegatedAdministrator
=== CONT  TestAccCloudFormationStackSetInstance_basic
=== CONT  TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU
=== CONT  TestAccCloudFormationStackSetInstance_regionOrder
=== CONT  TestAccCloudFormationStackSetInstance_delegatedAdministrator
=== CONT  TestAccCloudFormationStackSetInstance_concurrencyMode
=== CONT  TestAccCloudFormationStackSetInstance_parameterOverrides
=== CONT  TestAccCloudFormationStackSetInstance_deploymentTargets
=== CONT  TestAccCloudFormationStackSetInstance_Disappears_stackSet
=== CONT  TestAccCloudFormationStackSetInstance_operationPreferences
=== CONT  TestAccCloudFormationStackSetInstance_disappears
=== NAME  TestAccCloudFormationStackSetInstance_delegatedAdministrator
    stack_set_instance_test.go:413: this AWS account must not be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSetInstance_delegatedAdministrator (5.20s)
--- PASS: TestAccCloudFormationStackSetInstance_Disappears_stackSet (94.69s)
--- PASS: TestAccCloudFormationStackSetInstance_regionOrder (96.59s)
--- PASS: TestAccCloudFormationStackSetInstance_operationPreferences (98.41s)
--- PASS: TestAccCloudFormationStackSetInstance_concurrencyMode (98.60s)
--- PASS: TestAccCloudFormationStackSetInstance_basic (100.23s)
--- PASS: TestAccCloudFormationStackSetInstance_disappears (103.88s)
--- PASS: TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU (108.80s)
--- PASS: TestAccCloudFormationStackSetInstance_deploymentTargets (124.36s)
--- PASS: TestAccCloudFormationStackSetInstance_parameterOverrides (192.91s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     198.778s

```
