### PR TITLE
sns: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -76,5 +76,6 @@ jobs:
 
       # Services
       - run: make TEST=./internal/service/mq modern-check
+      - run: make TEST=./internal/service/sns modern-check
       - run: make TEST=./internal/service/wafregional modern-check
       - run: make TEST=./internal/service/wafv2 modern-check

--- a/internal/service/sns/platform_application.go
+++ b/internal/service/sns/platform_application.go
@@ -121,7 +121,7 @@ func resourcePlatformApplication() *schema.Resource {
 	}
 }
 
-func resourcePlatformApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlatformApplicationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -137,7 +137,7 @@ func resourcePlatformApplicationCreate(ctx context.Context, d *schema.ResourceDa
 		Platform:   aws.String(d.Get("platform").(string)),
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
 		return conn.CreatePlatformApplication(ctx, input)
 	}, "is not a valid role to allow SNS to write to Cloudwatch Logs")
 
@@ -150,7 +150,7 @@ func resourcePlatformApplicationCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourcePlatformApplicationRead(ctx, d, meta)...)
 }
 
-func resourcePlatformApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlatformApplicationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -187,7 +187,7 @@ func resourcePlatformApplicationRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourcePlatformApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlatformApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -229,7 +229,7 @@ func resourcePlatformApplicationUpdate(ctx context.Context, d *schema.ResourceDa
 		PlatformApplicationArn: aws.String(d.Id()),
 	}
 
-	_, err = tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
 		return conn.SetPlatformApplicationAttributes(ctx, input)
 	}, "is not a valid role to allow SNS to write to Cloudwatch Logs")
 
@@ -240,7 +240,7 @@ func resourcePlatformApplicationUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourcePlatformApplicationRead(ctx, d, meta)...)
 }
 
-func resourcePlatformApplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlatformApplicationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -310,7 +310,7 @@ func parsePlatformApplicationResourceID(input string) (arnS, name, platform stri
 	return
 }
 
-func isChangeSha256Removal(oldRaw, newRaw interface{}) bool {
+func isChangeSha256Removal(oldRaw, newRaw any) bool {
 	old, ok := oldRaw.(string)
 	if !ok {
 		return false

--- a/internal/service/sns/sms_preferences.go
+++ b/internal/service/sns/sms_preferences.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 )
 
-func validateMonthlySpend(v interface{}, k string) (ws []string, errors []error) {
+func validateMonthlySpend(v any, k string) (ws []string, errors []error) {
 	vInt := v.(int)
 	if vInt < 0 {
 		errors = append(errors, fmt.Errorf("setting SMS preferences: monthly spend limit value [%d] must be >= 0", vInt))
@@ -25,7 +25,7 @@ func validateMonthlySpend(v interface{}, k string) (ws []string, errors []error)
 	return
 }
 
-func validateDeliverySamplingRate(v interface{}, k string) (ws []string, errors []error) {
+func validateDeliverySamplingRate(v any, k string) (ws []string, errors []error) {
 	vInt, _ := strconv.Atoi(v.(string))
 	if vInt < 0 || vInt > 100 {
 		errors = append(errors, fmt.Errorf("setting SMS preferences: default percentage of success to sample value [%d] must be between 0 and 100", vInt))
@@ -135,7 +135,7 @@ func resourceSMSPreferences() *schema.Resource {
 	}
 }
 
-func resourceSMSPreferencesSet(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSMSPreferencesSet(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -159,7 +159,7 @@ func resourceSMSPreferencesSet(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceSMSPreferencesGet(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSMSPreferencesGet(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -172,7 +172,7 @@ func resourceSMSPreferencesGet(ctx context.Context, d *schema.ResourceData, meta
 	return sdkdiag.AppendFromErr(diags, SMSPreferencesAttributeMap.APIAttributesToResourceData(output.Attributes, d))
 }
 
-func resourceSMSPreferencesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSMSPreferencesDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 

--- a/internal/service/sns/topic.go
+++ b/internal/service/sns/topic.go
@@ -57,7 +57,7 @@ var (
 			ValidateFunc:          validation.StringIsJSON,
 			DiffSuppressFunc:      verify.SuppressEquivalentJSONWithEmptyDiffs,
 			DiffSuppressOnRefresh: true,
-			StateFunc: func(v interface{}) string {
+			StateFunc: func(v any) string {
 				json, _ := structure.NormalizeJsonString(v)
 				return json
 			},
@@ -81,7 +81,7 @@ var (
 			ValidateFunc:          validation.StringIsJSON,
 			DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
 			DiffSuppressOnRefresh: true,
-			StateFunc: func(v interface{}) string {
+			StateFunc: func(v any) string {
 				json, _ := structure.NormalizeJsonString(v)
 				return json
 			},
@@ -170,7 +170,7 @@ var (
 			ValidateFunc:          validation.StringIsJSON,
 			DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 			DiffSuppressOnRefresh: true,
-			StateFunc: func(v interface{}) string {
+			StateFunc: func(v any) string {
 				json, _ := structure.NormalizeJsonString(v)
 				return json
 			},
@@ -257,7 +257,7 @@ func resourceTopic() *schema.Resource {
 	}
 }
 
-func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -299,7 +299,7 @@ func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	// Retry for eventual consistency; if ABAC is in use, this takes some time
 	// usually about 10s, presumably for tags really to be there, and we get a
 	// permissions error.
-	_, err = tfresource.RetryWhenIsAErrorMessageContains[*types.AuthorizationErrorException](ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenIsAErrorMessageContains[*types.AuthorizationErrorException](ctx, propagationTimeout, func() (any, error) {
 		return nil, putTopicAttributes(ctx, conn, d.Id(), attributes)
 	}, "no identity-based policy allows")
 
@@ -312,7 +312,7 @@ func resourceTopicCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		err := createTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition(ctx), err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(meta.(*conns.AWSClient).Partition(ctx), err) {
 			return append(diags, resourceTopicRead(ctx, d, meta)...)
 		}
 
@@ -360,7 +360,7 @@ func resourceTopicRead(ctx context.Context, d *schema.ResourceData, meta any) di
 	return diags
 }
 
-func resourceTopicUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -379,7 +379,7 @@ func resourceTopicUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceTopicRead(ctx, d, meta)...)
 }
 
-func resourceTopicDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -399,7 +399,7 @@ func resourceTopicDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceTopicCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+func resourceTopicCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 	fifoTopic := diff.Get("fifo_topic").(bool)
 	archivePolicy := diff.Get("archive_policy").(string)
 	contentBasedDeduplication := diff.Get("content_based_deduplication").(bool)
@@ -459,7 +459,7 @@ func putTopicAttribute(ctx context.Context, conn *sns.Client, arn string, name, 
 		TopicArn:       aws.String(arn),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*types.InvalidParameterException](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*types.InvalidParameterException](ctx, timeout, func() (any, error) {
 		return conn.SetTopicAttributes(ctx, input)
 	})
 

--- a/internal/service/sns/topic_data_protection_policy.go
+++ b/internal/service/sns/topic_data_protection_policy.go
@@ -48,7 +48,7 @@ func resourceTopicDataProtectionPolicy() *schema.Resource {
 				ValidateFunc:          validation.StringIsJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -57,7 +57,7 @@ func resourceTopicDataProtectionPolicy() *schema.Resource {
 	}
 }
 
-func resourceTopicDataProtectionPolicyUpsert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicDataProtectionPolicyUpsert(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -85,7 +85,7 @@ func resourceTopicDataProtectionPolicyUpsert(ctx context.Context, d *schema.Reso
 	return append(diags, resourceTopicDataProtectionPolicyRead(ctx, d, meta)...)
 }
 
-func resourceTopicDataProtectionPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicDataProtectionPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -107,7 +107,7 @@ func resourceTopicDataProtectionPolicyRead(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceTopicDataProtectionPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicDataProtectionPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 

--- a/internal/service/sns/topic_data_source.go
+++ b/internal/service/sns/topic_data_source.go
@@ -41,7 +41,7 @@ func dataSourceTopic() *schema.Resource {
 	}
 }
 
-func dataSourceTopicRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTopicRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 

--- a/internal/service/sns/topic_policy.go
+++ b/internal/service/sns/topic_policy.go
@@ -51,7 +51,7 @@ func resourceTopicPolicy() *schema.Resource {
 				ValidateFunc:          validation.StringIsJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -60,7 +60,7 @@ func resourceTopicPolicy() *schema.Resource {
 	}
 }
 
-func resourceTopicPolicyUpsert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicPolicyUpsert(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -83,7 +83,7 @@ func resourceTopicPolicyUpsert(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceTopicPolicyRead(ctx, d, meta)...)
 }
 
-func resourceTopicPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -122,7 +122,7 @@ func resourceTopicPolicyRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceTopicPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 

--- a/internal/service/sns/topic_subscription.go
+++ b/internal/service/sns/topic_subscription.go
@@ -52,7 +52,7 @@ var (
 			ValidateFunc:          validation.StringIsJSON,
 			DiffSuppressFunc:      SuppressEquivalentTopicSubscriptionDeliveryPolicy,
 			DiffSuppressOnRefresh: true,
-			StateFunc: func(v interface{}) string {
+			StateFunc: func(v any) string {
 				json, _ := structure.NormalizeJsonString(v)
 				return json
 			},
@@ -73,7 +73,7 @@ var (
 			ValidateFunc:          validation.StringIsJSON,
 			DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
 			DiffSuppressOnRefresh: true,
-			StateFunc: func(v interface{}) string {
+			StateFunc: func(v any) string {
 				json, _ := structure.NormalizeJsonString(v)
 				return json
 			},
@@ -109,7 +109,7 @@ var (
 			ValidateFunc:          validation.StringIsJSON,
 			DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
 			DiffSuppressOnRefresh: true,
-			StateFunc: func(v interface{}) string {
+			StateFunc: func(v any) string {
 				json, _ := structure.NormalizeJsonString(v)
 				return json
 			},
@@ -120,7 +120,7 @@ var (
 			ValidateFunc:          validation.StringIsJSON,
 			DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
 			DiffSuppressOnRefresh: true,
-			StateFunc: func(v interface{}) string {
+			StateFunc: func(v any) string {
 				json, _ := structure.NormalizeJsonString(v)
 				return json
 			},
@@ -174,7 +174,7 @@ func resourceTopicSubscription() *schema.Resource {
 	}
 }
 
-func resourceTopicSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -229,11 +229,11 @@ func resourceTopicSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceTopicSubscriptionRead(ctx, d, meta)...)
 }
 
-func resourceTopicSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, subscriptionCreateTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, subscriptionCreateTimeout, func() (any, error) {
 		return findSubscriptionAttributesByARN(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -252,7 +252,7 @@ func resourceTopicSubscriptionRead(ctx context.Context, d *schema.ResourceData, 
 	return sdkdiag.AppendFromErr(diags, subscriptionAttributeMap.APIAttributesToResourceData(attributes, d))
 }
 
-func resourceTopicSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -270,7 +270,7 @@ func resourceTopicSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceTopicSubscriptionRead(ctx, d, meta)...)
 }
 
-func resourceTopicSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTopicSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SNSClient(ctx)
 
@@ -384,7 +384,7 @@ func findSubscriptionAttributesByARN(ctx context.Context, conn *sns.Client, arn 
 }
 
 func statusSubscriptionPendingConfirmation(ctx context.Context, conn *sns.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSubscriptionAttributesByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {
@@ -543,7 +543,7 @@ func normalizeTopicSubscriptionDeliveryPolicy(policy string) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func resourceTopicSubscriptionCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+func resourceTopicSubscriptionCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 	hasPolicy := diff.Get("filter_policy").(string) != ""
 	hasScope := !diff.GetRawConfig().GetAttr("filter_policy_scope").IsNull()
 	hadScope := diff.Get("filter_policy_scope").(string) != ""


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T='TestAccSNSSMSPreferences_serial/deliveryRole|TestAccSNSTopic_basic|TestAccSNSTopicDataProtectionPolicy_basic|TestAccSNSTopicDataSource_basic|TestAccSNSTopicPolicy_basic|TestAccSNSTopicSubscription_basic' K=sns
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/sns/... -v -count 1 -parallel 20 -run='TestAccSNSSMSPreferences_serial/deliveryRole|TestAccSNSTopic_basic|TestAccSNSTopicDataProtectionPolicy_basic|TestAccSNSTopicDataSource_basic|TestAccSNSTopicPolicy_basic|TestAccSNSTopicSubscription_basic'  -timeout 360m -vet=off
2025/03/12 21:47:45 Initializing Terraform AWS Provider...
=== RUN   TestAccSNSSMSPreferences_serial
=== PAUSE TestAccSNSSMSPreferences_serial
=== RUN   TestAccSNSTopicDataProtectionPolicy_basic
=== PAUSE TestAccSNSTopicDataProtectionPolicy_basic
=== RUN   TestAccSNSTopicDataSource_basic
=== PAUSE TestAccSNSTopicDataSource_basic
=== RUN   TestAccSNSTopicPolicy_basic
=== PAUSE TestAccSNSTopicPolicy_basic
=== RUN   TestAccSNSTopicSubscription_basic
=== PAUSE TestAccSNSTopicSubscription_basic
=== RUN   TestAccSNSTopic_basic
=== PAUSE TestAccSNSTopic_basic
=== CONT  TestAccSNSSMSPreferences_serial
=== CONT  TestAccSNSTopicPolicy_basic
=== CONT  TestAccSNSTopic_basic
=== CONT  TestAccSNSTopicSubscription_basic
=== RUN   TestAccSNSSMSPreferences_serial/deliveryRole
=== CONT  TestAccSNSTopicDataSource_basic
=== CONT  TestAccSNSTopicDataProtectionPolicy_basic
--- PASS: TestAccSNSSMSPreferences_serial (17.31s)
    --- PASS: TestAccSNSSMSPreferences_serial/deliveryRole (17.31s)
--- PASS: TestAccSNSTopicDataSource_basic (20.69s)
--- PASS: TestAccSNSTopicDataProtectionPolicy_basic (23.68s)
--- PASS: TestAccSNSTopicPolicy_basic (23.94s)
--- PASS: TestAccSNSTopic_basic (24.18s)
--- PASS: TestAccSNSTopicSubscription_basic (55.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sns	59.964s
```
