### PR TITLE
chore(appflow): add dataTransferApi property in appflow CustomConnectorSourceProperties

### DIFF
--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -820,6 +820,31 @@ func resourceFlow() *schema.Resource {
 													Required:     true,
 													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 1024)),
 												},
+												"data_transfer_api": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Computed: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+																Computed: true,
+																ValidateFunc: validation.All(
+																	validation.StringLenBetween(0, 64),
+																	validation.StringMatch(regexache.MustCompile(`[\w]+`), "must contain only alphanumeric and underscore (_) characters"),
+																),
+															},
+															"type": {
+																Type:             schema.TypeString,
+																Optional:         true,
+																Computed:         true,
+																ValidateDiagFunc: enum.Validate[types.DataTransferApiType](),
+															},
+														},
+													},
+												},
 											},
 										},
 									},
@@ -2231,6 +2256,24 @@ func expandAmplitudeSourceProperties(tfMap map[string]interface{}) *types.Amplit
 	return a
 }
 
+func expandDataTransferApi(tfMap map[string]interface{}) *types.DataTransferApi {
+	if tfMap == nil {
+		return nil
+	}
+
+	a := &types.DataTransferApi{}
+
+	if v, ok := tfMap["name"].(string); ok && v != "" {
+		a.Name = aws.String(v)
+	}
+
+	if v, ok := tfMap["type"].(string); ok && v != "" {
+		a.Type = types.DataTransferApiType(v)
+	}
+
+	return a
+}
+
 func expandCustomConnectorSourceProperties(tfMap map[string]interface{}) *types.CustomConnectorSourceProperties {
 	if tfMap == nil {
 		return nil
@@ -2244,6 +2287,10 @@ func expandCustomConnectorSourceProperties(tfMap map[string]interface{}) *types.
 
 	if v, ok := tfMap["entity_name"].(string); ok && v != "" {
 		a.EntityName = aws.String(v)
+	}
+
+	if v, ok := tfMap["data_transfer_api"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		a.DataTransferApi = expandDataTransferApi(v[0].(map[string]interface{}))
 	}
 
 	return a
@@ -3415,6 +3462,19 @@ func flattenAmplitudeSourceProperties(amplitudeSourceProperties *types.Amplitude
 	return m
 }
 
+func flattenDataTransferApi(dataTransferApi *types.DataTransferApi) map[string]interface{} {
+	if dataTransferApi == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{}
+
+	m["name"] = dataTransferApi.Name
+	m["type"] = dataTransferApi.Type
+
+	return m
+}
+
 func flattenCustomConnectorSourceProperties(customConnectorSourceProperties *types.CustomConnectorSourceProperties) map[string]interface{} {
 	if customConnectorSourceProperties == nil {
 		return nil
@@ -3428,6 +3488,10 @@ func flattenCustomConnectorSourceProperties(customConnectorSourceProperties *typ
 
 	if v := customConnectorSourceProperties.EntityName; v != nil {
 		m["entity_name"] = aws.ToString(v)
+	}
+
+	if v := customConnectorSourceProperties.DataTransferApi; v != nil {
+		m["data_transfer_api"] = []interface{}{flattenDataTransferApi(v)}
 	}
 
 	return m

--- a/website/docs/r/appflow_flow.html.markdown
+++ b/website/docs/r/appflow_flow.html.markdown
@@ -304,6 +304,7 @@ Amplitude, Datadog, Dynatrace, Google Analytics, Infor Nexus, Marketo, ServiceNo
 
 * `entity_name` - (Required) Entity specified in the custom connector as a source in the flow.
 * `custom_properties` - (Optional) Custom properties that are specific to the connector when it's used as a source in the flow. Maximum of 50 items.
+* `data_transfer_api` - (Optional) Specifies which API is used by Amazon AppFlow to transfer data.
 
 ##### S3 Source Properties
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Adding [dataTransferApi](https://docs.aws.amazon.com/appflow/1.0/APIReference/API_CustomConnectorSourceProperties.html#appflow-Type-CustomConnectorSourceProperties-dataTransferApi) property for CustomConnectorSourceProperties for Appflow.

### References
- https://docs.aws.amazon.com/appflow/1.0/APIReference/API_CustomConnectorSourceProperties.html
- https://docs.aws.amazon.com/appflow/1.0/APIReference/API_DataTransferApi.html


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```